### PR TITLE
Event Threat Health balancing

### DIFF
--- a/code/game/gamemodes/events/blob.dm
+++ b/code/game/gamemodes/events/blob.dm
@@ -68,9 +68,10 @@
 	anchored = 1
 	mouse_opacity = 2
 
-	var/maxHealth = 30
+	var/maxHealth = 25
 	var/health = 1
-	var/brute_resist = 1.3
+	var/health_regen = 1.8
+	var/brute_resist = 1.25
 	var/fire_resist = 0.75
 	var/expandType = /obj/effect/blob
 
@@ -191,7 +192,7 @@
 
 /obj/effect/blob/proc/regen()
 	if (!(QDELETED(core)))
-		health = min(health + 2, maxHealth)
+		health = min(health + health_regen, maxHealth)
 	else
 		core = null
 		//When the core is gone, the blob starts dying
@@ -371,7 +372,7 @@
 
 	//We'll occasionally spawn shield tiles instead of normal blobs
 	var/obj/effect/blob/child
-	if (prob(5))
+	if (prob(6))
 		child = new /obj/effect/blob/shield(loc, src)
 	else
 		child = new expandType(loc, src)
@@ -548,6 +549,7 @@
 	desc = "Some blob creature thingy"
 	maxHealth = 180
 	health = 180
+	health_regen = 2
 	brute_resist = 2
 	fire_resist = 1
 	density = TRUE

--- a/code/modules/mob/living/carbon/metroid/life.dm
+++ b/code/modules/mob/living/carbon/metroid/life.dm
@@ -99,7 +99,7 @@
 	if (halloss)
 		halloss = 0
 
-	if(prob(30))
+	if(prob(25))
 		adjustOxyLoss(-1)
 		adjustToxLoss(-1)
 		adjustFireLoss(-1)

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -7,8 +7,8 @@
 	speak_emote = list("chirps")
 
 	layer = 5
-	maxHealth = 150
-	health = 150
+	maxHealth = 120
+	health = 120
 	gender = NEUTER
 
 	update_icon = 0

--- a/code/modules/mob/living/carbon/metroid/powers.dm
+++ b/code/modules/mob/living/carbon/metroid/powers.dm
@@ -68,10 +68,10 @@
 
 			gain_nutrition(rand(20,25))
 
-			adjustOxyLoss(-10) //Heal yourself
-			adjustBruteLoss(-10)
-			adjustFireLoss(-10)
-			adjustCloneLoss(-10)
+			adjustOxyLoss(-8) //Heal yourself
+			adjustBruteLoss(-8)
+			adjustFireLoss(-8)
+			adjustCloneLoss(-8)
 			updatehealth()
 			if(Victim)
 				Victim.updatehealth()
@@ -117,7 +117,7 @@
 	if(!is_adult)
 		if(amount_grown >= 10)
 			is_adult = 1
-			maxHealth = 200
+			maxHealth = 180
 			amount_grown = 0
 			regenerate_icons()
 			name = text("[colour] [is_adult ? "adult" : "baby"] slime ([number])")

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
@@ -7,8 +7,8 @@
 
 	mob_size = MOB_MEDIUM
 
-	maxHealth = 200
-	health = 200
+	maxHealth = 170
+	health = 170
 
 	attack_sound = 'sound/weapons/spiderlunge.ogg'
 	speak_emote = list("chitters")
@@ -21,8 +21,8 @@
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/xenomeat
 	stop_automated_movement_when_pulled = 0
 
-	melee_damage_lower = 15
-	melee_damage_upper = 20
+	melee_damage_lower = 14
+	melee_damage_upper = 19
 
 	min_breath_required_type = 3
 	min_air_pressure = 15 //below this, brute damage is dealt

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
@@ -2,8 +2,8 @@
 /mob/living/carbon/superior_animal/giant_spider/hunter
 	desc = "Furry and black, it makes you shudder to look at it. This one has sparkling purple eyes."
 	icon_state = "hunter"
-	maxHealth = 120
-	health = 120
+	maxHealth = 100
+	health = 100
 	melee_damage_lower = 10
 	melee_damage_upper = 20
 	poison_per_bite = 5

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
@@ -11,7 +11,7 @@
 	health = 40
 	melee_damage_lower = 5
 	melee_damage_upper = 10
-	poison_per_bite = 10
+	poison_per_bite = 2
 	var/atom/cocoon_target
 	poison_type = "stoxin"
 	var/fed = 0


### PR DESCRIPTION
This PR slightly reduces the power of three main event threats. Generally numerical adjustments are in the range of 15-25%, small steps. With one exception, the nurse spiders.

Generally, all three of these threats have their own gimmicks, of which being tanky is not an intrinsic part. These changes make them a bit more manageable without compromising their unique points

Spiders:
Max health reduced on the two tankier classes

Nurse spider toxin per bite greatly, since this was never really balanced before. 
Sleep toxin causes the victim to fall asleep with a dose of 5+ units. Nurses now inject 2 per bite, meaning they need three attacks to knock someone out. Fewer hits will just cause slowness and drowsines


Slimes:
Reduced health regen (including from feeeding) and max health of baby and adult classes

Blobs: 
Reduced health, resistance and regen of the normal blob parts. Larger Shield blobs are unchanged