### PR TITLE
Hardsuit Fix

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -649,7 +649,6 @@
 			if(check_slot && check_slot == use_obj)
 				return
 
-			use_obj.forceMove(wearer)
 			if(!wearer.equip_to_slot_if_possible(use_obj, equip_to, TRUE)) //Disable_warning
 				use_obj.forceMove(src)
 				if(check_slot)


### PR DESCRIPTION
Makes hardsuits work again

Removes a completely pointless forcemove step which was screwing up the equipping process