### PR TITLE
Optimizes machines and processing subsystems

### DIFF
--- a/code/__defines/MC.dm
+++ b/code/__defines/MC.dm
@@ -32,6 +32,7 @@ if (Datum.is_processing) {\
 
 #define STOP_PROCESSING(Processor, Datum) \
 if(Datum.is_processing) {\
+	Processor.stopProcessingWrapper(Datum);\
 	if(Processor.processing.Remove(Datum)) {\
 		Datum.is_processing = null;\
 	} else {\

--- a/code/__marcos/subsystems.dm
+++ b/code/__marcos/subsystems.dm
@@ -15,6 +15,7 @@ if (Datum.is_processing) {\
 
 #define STOP_PROCESSING_IN_LIST(Datum, List) \
 if(Datum.is_processing) {\
+	SSmachines.stopProcessingWrapper(Datum, SSmachines.List);\
 	if(SSmachines.List.Remove(Datum)) {\
 		Datum.is_processing = null;\
 	} else {\

--- a/code/controllers/subsystems.dm
+++ b/code/controllers/subsystems.dm
@@ -43,6 +43,9 @@
 /datum/controller/subsystem/proc/PreInit()
 	return
 
+/datum/controller/subsystem/proc/stopProcessingWrapper() //called before a thing stops being processed
+	return
+
 //This is used so the mc knows when the subsystem sleeps. do not override.
 /datum/controller/subsystem/proc/ignite(resumed = 0)
 	set waitfor = 0


### PR DESCRIPTION
Instead of copying the entire processing list, machines and processing subsystems now use last position in their list to resume paused runs. A wrapper now moves the last position in list as needed when an object stops being processed.

This drastically reduces overhead for processing lists for these subsystems.