### PR TITLE
aghost shortcut for VV

### DIFF
--- a/code/_onclick/ghost.dm
+++ b/code/_onclick/ghost.dm
@@ -28,6 +28,12 @@
 		forceMove(get_turf(A))
 
 /mob/observer/ghost/ClickOn(var/atom/A, var/params)
+	var/list/pa = params2list(params)
+	if(check_rights(R_ADMIN)) // Admin click shortcuts
+		if(pa.Find("shift") && pa.Find("ctrl"))
+			client.debug_variables(A)
+			return
+
 	if(client.buildmode)
 		build_click(src, client.buildmode, params, A)
 		return

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -54,6 +54,8 @@ Admin:
 \tF6 = player-panel-new
 \tF7 = admin-pm
 \tF8 = Invisimin
+Admin Ghost:
+\tShift + Ctrl + Click = View Variables
 </font>"}
 
 	var/hotkey_mode = {"<font color='purple'>


### PR DESCRIPTION
This lets ghosted admins ctrl+shift+click on things to open their VV immediately without using the horrible dropdown. More useful for dev work than admin work, but still!

Port of some of https://github.com/ParadiseSS13/Paradise/pull/5203 

The Ctrl+click from the original PR is also nice, but that would override buildmode functionality here. If you have any suggestions, feel free.

