### PR TITLE
Voidsuit and Magboot fixes

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -33,7 +33,7 @@
 
 // Item inventory slot bitmasks.
 //These are usually hardcoded to define what slots an item CAN equip to
-#d efine SLOT_OCLOTHING         0x1
+#define SLOT_OCLOTHING         0x1
 #define SLOT_ICLOTHING         0x2
 #define SLOT_GLOVES            0x4
 #define SLOT_EYES              0x8

--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -4,12 +4,40 @@
 
 #define CANDLE_LUM 3 // For how bright candles are.
 
+
+// Item equipment slots.
+//This is the value used for the equip_slot variable to tell what slot an item is currently equipped into
+#define slot_none		 0
+#define slot_back        1
+#define slot_wear_mask   2
+#define slot_handcuffed  3
+#define slot_l_hand      4
+#define slot_r_hand      5
+#define slot_belt        6
+#define slot_wear_id     7
+#define slot_l_ear       8
+#define slot_glasses     9
+#define slot_gloves      10
+#define slot_head        11
+#define slot_shoes       12
+#define slot_wear_suit   13
+#define slot_w_uniform   14
+#define slot_l_store     15
+#define slot_r_store     16
+#define slot_s_store     17
+#define slot_in_backpack 18
+#define slot_legcuffed   19
+#define slot_r_ear       20
+#define slot_legs        21
+#define slot_accessory_buffer         22
+
 // Item inventory slot bitmasks.
-#define SLOT_OCLOTHING         0x1
+//These are usually hardcoded to define what slots an item CAN equip to
+#d efine SLOT_OCLOTHING         0x1
 #define SLOT_ICLOTHING         0x2
 #define SLOT_GLOVES            0x4
 #define SLOT_EYES              0x8
-#define SLOT_EARS              0x10
+#define SLOT_EARS              0x10	//Anything that can go on an ear, can go on either ear
 #define SLOT_MASK              0x20
 #define SLOT_HEAD              0x40
 #define SLOT_FEET              0x80
@@ -64,29 +92,7 @@
 #define BLOCKHEADHAIR   0x20    // Hides the user's hair overlay. Leaves facial hair.
 #define BLOCKHAIR       0x40    // Hides the user's hair, facial and otherwise.
 
-// Slots.
-#define slot_back        1
-#define slot_wear_mask   2
-#define slot_handcuffed  3
-#define slot_l_hand      4
-#define slot_r_hand      5
-#define slot_belt        6
-#define slot_wear_id     7
-#define slot_l_ear       8
-#define slot_glasses     9
-#define slot_gloves      10
-#define slot_head        11
-#define slot_shoes       12
-#define slot_wear_suit   13
-#define slot_w_uniform   14
-#define slot_l_store     15
-#define slot_r_store     16
-#define slot_s_store     17
-#define slot_in_backpack 18
-#define slot_legcuffed   19
-#define slot_r_ear       20
-#define slot_legs        21
-#define slot_accessory_buffer         22
+
 
 // Inventory slot strings.
 // since numbers cannot be used as associative list keys.

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -23,8 +23,16 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /obj/item/proc/attack_self(mob/user)
 	return
 
+
+// Called at the start of resolve_attackby(), before the actual attack.
+// Return a nonzero value to abort the attack
+/obj/item/proc/pre_attack(atom/a, mob/user)
+	return
+
 //I would prefer to rename this to attack(), but that would involve touching hundreds of files.
 /obj/item/proc/resolve_attackby(atom/A, mob/user, params)
+	if (pre_attack(A, user))
+		return 1 //Returning 1 passes an abort signal upstream
 	add_fingerprint(user)
 	return A.attackby(src, user, params)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -215,6 +215,15 @@
 /obj/item/proc/on_found(mob/finder as mob)
 	return
 
+
+//Called just before an item is placed in an equipment slot.
+//Use this to do any necessary preparations for equipping
+//Immediately after this, the equipping will be handled and then equipped will be called.
+//Returning a non-zero value will silently abort the equip operation
+/obj/item/proc/pre_equip(var/mob/user, var/slot)
+	return 0
+
+
 // called after an item is placed in an equipment slot
 // user is mob that equipped it
 // slot uses the slot_X defines found in items_clothing.dm

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -155,7 +155,7 @@
 
 	src.throwing = 0
 	if (src.loc == user)
-		if(!user.unEquip(src))
+		if(!user.prepare_for_slotmove(src))
 			return
 	else
 		if(isliving(src.loc))
@@ -186,12 +186,12 @@
 	if(zoom) zoom() //binoculars, scope, etc
 
 
-// Called whenever an object is moved around inside the mob's contents.
+// Called whenever an object is moved out of a mob's equip slot. Possibly into another slot, possibly to elsewhere
 // Linker proc: mob/proc/prepare_for_slotmove, which is referenced in proc/handle_item_insertion and obj/item/attack_hand.
 // This exists so that dropped() could exclusively be called when an item is dropped.
 /obj/item/proc/on_slotmove(var/mob/user)
 	if (zoom)
-zoom(user)
+		zoom(user)
 
 
 // called just as an item is picked up (loc is not yet changed)
@@ -752,3 +752,30 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 /obj/item/device
 	icon = 'icons/obj/device.dmi'
+
+//Returns true if the object is equipped to a mob, in any slot
+/obj/item/proc/is_equipped()
+	if (istype(loc, /mob))
+		if (equip_slot != slot_none)
+			return TRUE
+	return FALSE
+
+
+//Returns true if the object is worn on a mob's body.
+//Returns false if held in their hands, or if not on a mob at all
+/obj/item/proc/is_worn()
+	if (istype(loc, /mob))
+		if (equip_slot != slot_none && equip_slot != slot_l_hand && equip_slot != slot_r_hand)
+			return TRUE
+	return FALSE
+
+
+//Returns true if the object is held in a mob's hands
+//Returns false if worn on their body, or if not on a mob at all
+/obj/item/proc/is_held()
+	if (istype(loc, /mob))
+		if (equip_slot == slot_l_hand || equip_slot == slot_r_hand)
+			return TRUE
+	return FALSE
+
+//if any species is added with more than 2 arms, these will need updating

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -62,6 +62,11 @@
 	// Only slot_l_hand/slot_r_hand are implemented at the moment. Others to be implemented as needed.
 	var/list/item_icons = list()
 
+	var/equip_slot = 0 //The slot that this item was most recently equipped to.
+	//Note that this is, by design, not zeroed out when the item is removed from a mob
+		//In that case, it holds the number of the slot it was last in, which is potentially useful info
+	//For an accurate reading of the current slot, use item/get_equip_slot() which will return zero if not currently on a mob
+
 /obj/item/get_fall_damage()
 	return w_class * 2
 
@@ -779,3 +784,10 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	return FALSE
 
 //if any species is added with more than 2 arms, these will need updating
+
+//This is the correct way to get an object's equip slot. Will return zero if the object is not currently equipped to anyone
+/obj/item/proc/get_equip_slot()
+	if (istype(loc, /mob))
+		return equip_slot
+	else
+		return slot_none

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -108,8 +108,7 @@
 
 /obj/item/weapon/melee/energy/sword/dropped(var/mob/user)
 	..()
-	if(!istype(loc,/mob))
-		deactivate(user)
+	deactivate(user)
 
 /obj/item/weapon/melee/energy/sword/New()
 	blade_color = pick("red","blue","green","purple")

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -171,7 +171,7 @@
 			user << SPAN_NOTICE("Looks like the packet is out of cigarettes.")
 			return
 
-		// Instead of running equip_to_slot_if_possible() we check here first,
+		// We check here first,
 		// to avoid dousing cig with reagents if we're not going to equip it
 		if(!cig.mob_can_equip(user, slot_wear_mask))
 			return
@@ -179,7 +179,7 @@
 		// We call remove_from_storage first to manage the reagent transfer and
 		// UI updates.
 		remove_from_storage(cig, null)
-		user.equip_to_slot(cig, slot_wear_mask)
+		user.equip_to_slot_if_possible(cig, slot_wear_mask) //This check is redundant but it ensures pre_equip is called
 
 		reagents.maximum_volume = 15 * contents.len
 		user << SPAN_NOTICE("You take a cigarette out of the pack.")

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -373,7 +373,7 @@
 /obj/item/weapon/storage/proc/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
 	if(!istype(W)) return 0
 	if(usr)
-		usr.remove_from_mob(W)
+		usr.prepare_for_slotmove(W)
 		usr.update_icons()	//update our overlays
 	W.loc = src
 	W.on_enter_storage(src)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -13,7 +13,7 @@
 	var/armor_penetration = 0
 	var/corporation = null
 
-	var/equip_slot = 0
+
 
 /obj/get_fall_damage()
 	return w_class * 2

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -13,6 +13,8 @@
 	var/armor_penetration = 0
 	var/corporation = null
 
+	var/equip_slot = 0
+
 /obj/get_fall_damage()
 	return w_class * 2
 

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -35,17 +35,19 @@
 	user.update_action_buttons()
 
 
+//We want to allow the user to equip magboots even if they're already wearing shoes
+//As long as those shoes are not themselves magboots or similar overshoe-shoes
 /obj/item/clothing/shoes/magboots/mob_can_equip(mob/user, slot, disable_warning = 0)
 	if (slot == slot_shoes)
 		var/mob/living/carbon/human/H = user
 
 		if(H.shoes)
-			shoes = H.shoes
-			if(shoes.overshoes)
-				if (!disable_warning)
-					user << "You are unable to wear \the [src] as \the [H.shoes] are in the way."
-				shoes = null
-				return 0
+			if (istype(H.shoes, /obj/item/clothing/shoes))
+				var/obj/item/clothing/shoes/S = H.shoes
+				if(S.overshoes)
+					if (!disable_warning)
+						user << "You are unable to wear \the [src] as \the [H.shoes] are in the way."
+					return 0
 		return 1
 
 
@@ -58,6 +60,7 @@
 		var/obj/item/i = a
 		//Ensure that the thing you clicked on is a pair of shoes which are currently being worn
 		if (i.get_equip_slot() == slot_shoes)
+			//Start the equipping process. This will run through mob_can_equip and pre_equip
 			user.equip_to_slot_if_possible(src,slot_shoes)
 			return 1
 
@@ -68,7 +71,7 @@
 /obj/item/clothing/shoes/magboots/equipped()
 	..()
 	if (is_held())
-		remove()
+		remove() //If the magboots are taken into hands, release the shoes
 	else if (is_worn())
 		wearer = loc
 
@@ -80,18 +83,19 @@
 		if(H.shoes)
 			shoes = H.shoes
 			H.drop_from_inventory(shoes)	//Remove the old shoes so you can put on the magboots.
-			shoes.forceMove(src)
+			shoes.forceMove(src) //Old shoes are sucked up inside the magboots, they'll be released when the magboots are removed
 	return 0
 
 
 
-
+//This proc releases any contained shoes back onto the wearer, then nulls all the relevant values.
+//It is called when the magboots are dropped from the mob, or taken to any non-worn slot (ie, the hands)
 /obj/item/clothing/shoes/magboots/proc/remove()
 	var/mob/living/carbon/human/H = wearer
 	if(shoes)
 		if(!H.equip_to_slot_if_possible(shoes, slot_shoes))
 			shoes.forceMove(get_turf(src))
-		src.shoes = null
+		shoes = null
 	wearer = null
 
 /obj/item/clothing/shoes/magboots/examine(mob/user)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -36,7 +36,6 @@
 
 
 /obj/item/clothing/shoes/magboots/mob_can_equip(mob/user, slot, disable_warning = 0)
-	user << "Attempting to equip magboots in slot: [slot]"
 	if (slot == slot_shoes)
 		var/mob/living/carbon/human/H = user
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -560,6 +560,9 @@
 
 /obj/item/weapon/rig/equipped(mob/living/carbon/human/M)
 	..()
+	if (is_held())
+		remove()
+		return
 
 	if(seal_delay > 0 && istype(M) && M.back == src)
 		M.visible_message("<font color='blue'>[M] starts putting on \the [src]...</font>", "<font color='blue'>You start putting on \the [src]...</font>")
@@ -683,8 +686,15 @@
 
 /obj/item/weapon/rig/dropped(var/mob/user)
 	..()
-	for(var/piece in list("helmet","gauntlets","chest","boots"))
-		toggle_piece(piece, user, ONLY_RETRACT)
+	remove()
+
+/obj/item/weapon/rig/proc/retract()
+	if (wearer)
+		for(var/piece in list("helmet","gauntlets","chest","boots"))
+			toggle_piece(piece, wearer, ONLY_RETRACT)
+
+/obj/item/weapon/rig/proc/remove()
+	retract()
 	if(wearer)
 		wearer.wearing_rig = null
 		wearer = null

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -138,25 +138,29 @@
 
 	set name = "Eject Voidsuit Tank"
 	set category = "Object"
-	set src in usr
+	set src in view()
 
-	if(!isliving(src.loc))
+	if(!isliving(usr))
+		return
+
+	if (get_dist(usr, get_turf(src)) > 1)
+		usr << "<span class='warning'>You're too far away to eject the tank.</span>"
 		return
 
 	if(!tank)
-		usr << "There is no tank inserted."
+		usr << "<span class='warning'>There is no tank inserted.</span>"
 		return
 
-	var/mob/living/carbon/human/H = usr
+
+
+	var/mob/living/H = usr
 
 	if(!istype(H))
 		return
 	if(H.stat)
 		return
-	if(H.wear_suit != src)
-		return
 
-	H << "<span class='info'>You press the emergency release, ejecting \the [tank] from your suit.</span>"
+	H.visible_message("<span class='info'>[H] presses the emergency release, ejecting \the [tank] from the suit.</span>", "<span class='info'>You press the emergency release, ejecting \the [tank] from the suit.</span>", "<span class='info'>You hear a click and a hiss</span>")
 	tank.canremove = 1
 	H.drop_from_inventory(tank)
 	src.tank = null
@@ -211,7 +215,7 @@
 			W.forceMove(src)
 			boots = W
 		return
-	else if(istype(W,/obj/item/weapon/tank))
+	if(istype(W,/obj/item/weapon/tank))
 		if(tank)
 			user << "\The [src] already has an airtank installed."
 		else if(istype(W,/obj/item/weapon/tank/plasma))

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -124,6 +124,7 @@
 		helmet.canremove = 1
 		H.drop_from_inventory(helmet)
 		helmet.forceMove(src)
+		playsound(src.loc, 'sound/weapons/guns/interact/pistol_magin.ogg', 75, 1)
 	else
 		if(H.head)
 			H << SPAN_DANGER("You cannot deploy your helmet while wearing \the [H.head].")
@@ -132,6 +133,7 @@
 			helmet.pickup(H)
 			helmet.canremove = 0
 			H << "<span class='info'>You deploy your suit helmet, sealing you off from the world.</span>"
+			playsound(src.loc, 'sound/weapons/guns/interact/pistol_magin.ogg', 75, 1)
 	helmet.update_light(H)
 
 /obj/item/clothing/suit/space/void/verb/eject_tank()
@@ -205,6 +207,7 @@
 			user.drop_item()
 			W.forceMove(src)
 			src.helmet = W
+			playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		return
 	else if(istype(W,/obj/item/clothing/shoes/magboots))
 		if(boots)
@@ -214,6 +217,7 @@
 			user.drop_item()
 			W.forceMove(src)
 			boots = W
+			playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		return
 	if(istype(W,/obj/item/weapon/tank))
 		if(tank)
@@ -225,6 +229,7 @@
 			user.drop_item()
 			W.forceMove(src)
 			tank = W
+			playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		return
 
 	..()

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -43,6 +43,9 @@
 /obj/item/clothing/suit/space/void/equipped(mob/M)
 	..()
 
+	if (is_held())
+		retract()
+
 	var/mob/living/carbon/human/H = M
 
 	if(!istype(H)) return
@@ -71,7 +74,10 @@
 
 /obj/item/clothing/suit/space/void/dropped()
 	..()
+	retract()
 
+
+/obj/item/clothing/suit/space/void/proc/retract()
 	var/mob/living/carbon/human/H
 
 	if(helmet)

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -173,7 +173,7 @@
 	if(istype(W,/obj/item/clothing/accessory) || istype(W, /obj/item/weapon/hand_labeler))
 		return ..()
 
-	if(isliving(src.loc))
+	if(is_worn())
 		user << SPAN_WARNING("You cannot modify \the [src] while it is being worn.")
 		return
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -4,7 +4,7 @@
 	var/obj/item/E = get_equipped_item(slot)
 	if (istype(E))
 		if(istype(W))
-			E.attackby(W,src)
+			W.resolve_attackby(E, src)
 		else
 			E.attack_hand(src)
 	else
@@ -33,7 +33,7 @@
 		return FALSE
 
 	//Pre-equip intercepts here to let the item know it's about to be equipped
-	if (W.pre_equip(slot, src))
+	if (W.pre_equip(src, slot))
 		return FALSE
 
 	equip_to_slot(W, slot, redraw_mob) //This proc should not ever fail.

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -32,6 +32,10 @@
 				src << "\red You are unable to equip that." //Only print if del_on_fail is false
 		return FALSE
 
+	//Pre-equip intercepts here to let the item know it's about to be equipped
+	if (W.pre_equip(slot, src))
+		return FALSE
+
 	equip_to_slot(W, slot, redraw_mob) //This proc should not ever fail.
 	return TRUE
 
@@ -244,6 +248,7 @@ var/list/slot_equipment_priority = list(
 	if (src.client)
 		src.client.screen -= I
 	I.layer = initial(I.layer)
+	I.plane = initial(I.plane)
 	I.screen_loc = null
 	I.on_slotmove(src)
 	return 1

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -235,6 +235,19 @@ var/list/slot_equipment_priority = list(
 		I.dropped(src)
 	return TRUE
 
+//This function is an unsafe proc used to prepare an item for being moved to a slot, or from a mob to a container
+//It should be equipped to a new slot or forcemoved somewhere immediately after this is called
+/mob/proc/prepare_for_slotmove(obj/item/I)
+	if(!canUnEquip(I))
+		return 0
+	src.u_equip(I)
+	if (src.client)
+		src.client.screen -= I
+	I.layer = initial(I.layer)
+	I.screen_loc = null
+	I.on_slotmove(src)
+	return 1
+
 
 //Returns the item equipped to the specified slot, if any.
 /mob/proc/get_equipped_item(var/slot)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -233,7 +233,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 	if(!species || !species.hud || !(slot in species.hud.equip_slots)) return
 	if(ismob(W.loc))
 		var/mob/M = W.loc
-		if(M.get_inventory_slot(W) && !M.unEquip(W, src))
+		if(M.get_inventory_slot(W) && !M.prepare_for_slotmove(W))
 			return
 	W.forceMove(src)
 	switch(slot)


### PR DESCRIPTION
This PR is branched off of #1676, and requires it. So review and merge that first

This fixes a number of observed issues with magboots and voidsuits including #1658 and #1651

Modifiability of voidsuits is now standardised to work while held in hand or placed on the ground.
Attaching components to a voidsuit or toggling the helmet now has sounds.
Magboots massively refactored to function correctly and without any wierd behaviour.

Most notably, magboots were using the mob_can_equip, which is supposed to be a purely information gathering function, to actually affect the world. This was a dirty dirty hack, so its fixed