### PR TITLE
Plant Nerfing

### DIFF
--- a/code/game/gamemodes/events/spacevine.dm
+++ b/code/game/gamemodes/events/spacevine.dm
@@ -17,7 +17,7 @@
 /var/global/spacevines_spawned = 0
 
 /datum/event/spacevine
-	announceWhen	= 60
+	announceWhen	= 100
 
 /datum/event/spacevine/start()
 

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -30,7 +30,7 @@
 	mouse_opacity = 2
 
 	var/health = 10
-	var/max_health = 100
+	var/max_health = 60
 	var/growth_threshold = 0
 	var/growth_type = 0
 	var/max_growth = 0

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -239,7 +239,7 @@
 		update_icon()
 
 /obj/effect/plant/proc/is_mature()
-	return (health >= (max_health/3) && world.time > mature_time)
+	return (health >= (max_health*0.8) && world.time > mature_time)
 
 
 /obj/effect/plant/examine()

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -94,7 +94,7 @@
 		if (D)
 			health += rand(0,1.5)
 		else
-			health += rand(2,3.5)
+			health += rand(2.5,4)
 		refresh_icon()
 		if(health > max_health)
 			health = max_health
@@ -215,12 +215,15 @@
 
 /obj/effect/plant/proc/die_off()
 	// Kill off our plant.
-	if(plant) plant.die()
+	if(plant)
+		plant.die()
 
 	//Nearby plants suffer a bit too, so they won't immediately grow back
-	for (var/obj/effect/plant/P in orange(1, src))
-		P.health -= (P.max_health * 0.3)
-		P.check_health()
+	spawn(2)
+		if (!QDELETED(src))
+			for (var/obj/effect/plant/P in orange(1, src))
+				P.health -= (P.max_health * 0.5)
+				P.check_health()
 
 	// This turf is clear now, let our buddies know.
 	for(var/turf/simulated/check_turf in get_cardinal_neighbors())
@@ -229,6 +232,8 @@
 		for(var/obj/effect/plant/neighbor in check_turf.contents)
 			neighbor.neighbors |= check_turf
 			plant_controller.add_plant(neighbor)
-	spawn(1) if(src) qdel(src)
+
+	spawn(1)
+		qdel(src)
 
 #undef NEIGHBOR_REFRESH_TIME

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -92,9 +92,9 @@
 		//Plants can grow through closed airlocks, but more slowly, since they have to force metal to make space
 		var/obj/machinery/door/D = (locate(/obj/machinery/door) in loc)
 		if (D)
-			health += rand(0,2)
+			health += rand(0,1.5)
 		else
-			health += rand(3,5)
+			health += rand(2,3.5)
 		refresh_icon()
 		if(health > max_health)
 			health = max_health
@@ -216,6 +216,12 @@
 /obj/effect/plant/proc/die_off()
 	// Kill off our plant.
 	if(plant) plant.die()
+
+	//Nearby plants suffer a bit too, so they won't immediately grow back
+	for (var/obj/effect/plant/P in orange(1, src))
+		P.health -= (P.max_health * 0.3)
+		P.check_health()
+
 	// This turf is clear now, let our buddies know.
 	for(var/turf/simulated/check_turf in get_cardinal_neighbors())
 		if(!istype(check_turf))

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -72,7 +72,7 @@
 			tool_type = QUALITY_WELDING
 
 		if(tool_type)
-			if(W.use_tool(user, src, WORKTIME_FAST*0.75, tool_type, FAILCHANCE_VERY_EASY, required_stat = STAT_ROB))
+			if(W.use_tool(user, src, WORKTIME_FAST*0.65, tool_type, FAILCHANCE_VERY_EASY, required_stat = STAT_ROB))
 				user.visible_message(SPAN_DANGER("[user] cuts down the [src]."), SPAN_DANGER("You cut down the [src]."))
 				die_off()
 				return

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -72,7 +72,7 @@
 			tool_type = QUALITY_WELDING
 
 		if(tool_type)
-			if(W.use_tool(user, src, WORKTIME_FAST, tool_type, FAILCHANCE_VERY_EASY, required_stat = STAT_ROB))
+			if(W.use_tool(user, src, WORKTIME_FAST*0.75, tool_type, FAILCHANCE_VERY_EASY, required_stat = STAT_ROB))
 				user.visible_message(SPAN_DANGER("[user] cuts down the [src]."), SPAN_DANGER("You cut down the [src]."))
 				die_off()
 				return


### PR DESCRIPTION
Makes plants a little more manageable
Reduces their health
reduces regen
Reduces cutting time
When a plant dies, nearby neighbors now take some aoe damage
Raised minimum health threshold to expand, should significantly slow down expansion
adjusted announcement time to let it get started