### PR TITLE
Add missing adjacency check to locker altclick

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -211,7 +211,8 @@
 		user << SPAN_NOTICE("Access Denied")
 
 /obj/structure/closet/AltClick(mob/user as mob)
-	src.togglelock(user)
+	if(Adjacent(user))
+		src.togglelock(user)
 
 /obj/structure/closet/proc/CanToggleLock(var/mob/user, var/obj/item/weapon/card/id/id_card)
 	return allowed(user) || (istype(id_card) && check_access_list(id_card.GetAccess()))


### PR DESCRIPTION
fixes https://github.com/discordia-space/CEV-Eris/issues/2127