### PR TITLE
Missing arm and Shuttle fix

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -33,6 +33,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 	if(!W)
 		return FALSE
 	if(put_in_active_hand(W) || put_in_inactive_hand(W))
+		world << "Successfully put in hand"
 		return TRUE
 	else
 		return ..()
@@ -371,6 +372,10 @@ This saves us from having to call add_fingerprint() any time something is put in
 	if(covering && (covering.item_flags & COVER_PREVENT_MANIPULATION) && (covering.body_parts_covered & (I.body_parts_covered|check_flags)))
 		user << SPAN_WARNING("\The [covering] is in the way.")
 		return 0
+
+	if (!has_organ_for_slot(slot))
+		return FALSE
+
 	return 1
 
 /mob/living/carbon/human/get_equipped_item(var/slot)

--- a/maps/CEVEris/shuttles-eris.dm
+++ b/maps/CEVEris/shuttles-eris.dm
@@ -109,7 +109,9 @@
 	base_turf = /turf/space
 
 //Skipjack
-
+//antag Shuttles disabled by nanako, 2018-09-15
+//These shuttles are created with a subtypesof loop at runtime. Starting points for the skipjack and merc shuttle are not currentl mapped in
+/*
 /datum/shuttle/autodock/multi/antag/skipjack
 	name = "Skipjack"
 	warmup_time = 0
@@ -127,7 +129,7 @@
 	home_waypoint = "nav_skipjack_start"
 	arrival_message = "Attention, vessel detected entering vessel proximity."
 	departure_message = "Attention, vessel detected leaving vessel proximity."
-
+*/
 /obj/effect/shuttle_landmark/skipjack/start
 	name = "Raider Outpost"
 	icon_state = "shuttle-red"
@@ -157,7 +159,7 @@
 
 
 //Merc
-
+/*
 /datum/shuttle/autodock/multi/antag/mercenary
 	name = "Mercenary"
 	warmup_time = 0
@@ -175,7 +177,7 @@
 	home_waypoint = "nav_merc_start"
 	arrival_message = "Attention, vessel detected entering vessel proximity."
 	departure_message = "Attention, vessel detected leaving vessel proximity."
-
+*/
 /obj/effect/shuttle_landmark/merc/start
 	name = "Mercenary Base"
 	icon_state = "shuttle-red"


### PR DESCRIPTION
Fixes a rather severe inventory bug that could cause a false positive when trying to put things in the hands of people who are missing an arm.  Amongst other things, this was causing IDs to get stuck inside PDAs

Also fixes the damn shuttle runtimes, ive been meaning to do it for a week. Not worth the effort to make a seperate PR. Fixes #1870