### PR TITLE
Fixes multiple issues with rig visor

### DIFF
--- a/code/_onclick/hud/screen_objects/base_screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/base_screen_objects.dm
@@ -1090,6 +1090,11 @@ obj/screen/fire/DEADelize()
 		if (G.active && G.overlay)//check here need if someone want call this func directly
 			overlays |= G.overlay
 
+	if(istype(H.wearing_rig,/obj/item/weapon/rig))
+		var/obj/item/clothing/glasses/G = H.wearing_rig.getCurrentGlasses()
+		if (G && H.wearing_rig.visor.active)
+			overlays |= G.overlay
+
 
 /*	if(owner.gun_move_icon)
 		if(!(target_permissions & TARGET_CAN_MOVE))

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -83,6 +83,10 @@
 	var/datum/wires/rig/wires
 	var/datum/effect/effect/system/spark_spread/spark_system
 
+/obj/item/weapon/rig/proc/getCurrentGlasses()
+	if(wearer && visor && visor && visor.vision && visor.vision.glasses && (!helmet || (wearer.head && helmet == wearer.head)))
+		return visor.vision.glasses
+
 /obj/item/weapon/rig/examine()
 	usr << "This is \icon[src][src.name]."
 	usr << "[src.desc]"

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -56,11 +56,11 @@
 		process_glasses(glasses)
 	if(istype(src.wear_mask, /obj/item/clothing/mask))
 		add_clothing_protection(wear_mask)
-	if(istype(back,/obj/item/weapon/rig))
-		process_rig(back)
+	if(istype(wearing_rig,/obj/item/weapon/rig))
+		process_rig(wearing_rig)
 
-/mob/living/carbon/human/proc/process_glasses(var/obj/item/clothing/glasses/G)
-	if(G && G.active)
+/mob/living/carbon/human/proc/process_glasses(var/obj/item/clothing/glasses/G, var/forceActive)
+	if(G && (G.active || forceActive))
 		equipment_darkness_modifier += G.darkness_view
 		equipment_vision_flags |= G.vision_flags
 		equipment_prescription = equipment_prescription || G.prescription
@@ -82,8 +82,9 @@
 	if(O.helmet && O.helmet == head && (O.helmet.body_parts_covered & EYES))
 		if((O.offline && O.offline_vision_restriction == 2) || (!O.offline && O.vision_restriction == 2))
 			equipment_tint_total += TINT_BLIND
-	if(O.visor && O.visor.active && O.visor.vision && O.visor.vision.glasses && (!O.helmet || (head && O.helmet == head)))
-		process_glasses(O.visor.vision.glasses)
+	var/obj/item/clothing/glasses/G = O.getCurrentGlasses()
+	if(G && O.visor.active)
+		process_glasses(G,1)
 
 /mob/living/carbon/human/proc/get_core_implant()
 	var/obj/item/weapon/implant/core_implant/C = locate(/obj/item/weapon/implant/core_implant, src)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -253,9 +253,10 @@
 
 		env.merge(removed)
 
-	for(var/mob/living/carbon/human/l in view(src, min(7, round(sqrt(power/6))))) // If they can see it without mesons on.  Bad on them.
-		if(!istype(l.glasses, /obj/item/clothing/glasses/meson))
-			l.hallucination = max(0, min(200, l.hallucination + power * config_hallucination_power * sqrt( 1 / max(1,get_dist(l, src)) ) ) )
+	for(var/mob/living/carbon/human/H in view(src, min(7, round(sqrt(power/6))))) // If they can see it without mesons on.  Bad on them.
+		if(!istype(H.glasses, /obj/item/clothing/glasses/meson))
+			if (!(istype(H.wearing_rig, /obj/item/weapon/rig) && istype(H.wearing_rig.getCurrentGlasses(), /obj/item/clothing/glasses/meson)))
+				H.hallucination = max(0, min(200, H.hallucination + power * config_hallucination_power * sqrt( 1 / max(1,get_dist(H, src)) ) ) )
 
 	//adjusted range so that a power of 170 (pretty high) results in 9 tiles, roughly the distance from the core to the engine monitoring room.
 	//note that the rads given at the maximum range is a constant 0.2 - as power increases the maximum range merely increases.


### PR DESCRIPTION
Adds a proc rig.getCurrentGlasses() which returns current glasses regardless rig.visor.active state.

Fixes supermatter not recognizing rig visor mesons
Adds an override into process_glasses to bypass newly added cell dependency of various glasses.
Adds a check into glasses_overlay to apply active rig visor overlay.

Combination of https://github.com/discordia-space/CEV-Eris/pull/2160 and https://github.com/discordia-space/CEV-Eris/pull/2149