### PR TITLE
Cyberplant colors

### DIFF
--- a/code/game/objects/structures/cyberplants.dm
+++ b/code/game/objects/structures/cyberplants.dm
@@ -3,11 +3,12 @@
 	desc = "One of those famous Aster's holoplants! Add to your Space a bit of the comfort from old Earth, by buying this blue buddy. A nuclear battery and a rugged case guarantee that your flower will survive journey to another galaxy, and variety of plant types won't let you to get bored along the way!"
 	icon = 'icons/obj/cyberplants.dmi'
 	icon_state = "holopot"
-	light_color = "#3C94C5"
-	var/autostripes = TRUE
+	light_color = rgb(60, 148, 197)
+	var/brightness_on = 4
 	var/emaged = FALSE
 	var/interference = FALSE
 	var/icon/plant = null
+	var/plant_color = rgb(60, 148, 197)
 	var/global/list/possible_plants = list(
 		"plant-1",
 		"plant-10",
@@ -16,44 +17,136 @@
 		"plant-13",
 		"plant-xmas",
 	)
+	var/global/list/possible_colors = list(
+		rgb(60, 148, 197),
+		COLOR_NAVY_BLUE,
+		COLOR_GREEN,
+		COLOR_DARK_GRAY,
+		COLOR_MAROON,
+		COLOR_PURPLE,
+		COLOR_VIOLET,
+		COLOR_OLIVE,
+		COLOR_BROWN_ORANGE,
+		COLOR_DARK_ORANGE,
+		COLOR_SEDONA,
+		COLOR_DARK_BROWN,
+		COLOR_BLUE,
+		COLOR_DEEP_SKY_BLUE,
+		COLOR_LIME,
+		COLOR_CYAN,
+		COLOR_TEAL,
+		COLOR_RED,
+		COLOR_PINK,
+		COLOR_ORANGE,
+		COLOR_YELLOW,
+		COLOR_BROWN,
+		COLOR_SUN,
+		COLOR_BLUE_LIGHT,
+		COLOR_RED_LIGHT,
+		COLOR_BEIGE,
+		COLOR_LUMINOL,
+		COLOR_SILVER,
+		COLOR_WHITE,
+		COLOR_NT_RED,
+		COLOR_BOTTLE_GREEN,
+		COLOR_GUNMETAL,
+		COLOR_CHESTNUT,
+		COLOR_BEASTY_BROWN,
+		COLOR_WHEAT,
+		COLOR_CYAN_BLUE,
+		COLOR_LIGHT_CYAN,
+		COLOR_PAKISTAN_GREEN,
+		COLOR_HULL,
+		COLOR_AMBER,
+		COLOR_COMMAND_BLUE,
+		COLOR_SKY_BLUE,
+		COLOR_CIVIE_GREEN,
+		COLOR_TITANIUM,
+		COLOR_DARK_GUNMETAL,
+	)
 
 /obj/structure/cyberplant/New()
 	..()
-	plant = prepare_icon(plant)
+	change_plant(plant)
+	change_color()
+
+	update_icon()
+
+	set_light(brightness_on, brightness_on/2)
+
+/obj/structure/cyberplant/update_icon()
+	..()
+	overlays.Cut()
+	if (!plant)
+		return
+
 	overlays += plant
-	set_light(3)
+
+/obj/structure/cyberplant/proc/change_plant(var/state)
+	plant = prepare_icon(state)
+
+/obj/structure/cyberplant/proc/change_color(var/color)
+	if (!plant)
+		return
+
+	if(!color)
+		color = pick(possible_colors)
+
+	light_color = color
+	plant.ColorTone(color)
+
+/obj/structure/cyberplant/attack_hand(var/mob/user)
+	if(!interference)
+		change_plant()
+		update_icon()
 
 /obj/structure/cyberplant/proc/prepare_icon(var/state)
 	if(!state)
 		state = pick(possible_plants)
-	if(autostripes)
-		var/plant_icon = icon(icon, state)
-		return getHologramIcon(plant_icon, 0)
-	else
-		return image(icon, state)
+
+	var/plant_icon = icon(icon, state)
+	return getHologramIcon(plant_icon, 0)
 
 /obj/structure/cyberplant/emag_act()
 	if(emaged)
 		return
 
 	emaged = TRUE
-	overlays -= plant
-	plant = prepare_icon("emaged")
-	overlays += plant
+	plant = change_plant("emaged")
 
-/obj/structure/cyberplant/Crossed(var/mob/living/L)
-	if(!interference && istype(L))
+	update_icon()
+
+/obj/structure/cyberplant/proc/doInterference()
+	if(!interference)
 		interference = TRUE
 		spawn(0)
+			if (!src || QDELETED(src))
+				return
+
 			overlays.Cut()
-			set_light(0)
+			set_light(0, 0)
 			sleep(3)
+			if (!src || QDELETED(src))
+				return
+
 			overlays += plant
-			set_light(3)
+			set_light(brightness_on, brightness_on/2)
 			sleep(3)
+			if (!src || QDELETED(src))
+				return
+
 			overlays -= plant
-			set_light(0)
+			set_light(0, 0)
 			sleep(3)
-			overlays += plant
-			set_light(3)
+			if (!src || QDELETED(src))
+				return
+
+			change_color()
+			set_light(brightness_on, brightness_on/2)
+			update_icon()
+
 			interference = FALSE
+
+/obj/structure/cyberplant/Crossed(var/mob/living/L)
+	if (istype(L))
+		doInterference()


### PR DESCRIPTION
Cyberplants now pick a random color from a predetermined list when spawned or when walked over.
Clicking cyberplants with empty hand randomizes what type of plant is being displayed.

Fixes cyberplants not emitting any light. Light is now based on plant color.