### PR TITLE
Makes centcomm (spacefortress) airlocks opaque

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -107,7 +107,7 @@
 /obj/machinery/door/airlock/centcom
 	name = "Airlock"
 	icon = 'icons/obj/doors/Doorele.dmi'
-	opacity = 0
+	opacity = 1
 
 /obj/machinery/door/airlock/vault
 	name = "Vault"


### PR DESCRIPTION
Fixes this
![default](https://user-images.githubusercontent.com/5739068/47602514-c7a63a00-d9e8-11e8-83b2-9c6c822df57a.png)