### PR TITLE
Fixes faulty memoization runtime in wall_icon

### DIFF
--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -47,8 +47,7 @@
 	if(!material)
 		return
 
-	if(!damage_overlays[1]) //list hasn't been populated
-		generate_overlays()
+	var/list/damage_overlays = getOverlays()
 
 	overlays.Cut()
 	var/image/I
@@ -93,14 +92,23 @@
 		overlays += damage_overlays[overlay]
 	return
 
-/turf/simulated/wall/proc/generate_overlays()
-	var/alpha_inc = 256 / damage_overlays.len
+/turf/simulated/wall/proc/getOverlays()
+	var/static/list/damage_overlays
+	if (damage_overlays)
+		return damage_overlays
 
-	for(var/i = 1; i <= damage_overlays.len; i++)
+	damage_overlays = new
+
+	var/overlayCount = 16
+	var/alpha_inc = 256 / overlayCount
+
+	for(var/i = 1; i <= overlayCount; i++)
 		var/image/img = image(icon = 'icons/turf/walls.dmi', icon_state = "overlay_damage")
 		img.blend_mode = BLEND_MULTIPLY
 		img.alpha = (i * alpha_inc) - 1
-		damage_overlays[i] = img
+		damage_overlays.Add(img)
+
+	return damage_overlays
 
 
 /turf/simulated/wall/proc/update_connections(propagate = 0)

--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -47,8 +47,6 @@
 	if(!material)
 		return
 
-	var/list/damage_overlays = getOverlays()
-
 	overlays.Cut()
 	var/image/I
 
@@ -91,25 +89,6 @@
 
 		overlays += damage_overlays[overlay]
 	return
-
-/turf/simulated/wall/proc/getOverlays()
-	var/static/list/damage_overlays
-	if (damage_overlays)
-		return damage_overlays
-
-	damage_overlays = new
-
-	var/overlayCount = 16
-	var/alpha_inc = 256 / overlayCount
-
-	for(var/i = 1; i <= overlayCount; i++)
-		var/image/img = image(icon = 'icons/turf/walls.dmi', icon_state = "overlay_damage")
-		img.blend_mode = BLEND_MULTIPLY
-		img.alpha = (i * alpha_inc) - 1
-		damage_overlays.Add(img)
-
-	return damage_overlays
-
 
 /turf/simulated/wall/proc/update_connections(propagate = 0)
 	if(!material)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -21,6 +21,7 @@
 	var/construction_stage
 	var/hitsound = 'sound/weapons/Genhit.ogg'
 	var/list/wall_connections = list("0", "0", "0", "0")
+	var/static/list/damage_overlays
 
 // Walls always hide the stuff below them.
 /turf/simulated/wall/levelupdate()
@@ -28,6 +29,18 @@
 		O.hide(1)
 
 /turf/simulated/wall/New(var/newloc, var/materialtype, var/rmaterialtype)
+	if (!damage_overlays)
+		damage_overlays = new
+
+		var/overlayCount = 16
+		var/alpha_inc = 256 / overlayCount
+
+		for(var/i = 1; i <= overlayCount; i++)
+			var/image/img = image(icon = 'icons/turf/walls.dmi', icon_state = "overlay_damage")
+			img.blend_mode = BLEND_MULTIPLY
+			img.alpha = (i * alpha_inc) - 1
+			damage_overlays.Add(img)
+
 	..(newloc)
 	icon_state = "blank"
 	if(!materialtype)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -13,7 +13,6 @@
 	var/ricochet_id = 0
 	var/damage = 0
 	var/damage_overlay = 0
-	var/global/damage_overlays[16]
 	var/active
 	var/can_open = 0
 	var/material/material


### PR DESCRIPTION
Fixes https://github.com/discordia-space/CEV-Eris/issues/2145

The only other cause for this runtime could be that `overlays.Cut()` is somehow responsible, but I cannot imagine how.