### PR TITLE
aieye and rampant ai fixes

### DIFF
--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -35,8 +35,12 @@
 	if(doequip)
 		equip()
 
-	//if(announce)
+	//if(announce) //why this one is commented? It prevents ai from to be a malf
 	//	greet()
+
+	//i'm not sure, so i make here a special check for ai
+	if(istype(src, /datum/antagonist/rogue_ai) && announce)
+		greet()
 
 	return TRUE
 

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -51,6 +51,9 @@ proc/overmap_spacetravel(var/turf/space/T, var/atom/movable/A)
 	if (!T || !A)
 		return
 
+	if(istype(A, /mob/observer/eye/aiEye))
+		return
+
 	var/obj/effect/overmap/M = map_sectors["[T.z]"]
 	if (!M)
 		return


### PR DESCRIPTION
Fixes #2106 
Now rogue ai setups properly

Fixes #1965 
Spacetravel for ai eye now prevented, so aieye cannot going off from eris and be accidentally deleted