### PR TITLE
server starts initialisation without players

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -86,11 +86,7 @@ var/game_id = null
 
 	. = ..()
 
-#ifndef UNIT_TEST
-
-	sleep_offline = 1
-
-#else
+#ifdef UNIT_TEST
 	log_unit_test("Unit Tests Enabled.  This will destroy the world when testing is complete.")
 	load_unit_test_changes()
 #endif


### PR DESCRIPTION
Now server wont wait for players to start subsystems initialisation.
It will speed up debug time removing necessity to join server to start init.
Should not cause problems.