### PR TITLE
Should resolve any/most resource dupe/farming issues with autolathe.

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -581,8 +581,11 @@ proc/GaussRandRound(var/sigma, var/roundto)
 	return round(GaussRand(sigma), roundto)
 
 //Will return the contents of an atom recursivly to a depth of 'searchDepth'
-/atom/proc/GetAllContents(searchDepth = 5)
+/atom/proc/GetAllContents(searchDepth = 5, includeSelf = FALSE)
 	var/list/toReturn = list()
+
+	if(includeSelf)
+		toReturn += src
 
 	for(var/atom/part in contents)
 		toReturn += part

--- a/code/datums/autolathe/autolathe_datums.dm
+++ b/code/datums/autolathe/autolathe_datums.dm
@@ -12,12 +12,28 @@
 			continue
 
 		var/obj/item/I = new recipe.path
-		if(I.matter && !recipe.resources) //This can be overidden in the datums.
+		if(I.matter && I.matter.len && !recipe.resources) //This can be overidden in the datums.
 			recipe.resources = list()
-			for(var/material in I.matter)
-				recipe.resources[material] = round(I.matter[material]*1.25) // More expensive to produce than they are to recycle.
+
+			for(var/obj/O in I.GetAllContents(includeSelf = TRUE)) // we also count any additional matter that comes with item itself, like battery inside a flashlight
+				if(!O.matter || !O.matter.len)
+					continue
+
+				var/obj/item/stack/material/stack
+				if(istype(O, /obj/item/stack))
+					stack = O
+
+				for(var/material in O.matter)
+					if(stack) // "if" instead of "?" for readability
+						recipe.resources[material] += stack.matter[material] * stack.get_amount()
+					else
+						recipe.resources[material] += O.matter[material]
+
 		if(!recipe.resources)
 			recipe.resources = list()
+		else
+			for(var/material in recipe.resources)
+				recipe.resources[material] = round(recipe.resources[material] * 1.25, 1) // More expensive to produce than they are to recycle.
 
 		if(I.matter_reagents && !recipe.reagents) //This can be overidden in the datums.
 			recipe.reagents = list()

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -1,3 +1,5 @@
+#define SANITIZE_LATHE_COST(n) max(1, n) // makes sure that discounted prices from upgraded lathe no less than 1 unit.
+
 /obj/machinery/autolathe
 	name = "autolathe"
 	desc = "It produces items using metal and glass."
@@ -101,7 +103,7 @@
 
 		var/list/RS = list()
 		for(var/mat in R.resources)
-			RS.Add(list(list("name" = mat, "req" = round(R.resources[mat] * mat_efficiency))))
+			RS.Add(list(list("name" = mat, "req" = SANITIZE_LATHE_COST(round(R.resources[mat] * mat_efficiency)))))
 
 		data["req_materials"] = RS
 
@@ -254,7 +256,6 @@
 		if(making_recipe && making_left)
 			make(making_recipe.type,making_left)
 
-
 /obj/machinery/autolathe/proc/eat(var/mob/living/user)
 	if(!istype(user))
 		return
@@ -278,32 +279,50 @@
 		return
 
 	var/filltype = 0       // Used to determine message.
+	var/reagents_filltype = 0
 	var/total_used = 0     // Amount of material used.
 	var/mass_per_sheet = 0 // Amount of material constituting one sheet.
 
-	for(var/material in eating.matter)
-		if(!(material in stored_material))
-			stored_material[material] = 0
+	for(var/obj/O in eating.GetAllContents(includeSelf = TRUE))
+		if(O.matter && O.matter.len)
+			for(var/material in O.matter)
+				if(!(material in stored_material))
+					stored_material[material] = 0
 
-		if(stored_material[material] >= storage_capacity)
-			continue
+				if(stored_material[material] >= storage_capacity)
+					continue
 
-		var/total_material = round(eating.matter[material])
+				var/total_material = round(O.matter[material])
 
-		//If it's a stack, we eat multiple sheets.
-		if(istype(eating,/obj/item/stack))
-			var/obj/item/stack/material/stack = eating
-			total_material *= stack.get_amount()
+				//If it's a stack, we eat multiple sheets.
+				if(istype(O,/obj/item/stack))
+					var/obj/item/stack/material/stack = O
+					total_material *= stack.get_amount()
 
-		if(stored_material[material] + total_material > storage_capacity)
-			total_material = storage_capacity - stored_material[material]
-			filltype = 1
-		else
-			filltype = 2
+				if(stored_material[material] + total_material > storage_capacity)
+					total_material = storage_capacity - stored_material[material]
+					filltype = 1
+				else
+					filltype = 2
 
-		stored_material[material] += total_material
-		total_used += total_material
-		mass_per_sheet += eating.matter[material]
+				stored_material[material] += total_material
+				total_used += total_material
+				mass_per_sheet += O.matter[material]
+
+		if(O.matter_reagents)
+			if(container)
+				var/datum/reagents/RG = new(0)
+				for(var/r in O.matter_reagents)
+					RG.maximum_volume += O.matter_reagents[r]
+					RG.add_reagent(r ,O.matter_reagents[r])
+				reagents_filltype = 1
+				RG.trans_to(container, RG.total_volume)
+
+			else
+				reagents_filltype = 2
+
+		if(O.reagents && container)
+			O.reagents.trans_to(container, O.reagents.total_volume)
 
 	if(!filltype)
 		user << SPAN_NOTICE("\The [src] is full. Please remove material from the autolathe in order to insert more.")
@@ -313,20 +332,10 @@
 	else
 		user << SPAN_NOTICE("You fill \the [src] with \the [eating].")
 
-	if(eating.matter_reagents)
-		if(container)
-			var/datum/reagents/RG = new(0)
-			for(var/r in eating.matter_reagents)
-				RG.maximum_volume += eating.matter_reagents[r]
-				RG.add_reagent(r ,eating.matter_reagents[r])
-
-			RG.trans_to(container, RG.total_volume)
-			user << SPAN_NOTICE("Some liquid flowed to \the [container].")
-		else
-			user << SPAN_NOTICE("Some liquid flowed to the floor from autolathe beaker slot.")
-
-	if(eating.reagents && container)
-		eating.reagents.trans_to(container,eating.reagents.total_volume)
+	if(reagents_filltype == 1)
+		user << SPAN_NOTICE("Some liquid flowed to \the [container].")
+	else if(reagents_filltype == 2)
+		user << SPAN_NOTICE("Some liquid flowed to the floor from autolathe beaker slot.")
 
 	flick("autolathe_o", src) // Plays metal insertion animation. Work out a good way to work out a fitting animation. ~Z
 
@@ -363,7 +372,7 @@
 
 		//Check if we have enough materials.
 		for(var/material in making_recipe.resources)
-			if(isnull(stored_material[material]) || stored_material[material] < round(making_recipe.resources[material] * mat_efficiency))
+			if(isnull(stored_material[material]) || stored_material[material] < SANITIZE_LATHE_COST(round(making_recipe.resources[material] * mat_efficiency)))
 				not_enough_resources = TRUE
 				break
 
@@ -381,7 +390,7 @@
 
 		//Consume materials.
 		for(var/material in making_recipe.resources)
-			stored_material[material] = max(0, stored_material[material] - round(making_recipe.resources[material] * mat_efficiency))
+			stored_material[material] = max(0, stored_material[material] - SANITIZE_LATHE_COST(round(making_recipe.resources[material] * mat_efficiency)))
 
 
 		for(var/reagent in making_recipe.reagents)
@@ -482,3 +491,5 @@
 
 	..()
 	return 1
+
+#undef SANITIZE_LATHE_COST

--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -32,7 +32,7 @@
 	if(matter.len)
 		for(var/material_type in matter)
 			if(!isnull(matter[material_type]))
-				matter[material_type] *= force_divisor // May require a new var instead.
+				matter[material_type] = round(max(1, matter[material_type] * force_divisor)) // current system uses rounded values, so no less than 1.
 
 /obj/item/weapon/material/get_material()
 	return material


### PR DESCRIPTION
* resolves #1565
* Autolathe now checks recycled atom contents and counts that materials too so nothing goes to waste just because player forgot to eject something from an item before recycling.
* Autolathe recipes initialization stage now checks item's contents too, e.g: crafting flashlight with power cell will cost more than flashlight without power cell.
* Minimum recipe matter price now can't be less than 1 (even in upgraded lathe), previously items with price like 0.2 were rounded to 0 (this was requested).
* I know that price rounding is intended, but i think it brings more problems than resolves, because with rounded values something can be lost or get more than it should, so maybe there still some hidden farming issues are present, but major problems should be fixed.