### PR TITLE
Wall Process Fix

### DIFF
--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -35,6 +35,11 @@
 	else if(material.opacity < 0.5 && opacity)
 		set_light(0)
 
+	//IF we have a radioactive material on our walls then we need to process
+	var/total_radiation = material.radioactivity + (reinf_material ? reinf_material.radioactivity / 2 : 0)
+	if(total_radiation)
+		START_PROCESSING(SSturf, src) //Used for radiation.
+
 	//Update will be false at roundstart
 	if (update)
 		update_connections(1)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -53,7 +53,6 @@
 
 
 /turf/simulated/wall/Initialize(var/mapload)
-	START_PROCESSING(SSturf, src) //Used for radiation.
 	..()
 
 	if (mapload)


### PR DESCRIPTION
Moves the start of wall processing into set material, and only starts if we have a radioactive material

radiation is all wall processing is used for. previously every wall started processing for at least one tick