### PR TITLE
Putdown animation safety fix

### DIFF
--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -318,31 +318,30 @@ note dizziness decrements automatically in the mob's Life() proc.
 	animate(I, pixel_x = to_x, pixel_y = to_y, time = 3, transform = matrix() * 0, easing = CUBIC_EASING)
 	sleep(3)
 
-/atom/movable/proc/do_putdown_animation(atom/target)
-	set waitfor = FALSE
+/atom/movable/proc/do_putdown_animation(atom/target, mob/user)
+	spawn()
+		var/old_invisibility = invisibility // I don't know, it may be used.
+		invisibility = 100
+		var/turf/old_loc = get_turf(user)
+		var/image/I = image(icon = src, loc = old_loc, layer = layer + 0.1)
+		I.plane = GAME_PLANE
+		I.transform = matrix() * 0
+		I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 
-	var/old_invisibility = invisibility // I don't know, it may be used.
-	invisibility = 100
-	var/turf/old_loc = get_turf(src)
-	var/image/I = image(icon = src, loc = src.loc, layer = layer + 0.1)
-	I.plane = GAME_PLANE
-	I.transform = matrix() * 0
-	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+		flick_overlay(I, clients, 4)
 
-	flick_overlay(I, clients, 4)
+		var/to_x = (target.x - old_loc.x) * 32 + pixel_x
+		var/to_y = (target.y - old_loc.y) * 32 + pixel_y
+		var/old_x = pixel_x
+		var/old_y = pixel_y
+		pixel_x = 0
+		pixel_y = 0
 
-	var/to_x = (target.x - old_loc.x) * 32 + pixel_x
-	var/to_y = (target.y - old_loc.y) * 32 + pixel_y
-	var/old_x = pixel_x
-	var/old_y = pixel_y
-	pixel_x = 0
-	pixel_y = 0
-
-	animate(I, pixel_x = to_x, pixel_y = to_y, time = 3, transform = matrix(), easing = CUBIC_EASING)
-	sleep(3)
-	invisibility = old_invisibility
-	pixel_x = old_x
-	pixel_y = old_y
+		animate(I, pixel_x = to_x, pixel_y = to_y, time = 3, transform = matrix(), easing = CUBIC_EASING)
+		sleep(3)
+		invisibility = old_invisibility
+		pixel_x = old_x
+		pixel_y = old_y
 
 /atom/movable/proc/simple_move_animation(atom/target)
 	set waitfor = FALSE

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -170,7 +170,7 @@ var/list/slot_equipment_priority = list(
 			return TRUE // self destroying objects (tk, grabs)
 
 		if(W.loc != Target)
-			W.do_putdown_animation(Target)
+			W.do_putdown_animation(Target, src)
 			W.forceMove(Target, drop_flag)
 		update_icons()
 		return TRUE

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -61,8 +61,8 @@
 //This is mainly so that janiborg can put things on tables
 /obj/structure/table/MouseDrop_T(atom/A, mob/user, src_location, over_location, src_control, over_control, params)
 	if(istype(A.loc, /mob))
-		user.unEquip(A, loc)
-		set_pixel_click_offset(A, params)
+		if (user.unEquip(A, loc))
+			set_pixel_click_offset(A, params)
 		return
 
 	if (istype(A, /obj/item) && istype(A.loc, /turf) && (A.Adjacent(src) || user.Adjacent(src)))
@@ -135,7 +135,6 @@
 		user << SPAN_WARNING("There's nothing to put \the [W] on! Try adding plating to \the [src] first.")
 		return
 
-	set_pixel_click_offset(W, params)
-	user.unEquip(W, src.loc)
-
+	if (user.unEquip(W, loc))
+		set_pixel_click_offset(W, params)
 /obj/structure/table/attack_tk() // no telehulk sorry


### PR DESCRIPTION
Restores safety checks
adds a user param to putdown animation
wraps putdown in spawn

This makes everything work perfectly without any need to rearrange safety checks