### PR TITLE
You can now store all stacks of ammo in your tactical belt.

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -113,7 +113,7 @@
 		/obj/item/weapon/handcuffs,
 		/obj/item/device/flash,
 		/obj/item/clothing/glasses,
-		/obj/item/ammo_casing/shotgun,
+		/obj/item/ammo_casing,
 		/obj/item/ammo_magazine,
 		/obj/item/weapon/cell/small,
 		/obj/item/weapon/reagent_containers/food/snacks/donut,


### PR DESCRIPTION
Since you can store shotgun ammo here, we should just store everything here. Revolvers can use this.