### PR TITLE
Fixes glasses related bugs.

### DIFF
--- a/code/modules/clothing/glasses/welding.dm
+++ b/code/modules/clothing/glasses/welding.dm
@@ -5,12 +5,11 @@
 	item_state = "welding-g"
 	action_button_name = "Flip Welding Goggles"
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 2)
-	var/up = FALSE
 	flash_protection = FLASH_PROTECTION_MAJOR
 	tint = TINT_HEAVY
 
 /obj/item/clothing/glasses/welding/attack_self()
-	toggle()
+	adjust()
 
 
 /obj/item/clothing/glasses/welding/verb/adjust()
@@ -19,8 +18,8 @@
 	set src in usr
 
 	if(usr.canmove && !usr.stat && !usr.restrained())
-		if(src.up)
-			src.up = !src.up
+		if(!src.active)
+			src.active = !src.active
 			flags_inv |= HIDEEYES
 			body_parts_covered |= EYES
 			icon_state = initial(icon_state)
@@ -28,7 +27,7 @@
 			tint = initial(tint)
 			usr << "You flip \the [src] down to protect your eyes."
 		else
-			src.up = !src.up
+			src.active = !src.active
 			flags_inv &= ~HIDEEYES
 			body_parts_covered &= ~EYES
 			icon_state = "[initial(icon_state)]up"

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -729,6 +729,7 @@
 	return 1
 
 /mob/living/carbon/human/handle_regular_hud_updates()
+	. = ..()
 	for (var/obj/screen/H in HUDprocess)
 //		var/obj/screen/B = H
 		H.Process()
@@ -764,7 +765,7 @@
 
 	// now handle what we see on our screen
 
-	if(!..())
+	if(!.)
 		return
 
 //	if(damageoverlay.overlays)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -323,6 +323,9 @@
 	if(!H.druggy)
 		H.see_in_dark = (H.sight == SEE_TURFS|SEE_MOBS|SEE_OBJS) ? 8 : min(darksight + H.equipment_darkness_modifier, 8)
 
+	if(H.equipment_see_invis)
+		H.see_invisible = H.equipment_see_invis
+
 	if(H.equipment_tint_total >= TINT_BLIND)
 		H.eye_blind = max(H.eye_blind, 1)
 
@@ -333,7 +336,9 @@
 		return 1
 
 	if(config.welder_vision)
-		if((!H.equipment_prescription && (H.disabilities & NEARSIGHTED)) || H.equipment_tint_total == TINT_MODERATE)
+		if(H.equipment_tint_total == TINT_HEAVY)
+			H.client.screen += global_hud.darkMask
+		else if((!H.equipment_prescription && (H.disabilities & NEARSIGHTED)) || H.equipment_tint_total == TINT_MODERATE)
 			H.client.screen += global_hud.vimpaired
 //	if(H.eye_blurry)	H.client.screen += global_hud.blurry
 //	if(H.druggy)		H.client.screen += global_hud.druggy

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -178,11 +178,7 @@
 	see_invisible = SEE_INVISIBLE_LEVEL_TWO
 
 /mob/living/proc/handle_hud_icons()
-	handle_hud_icons_health()
 	handle_hud_glasses()
-
-/mob/living/proc/handle_hud_icons_health()
-	return
 
 /*/mob/living/proc/HUD_create()
 	if (!usr.client)


### PR DESCRIPTION
* Meson, thermal, nvg now properly disables shadows.
* Welding and any glasses that uses tint now properly adds tint overlay into player screen.
* Fixed broken wielding glasses action button.
* Fixed some call logic in handle_regular_hud_updates() because of that proc call race, blindfold glasses didn't work (or actually glasses that use TINT_BLIND and depends on blind overlay) , because parent call sets eye_blind or whatever from which HUDprocess things depends (maybe fixed something more, as HUDprocess mostly updates stuff based off vars from life proc.
* Removed unused handle_hud_icons_health which i found while was working on fixing logic with handle_regular_hud_updates.