### PR TITLE
Rejuvenate Runtime Fix

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -98,6 +98,7 @@
 
 	if(owner)
 		owner.organs -= src
+		owner.bad_external_organs -= src
 		owner.organs_by_name -= src.organ_tag
 
 	if(module)


### PR DESCRIPTION
Fixes a case where an injured person (that is pretty much everyone) who gets admin-rejuvenated will endlessly spam runtime errors.

The cause was damaged parts not being removed from bad_external_organs. The parent mob would hold a reference, preventing deletion and constantly trying to process them