### PR TITLE
Some fixes of bullet pile system

### DIFF
--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -158,9 +158,24 @@
 			user << SPAN_WARNING("[src] is full.")
 			return
 
-		user.remove_from_mob(C)
-		C.loc = src
-		loaded.Insert(1, C) //add to the head of the list
+		if(C.amount > 1)
+			C.amount -= 1
+			var/obj/item/ammo_casing/inserted_casing = new /obj/item/ammo_casing(src)
+			inserted_casing.desc = C.desc
+			inserted_casing.caliber = C.caliber
+			inserted_casing.projectile_type = C.projectile_type
+			inserted_casing.icon_state = C.icon_state
+			inserted_casing.spent_icon = C.spent_icon
+			inserted_casing.maxamount = C.maxamount
+			if(ispath(inserted_casing.projectile_type) && C.BB)
+				inserted_casing.BB = new inserted_casing.projectile_type(inserted_casing)
+			C.update_icon()
+			inserted_casing.update_icon()
+			loaded.Insert(1, inserted_casing)
+		else
+			user.remove_from_mob(C)
+			C.loc = src
+			loaded.Insert(1, C) //add to the head of the list
 		user.visible_message("[user] inserts \a [C] into [src].", SPAN_NOTICE("You insert \a [C] into [src]."))
 		if(bulletinsert_sound) playsound(src.loc, bulletinsert_sound, 75, 1)
 


### PR DESCRIPTION
In last pull this code wasn't copied to both places where it should've been, only to one.
This fixes, for example, piles of shotgun slugs being fully placed inside double-barreled shotgun.