### PR TITLE
Fixes rig visors not working with glasses overlay

### DIFF
--- a/code/_onclick/hud/screen_objects/base_screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/base_screen_objects.dm
@@ -1090,6 +1090,12 @@ obj/screen/fire/DEADelize()
 		if (G.active && G.overlay)//check here need if someone want call this func directly
 			overlays |= G.overlay
 
+	if(istype(H.back,/obj/item/weapon/rig))
+		var/obj/item/weapon/rig/O = H.back
+		if(O.visor && O.visor.active && O.visor.vision && O.visor.vision.glasses && (!O.helmet || (H.head && O.helmet == H.head)))
+			if (O.visor.vision.glasses.overlay)
+				overlays |= O.visor.vision.glasses.overlay
+
 
 /*	if(owner.gun_move_icon)
 		if(!(target_permissions & TARGET_CAN_MOVE))

--- a/code/_onclick/hud/screen_objects/base_screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/base_screen_objects.dm
@@ -1090,8 +1090,8 @@ obj/screen/fire/DEADelize()
 		if (G.active && G.overlay)//check here need if someone want call this func directly
 			overlays |= G.overlay
 
-	if(istype(H.back,/obj/item/weapon/rig))
-		var/obj/item/weapon/rig/O = H.back
+	if(istype(H.wearing_rig,/obj/item/weapon/rig))
+		var/obj/item/weapon/rig/O = H.wearing_rig
 		if(O.visor && O.visor.active && O.visor.vision && O.visor.vision.glasses && (!O.helmet || (H.head && O.helmet == H.head)))
 			if (O.visor.vision.glasses.overlay)
 				overlays |= O.visor.vision.glasses.overlay

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -59,8 +59,8 @@
 	if(istype(back,/obj/item/weapon/rig))
 		process_rig(back)
 
-/mob/living/carbon/human/proc/process_glasses(var/obj/item/clothing/glasses/G)
-	if(G && G.active)
+/mob/living/carbon/human/proc/process_glasses(var/obj/item/clothing/glasses/G, var/forceActive)
+	if(G && (G.active || forceActive))
 		equipment_darkness_modifier += G.darkness_view
 		equipment_vision_flags |= G.vision_flags
 		equipment_prescription = equipment_prescription || G.prescription
@@ -83,7 +83,7 @@
 		if((O.offline && O.offline_vision_restriction == 2) || (!O.offline && O.vision_restriction == 2))
 			equipment_tint_total += TINT_BLIND
 	if(O.visor && O.visor.active && O.visor.vision && O.visor.vision.glasses && (!O.helmet || (head && O.helmet == head)))
-		process_glasses(O.visor.vision.glasses)
+		process_glasses(O.visor.vision.glasses, 1)
 
 /mob/living/carbon/human/proc/get_core_implant()
 	var/obj/item/weapon/implant/core_implant/C = locate(/obj/item/weapon/implant/core_implant, src)


### PR DESCRIPTION
Adds an override into process_glasses to bypass newly added cell dependency of various glasses.
Adds a check into glasses_overlay to apply active rig visor overlay.