### PR TITLE
Window Interactions and Audio

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -116,7 +116,7 @@ var/list/bullet_hit_object_sound = list('sound/weapons/guns/misc/bullethit.ogg')
 			var/z_dist = abs(T.z - turf_source.z)
 			z_dist *= 0.5 //The reduction in volume over zlevels was too much
 			if(T && z_dist <= 1)
-				M.playsound_local(turf_source, soundin, vol/(1+z_dist), vary, frequency, falloff, is_global, use_pressure)
+				M.playsound_local(turf_source, soundin, vol/(1+z_dist), vary, extrarange, frequency, falloff, is_global, use_pressure)
 
 var/const/FALLOFF_SOUNDS = 0.5
 


### PR DESCRIPTION
The main feature of this PR is to fix an audio bug i accidentally introduced with my shieldgen PR

But aside from that, it also tweaks a few interactions with windows:

All impacts against windows are now routed through the hit function, which makes an impact sound. This includes hitting it with things, throwing things at it, smashing people against it, etc.

Shoving someone into a window now makes them do an attack animation against it. It looks fun

Tweaks tool interactions with windows. Now whenever you're in harm intent, you will always attack the window instead of attempting to use tools on it. This allows you to smash windows with tools which previously wasnt possible

When not in harm intent, you will never attack the window with tools, so no smacking it while you're trying to repair it. At least, not with the specific tools that are used for windows