### PR TITLE
5 runtimes fix pack.

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -125,7 +125,7 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 
 	var/turf/simulated/my_tile = loc
 	if(!istype(my_tile) || !my_tile.zone)
-		if(my_tile.fire == src)
+		if(my_tile && my_tile.fire == src)
 			my_tile.fire = null
 		RemoveFire()
 		return 1

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -217,9 +217,10 @@
 
 	//done throwing, either because it hit something or it finished moving
 	var/turf/new_loc = get_turf(src)
-	if(isobj(src))
-		src.throw_impact(new_loc,speed)
-	new_loc.Entered(src)
+	if(new_loc)
+		if(isobj(src))
+			src.throw_impact(new_loc,speed)
+		new_loc.Entered(src)
 	src.throwing = 0
 	src.thrower = null
 	src.throw_source = null

--- a/code/modules/overmap/ships/engines/thermal.dm
+++ b/code/modules/overmap/ships/engines/thermal.dm
@@ -94,10 +94,12 @@
 		audible_message(src,"<span class='warning'>[src] coughs once and goes silent!</span>")
 		on = !on
 		return 0
-	var/exhaust_dir = reverse_direction(dir)
 	var/datum/gas_mixture/removed = air_contents.remove(moles_per_burn * thrust_limit)
+	if(!removed)
+		return 0
 	. = calculate_thrust(removed)
 	playsound(loc, 'sound/machines/thruster.ogg', 100 * thrust_limit, 0, world.view * 4, 0.1)
+	var/exhaust_dir = reverse_direction(dir)
 	var/turf/T = get_step(src,exhaust_dir)
 	if(T)
 		T.assume_air(removed)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -75,6 +75,9 @@
 
 /obj/item/weapon/gun/energy/examine(mob/user)
 	..(user)
+	if(!cell)
+		user << SPAN_NOTICE("Has no battery cell inserted.")
+		return
 	var/shots_remaining = round(cell.charge / charge_cost)
 	user << "Has [shots_remaining] shot\s remaining."
 	return

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -21,7 +21,7 @@
 
 	//returns how well tool is suited for this step
 	proc/tool_quality(obj/item/tool)
-		if(requedQuality)
+		if(requedQuality && tool.tool_qualities)
 			return tool.tool_qualities[requedQuality]
 		else
 			for (var/T in allowed_tools)


### PR DESCRIPTION
Each fix in its own commit:
* fixes #1551 - gas_mixture/proc/remove() return null, if it removed zero gas
* fixes #1545 - null.fire because it passes !istype(my_tile) check
* fixes #1550 - bad_index in this case when trying to access associative list when its null (and tool_qualities list is null for any tool by default).
* fixes #1547 - probably happens when item gets qdeled mid throwing state or for whatever reason its loc is null by that moment.
* fixes #1549 - there is a plenty of cell var checks in other places, so i think it needs here too.