### PR TITLE
Inventory basics, step 1

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -633,6 +633,7 @@
 #include "code\game\objects\effects\spawners\gibspawner.dm"
 #include "code\game\objects\effects\spawners\loot.dm"
 #include "code\game\objects\effects\spawners\maintshroom.dm"
+#include "code\game\objects\items\_inventory.dm"
 #include "code\game\objects\items\apc_frame.dm"
 #include "code\game\objects\items\blueprints.dm"
 #include "code\game\objects\items\bodybag.dm"

--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -77,7 +77,7 @@
 #define BLOCK_GAS_SMOKE_EFFECT     0x10 // Blocks the effect that chemical clouds would have on a mob -- glasses, mask and helmets ONLY! (NOTE: flag shared with ONESIZEFITSALL)
 #define FLEXIBLEMATERIAL           0x20 // At the moment, masks with this flag will not prevent eating even if they are covering your face.
 #define COVER_PREVENT_MANIPULATION 0x40 // Only clothing with this flag will prevent manipulation under it. Its for space suits and such, unlike from usual Bay12 rules of clothing manipulation.
-
+#define DRAG_AND_DROP_UNEQUIP      0x80 // Allow you put intems in hands with drag and drop
 
 // Flags for pass_flags.
 #define PASSTABLE  0x1

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -12,7 +12,6 @@
 	var/hitsound = null
 	var/worksound = null
 	var/storage_cost = null
-	var/slot_flags = 0		//This is used to determine on which slots an item can fit.
 	var/no_attack_log = 0			//If it's an item we don't want to log attack_logs with, set this to 1
 	pass_flags = PASSTABLE
 //	causeerrorheresoifixthis
@@ -35,8 +34,6 @@
 	var/flags_inv = 0
 	var/body_parts_covered = 0 //see setup.dm for appropriate bit flags
 
-	var/item_flags = 0 //Miscellaneous flags pertaining to equippable objects.
-
 	var/list/tool_qualities = null// List of item qualities for tools system. See qualities.dm.
 
 	//var/heat_transfer_coefficient = 1 //0 prevents all transfers, 1 is invisible
@@ -44,7 +41,6 @@
 	var/permeability_coefficient = 1 // for chemicals/diseases
 	var/siemens_coefficient = 1 // for electrical admittance/conductance (electrocution checks and shit)
 	var/slowdown = 0 // How much clothing is slowing you down. Negative values speeds you up
-	var/canremove = 1 //Mostly for Ninja code at this point but basically will not allow the item to be removed if set to 0. /N
 	var/list/armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	var/list/allowed = null //suit storage stuff.
 	var/obj/item/device/uplink/hidden/hidden_uplink = null // All items can have an uplink hidden inside, just remember to add the triggers.
@@ -61,11 +57,6 @@
 	// If icon_override or sprite_sheets are set they will take precendence over this, assuming they apply to the slot in question.
 	// Only slot_l_hand/slot_r_hand are implemented at the moment. Others to be implemented as needed.
 	var/list/item_icons = list()
-
-	var/equip_slot = 0 //The slot that this item was most recently equipped to.
-	//Note that this is, by design, not zeroed out when the item is removed from a mob
-		//In that case, it holds the number of the slot it was last in, which is potentially useful info
-	//For an accurate reading of the current slot, use item/get_equip_slot() which will return zero if not currently on a mob
 
 /obj/item/get_fall_damage()
 	return w_class * 2
@@ -158,7 +149,7 @@
 	else
 		if(isliving(src.loc))
 			return
-	
+
 	if(user.put_in_active_hand(src) && old_loc )
 		if (user != old_loc.get_holding_mob())
 			do_pickup_animation(user,old_loc)
@@ -177,13 +168,6 @@
 
 /obj/item/proc/moved(mob/user as mob, old_loc as turf)
 	return
-
-//Called whenever an item is dropped on the floor, thrown, or placed into a container.
-//It is called after loc is set, so if placed in a container its loc will be that container.
-/obj/item/proc/dropped(mob/user as mob)
-	..()
-	if(zoom) zoom() //binoculars, scope, etc
-
 
 // Called whenever an object is moved out of a mob's equip slot. Possibly into another slot, possibly to elsewhere
 // Linker proc: mob/proc/prepare_for_slotmove, which is referenced in proc/handle_item_insertion and obj/item/attack_hand.
@@ -208,153 +192,6 @@
 // called when "found" in pockets and storage items. Returns 1 if the search should end.
 /obj/item/proc/on_found(mob/finder as mob)
 	return
-
-
-//Called just before an item is placed in an equipment slot.
-//Use this to do any necessary preparations for equipping
-//Immediately after this, the equipping will be handled and then equipped will be called.
-//Returning a non-zero value will silently abort the equip operation
-/obj/item/proc/pre_equip(var/mob/user, var/slot)
-	return 0
-
-
-// called after an item is placed in an equipment slot
-// user is mob that equipped it
-// slot uses the slot_X defines found in items_clothing.dm
-// for items that can be placed in multiple slots
-// note this isn't called during the initial dressing of a player
-/obj/item/proc/equipped(var/mob/user, var/slot)
-	if(!istype(user))
-		equip_slot = slot_none
-		return
-
-	equip_slot = slot
-	layer = 20
-	if(user.client)	user.client.screen |= src
-	if(user.pulling == src) user.stop_pulling()
-	if(user.l_hand)
-		user.l_hand.update_held_icon()
-	if(user.r_hand)
-		user.r_hand.update_held_icon()
-
-//Defines which slots correspond to which slot flags
-var/list/global/slot_flags_enumeration = list(
-	"[slot_wear_mask]" = SLOT_MASK,
-	"[slot_back]" = SLOT_BACK,
-	"[slot_wear_suit]" = SLOT_OCLOTHING,
-	"[slot_gloves]" = SLOT_GLOVES,
-	"[slot_shoes]" = SLOT_FEET,
-	"[slot_belt]" = SLOT_BELT,
-	"[slot_glasses]" = SLOT_EYES,
-	"[slot_head]" = SLOT_HEAD,
-	"[slot_l_ear]" = SLOT_EARS|SLOT_TWOEARS,
-	"[slot_r_ear]" = SLOT_EARS|SLOT_TWOEARS,
-	"[slot_w_uniform]" = SLOT_ICLOTHING,
-	"[slot_wear_id]" = SLOT_ID,
-	"[slot_accessory_buffer]" = SLOT_ACCESSORY_BUFFER,
-	)
-
-//the mob M is attempting to equip this item into the slot passed through as 'slot'. Return 1 if it can do this and 0 if it can't.
-//If you are making custom procs but would like to retain partial or complete functionality of this one, include a 'return ..()' to where you want this to happen.
-//Set disable_warning to 1 if you wish it to not give you outputs.
-//Should probably move the bulk of this into mob code some time, as most of it is related to the definition of slots and not item-specific
-/obj/item/proc/mob_can_equip(M as mob, slot, disable_warning = 0)
-	if(!slot) return 0
-	if(!M) return 0
-
-	if(!ishuman(M)) return 0
-
-	var/mob/living/carbon/human/H = M
-	var/list/mob_equip = list()
-	if(H.species.hud && H.species.hud.equip_slots)
-		mob_equip = H.species.hud.equip_slots
-
-	if(H.species && !(slot in mob_equip))
-		return 0
-
-	//First check if the item can be equipped to the desired slot.
-	if("[slot]" in slot_flags_enumeration)
-		var/req_flags = slot_flags_enumeration["[slot]"]
-		if(!(req_flags & slot_flags))
-			return 0
-
-	//Next check that the slot is free
-	if(H.get_equipped_item(slot))
-		return 0
-
-	//Next check if the slot is accessible.
-	var/mob/_user = disable_warning? null : H
-	if(!H.slot_is_accessible(slot, src, _user))
-		return 0
-
-	//Lastly, check special rules for the desired slot.
-	switch(slot)
-		if(slot_l_ear, slot_r_ear)
-			var/slot_other_ear = (slot == slot_l_ear)? slot_r_ear : slot_l_ear
-			if( (w_class > ITEM_SIZE_TINY) && !(slot_flags & SLOT_EARS) )
-				return 0
-			if( (slot_flags & SLOT_TWOEARS) && H.get_equipped_item(slot_other_ear) )
-				return 0
-		if(slot_wear_id)
-			if(!H.w_uniform && (slot_w_uniform in mob_equip))
-				if(!disable_warning)
-					H << SPAN_WARNING("You need a jumpsuit before you can attach this [name].")
-				return 0
-		if(slot_l_store, slot_r_store)
-			if(!H.w_uniform && (slot_w_uniform in mob_equip))
-				if(!disable_warning)
-					H << SPAN_WARNING("You need a jumpsuit before you can attach this [name].")
-				return 0
-			if(slot_flags & SLOT_DENYPOCKET)
-				return 0
-			if( w_class > ITEM_SIZE_SMALL && !(slot_flags & SLOT_POCKET) )
-				return 0
-		if(slot_s_store)
-			if(!H.wear_suit && (slot_wear_suit in mob_equip))
-				if(!disable_warning)
-					H << SPAN_WARNING("You need a suit before you can attach this [name].")
-				return 0
-			if(!H.wear_suit.allowed)
-				if(!disable_warning)
-					usr << SPAN_WARNING("You somehow have a suit with no defined allowed items for suit storage, stop that.")
-				return 0
-			if( !(istype(src, /obj/item/device/pda) || istype(src, /obj/item/weapon/pen) || is_type_in_list(src, H.wear_suit.allowed)) )
-				return 0
-		if(slot_handcuffed)
-			if(!istype(src, /obj/item/weapon/handcuffs))
-				return 0
-		if(slot_legcuffed)
-			if(!istype(src, /obj/item/weapon/legcuffs))
-				return 0
-		if(slot_in_backpack) //used entirely for equipping spawned mobs or at round start
-			var/allow = 0
-			if(H.back && istype(H.back, /obj/item/weapon/storage/backpack))
-				var/obj/item/weapon/storage/backpack/B = H.back
-				if(B.can_be_inserted(src,1))
-					allow = 1
-			if(!allow)
-				return 0
-		if(slot_accessory_buffer)
-			if(!H.w_uniform && (slot_w_uniform in mob_equip))
-				if(!disable_warning)
-					H << SPAN_WARNING("You need a jumpsuit before you can attach this [name].")
-				return 0
-			var/obj/item/clothing/under/uniform = H.w_uniform
-			if(uniform.accessories.len && !uniform.can_attach_accessory(src))
-				if (!disable_warning)
-					H << SPAN_WARNING("You already have an accessory of this type attached to your [uniform].")
-				return 0
-	return 1
-
-/obj/item/proc/mob_can_unequip(mob/M, slot, disable_warning = 0)
-	if(!slot) return 0
-	if(!M) return 0
-
-	if(!canremove)
-		return 0
-	if(!M.slot_is_accessible(slot, src, disable_warning? null : M))
-		return 0
-	return 1
 
 /obj/item/verb/verb_pickup()
 	set src in oview(1)
@@ -765,37 +602,3 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 /obj/item/device
 	icon = 'icons/obj/device.dmi'
-
-//Returns true if the object is equipped to a mob, in any slot
-/obj/item/proc/is_equipped()
-	if (istype(loc, /mob))
-		if (equip_slot != slot_none)
-			return TRUE
-	return FALSE
-
-
-//Returns true if the object is worn on a mob's body.
-//Returns false if held in their hands, or if not on a mob at all
-/obj/item/proc/is_worn()
-	if (istype(loc, /mob))
-		if (equip_slot != slot_none && equip_slot != slot_l_hand && equip_slot != slot_r_hand)
-			return TRUE
-	return FALSE
-
-
-//Returns true if the object is held in a mob's hands
-//Returns false if worn on their body, or if not on a mob at all
-/obj/item/proc/is_held()
-	if (istype(loc, /mob))
-		if (equip_slot == slot_l_hand || equip_slot == slot_r_hand)
-			return TRUE
-	return FALSE
-
-//if any species is added with more than 2 arms, these will need updating
-
-//This is the correct way to get an object's equip slot. Will return zero if the object is not currently equipped to anyone
-/obj/item/proc/get_equip_slot()
-	if (istype(loc, /mob))
-		return equip_slot
-	else
-		return slot_none

--- a/code/game/objects/items/_inventory.dm
+++ b/code/game/objects/items/_inventory.dm
@@ -1,0 +1,215 @@
+// All docs for procs in that file located in code/modules/mob/inventory/_docs.dm
+/obj/item
+	var/slot_flags = 0		//This is used to determine on which slots an item can fit
+	var/canremove  = TRUE	//Will not allow the item to be removed
+	var/item_flags = 0		//Miscellaneous flags pertaining to equippable objects.
+	var/equip_slot = 0		//The slot that this item was most recently equipped to.
+		//Note that this is, by design, not zeroed out when the item is removed from a mob
+		//In that case, it holds the number of the slot it was last in, which is potentially useful info
+		//For an accurate reading of the current slot,
+		//  use item/get_equip_slot() which will return zero if not currently on a mob
+
+
+/obj/item/proc/pre_equip(var/mob/user, var/slot)
+	return 0
+
+
+/obj/item/proc/equipped(var/mob/user, var/slot)
+	if(!istype(user))
+		equip_slot = slot_none
+		return
+
+	equip_slot = slot
+	layer = 20
+	if(user.client)	user.client.screen |= src
+	if(user.pulling == src) user.stop_pulling()
+	if(user.l_hand)
+		user.l_hand.update_held_icon()
+	if(user.r_hand)
+		user.r_hand.update_held_icon()
+
+
+/obj/item/proc/dropped(mob/user as mob)
+	..()
+	if(zoom) zoom() //binoculars, scope, etc
+
+
+//Defines which slots correspond to which slot flags
+var/list/global/slot_flags_enumeration = list(
+	"[slot_wear_mask]" = SLOT_MASK,
+	"[slot_back]" = SLOT_BACK,
+	"[slot_wear_suit]" = SLOT_OCLOTHING,
+	"[slot_gloves]" = SLOT_GLOVES,
+	"[slot_shoes]" = SLOT_FEET,
+	"[slot_belt]" = SLOT_BELT,
+	"[slot_glasses]" = SLOT_EYES,
+	"[slot_head]" = SLOT_HEAD,
+	"[slot_l_ear]" = SLOT_EARS|SLOT_TWOEARS,
+	"[slot_r_ear]" = SLOT_EARS|SLOT_TWOEARS,
+	"[slot_w_uniform]" = SLOT_ICLOTHING,
+	"[slot_wear_id]" = SLOT_ID,
+	"[slot_accessory_buffer]" = SLOT_ACCESSORY_BUFFER,
+	)
+
+
+//the mob M is attempting to equip this item into the slot passed through as 'slot'. Return 1 if it can do this and 0 if it can't.
+//If you are making custom procs but would like to retain partial or complete functionality of this one, include a 'return ..()' to where you want this to happen.
+//Set disable_warning to 1 if you wish it to not give you outputs.
+//Should probably move the bulk of this into mob code some time, as most of it is related to the definition of slots and not item-specific
+/obj/item/proc/mob_can_equip(M as mob, slot, disable_warning = 0)
+	if(!slot) return 0
+	if(!M) return 0
+
+	if(!ishuman(M)) return 0
+
+	var/mob/living/carbon/human/H = M
+	var/list/mob_equip = list()
+	if(H.species.hud && H.species.hud.equip_slots)
+		mob_equip = H.species.hud.equip_slots
+
+	if(H.species && !(slot in mob_equip))
+		return 0
+
+	//First check if the item can be equipped to the desired slot.
+	if("[slot]" in slot_flags_enumeration)
+		var/req_flags = slot_flags_enumeration["[slot]"]
+		if(!(req_flags & slot_flags))
+			return 0
+
+	//Next check that the slot is free
+	if(H.get_equipped_item(slot))
+		return 0
+
+	//Next check if the slot is accessible.
+	var/mob/_user = disable_warning? null : H
+	if(!H.slot_is_accessible(slot, src, _user))
+		return 0
+
+	//Lastly, check special rules for the desired slot.
+	switch(slot)
+		if(slot_l_ear, slot_r_ear)
+			var/slot_other_ear = (slot == slot_l_ear)? slot_r_ear : slot_l_ear
+			if( (w_class > ITEM_SIZE_TINY) && !(slot_flags & SLOT_EARS) )
+				return 0
+			if( (slot_flags & SLOT_TWOEARS) && H.get_equipped_item(slot_other_ear) )
+				return 0
+		if(slot_wear_id)
+			if(!H.w_uniform && (slot_w_uniform in mob_equip))
+				if(!disable_warning)
+					H << SPAN_WARNING("You need a jumpsuit before you can attach this [name].")
+				return 0
+		if(slot_l_store, slot_r_store)
+			if(!H.w_uniform && (slot_w_uniform in mob_equip))
+				if(!disable_warning)
+					H << SPAN_WARNING("You need a jumpsuit before you can attach this [name].")
+				return 0
+			if(slot_flags & SLOT_DENYPOCKET)
+				return 0
+			if( w_class > ITEM_SIZE_SMALL && !(slot_flags & SLOT_POCKET) )
+				return 0
+		if(slot_s_store)
+			if(!H.wear_suit && (slot_wear_suit in mob_equip))
+				if(!disable_warning)
+					H << SPAN_WARNING("You need a suit before you can attach this [name].")
+				return 0
+			if(!H.wear_suit.allowed)
+				if(!disable_warning)
+					usr << SPAN_WARNING("You somehow have a suit with no defined allowed items for suit storage, stop that.")
+				return 0
+			if( !(istype(src, /obj/item/device/pda) || istype(src, /obj/item/weapon/pen) || is_type_in_list(src, H.wear_suit.allowed)) )
+				return 0
+		if(slot_handcuffed)
+			if(!istype(src, /obj/item/weapon/handcuffs))
+				return 0
+		if(slot_legcuffed)
+			if(!istype(src, /obj/item/weapon/legcuffs))
+				return 0
+		if(slot_in_backpack) //used entirely for equipping spawned mobs or at round start
+			var/allow = 0
+			if(H.back && istype(H.back, /obj/item/weapon/storage/backpack))
+				var/obj/item/weapon/storage/backpack/B = H.back
+				if(B.can_be_inserted(src,1))
+					allow = 1
+			if(!allow)
+				return 0
+		if(slot_accessory_buffer)
+			if(!H.w_uniform && (slot_w_uniform in mob_equip))
+				if(!disable_warning)
+					H << SPAN_WARNING("You need a jumpsuit before you can attach this [name].")
+				return 0
+			var/obj/item/clothing/under/uniform = H.w_uniform
+			if(uniform.accessories.len && !uniform.can_attach_accessory(src))
+				if (!disable_warning)
+					H << SPAN_WARNING("You already have an accessory of this type attached to your [uniform].")
+				return 0
+	return 1
+
+
+/obj/item/proc/mob_can_unequip(mob/M, slot, disable_warning = 0)
+	if(!slot) return 0
+	if(!M) return 0
+
+	if(!canremove)
+		return 0
+	if(!M.slot_is_accessible(slot, src, disable_warning? null : M))
+		return 0
+	return 1
+
+
+/obj/item/proc/is_equipped()
+	if (istype(loc, /mob))
+		if (equip_slot != slot_none)
+			return TRUE
+	return FALSE
+
+
+/obj/item/proc/is_worn()
+	if (istype(loc, /mob))
+		if (equip_slot != slot_none && equip_slot != slot_l_hand && equip_slot != slot_r_hand)
+			return TRUE
+	return FALSE
+
+
+/obj/item/proc/is_held()
+	if (istype(loc, /mob))
+		if (equip_slot == slot_l_hand || equip_slot == slot_r_hand)
+			return TRUE
+	return FALSE
+
+
+/obj/item/proc/get_equip_slot()
+	if (istype(loc, /mob))
+		return equip_slot
+	else
+		return slot_none
+
+
+/obj/item/MouseDrop(obj/over_object)
+	if(item_flags & DRAG_AND_DROP_UNEQUIP && isliving(usr))
+		if(try_uneqip(over_object, usr))
+			return
+	return ..()
+
+
+/obj/item/proc/try_uneqip(target, mob/living/user)
+	if(loc == user && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if (!istype(target, /obj/screen/inventory/hand))
+			return
+
+		//makes sure that the storage is equipped, so that we can't drag it into our hand from miles away.
+		//there's got to be a better way of doing this.
+		if(src.loc != H || H.incapacitated())
+			return
+		if (!H.unEquip(src))
+			return
+
+		var/obj/screen/inventory/hand/Hand = target
+		switch(Hand.slot_id)
+			if(slot_r_hand)
+				H.put_in_r_hand(src)
+			if(slot_l_hand)
+				H.put_in_l_hand(src)
+		src.add_fingerprint(usr)
+		return TRUE
+

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -316,11 +316,10 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /obj/item/device/pda/GetID()
 	return id
 
-/obj/item/device/pda/MouseDrop(obj/over_object as obj, src_location, over_location)
-	var/mob/M = usr
+/obj/item/device/pda/MouseDrop(obj/over_object, src_location, over_location)
 	if((!istype(over_object, /obj/screen)) && can_use())
-		return attack_self(M)
-	return
+		return attack_self(usr)
+	return ..()
 
 
 /obj/item/device/pda/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -27,39 +27,12 @@
 //See /obj/item/clothing/suit/storage for an example.
 
 //items that use internal storage have the option of calling this to emulate default storage MouseDrop behaviour.
-//returns 1 if the master item's parent's MouseDrop() should be called, 0 otherwise. It's strange, but no other way of
-//doing it without the ability to call another proc's parent, really.
-/obj/item/weapon/storage/internal/proc/handle_mousedrop(mob/user as mob, obj/over_object as obj)
-	if (ishuman(user) || issmall(user)) //so monkeys can take off their backpacks -- Urist
-
-		if (istype(user.loc,/obj/mecha)) // stops inventory actions in a mech
-			return 0
-
-		if(over_object == user && Adjacent(user)) // this must come before the screen objects only block
+//returns TRUE if the master item's parent's MouseDrop() shouldn't be called, FALSE otherwise.
+/obj/item/weapon/storage/internal/proc/handle_mousedrop(mob/living/carbon/human/user, obj/over_object)
+	if (istype(user))
+		if(over_object == user && Adjacent(user))
 			src.open(user)
-			return 0
-
-		if (!( istype(over_object, /obj/screen) ))
-			return 1
-
-		//makes sure master_item is equipped before putting it in hand, so that we can't drag it into our hand from miles away.
-		//there's got to be a better way of doing this...
-		if (!(master_item.loc == user) || (master_item.loc && master_item.loc.loc == user))
-			return 0
-
-		if (!( user.restrained() ) && !( user.stat ) && (istype(over_object, /obj/screen/inventory/hand)))
-			var/obj/screen/inventory/hand/H = over_object
-			switch(H.slot_id)
-				if(slot_r_hand)
-					user.u_equip(master_item)
-					user.put_in_r_hand(master_item)
-				if(slot_l_hand)
-					user.u_equip(master_item)
-					user.put_in_l_hand(master_item)
-			master_item.add_fingerprint(user)
-
-			return 0
-	return 0
+			return TRUE
 
 //items that use internal storage have the option of calling this to emulate default storage attack_hand behaviour.
 //returns 1 if the master item's parent's attack_hand() should be called, 0 otherwise.

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -9,6 +9,7 @@
 	name = "storage"
 	icon = 'icons/obj/storage.dmi'
 	w_class = ITEM_SIZE_NORMAL
+	item_flags = DRAG_AND_DROP_UNEQUIP
 	var/list/can_hold = new/list() //List of objects which this item can store (if set, it can't store anything else)
 	var/list/cant_hold = new/list() //List of objects which this item can't store (in effect only if can_hold isn't set)
 	var/list/is_seeing = new/list() //List of mobs which are currently seeing the contents of this item's storage
@@ -42,50 +43,10 @@
 	qdel(closer)
 	. = ..()
 
-/obj/item/weapon/storage/MouseDrop(obj/over_object as obj)
-	if(!canremove && istype(loc, /mob))
-		return
-
-	if ((ishuman(usr) || issmall(usr)) && !ismouse(usr)) //so monkeys can take off their backpacks -- Urist
-
-		if (istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech. why?
-			return
-
-		if(over_object == usr && Adjacent(usr)) // this must come before the screen objects only block
-			src.open(usr)
-			return
-
-		if (!( istype(over_object, /obj/screen) ))
-			return ..()
-
-		//makes sure that the storage is equipped, so that we can't drag it into our hand from miles away.
-		//there's got to be a better way of doing this.
-		if (!(src.loc == usr) || (src.loc && src.loc.loc == usr))
-			return
-
-		if (( usr.restrained() ) || ( usr.stat ))
-			return
-
-
-		if ((src.loc == usr) && !(istype(over_object, /obj/screen)) && !usr.unEquip(src))
-			return
-
-		if (istype(over_object, /obj/screen/inventory/hand))
-			var/obj/screen/inventory/hand/H = over_object
-			switch(H.slot_id)
-				if(slot_r_hand)
-					usr.u_equip(src)
-					usr.put_in_r_hand(src)
-				if(slot_l_hand)
-					usr.u_equip(src)
-					usr.put_in_l_hand(src)
-			return
-
-		src.add_fingerprint(usr)
+/obj/item/weapon/storage/MouseDrop(obj/over_object)
+	if(ishuman(usr) && loc == usr == over_object && !usr.incapacitated())
+		return src.open(usr)
 	return ..()
-
-
-
 
 
 /obj/item/weapon/storage/proc/return_inv()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1,6 +1,7 @@
 /obj/item/clothing
 	name = "clothing"
 	siemens_coefficient = 0.9
+	item_flags = DRAG_AND_DROP_UNEQUIP
 	var/flash_protection = FLASH_PROTECTION_NONE	// Sets the item's level of flash protection.
 	var/tint = TINT_NONE							// Sets the item's level of visual impairment tint.
 	var/list/species_restricted = null				// Only these species can wear this kit.
@@ -147,12 +148,14 @@
 
 
 /obj/item/clothing/ears/earmuffs/mp3/MouseDrop(over_object)
-    if((src.loc == usr) && istype(over_object, /obj/screen/inventory/hand) && eject_item(cell, usr))
-        cell = null
+	if((src.loc == usr) && istype(over_object, /obj/screen/inventory/hand) && eject_item(cell, usr))
+		cell = null
+	else
+		return ..()
 
 /obj/item/clothing/ears/earmuffs/mp3/attackby(obj/item/C, mob/living/user)
-    if(istype(C, suitable_cell) && !cell && insert_item(C, user))
-        src.cell = C
+	if(istype(C, suitable_cell) && !cell && insert_item(C, user))
+		src.cell = C
 
 ///////////////////////////////////////////////////////////////////////
 //Glasses

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -44,26 +44,6 @@
 		return
 	return ..()
 
-/obj/item/clothing/MouseDrop(var/obj/over_object)
-	if (ishuman(usr) || issmall(usr))
-		//makes sure that the clothing is equipped so that we can't drag it into our hand from miles away.
-		if (!(src.loc == usr))
-			return
-
-		if (( usr.restrained() ) || ( usr.stat ))
-			return
-
-		if (!usr.unEquip(src))
-			return
-		if (istype(over_object, /obj/screen/inventory/hand))
-			var/obj/screen/inventory/hand/H = over_object
-			switch(H.slot_id)
-				if(slot_r_hand)
-					usr.put_in_r_hand(src)
-				if(slot_l_hand)
-					usr.put_in_l_hand(src)
-		src.add_fingerprint(usr)
-
 /obj/item/clothing/examine(var/mob/user)
 	..(user)
 	if(accessories.len)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -2,7 +2,7 @@
 /obj/item/clothing/suit/armor
 	allowed = list(/obj/item/weapon/gun/energy,/obj/item/device/radio,/obj/item/weapon/reagent_containers/spray/pepper,/obj/item/weapon/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
-	item_flags = THICKMATERIAL
+	item_flags = THICKMATERIAL|DRAG_AND_DROP_UNEQUIP
 
 	cold_protection = UPPER_TORSO|LOWER_TORSO
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/suit/storage
+	item_flags = DRAG_AND_DROP_UNEQUIP
 	var/obj/item/weapon/storage/internal/pockets
 
 /obj/item/clothing/suit/storage/New()
@@ -13,15 +14,15 @@
 	pockets = null
 	. = ..()
 
-/obj/item/clothing/suit/storage/attack_hand(mob/user as mob)
+/obj/item/clothing/suit/storage/attack_hand(mob/user)
 	if (pockets.handle_attack_hand(user))
 		..(user)
 
-/obj/item/clothing/suit/storage/MouseDrop(obj/over_object as obj)
-	if (pockets.handle_mousedrop(usr, over_object))
+/obj/item/clothing/suit/storage/MouseDrop(obj/over_object)
+	if(!pockets.handle_mousedrop(usr, over_object))
 		..(over_object)
 
-/obj/item/clothing/suit/storage/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/clothing/suit/storage/attackby(obj/item/W, mob/user)
 	..()
 	pockets.attackby(W, user)
 

--- a/code/modules/mob/inventory/_docs.dm
+++ b/code/modules/mob/inventory/_docs.dm
@@ -1,0 +1,96 @@
+// ITEMS //
+/*
+Most procs from that categoy located in:
+ code/game/objects/items.dm
+*/
+
+
+/obj/item/proc/update_wear_icon(redraw_mob = TRUE)
+/*
+Replacement for outdated update_holding_icon()/update_clothing_icon()
+Found occupied slot and update it icon
+*/
+
+
+/obj/item/proc/pre_equip(var/mob/user, var/slot)
+/*
+Called just before an item is placed in an equipment slot.
+Use this to do any necessary preparations for equipping
+Immediately after this, the equipping will be handled and then equipped will be called.
+Returning a non-zero value will silently abort the equip operation
+Important notes:
+	- Can take few ticks if needed!
+	- Called before unequip (if holding by mob) and can still be located in another mob!
+By default here located equip sound calls.
+*/
+
+
+/obj/item/proc/equipped(var/mob/Mob, var/slot)
+/*
+Called after an item is placed in an equipment slot
+User is mob that equipped it
+Slot uses the slot_X defines found in items_clothing.dm
+*/
+
+/obj/item/proc/dropped(mob/Mob)
+/*
+Called whenever an item is dropped from INVENTORY SLOT.
+Important note:
+	- It is called after loc is set, so if placed in a container its loc will be that container.
+By default drop zoom if enabled.
+*/
+
+
+/obj/item/proc/can_be_equipped(mob/Mob, slot, disable_warning = FALSE)
+/*
+The mob M is attempting to equip this item into the slot passed through as 'slot'.
+Return TRUE if it can do this and FALSE if it can't.
+Set disable_warning to TRUE if you wish it to not give you outputs.
+*/
+
+
+/obj/item/proc/can_be_unequipped(mob/Mob, slot, disable_warning = FALSE)
+/*
+Analogue for can_be_equipped(..) but used for unequip
+Default proc return canremove value.
+*/
+
+
+/obj/item/proc/is_equipped()
+/*
+Returns TRUE if the object is equipped to a mob, in any slot
+Important note:
+	- return TRUE/FALSE not occupied slot id!
+*/
+
+
+/obj/item/proc/is_worn()
+/*
+Analogue for is_equipped() but return TRUE if Item is equipped to one of body slots (not hands)
+Important notes:
+	- will return FALSE if item located in hands slot!
+	- robot slots currently not counted as hands -> counted as body slots don't be confused
+*/
+
+
+/obj/item/proc/is_held()
+/*
+Kind of inverse proc for is_worn() return TRUE if item occupy one of hands slot
+Important note:
+	- robot slots currently not counted as hands
+*/
+
+
+/obj/item/proc/get_equip_slot()
+/*
+This is the correct way to get an object's equip slot.
+Will return zero if the object is not currently equipped to anyone
+*/
+
+
+/obj/item/proc/try_uneqip(target, mob/living/user)
+/*
+Not directly related to inventory procs
+Used for unequipping things from mob inventory to hands with mouse DragnDrop
+Called by /obj/item/MouseDrop(obj/over_object)
+*/

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -5,6 +5,7 @@
 	item_state = "clipboard"
 	throwforce = 0
 	w_class = ITEM_SIZE_SMALL
+	item_flags = DRAG_AND_DROP_UNEQUIP
 	throw_speed = 3
 	throw_range = 10
 	var/obj/item/weapon/pen/haspen		//The stored pen.
@@ -13,25 +14,6 @@
 
 /obj/item/weapon/clipboard/New()
 	update_icon()
-
-/obj/item/weapon/clipboard/MouseDrop(obj/over_object as obj) //Quick clipboard fix. -Agouri
-	if(ishuman(usr))
-		var/mob/M = usr
-		if(!(istype(over_object, /obj/screen) ))
-			return ..()
-
-		if(!M.restrained() && !M.stat && istype(over_object, /obj/screen/inventory/hand))
-			var/obj/screen/inventory/hand/H = over_object
-			switch(H.slot_id)
-				if(slot_r_hand)
-					M.u_equip(src)
-					M.put_in_r_hand(src)
-				if(slot_l_hand)
-					M.u_equip(src)
-					M.put_in_l_hand(src)
-
-			add_fingerprint(usr)
-			return
 
 /obj/item/weapon/clipboard/update_icon()
 	overlays.Cut()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -88,29 +88,6 @@ var/global/photo_count = 0
 	item_state = "briefcase"
 	can_hold = list(/obj/item/weapon/photo)
 
-/obj/item/weapon/storage/photo_album/MouseDrop(obj/over_object as obj)
-
-	if((ishuman(usr)))
-		var/mob/M = usr
-		if(!( istype(over_object, /obj/screen) ))
-			return ..()
-		playsound(loc, "rustle", 50, 1, -5)
-		if((!( M.restrained() ) && !( M.stat ) && M.back == src))
-			switch(over_object.name)
-				if(BP_R_ARM)
-					M.u_equip(src)
-					M.put_in_r_hand(src)
-				if(BP_L_ARM)
-					M.u_equip(src)
-					M.put_in_l_hand(src)
-			add_fingerprint(usr)
-			return
-		if(over_object == usr && in_range(src, usr) || usr.contents.Find(src))
-			if(usr.s_active)
-				usr.s_active.close(usr)
-			show_to(usr)
-			return
-	return
 
 /*********
 * camera *


### PR DESCRIPTION
Changes:
- Move drag_n_drop for unequip to `/obj/item` code, ability bound to flag `DRAG_AND_DROP_UNEQUIP`

Moving:
- Moved inventory related item procs/vars to `code/game/objects/items/_inventory.dm`

Docs:
- add item procs docs to `code/modules/mob/inventory/_docs.dm`
Current docs may not reflect the real procs! Procs/docs will be update with following PRs.