### PR TITLE
Antag Weighting

### DIFF
--- a/code/game/gamemodes/roleset/excelsior.dm
+++ b/code/game/gamemodes/roleset/excelsior.dm
@@ -7,7 +7,7 @@
 	//max_cost = 20
 
 	base_quantity = 2 //They're a group antag, we want a few of em
-	scaling_threshold = 10
+	scaling_threshold = 8
 
 	req_crew = 10
 	req_heads = 1

--- a/code/game/gamemodes/roleset/simple.dm
+++ b/code/game/gamemodes/roleset/simple.dm
@@ -23,7 +23,7 @@
 	role_id = ROLE_INQUISITOR
 	weight = 0.2
 	req_crew = 7
-	cost = -30 //This is an antitag, it has a negative cost to allow more antags to exist
+	event_pools = list(EVENT_LEVEL_ROLESET = -30) //This is an antitag, it has a negative cost to allow more antags to exist
 
 /datum/storyevent/roleset/inquisitor/get_special_weight(var/new_weight)
 	var/c_count = 0
@@ -49,7 +49,7 @@
 	role_id = ROLE_MARSHAL
 	weight = 0.2
 	req_crew = 20
-	cost = -30 //This is an antitag, it has a negative cost to allow more antags to exist
+	event_pools = list(EVENT_LEVEL_ROLESET = -30) //This is an antitag, it has a negative cost to allow more antags to exist
 
 /datum/storyevent/roleset/marshal/get_special_weight(var/new_weight)
 	var/a_count = 0

--- a/code/game/gamemodes/roleset/simple.dm
+++ b/code/game/gamemodes/roleset/simple.dm
@@ -4,7 +4,6 @@
 	role_id = ROLE_BORER
 	weight = 0.4
 
-	req_crew = 15
 
 	base_quantity = 2
 	scaling_threshold = 15
@@ -22,7 +21,7 @@
 	name = "inquisitor"
 	role_id = ROLE_INQUISITOR
 	weight = 0.2
-	req_crew = 7
+	req_crew = 10
 	event_pools = list(EVENT_LEVEL_ROLESET = -30) //This is an antitag, it has a negative cost to allow more antags to exist
 
 /datum/storyevent/roleset/inquisitor/get_special_weight(var/new_weight)
@@ -48,7 +47,7 @@
 	name = "marshal"
 	role_id = ROLE_MARSHAL
 	weight = 0.2
-	req_crew = 20
+	req_crew = 10
 	event_pools = list(EVENT_LEVEL_ROLESET = -30) //This is an antitag, it has a negative cost to allow more antags to exist
 
 /datum/storyevent/roleset/marshal/get_special_weight(var/new_weight)
@@ -65,6 +64,5 @@
 	name = "changeling"
 	role_id = ROLE_CHANGELING
 
-	req_crew = 7
 	base_quantity = 2
 	scaling_threshold = 15

--- a/code/game/gamemodes/roleset/simple.dm
+++ b/code/game/gamemodes/roleset/simple.dm
@@ -2,7 +2,7 @@
 	id = "borer"
 	name = "cortical borers"
 	role_id = ROLE_BORER
-	weight = 0.5
+	weight = 0.4
 
 	req_crew = 15
 
@@ -14,7 +14,7 @@
 	id = "traitor"
 	name = "traitor"
 	role_id = ROLE_TRAITOR
-	weight = 1
+	weight = 1.2
 	scaling_threshold = 10
 
 /datum/storyevent/roleset/inquisitor
@@ -23,6 +23,7 @@
 	role_id = ROLE_INQUISITOR
 	weight = 0.2
 	req_crew = 7
+	cost = -30 //This is an antitag, it has a negative cost to allow more antags to exist
 
 /datum/storyevent/roleset/inquisitor/get_special_weight(var/new_weight)
 	var/c_count = 0
@@ -46,7 +47,9 @@
 	id = "marshal"
 	name = "marshal"
 	role_id = ROLE_MARSHAL
+	weight = 0.2
 	req_crew = 20
+	cost = -30 //This is an antitag, it has a negative cost to allow more antags to exist
 
 /datum/storyevent/roleset/marshal/get_special_weight(var/new_weight)
 	var/a_count = 0
@@ -54,10 +57,8 @@
 		if(A.owner && A.is_active() && !A.is_dead())
 			a_count++
 
-	var/maxc = (a_count > 3) ? a_count : 3
-	new_weight *= weight_mult(weight,maxc,0,maxc)
+	return new_weight * max(a_count, 1)
 
-	return new_weight
 
 /datum/storyevent/roleset/changeling
 	id = "changeling"

--- a/code/game/gamemodes/storyevent.dm
+++ b/code/game/gamemodes/storyevent.dm
@@ -141,7 +141,7 @@
 	if(req < 0)
 		return 1
 	if(val < min || val > max)
-		return 0
+		return 1
 	var/mod = (min+max/2)**2
 	return max(mod-(abs(val-req)**2),0)/mod
 


### PR DESCRIPTION
Fixes the cost of our antitags - marshal and inquisitor. They now have a negative cost, as they were supposed to, meaning that normal antags will usually spawn alongside them

Tweaked weights of a few antags, notably increased traitor weight, its tried and tested, the bread and butter of antags

Reduced marshal initial weight, but tweaked their weight to properly scale with quantity of antags

Removes the crew weight requirements from most non-group antags, it was just nuking their weighting to hell and making changelings really rare