### PR TITLE
Rebalanced explosive critical failure for tools

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -549,26 +549,32 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 					H.get_organ(H.get_holding_hand(src)).embed(src)
 					return
 
-			if(85 to 93)
+			if(85 to 94)
 				if(ishuman(user))
 					user << SPAN_DANGER("Your [src] broke beyond repair!")
 					new /obj/item/weapon/material/shard/shrapnel(user.loc)
 					qdel(src)
 					return
 
-			if(94 to 100)
+			if(95 to 100)
 				if(ishuman(user))
 					if(istype(src, /obj/item/weapon/tool))
 						var/obj/item/weapon/tool/T = src
 						if(T.use_fuel_cost)
 							user << SPAN_DANGER("You ignite the fuel of the [src]!")
-							explosion(src.loc,-1,1,2)
-							qdel(src)
+							var/fuel = T.get_fuel()
+							T.consume_fuel(fuel)
+							user.adjust_fire_stacks(fuel/10)
+							user.IgniteMob()
 							return
-						if(T.use_power_cost)
+						if(T.use_power_cost && T.cell)
 							user << SPAN_DANGER("You overload the cell in the [src]!")
-							explosion(src.loc,-1,1,2)
-							qdel(src)
+							if (T.cell.charge >= 400)
+								explosion(src.loc,-1,0,2)
+							else
+								explosion(src.loc,-1,0,1)
+							qdel(T.cell)
+							T.cell = null
 							return
 
 


### PR DESCRIPTION
Fuel tools now instead of exploding ignite their user based on their fuel.
Cell based tools had their explosion strength lowered, size increases for cells with at least 400 charge.