### PR TITLE
Mining shuttle fix

### DIFF
--- a/code/game/machinery/embedded_controller/airlock_controllers.dm
+++ b/code/game/machinery/embedded_controller/airlock_controllers.dm
@@ -12,7 +12,7 @@
 	var/tag_shuttle_mech_sensor
 	var/tag_secure = 0
 
-/obj/machinery/embedded_controller/radio/airlock/Initialize()
+/obj/machinery/embedded_controller/radio/airlock/New()
 	. = ..()
 	program = new/datum/computer/file/embedded_program/airlock(src)
 

--- a/code/game/machinery/embedded_controller/airlock_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_docking_controller.dm
@@ -5,7 +5,7 @@
 	var/datum/computer/file/embedded_program/docking/airlock/docking_program
 	tag_secure = 1
 
-/obj/machinery/embedded_controller/radio/airlock/docking_port/Initialize()
+/obj/machinery/embedded_controller/radio/airlock/docking_port/New()
 	. = ..()
 	airlock_program = new/datum/computer/file/embedded_program/airlock/docking(src)
 	docking_program = new/datum/computer/file/embedded_program/docking/airlock(src, airlock_program)

--- a/code/game/machinery/embedded_controller/airlock_docking_controller_multi.dm
+++ b/code/game/machinery/embedded_controller/airlock_docking_controller_multi.dm
@@ -9,11 +9,13 @@
 
 	var/datum/computer/file/embedded_program/docking/multi/docking_program
 
-/obj/machinery/embedded_controller/radio/docking_port_multi/Initialize()
+/obj/machinery/embedded_controller/radio/docking_port_multi/New()
 	. = ..()
 	docking_program = new/datum/computer/file/embedded_program/docking/multi(src)
 	program = docking_program
 
+/obj/machinery/embedded_controller/radio/docking_port_multi/Initialize()
+	.=..()
 	var/list/names = splittext(child_names_txt, ";")
 	var/list/tags = splittext(child_tags_txt, ";")
 

--- a/code/game/machinery/embedded_controller/docking_program.dm
+++ b/code/game/machinery/embedded_controller/docking_program.dm
@@ -73,9 +73,11 @@
 
 /datum/computer/file/embedded_program/docking/New()
 	..()
+
 	var/datum/existing = locate(id_tag) //in case a datum already exists with our tag
 	if(existing)
 		existing.tag = null //take it from them
+
 
 	tag = id_tag //Greatly simplifies shuttle initialization
 

--- a/code/game/machinery/embedded_controller/embedded_program_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_program_base.dm
@@ -11,6 +11,8 @@
 		var/obj/machinery/embedded_controller/radio/R = M
 		id_tag = R.id_tag
 
+	id_tag = copytext(id_tag, 1)
+
 /datum/computer/file/embedded_program/proc/receive_user_command(command)
 	return
 

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -25,7 +25,7 @@
 
 /obj/effect/shuttle_landmark/New()
 	..()
-	tag = landmark_tag //since tags cannot be set at compile time
+	tag = copytext(landmark_tag, 1) //since tags cannot be set at compile time
 	if(autoset)
 		base_area = get_area(src)
 		var/turf/T = get_turf(src)


### PR DESCRIPTION
Fixes the mining shuttle being locked at roundstart, by working around a byond bug.

Somehow, string tables are occasionally broken. Compiletime inputs - ie, values entered into map instances in the editor - occasionally don't get assigned to the correct string in the table, and thus fail to match against strings that are identical. This is a byond bug and beyond our power to fix

The fix that i've implemented here is to use copytext on shuttle tags in new, which creates a "new" string out of them which correctly inserts into the stringtable and works as intended. This is a workaround for the aforementioned bug, and it should be a permanant solution.

We should look at doing something like this for all map-edited values like network and radio tags on buttons, cameras, etc