### PR TITLE
Resolves situation when players complaining about disabled chats, una…

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -111,7 +111,8 @@ datum/preferences
 		client_ckey = C.ckey
 		if(!IsGuestKey(C.key))
 			load_path(C.ckey)
-			load_preferences()
+			if(!load_preferences()) // mostly TRUE for new player that has no savefils yet on server
+				sanitize_preferences() // gives such player default values.
 			load_and_update_character()
 
 /datum/preferences/proc/load_and_update_character(var/slot)


### PR DESCRIPTION
…ble to use some preferences options, runtimes related to this and so on.

Current system has no default initialized vars for any new player without saved preferences on server, which raises runtimes and so on. Dunno if there is better solution.

* fixes #1576 
* fixes #1548
* fixes #1269 

Maybe fixed something else related to this.