### PR TITLE
Moebius Shared Access

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -14,9 +14,12 @@
 	economic_modifier = 10
 	also_known_languages = list(LANGUAGE_CYRILLIC = 10)
 	access = list(
-		access_medical, access_medical_equip, access_morgue, access_genetics, access_heads,
-		access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
-		access_keycard_auth, access_sec_doors, access_psychiatrist, access_eva, access_external_airlocks
+		access_rd, access_heads, access_tox, access_genetics, access_morgue,access_tox_storage, \
+		access_teleporter,access_sec_doors,access_medical, access_medical_equip, access_chemistry, \
+		access_virology, access_cmo, access_surgery, access_psychiatrist,access_research, \
+		access_robotics, access_xenobiology,access_ai_upload, access_tech_storage, access_eva, \
+		access_external_airlocks,access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, \
+		access_xenoarch, access_network
 	)
 
 	ideal_character_age = 50
@@ -63,7 +66,7 @@
 	also_known_languages = list(LANGUAGE_CYRILLIC = 10)
 	access = list(
 		access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology,
-		access_genetics
+		access_genetics, access_robotics, access_research
 	)
 	idtype = /obj/item/weapon/card/id/med
 
@@ -104,7 +107,7 @@
 	economic_modifier = 5
 	also_known_languages = list(LANGUAGE_CYRILLIC = 10)
 	access = list(
-		access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology
+		access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology, access_research, access_tox, access_tox_storage,
 	)
 	idtype = /obj/item/weapon/card/id/chem
 
@@ -144,7 +147,8 @@
 	selection_color = "#ffeef0"
 	also_known_languages = list(LANGUAGE_CYRILLIC = 10)
 	access = list(
-		access_medical, access_medical_equip, access_morgue, access_psychiatrist
+		access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology,
+		access_genetics, access_robotics, access_research
 	)
 
 	stat_modifers = list(
@@ -181,7 +185,7 @@
 	also_known_languages = list(LANGUAGE_CYRILLIC = 20)
 	access = list(
 		access_medical, access_medical_equip, access_morgue, access_surgery,
-		access_eva, access_maint_tunnels, access_external_airlocks, access_psychiatrist
+		access_eva, access_maint_tunnels, access_external_airlocks, access_psychiatrist, access_robotics, access_research
 	)
 
 	stat_modifers = list(

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -14,11 +14,12 @@
 	economic_modifier = 15
 	also_known_languages = list(LANGUAGE_CYRILLIC = 10)
 	access = list(
-		access_rd, access_heads, access_tox, access_genetics, access_morgue,
-		access_tox_storage, access_teleporter, access_sec_doors,
-		access_medical, access_medical_equip, access_chemistry, access_virology, access_cmo, access_surgery, access_psychiatrist,
-		access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage, access_eva, access_external_airlocks,
-		access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network
+		access_rd, access_heads, access_tox, access_genetics, access_morgue,access_tox_storage, \
+		access_teleporter,access_sec_doors,access_medical, access_medical_equip, access_chemistry, \
+		access_virology, access_cmo, access_surgery, access_psychiatrist,access_research, \
+		access_robotics, access_xenobiology,access_ai_upload, access_tech_storage, access_eva, \
+		access_external_airlocks,access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, \
+		access_xenoarch, access_network
 	)
 	ideal_character_age = 50
 
@@ -62,7 +63,7 @@
 	also_known_languages = list(LANGUAGE_CYRILLIC = 10)
 	access = list(
 		access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch,
-		access_genetics
+		access_genetics, access_medical
 	)
 	idtype = /obj/item/weapon/card/id/sci
 
@@ -103,7 +104,7 @@
 	economic_modifier = 5
 	also_known_languages = list(LANGUAGE_CYRILLIC = 10)
 	access = list(
-		access_robotics, access_tox, access_tox_storage, access_tech_storage, access_morgue, access_research
+		access_robotics, access_tox, access_tox_storage, access_tech_storage, access_morgue, access_research, access_medical
 	) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	idtype = /obj/item/weapon/card/id/dkgrey
 


### PR DESCRIPTION
Given that our medical and research departments are both under the same company, i believe it makes sense to allow them closer relations.

This PR Adjusts the access of moebius research and medical personnel, so that each has some access in the others' department. The intention is that they'll visit each other regularly, make friends with their colleagues, take an interest in each other's work, and expand the playerbases of both areas. Having broader access makes them both more appealing.
They can visit each other's breakrooms for tea, and hide in each other's departments during clown rampages.

The reasons why I think this should be done are numerous
First and foremost is lore.  Med and sci are the same organisation, the sharing of resources makes sense. Eris' lore and unique setting are what makes it different from other servers, it's another way in which we can be special and unique


Secondly, they are the same organisation, but more significantly, that organisation is not the same as all the other departments.  Engineering, security, cargo etc, are all different factions. Encouraging them to work together is a move intended to promote more tribalism in faction relations, generate some workplace conflict. I hope to see med and sci teaming up - especially in times of crisis, and looking after their own before other departments


Third thing that comes to mind, research is pretty isolated here. Moreso than on other servers i've seen, anyone outside it just gets a blank wall, people in there are pretty lonely. Having some coworkers who can come in and visit will help greatly with that. Science will always have cool things to show off, and medical staff usually have a lot of free time to go wandering, while they're waiting for people to get hurt


Fourth reason is efficiency. Paramedics could do with mech bay access to retrieve and park odysseus. Making chemistry a shared resource means you don't necessarily need two chemists, one can work for both departments. In my experience a chemist often ends up with nothing to do after they make medicines and goes SSD out of boredom. On the other hand, nobody really joins science just to  be a chemist, there's not enough for one to do



The exact list of changes is as follows:
Biolab Officer and Expedition Overseer, the heads (CMO and RD) are given complete, unrestricted access in each others departments. Both of them can enter every part of medical and research

All medical personnel get research access, allowing them to wander the halls of science. Most of them get robotics access too, since medical works closely with robotics. Moving odysseus mechs around, transporting patients with prosthetics, or corpses to be borged, etc.

Scientists get general medical access, and chemistry access. Chemistry has lots of scientific applications

Chemists get access to toxins and toxin storage, for obvious reasons. They don't get robotics though

Psychiatrists are given the same access as doctors. They're kind of useless otherwise. 
Honestly psychiatrist is always one of the least played roles, even on a high RP server like aurora. We should give serious thought to simply removing the role, and making it an alt title of doctor instead.

fixes #1975 