### PR TITLE
fix firealarm security light color level

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -917,16 +917,17 @@ FIRE ALARM
 			set_light(l_range = 1.5, l_power = 0.5, l_color = COLOR_RED)
 		else
 			icon_state = "fire0"
+			var/new_color = null
 			switch(seclevel)
 				if(SEC_LEVEL_GREEN)
-					color = COLOR_LIME
+					new_color = COLOR_LIME
 				if(SEC_LEVEL_BLUE)
-					color = "#1024A9"
+					new_color = "#1024A9"
 				if(SEC_LEVEL_RED)
-					color = COLOR_RED
+					new_color = COLOR_RED
 				if(SEC_LEVEL_DELTA)
-					color = "#FF6633"
-			set_light(l_range = 1.5, l_power = 0.5, l_color = light_color)
+					new_color = "#FF6633"
+			set_light(l_range = 1.5, l_power = 0.5, l_color = new_color)
 		src.overlays += image('icons/obj/monitors.dmi', "overlay_[num2seclevel(seclevel)]")
 
 /obj/machinery/firealarm/fire_act(datum/gas_mixture/air, temperature, volume)


### PR DESCRIPTION
Fixes this issue:
![image](https://user-images.githubusercontent.com/17644501/31292974-2e5f6f86-aade-11e7-98b4-08c1fdb472bb.png)
