### PR TITLE
Fixes multiple furniture dismantle returns

### DIFF
--- a/code/datums/craft/recipes/furniture.dm
+++ b/code/datums/craft/recipes/furniture.dm
@@ -29,7 +29,7 @@
 	name = "shelf"
 	result = /obj/structure/table/rack/shelf
 	steps = list(
-		list(CRAFT_MATERIAL, 3, MATERIAL_STEEL),
+		list(CRAFT_MATERIAL, 2, MATERIAL_STEEL),
 	)
 
 /datum/craft_recipe/furniture/closet

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -43,6 +43,8 @@
 	var/store_items = 1
 	var/store_mobs = 1
 
+	var/dismantle_material = /obj/item/stack/material/steel
+
 /obj/structure/closet/can_prevent_fall()
 	return TRUE
 
@@ -334,7 +336,7 @@
 			return 0
 		if(QUALITY_WELDING in I.tool_qualities)
 			if(I.use_tool(user, src, WORKTIME_FAST, QUALITY_WELDING, FAILCHANCE_EASY, required_stat = STAT_MEC))
-				new /obj/item/stack/material/steel(src.loc)
+				new dismantle_material(src.loc, 10)
 				src.visible_message(
 					SPAN_NOTICE("\The [src] has been cut apart by [user] with \the [I]."),
 					"You hear welding."

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -6,6 +6,7 @@
 	climbable = TRUE
 	dense_when_open = TRUE
 	var/rigged = FALSE
+	dismantle_material = /obj/item/stack/material/plasteel
 
 
 /obj/structure/closet/crate/open()
@@ -131,6 +132,7 @@
 	name = "plastic crate"
 	desc = "A rectangular plastic crate."
 	icon_state = "plasticcrate"
+	dismantle_material = /obj/item/stack/material/plastic
 
 /obj/structure/closet/crate/internals
 	name = "internals crate"

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -10,6 +10,7 @@
 	var/material/reinf_material
 	var/reinforcing = 0
 	var/resistance = RESISTANCE_TOUGH
+	var/dismantle_materials_count = 5
 
 /obj/structure/girder/displaced
 	icon_state = "displaced"
@@ -21,6 +22,7 @@
 /obj/structure/girder/low
 	health = 120
 	cover = 25 //how much cover the girder provides against projectiles.
+	dismantle_materials_count = 3
 
 /obj/structure/girder/attack_generic(var/mob/user, var/damage, var/attack_message = "smashes apart", var/wallbreaker)
 	if(!damage || !wallbreaker)
@@ -251,7 +253,7 @@
 	reinforcing = 0
 
 /obj/structure/girder/proc/dismantle()
-	new /obj/item/stack/material/steel(src.loc, 5)
+	new /obj/item/stack/material/steel(src.loc, dismantle_materials_count)
 	qdel(src)
 
 /obj/structure/girder/attack_hand(mob/user as mob)

--- a/code/game/objects/structures/low_wall.dm
+++ b/code/game/objects/structures/low_wall.dm
@@ -431,6 +431,7 @@
 	playsound(src, 'sound/items/Welder.ogg', 100, 1)
 	if(!no_product)
 		new /obj/structure/girder/low(loc)
+		new /obj/item/stack/material/steel(loc, 1)
 
 	clear_plants()
 	update_connections(1)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -159,7 +159,7 @@
 	update_icon()
 
 /obj/structure/bed/proc/dismantle()
-	material.place_sheet(get_turf(src))
+	new material(loc, 5)
 	if(padding_material)
 		padding_material.place_sheet(get_turf(src))
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -291,11 +291,10 @@
 						return
 					if(I.use_tool(user, src, WORKTIME_FAST, tool_type, FAILCHANCE_EASY, required_stat = STAT_MEC))
 						visible_message(SPAN_NOTICE("[user] dismantles \the [src]."))
-						if(dir == SOUTHWEST)
-							var/obj/item/stack/material/mats = new glasstype(loc)
-							mats.amount = is_fulltile() ? 4 : 2
+						if(is_fulltile())
+							new glasstype(loc, 6)
 						else
-							new glasstype(loc)
+							new glasstype(loc, 1)
 						qdel(src)
 						return
 				return 1 //No whacking the window with tools unless harm intent

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -46,7 +46,7 @@
 		user << SPAN_NOTICE("You begin dismantling \the [src].")
 		if(do_after(user,25,src))
 			user << SPAN_NOTICE("You dismantle \the [src].")
-			new /obj/item/stack/material/wood(get_turf(src), amount = 3)
+			new /obj/item/stack/material/wood(get_turf(src), 10)
 			for(var/obj/item/weapon/book/b in contents)
 				b.loc = (get_turf(src))
 			qdel(src)


### PR DESCRIPTION
All items under furniture crafting tab return their crafting cost when properly dismantled, except for wooden barricade.

Shelf crafting cost lowered to 2 metal sheets to equal rack crafting cost, since they are identical objects in all but sprite.

Full windows and low walls now return their full cost when properly dismantled.