### PR TITLE
Blob QOL Tweaks

### DIFF
--- a/code/game/gamemodes/events/blob.dm
+++ b/code/game/gamemodes/events/blob.dm
@@ -72,7 +72,7 @@
 	var/health = 1
 	var/health_regen = 1.8
 	var/brute_resist = 1.25
-	var/fire_resist = 0.75
+	var/fire_resist = 0.6
 	var/expandType = /obj/effect/blob
 
 	//We will periodically update and track neighbors in two lists:
@@ -481,21 +481,34 @@
 /*******************
 	BLOB DEFENSE
 ********************/
+
+//Bullets which hit a blob will keep going on through if they kill it
 /obj/effect/blob/bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj)
 		return
 
+	var/absorbed_damage //The amount of damage that will be subtracted from the projectile
+	var/taken_damage //The amount of damage the blob will recieve
 	switch(Proj.damage_type)
 		if(BRUTE)
-			take_damage(Proj.damage / brute_resist)
+			absorbed_damage = min(health * brute_resist, Proj.damage)
+			taken_damage = (Proj.damage / brute_resist)
 		if(BURN)
-			take_damage(Proj.damage / fire_resist)
-	return 0
+			absorbed_damage = min(health * fire_resist, Proj.damage)
+			taken_damage= (Proj.damage / fire_resist)
+
+	spawn()
+		take_damage(taken_damage)
+	Proj.damage -= absorbed_damage
+	if (Proj.damage <= 0)
+		return 0
+	else
+		return PROJECTILE_CONTINUE
 
 /obj/effect/blob/attackby(var/obj/item/weapon/W, var/mob/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if(W.force && !(W.flags & NOBLUDGEON))
-		visible_message("<span class='danger'>\The [src] has been attacked with \the [W][(user ? " by [user]." : ".")]</span>")
+		user.do_attack_animation(src, TRUE)
 		var/damage = 0
 		switch(W.damtype)
 			if("fire")


### PR DESCRIPTION
Removed textspam from attacking blobs. Now you do a proper visual attack animation and no visible message spam. There's more than enough feedback to see what's going on, without a thousand entries of "<Person> has hit the blob!"

Projectiles which kill a blob will now keep going until they run out of damage.  So far i've managed to kill three in a line with a laser cannon, but maybe someone with an emitter can beat that score!