### PR TITLE
Double Click Fix

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -1524,7 +1524,7 @@
 #include "code\modules\mob\living\silicon\login.dm"
 #include "code\modules\mob\living\silicon\say.dm"
 #include "code\modules\mob\living\silicon\silicon.dm"
-#include "code\modules\mob\living\silicon\subystems.dm"
+#include "code\modules\mob\living\silicon\subsystems.dm"
 #include "code\modules\mob\living\silicon\ai\ai.dm"
 #include "code\modules\mob\living\silicon\ai\ai_movement.dm"
 #include "code\modules\mob\living\silicon\ai\death.dm"

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -39,8 +39,7 @@
 		usr.ClickOn(target, params)
 
 /atom/Click(var/location, var/control, var/params) // This is their reaction to being clicked on (standard proc)
-	if(src)
-		usr.ClickOn(src, params)
+	return
 
 /atom/DblClick(var/location, var/control, var/params)
 	if(src)

--- a/code/_onclick/hud/screen_objects/robot_screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/robot_screen_objects.dm
@@ -10,7 +10,7 @@
 
 /obj/screen/silicon/radio/Click()
 	usr:radio_menu()
-
+	return TRUE
 
 
 /obj/screen/silicon/panel
@@ -19,6 +19,7 @@
 
 /obj/screen/silicon/panel/Click()
 	usr:installed_modules()
+	return TRUE
 
 /obj/screen/silicon/store
 	name = "store"
@@ -33,6 +34,8 @@
 			inv.update_icon()
 	else
 		R << "You haven't selected a module yet."
+	return TRUE
+
 
 /obj/screen/silicon/module
 	name = "moduleNo"
@@ -75,9 +78,9 @@
 	if (isrobot(parentmob))
 		var/mob/living/silicon/robot/R = parentmob
 		R.toggle_module(module_num)
-		return
+		return TRUE
 	log_debug("[parentmob] have type [parentmob.type], but try use /obj/screen/silicon/module/Click() from [src]")
-	return
+	return TRUE
 
 /obj/screen/silicon/cell
 	name = "cell"
@@ -159,6 +162,7 @@
 			return TRUE
 		R.pick_module()
 		update_icon()
+	return TRUE
 
 /obj/screen/silicon/module_select/update_icon()
 	var/mob/living/silicon/robot/R = parentmob
@@ -173,9 +177,11 @@
 		var/mob/living/silicon/robot/R = parentmob
 		if(R.module)
 			R.toggle_show_robot_modules()
-			return TRUE
 		else
 			R << "You haven't selected a module yet."
+
+	return TRUE
+
 
 
 

--- a/code/controllers/admin.dm
+++ b/code/controllers/admin.dm
@@ -19,7 +19,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/statclick)
 
 /obj/effect/statclick/debug/Click()
 	if(!usr.client.holder || !target)
-		return
+		return TRUE
 	if(!class)
 		if(istype(target, /datum/controller/subsystem))
 			class = "subsystem"

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -267,6 +267,7 @@
 							)
 		AddHref(href_list)
 		module.holder.Topic(usr, href_list)
+		return TRUE
 
 /stat_rig_module/DblClick()
 	return Click()

--- a/code/modules/mob/living/silicon/subsystems.dm
+++ b/code/modules/mob/living/silicon/subsystems.dm
@@ -103,3 +103,4 @@
 
 /stat_silicon_subsystem/Click()
 	subsystem.ui_interact(usr, state = ui_state)
+	return TRUE


### PR DESCRIPTION
The worst bug i've seen on eris so far :P

EkuDza switched click handling over to a new reciprocity based system, where each atom would get Click called on it, and then user.ClickOn(that atom) would only get called if the atom returned zero from its Click call. If it returns a nonzero value, the click is dropped. This is good and an improvement

The problem was, he forgot to remove the call to usr.ClickOn from the baseline Atom.Click proc, so the two systems were working simultaneously and every click was triggering another click after the first one resolved

I also searched whole codebase for Click overrides and set their return values appropriately, a couple had been missed
And in the process i found a file named "subystems.dm", i corrected this obvious spelling error

fixes #1911