### PR TITLE
Hostile mobs now loose interest in humans using config's health_threshold_crit value …

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -323,7 +323,7 @@
 /mob/living/simple_animal/proc/SA_attackable(target_mob)
 	if (isliving(target_mob))
 		var/mob/living/L = target_mob
-		if(!L.stat && L.health >= 0)
+		if(!L.stat && L.health >= (ishuman(L) ? config.health_threshold_crit : 0))
 			return (0)
 	if (istype(target_mob,/obj/mecha))
 		var/obj/mecha/M = target_mob


### PR DESCRIPTION
… , since 0 health for humans does not mean death even with default config settings, which raises awkward situation.