### PR TITLE
Space Equipping Fix

### DIFF
--- a/code/game/objects/items/_inventory.dm
+++ b/code/game/objects/items/_inventory.dm
@@ -63,7 +63,7 @@
 
 /obj/item/proc/is_worn()
 	//If equip_slot is zero then it has never been equipped
-	if (!equip_slot)
+	if (equip_slot == slot_none)
 		return FALSE
 
 	if (ismob(loc))
@@ -72,7 +72,7 @@
 
 /obj/item/proc/is_held()
 	//If equip_slot is zero then it has never been equipped
-	if (!equip_slot)
+	if (equip_slot == slot_none)
 		return FALSE
 
 	if (ismob(loc))

--- a/code/game/objects/items/_inventory.dm
+++ b/code/game/objects/items/_inventory.dm
@@ -62,11 +62,19 @@
 
 
 /obj/item/proc/is_worn()
+	//If equip_slot is zero then it has never been equipped
+	if (!equip_slot)
+		return FALSE
+
 	if (ismob(loc))
 		return !(equip_slot in unworn_slots)
 
 
 /obj/item/proc/is_held()
+	//If equip_slot is zero then it has never been equipped
+	if (!equip_slot)
+		return FALSE
+
 	if (ismob(loc))
 		return equip_slot in list(slot_l_hand, slot_r_hand,slot_robot_equip_1,slot_robot_equip_2,slot_robot_equip_3)
 


### PR DESCRIPTION
Turns out the isworn/isheld procs were flawed. 
By setting them to check for a zero equip slot, all problems are solved. The equip slot is always zero until after the first time an item is successfully equipped