### PR TITLE
Window Shutter Fix

### DIFF
--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -41,9 +41,9 @@
 #define CLOSED_BLASTDOOR_LAYER 3.05
 #define CLOSED_DOOR_LAYER 3.1
 #define CLOSED_FIREDOOR_LAYER 3.11
-#define SHUTTER_LAYER 3.12 // HERE BE DRAGONS
 #define ABOVE_OBJ_LAYER 3.2
 #define ABOVE_WINDOW_LAYER 3.3
+#define SHUTTER_LAYER 3.35 //Shutters need to be above windows
 #define SIGN_LAYER 3.4
 
 #define BELOW_MOB_LAYER 3.7


### PR DESCRIPTION
Changes the shutter layer so that it draws above windows.

https://i.imgur.com/0iHCOUJ.png
https://i.imgur.com/UnFVxBy.png

SHUTTER_LAYER is now a little above ABOVE_WINDOW_LAYER. This means that the shutters can also cover anything stuck onto windows, like bits of paper taped there maybe