### PR TITLE
The Most Serene Mausoleum

### DIFF
--- a/code/__defines/callbacks.dm
+++ b/code/__defines/callbacks.dm
@@ -3,4 +3,3 @@
 #define CALLBACK new /datum/callback
 #define INVOKE_ASYNC ImmediateInvokeAsync
 
-#define QDEL_IN(item, time) addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, item), time, TIMER_STOPPABLE)

--- a/code/__defines/callbacks.dm
+++ b/code/__defines/callbacks.dm
@@ -2,3 +2,5 @@
 
 #define CALLBACK new /datum/callback
 #define INVOKE_ASYNC ImmediateInvokeAsync
+
+#define QDEL_IN(item, time) addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, item), time, TIMER_STOPPABLE)

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -50,6 +50,11 @@
 
 #define isdrone(A) istype(A, /mob/living/silicon/robot/drone)
 
+//-----------------Objects
+#define isitem(A) istype(A, /obj/item)
+
+#define istool(A) istype(A, /obj/item/weapon/tool)
+
 #define isWrench(A) istype(A, /obj/item/weapon/tool/wrench)
 
 #define isWelder(A) istype(A, /obj/item/weapon/tool/weldingtool)

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -175,7 +175,7 @@
 		time_to_finish = 0
 
 	var/obj/item/weapon/tool/T
-	if(istype(src, /obj/item/weapon/tool))
+	if(istool(src))
 		T = src
 		if(!T.check_tool_effects(user, time_to_finish))
 			return TOOL_USE_CANCEL
@@ -589,7 +589,7 @@
 
 	if (has_quality(QUALITY_ADHESIVE) && proximity)
 		//Tape can be used to repair other tools
-		if (istype(O, /obj/item/weapon/tool))
+		if (istool(O))
 			var/obj/item/weapon/tool/T = O
 			if (T.unreliability)
 				user.visible_message(SPAN_NOTICE("[user] begins repairing \the [O] with the [src]!"))

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -70,13 +70,12 @@
 //No network connection. Robots can physically open it, but not remotely
 //AI can't open it at all, anything inside a morgue drawer is hidden from the AI
 /obj/structure/morgue/attack_ai(var/mob/living/user)
-	if (user in range(1, src))
+	if(Adjacent(user))
 		toggle(user)
 
-/obj/structure/morgue/attack_hand(mob/user as mob)
+/obj/structure/morgue/attack_hand(var/mob/living/user)
 	toggle(user)
 	add_fingerprint(user)
-	return
 
 /obj/structure/morgue/proc/toggle(var/mob/living/user)
 	if(world.time < next_toggle)
@@ -104,17 +103,16 @@
 	connected = new /obj/structure/m_tray( loc )
 	connected.connected = src
 	connected.set_dir(dir)
-	for(var/atom/movable/A as mob|obj in src)
-		if (!A.anchored)
-			A.forceMove(loc)
+	for(var/atom/movable/A in src)
+		A.forceMove(loc)
 
 	sleep(1)//Things need to exist for some time, in order to animate correctly
 
 	var/glidesize = DELAY2GLIDESIZE(5)
-	connected.forceMove(T, glidesize)
+	connected.forceMove(T, glide_size_override=glidesize)
 	for(var/atom/movable/A in loc)
 		if (!A.anchored)
-			A.forceMove(T,glidesize)
+			A.forceMove(T,glide_size_override=glidesize)
 
 
 
@@ -126,9 +124,9 @@
 	var/glidesize = DELAY2GLIDESIZE(5)
 	for(var/atom/movable/A in connected.loc)
 		if (!A.anchored)
-			A.forceMove(loc,glidesize)
+			A.forceMove(loc,glide_size_override=glidesize)
 
-	connected.forceMove(loc,glidesize)
+	connected.forceMove(loc,glide_size_override=glidesize)
 	QDEL_IN(connected, 5)
 	sleep(5)//Give them time to slide in before storing
 	for(var/atom/movable/A in loc)


### PR DESCRIPTION
Refactors morgue storage units a fair bit:

![slide](https://imgur.com/24vz4bY.gif)
Morgue drawers and their contents are now fully animated, sliding in and out

Morgue units now have an upper limit on storage capacity. Shouldn't really be an issue as long as you use bodybags properly. Intended to prevent issues like sliding a thousand sheets of paper in and out, prevents possibility of spam crashing server

Minimum cooldown of 1.5 seconds added to toggling morgue drawer, again for spam protection.

Lots of little bugs and wierdness fixed
fixes #2316 