### PR TITLE
Altar/Optable Tweaks

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -11,7 +11,11 @@
 	var/mob/living/carbon/human/victim = null
 
 	var/obj/machinery/computer/operating/computer = null
+	can_buckle = TRUE
+	buckle_dir = SOUTH
+	buckle_lying = TRUE //bed-like behavior, forces mob.lying = buckle_lying if != -1
 
+	var/y_offset = 0
 /obj/machinery/optable/New()
 	..()
 	for(var/dir in list(NORTH,EAST,SOUTH,WEST))
@@ -45,6 +49,8 @@
 		visible_message(SPAN_DANGER("\The [usr] destroys \the [src]!"))
 		src.density = 0
 		qdel(src)
+	if (victim && !user.incapacitated(INCAPACITATION_DEFAULT))
+		user_unbuckle_mob(user)
 	return
 
 /obj/machinery/optable/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
@@ -62,6 +68,7 @@
 			src.victim = M
 			icon_state = M.pulse() ? "optable-active" : "optable-idle"
 			return 1
+
 	src.victim = null
 	icon_state = "optable-idle"
 	return 0
@@ -79,7 +86,6 @@
 	if (C.client)
 		C.client.perspective = EYE_PERSPECTIVE
 		C.client.eye = src
-	C.resting = 1
 	C.loc = src.loc
 	for(var/obj/O in src)
 		O.loc = src.loc
@@ -87,9 +93,8 @@
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
 		src.victim = H
-		icon_state = H.pulse() ? "optable-active" : "optable-idle"
-	else
-		icon_state = "optable-idle"
+	buckle_mob(C)
+
 
 /obj/machinery/optable/MouseDrop_T(mob/target, mob/user)
 
@@ -124,3 +129,11 @@
 		usr << SPAN_NOTICE("Unbuckle \the [patient] first!")
 		return 0
 	return 1
+
+/obj/machinery/optable/post_buckle_mob(mob/living/M as mob)
+	if(M == buckled_mob)
+		M.pixel_y = y_offset
+	else
+		M.pixel_y = 0
+
+	check_victim()

--- a/code/modules/core_implant/cruciform/machinery/altar.dm
+++ b/code/modules/core_implant/cruciform/machinery/altar.dm
@@ -3,3 +3,5 @@
 	desc = "The altar."
 	icon = 'icons/obj/neotheology_machinery.dmi'
 	icon_state = "optable-idle"
+	y_offset = 10
+


### PR DESCRIPTION
![sacrifice](https://i.imgur.com/PaY3XGJ.png)

Slightly reworks Operating tables and altars to work with proper buckling. This makes them generally more robust and easier to work with. It also means that when the victim is cuffed or otherwise restrained, they can't easily get themselves down. Allowing for non consensual rituals, sacrifices, and mad surgery

In addition, fixes #1844
The victim now has a Y offset which ensures they are correctly positioned on the altar