### PR TITLE
EFTPOS Scanner size tweak

### DIFF
--- a/code/modules/economy/EFTPOS.dm
+++ b/code/modules/economy/EFTPOS.dm
@@ -3,6 +3,7 @@
 	desc = "Swipe your ID card to make purchases electronically."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "eftpos"
+	w_class = ITEM_SIZE_SMALL
 	var/machine_id = ""
 	var/eftpos_name = "Default EFTPOS scanner"
 	var/transaction_locked = 0


### PR DESCRIPTION
Tweaked EFTPOs scanner item size from Normal to Small, enabling it to fit within pocket slots.

A bit of a non issue to be frank, although I did find it to be a tad of a nuisance having to either lug the scanner around in one of your hands everywhere, or having to shove it into your backpack and then remove it everytime you wanted to process a transaction with the scanner.


