### PR TITLE
Performance fix in generate_blood_overlay proc.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -496,18 +496,21 @@ var/list/global/slot_flags_enumeration = list(
 		blood_DNA[M.dna.unique_enzymes] = M.dna.b_type
 	return 1 //we applied blood to the item
 
+var/global/list/items_blood_overlay_by_type = list()
 /obj/item/proc/generate_blood_overlay()
 	if(blood_overlay)
 		return
 
-	var/icon/I = new /icon(icon, icon_state)
-	I.Blend(new /icon('icons/effects/blood.dmi', rgb(255,255,255)),ICON_ADD) //fills the icon_state with white (except where it's transparent)
-	I.Blend(new /icon('icons/effects/blood.dmi', "itemblood"),ICON_MULTIPLY) //adds blood and the remaining white areas become transparant
-
-	//not sure if this is worth it. It attaches the blood_overlay to every item of the same type if they don't have one already made.
-	for(var/obj/item/A in world)
-		if(A.type == type && !A.blood_overlay)
-			A.blood_overlay = image(I)
+	var/image/IMG = items_blood_overlay_by_type[type]
+	if(IMG)
+		blood_overlay = IMG
+	else
+		var/icon/ICO = new /icon(icon, icon_state)
+		ICO.Blend(new /icon('icons/effects/blood.dmi', rgb(255, 255, 255)), ICON_ADD) // fills the icon_state with white (except where it's transparent)
+		ICO.Blend(new /icon('icons/effects/blood.dmi', "itemblood"), ICON_MULTIPLY)   // adds blood and the remaining white areas become transparant
+		IMG = image("icon" = ICO)
+		items_blood_overlay_by_type[type] = IMG
+		blood_overlay = IMG
 
 /obj/item/proc/showoff(mob/user)
 	for (var/mob/M in view(user))


### PR DESCRIPTION
Boosts performance in heavy gun fight where a lot of blood spawns on stuff or whatever close to that situation.

Actually port of https://github.com/TauCetiStation/TauCetiClassic/commit/cb060817d5e0a84c0de15fe021a839bb9166fbfb

Long story short: "in world" loops should be avoided in features where such procs used often.
**How to reproduce:** spawn a gun (i used c20r gun in short bursts mode (5 bullets per click)), then spawn a human, then simply start shooting repeatedly towards human so that he starts getting bullet shrapnel and keep one of your eye in MC tab watching how CPU sometimes sky jumps.

A also made new profile tests if interested:
```
Proc Name                                    Self CPU    Total CPU    Real Time        Calls
-----------------------------------------    ---------    ---------    ---------    ---------
/obj/item/proc/generate_blood_overlay         0.517        0.518        0.518           11 < now
/obj/item/proc/generate_blood_overlay         0.000        0.000        0.000           11 < with this commit
```