### PR TITLE
Fixed some autolathe bugs with recent autolathe merge update.

### DIFF
--- a/nano/templates/autolathe.tmpl
+++ b/nano/templates/autolathe.tmpl
@@ -156,10 +156,10 @@ Used In File(s): \code\game\machinery\autolathe.dm
 				{{/if}}
 			</div>
 			{{if data.current}}
+				<div class="itemLabelWidest">Printing {{:data.current}}</div>
 				{{if data.error}}
 					<div class="itemLabelWidest"><div class="bad">{{:data.error}}</div></div>
 				{{else}}
-					<div class="itemLabelWidest">Printing {{:data.current}}</div>
 					<div class="itemLabelWidest">{{:data.progress}}/{{:data.current_time}}</div>
 				{{/if}}
 				<div class="item">


### PR DESCRIPTION
* Fixed bug where autolathe refuses to produce an item, when player put enough resources for only one try.
* Fixed bug where autolathe UI only shows last required mat for current printing item.
* Small change in nano template - now it also shows recipe name when there is error.
* Also removed working animation play, when autolathe is in error state.