### PR TITLE
Shield Fixes

### DIFF
--- a/code/__defines/shields.dm
+++ b/code/__defines/shields.dm
@@ -3,7 +3,7 @@
 #define SHIELD_DAMTYPE_HEAT 3		// Heat damage - Lasers, fire
 
 #define ENERGY_PER_HP (50 KILOWATTS)// Base amount energy that will be deducted from the generator's internal reserve per 1 HP of damage taken
-#define ENERGY_UPKEEP_PER_TILE 80	// Base upkeep per tile protected. Multiplied by various enabled shield modes. Without them the field does literally nothing.
+#define ENERGY_UPKEEP_PER_TILE 65	// Base upkeep per tile protected. Multiplied by various enabled shield modes. Without them the field does literally nothing.
 
 
 // This shield model is slightly inspired by Sins of a Solar Empire series. In short, shields are designed to analyze what hits them, and adapt themselves against that type of damage.
@@ -55,4 +55,4 @@
 #define SHIELD_DISCHARGING 1		// The shield is shutting down and discharging.
 #define SHIELD_RUNNING 2			// The shield is running
 
-#define SHIELD_SHUTDOWN_DISPERSION_RATE (500 KILOWATTS) // The rate at which shield energy disperses when shutdown is initiated.
+#define SHIELD_SHUTDOWN_DISPERSION_RATE (400 KILOWATTS) // The rate at which shield energy disperses when shutdown is initiated.

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -24,7 +24,7 @@
 	level = 1
 
 /turf/simulated/shuttle/plating/is_plating()
-	return 1
+	return TRUE
 
 /turf/simulated/floor/plating/under
 	name = "underplating"

--- a/code/modules/modular_computers/file_system/programs/shield_control.dm
+++ b/code/modules/modular_computers/file_system/programs/shield_control.dm
@@ -68,9 +68,8 @@
 		genloc = ""
 
 /datum/nano_module/shield_control/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
-	var/data[0]
 
-
+	var/list/data = program.get_header_data()
 
 	if (istype(gen))
 		data["genloc"] = genloc
@@ -115,11 +114,14 @@
 		. = 1
 		return
 
-	if (!gen || gen.ai_control_disabled)
+	if (!gen || gen.ai_control_disabled || !gen.anchored)
 		//Remote software control works the same as AI control.  Cutting that wire disables remote
+		//If the generator has been unwrenched we also lose connection
 		playsound_host('sound/machines/buzz-two.ogg', 50)
 		gen = null //Cut our connection, and we'll be unable to reconnect
 		return
+
+
 
 	//Doesn't respond while disabled
 	if (gen.offline_for)

--- a/code/modules/shield_generators/hull.dm
+++ b/code/modules/shield_generators/hull.dm
@@ -87,6 +87,7 @@
 
 		tendrils_deployed = TRUE
 		update_icon()
+
 		return TRUE
 
 	else if (target_state == FALSE)
@@ -95,8 +96,18 @@
 			qdel(SC)
 		tendrils_deployed = FALSE
 		update_icon()
+
 		return FALSE
 
+/obj/machinery/power/shield_generator/hull/Process()
+	if (anchored)
+		return ..()
+	else
+		return
+
+/obj/machinery/power/shield_generator/hull/Topic(href, href_list)
+	if (anchored)
+		return ..(href, href_list)
 
 /obj/machinery/shield_conduit
 	name = "Shield"
@@ -114,7 +125,6 @@
 		if(anchored)
 			user << SPAN_NOTICE("You unsecure the [src] from the floor!")
 			toggle_tendrils(FALSE)
-
 			anchored = FALSE
 		else
 			if(istype(get_turf(src), /turf/space)) return //No wrenching these in space!


### PR DESCRIPTION
Fixes being impossible to exit the shield control program
Fixes stored energy being entirely instantly drained in various circumstances
Tightens up checks about being anchored
Fixes many wrong displays of status
Shield now charges while turned off, as long as it's installed properly
Reduces upkeep power costs, from 80 to 65