### PR TITLE
Disposal Machinery Layer Fix. Fixes #1616

### DIFF
--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -3,9 +3,11 @@
 	desc = "It's an arrow hanging in mid-air. There may be a wizard about."
 	icon = 'icons/mob/screen1.dmi'
 	icon_state = "arrow"
+	plane = GAME_PLANE
 	layer = POINT_LAYER
 	anchored = 1
 	mouse_opacity = 0
+
 
 // Used for spray that you spray at walls, tables, hydrovats etc
 /obj/effect/decal/spraystill

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -16,7 +16,7 @@
 	icon_state = "disposal"
 	anchored = 1
 	density = 1
-	layer = DISPOSAL_PIPE_LAYER			// slightly lower than wires and other pipes
+	layer = LOW_OBJ_LAYER //This allows disposal bins to be underneath tables
 	var/datum/gas_mixture/air_contents	// internal reservoir
 	var/mode = 1	// item mode 0=off 1=charging 2=charged
 	var/flush = 0	// true if flush handle is pulled
@@ -1401,6 +1401,7 @@
 	icon_state = "outlet"
 	density = 1
 	anchored = 1
+	layer = BELOW_OBJ_LAYER //So we can see things that are being ejected
 	var/active = 0
 	var/turf/target	// this will be where the output objects are 'thrown' to.
 	var/mode = 0

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -374,7 +374,7 @@
 	desc = "A chute for big and small packages alike!"
 	density = 1
 	icon_state = "intake"
-
+	layer = BELOW_OBJ_LAYER //So that things being ejected are visible
 	var/c_mode = 0
 
 /obj/machinery/disposal/deliveryChute/New()


### PR DESCRIPTION
Sets the layers for Disposal bins, and Disposal Intake/Outlet machines.

The bins are given a layer that allows them to theoretically be placed under tables. This is a thing that could be done in future

Disposal machinery are given a layer just below normal objects, so things will draw ontop of them.

The pipes and conveyor belts are unchanged, they work fine.