### PR TITLE
Makes blob not spawn in protected areas

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -122,6 +122,7 @@ area/space/atmosalert()
 	return
 
 /area/turret_protected/
+	flags = AREA_FLAG_CRITICAL
 
 /area/arrival
 	requires_power = 0
@@ -2311,7 +2312,6 @@ area/space/atmosalert()
 	name = "\improper AI Upload Chamber"
 	icon_state = "ai_upload"
 	ambience = list('sound/ambience/ambimalf.ogg')
-	flags = AREA_FLAG_CRITICAL
 
 /area/turret_protected/ai_upload_foyer
 	name = "AI Upload Access"

--- a/code/game/gamemodes/events/blob.dm
+++ b/code/game/gamemodes/events/blob.dm
@@ -28,7 +28,7 @@
 	level_seven_announcement()
 
 /datum/event/blob/start()
-	var/area/A = random_ship_area(TRUE)
+	var/area/A = random_ship_area(filter_players = TRUE, filter_critical = TRUE)
 	var/turf/T = A.random_space()
 	if(!T)
 		log_and_message_admins("Blob failed to find a viable turf.")


### PR DESCRIPTION
All `turret_protected` areas are now considered critical for events.