### PR TITLE
Lobby Chat OOC. Fixes #1637

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -19,6 +19,10 @@
 /mob/new_player/New()
 	mob_list += src*/
 
+/mob/new_player/say(var/message, var/datum/language/speaking = null, var/verb="says", var/alt_name="")
+	if (client)
+		client.ooc(message)
+
 /mob/new_player/verb/new_player_panel()
 	set src = usr
 	new_player_panel_proc()


### PR DESCRIPTION
Causes chat in the lobby to be routed to the OOC verb, instead of silently discarded. OOC is the only channel they can read anyway

This is kind of a big deal for new players who would be confused as to why they're typing and nothing comes up.
Also generally, manually typing ooc gets annoying