### PR TITLE
Workaround for supply shuttle not getting Eris docking codes because …

### DIFF
--- a/code/modules/shuttles/shuttle_autodock.dm
+++ b/code/modules/shuttles/shuttle_autodock.dm
@@ -27,9 +27,7 @@
 	if(active_docking_controller)
 		set_docking_codes(active_docking_controller.docking_codes)
 	else if(config.use_overmap)
-		var/obj/effect/overmap/location = map_sectors["[current_location.z]"]
-		if(location && location.docking_codes)
-			set_docking_codes(location.docking_codes)
+		initialize_overmap_docking_codes()
 	dock()
 
 	//Optional transition area
@@ -42,6 +40,11 @@
 	landmark_transition = null
 
 	return ..()
+
+/datum/shuttle/autodock/proc/initialize_overmap_docking_codes()
+	var/obj/effect/overmap/location = map_sectors["[current_location.z]"]
+	if(location && location.docking_codes)
+		set_docking_codes(location.docking_codes)
 
 /datum/shuttle/autodock/proc/set_docking_codes(var/code)
 	docking_codes = code

--- a/maps/CEVEris/shuttles-eris.dm
+++ b/maps/CEVEris/shuttles-eris.dm
@@ -214,6 +214,12 @@
 	waypoint_station = "nav_cargo_vessel"
 	dock_target = "supply_shuttle"
 
+/datum/shuttle/autodock/ferry/supply/drone/initialize_overmap_docking_codes()
+	var/obj/effect/shuttle_landmark/supply/station/LM = locate() // no "LM == null" check because landmark should exist always anyway and if it runtimes, then it means time to look in to this proc.
+	var/obj/effect/overmap/location = map_sectors["[LM.z]"]
+	if(location && location.docking_codes)
+		set_docking_codes(location.docking_codes)
+
 /obj/effect/shuttle_landmark/supply/centcom
 	name = "Centcom"
 	landmark_tag = "nav_cargo_start"


### PR DESCRIPTION
…of z-level difference and because of that airlocks do not open when supply shuttle docks with Eris.