### PR TITLE
Some fixes for inventory system

### DIFF
--- a/code/controllers/subsystems/inventory.dm
+++ b/code/controllers/subsystems/inventory.dm
@@ -16,7 +16,7 @@ SUBSYSTEM_DEF(inventory)
 		slots[S.id] = S
 
 /datum/controller/subsystem/inventory/proc/get_slot_datum(slot)
-	return slots.len > slot ? slots[slot] : null
+	return slots.len >= slot ? slots[slot] : null
 
 /datum/controller/subsystem/inventory/proc/update_mob(mob/living/target, slot, redraw)
 	var/datum/inventory_slot/IS = get_slot_datum(slot)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -575,19 +575,21 @@
 /obj/item/weapon/rig/pre_equip(var/mob/user, var/slot)
 	if (slot == rig_wear_slot)
 		if(seal_delay > 0)
-			user.visible_message("<font color='blue'>[user] starts putting on \the [src]...</font>", "<font color='blue'>You start putting on \the [src]...</font>")
+			user.visible_message(
+				SPAN_NOTICE("[user] starts putting on \the [src]..."),
+				SPAN_NOTICE("You start putting on \the [src]...")
+			)
 			if(!do_after(user,seal_delay,src))
-				return 1 //A nonzero return value will cause the equipping operation to fail
+				return TRUE //A nonzero return value will cause the equipping operation to fail
 
 
 /obj/item/weapon/rig/equipped(var/mob/user, var/slot)
 	..()
-	if (is_held())
-		remove()
-		return
-
 	if (slot == rig_wear_slot)
-		user.visible_message("<font color='blue'><b>[user] struggles into \the [src].</b></font>", "<font color='blue'><b>You struggle into \the [src].</b></font>")
+		user.visible_message(
+			SPAN_NOTICE("<b>[user] struggles into \the [src].</b>"),
+			SPAN_NOTICE("<b>You struggle into \the [src].</b>")
+		)
 		wearer = user
 		wearer.wearing_rig = src
 		update_icon()

--- a/code/modules/mob/inventory/_docs.dm
+++ b/code/modules/mob/inventory/_docs.dm
@@ -41,7 +41,8 @@ It calls:
 /mob/proc/equip_to_appropriate_slot(obj/item/Item)
 /*
 Puts the Item into an appropriate slot in a human's inventory
-returns FALSE if it cannot, TRUE if successful
+Checks all slots present in slot_equipment_priority list one by one
+Returns found id of slot in which item was equipped or FALSE
 It calls:
 	- equip_to_slot_if_possible(Item, slot, disable_warning = TRUE)
 */

--- a/code/modules/mob/inventory/equip.dm
+++ b/code/modules/mob/inventory/equip.dm
@@ -13,7 +13,7 @@
 
 	//Pre-equip can take time
 	if(world_time != world.timeofday)
-		if(mob_can_equip(src, Item, slot, disable_warning))
+		if(!mob_can_equip(src, Item, slot, disable_warning))
 			return FALSE
 
 	if(Item.is_equipped())
@@ -65,7 +65,7 @@ var/list/slot_equipment_priority = list(
 		return FALSE
 	for(var/slot in slot_equipment_priority)
 		if(equip_to_slot_if_possible(Item, slot, disable_warning = TRUE))
-			return TRUE
+			return slot
 	return FALSE
 
 

--- a/code/modules/mob/inventory/slots.dm
+++ b/code/modules/mob/inventory/slots.dm
@@ -221,15 +221,21 @@
 	req_item_in_slot = slot_wear_suit
 	update_proc = /mob/proc/update_inv_s_store
 
-/datum/inventory_slot/special_store/can_equip(obj/item/I, mob/living/carbon/human/owner, disable_warning)
-	if(!..())
-		return FALSE
+/datum/inventory_slot/suit_store/can_equip(obj/item/I, mob/living/carbon/human/owner, disable_warning)
 	var/obj/item/wear_suit = owner.get_equipped_item(slot_wear_suit)
+	if(!wear_suit)
+		if(!disable_warning)
+			owner << SPAN_WARNING("You need some suit to wear items in [name].")
+		return FALSE
 	if(!wear_suit.allowed)
 		if(!disable_warning)
 			owner << SPAN_WARNING("You can't attach anything to that [wear_suit].")
 		return FALSE
-	return is_type_in_list(src, wear_suit.allowed + list(/obj/item/device/pda, /obj/item/weapon/pen))
+	if( !is_type_in_list(I, wear_suit.allowed + list(/obj/item/device/pda, /obj/item/weapon/pen)) )
+		if(!disable_warning)
+			owner << SPAN_WARNING("You can't attach [I] to that [wear_suit].")
+		return FALSE
+	return TRUE
 
 
 //Special virtual slots. Here for backcompability.
@@ -245,8 +251,11 @@
 /datum/inventory_slot/accessory
 	name = "Slot accessory"
 	id = slot_accessory_buffer
+	req_type = /obj/item/clothing/accessory
 
 /datum/inventory_slot/accessory/can_equip(obj/item/I, mob/living/carbon/human/owner, disable_warning)
+	if(!istype(I, req_type))
+		return FALSE
 	var/obj/item/clothing/under/uniform = owner.get_equipped_item(slot_w_uniform)
 	if(!uniform)
 		if(!disable_warning)


### PR DESCRIPTION
Fixed:
- `mob_can_equip(...)`check invert value if `pre_equip` take more than one tick.
- "suit storage" slot datum `can_equip` proc always returns FALSE (also add more feedback)
- inventory subsystem return null for slot with higher id (accessory_buffer). fix #2200