### PR TITLE
Ritual Refactor

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -44,6 +44,11 @@ var/global/list/poster_designs = list()
 // Uplinks
 var/list/obj/item/device/uplink/world_uplinks = list()
 
+
+//Neotheology
+var/global/list/all_rituals = list() //List of all rituals
+var/list/global_ritual_cooldowns = list() // internal lists. Use ritual's cooldown_category
+
 //Preferences stuff
 	//Bodybuilds
 var/global/list/male_body_builds = list()
@@ -124,6 +129,7 @@ var/global/list/unworn_slots = list(slot_l_hand,slot_r_hand, slot_l_store, slot_
 //////////////////////////
 
 /proc/makeDatumRefLists()
+
 	var/list/paths
 
 	//Bodybuilds
@@ -214,19 +220,19 @@ var/global/list/unworn_slots = list(slot_l_hand,slot_r_hand, slot_l_store, slot_
 		var/datum/hud/C = new T
 		global.HUDdatums[C.name] = C
 
+	//Rituals
+	paths = typesof(/datum/ritual)
+	for(var/T in paths)
+		var/datum/ritual/R = new T
+
+		//Rituals which are just categories for subclasses will have a null phrase
+		if (R.phrase)
+			all_rituals[R.name] = R
+
+
 	return 1
 
-/* // Uncomment to debug chemical reaction list.
-/client/verb/debug_chemical_list()
 
-	for (var/reaction in chemical_reactions_list)
-		. += "chemical_reactions_list\[\"[reaction]\"\] = \"[chemical_reactions_list[reaction]]\"\n"
-		if(islist(chemical_reactions_list[reaction]))
-			var/list/L = chemical_reactions_list[reaction]
-			for(var/t in L)
-				. += "    has: [t]\n"
-	world << .
-*/
 var/global/list/admin_permissions = list(
 	"fun" = 0x1,
 	"server" = 0x2,

--- a/code/modules/core_implant/core_implant.dm
+++ b/code/modules/core_implant/core_implant.dm
@@ -13,7 +13,8 @@
 	var/max_power = 0
 	var/power_regen = 0.5
 	var/success_modifier = 1
-	var/list/rituals = list()
+	var/list/known_rituals = list() //A list of names of rituals which are recorded in this cruciform
+	//These are used to retrieve the actual ritual datums from the global all_rituals list
 
 	var/list/modules = list()
 	var/list/upgrades = list()
@@ -55,18 +56,17 @@
 	STOP_PROCESSING(SSobj, src)
 
 /obj/item/weapon/implant/core_implant/proc/update_rituals()
-	rituals = list()
+	known_rituals = list()
 	for(var/datum/core_module/rituals/M in modules)
 		if(istype(src,M.implant_type))
-			for(var/R in M.rituals)
-				if(!(R in rituals))
-					rituals.Add(R)
+			for(var/R in M.module_rituals)
+				known_rituals |= R
 
 /obj/item/weapon/implant/core_implant/proc/add_ritual_verbs()
 	if(!wearer || !active)
 		return
 
-	for(var/r in rituals)
+	for(var/r in known_rituals)
 		if(ispath(r,/datum/ritual/mind))
 			var/datum/ritual/mind/m = r
 			wearer.verbs |= initial(m.activator_verb)
@@ -75,7 +75,7 @@
 	if(!wearer || !active)
 		return
 
-	for(var/r in rituals)
+	for(var/r in known_rituals)
 		if(ispath(r,/datum/ritual/mind))
 			var/datum/ritual/mind/m = r
 			wearer.verbs.Remove(initial(m.activator_verb))
@@ -109,8 +109,8 @@
 	if(wearer != H)
 		return
 
-	for(var/RT in rituals)
-		var/datum/ritual/R = new RT
+	for(var/RT in known_rituals)
+		var/datum/ritual/R = all_rituals[RT]
 		if(R.compare(message))
 			if(R.power > src.power)
 				H << SPAN_DANGER("Not enough energy for the [R.name].")
@@ -157,8 +157,8 @@
 			if(EM.type == CM.type)
 				return FALSE
 
-	CM.set_up()
 	CM.implant = src
+	CM.set_up()
 	CM.install_time = world.time
 	CM.preinstall()
 	modules.Add(CM)
@@ -186,4 +186,4 @@
 			CM.uninstall()
 
 /obj/item/weapon/implant/core_implant/proc/get_rituals()
-	return rituals
+	return known_rituals

--- a/code/modules/core_implant/cruciform/modules.dm
+++ b/code/modules/core_implant/cruciform/modules.dm
@@ -98,20 +98,31 @@
 
 /datum/core_module/rituals/cruciform
 	implant_type = /obj/item/weapon/implant/core_implant/cruciform
+	var/list/ritual_types = list()
+
+/datum/core_module/rituals/cruciform/set_up()
+	for (var/grouptype in ritual_types)
+		for (var/rn in all_rituals)
+			var/datum/ritual/R = all_rituals[rn]
+			if (istype(R, grouptype))
+				module_rituals |= R.name
+
+/datum/core_module/rituals/cruciform/base
+	ritual_types = list(/datum/ritual/cruciform/base,
+	/datum/ritual/targeted/cruciform/base,
+	/datum/ritual/group/cruciform)
 
 
-/datum/core_module/rituals/cruciform/base/set_up()
-	rituals = subtypesof(/datum/ritual/cruciform/base)+subtypesof(/datum/ritual/targeted/cruciform/base)
-	rituals += subtypesof(/datum/ritual/group/cruciform)
-
-/datum/core_module/rituals/cruciform/priest/set_up()
-	rituals = subtypesof(/datum/ritual/cruciform/priest)+subtypesof(/datum/ritual/targeted/cruciform/priest)
+/datum/core_module/rituals/cruciform/priest
+	ritual_types = list(/datum/ritual/cruciform/priest,
+	/datum/ritual/targeted/cruciform/priest)
 
 
 
-/datum/core_module/rituals/cruciform/inquisitor/set_up()
-	rituals = subtypesof(/datum/ritual/inquisitor)+subtypesof(/datum/ritual/targeted/inquisitor)
+/datum/core_module/rituals/cruciform/inquisitor
+	ritual_types = list(/datum/ritual/inquisitor,
+	/datum/ritual/targeted/inquisitor)
 
 
-/datum/core_module/rituals/cruciform/crusader/set_up()
-	rituals = list()
+/datum/core_module/rituals/cruciform/crusader
+	ritual_types = list(/datum/ritual/cruciform/crusader)

--- a/code/modules/core_implant/cruciform/rituals/group.dm
+++ b/code/modules/core_implant/cruciform/rituals/group.dm
@@ -134,12 +134,14 @@
 	var/obj/item/weapon/implant/core_implant/CI = M.get_cruciform()
 	if(CI)
 		if(cnt >= 2)
-			if(!locate(/datum/ritual/cruciform/crusader/brotherhood) in CI.rituals)
-				CI.rituals += /datum/ritual/cruciform/crusader/brotherhood
+			var/datum/ritual/cruciform/crusader/C = /datum/ritual/cruciform/crusader/brotherhood
+			CI.known_rituals |= initial(C.name)
+
 		if(cnt >= 3)
-			if(!locate(/datum/ritual/cruciform/crusader/battle_call) in CI.rituals)
-				CI.rituals += /datum/ritual/cruciform/crusader/battle_call
+			var/datum/ritual/cruciform/crusader/C = /datum/ritual/cruciform/crusader/battle_call
+			CI.known_rituals |= initial(C.name)
+
 		if(cnt >= 4)
-			if(!locate(/datum/ritual/cruciform/crusader/flash) in CI.rituals)
-				CI.rituals += /datum/ritual/cruciform/crusader/flash
+			var/datum/ritual/cruciform/crusader/C = /datum/ritual/cruciform/crusader/flash
+			CI.known_rituals |= initial(C.name)
 

--- a/code/modules/core_implant/module.dm
+++ b/code/modules/core_implant/module.dm
@@ -46,7 +46,7 @@
 
 /datum/core_module/rituals
 	unique = TRUE
-	var/list/rituals = list()
+	var/list/module_rituals = list()
 	implant_type = /obj/item/weapon/implant/core_implant
 
 /datum/core_module/rituals/install()

--- a/code/modules/core_implant/ritual.dm
+++ b/code/modules/core_implant/ritual.dm
@@ -1,4 +1,3 @@
-var/list/global_ritual_cooldowns = list() // internal lists. Use ritual's cooldown_category
 /mob/living/carbon/human/var/list/personal_ritual_cooldowns = list()
 
 

--- a/code/modules/core_implant/ritual_book.dm
+++ b/code/modules/core_implant/ritual_book.dm
@@ -30,8 +30,8 @@
 		var/list/rdata = list()
 		var/list/cdata = list()
 
-		for(var/RT in CI.rituals)
-			var/datum/ritual/R = new RT
+		for(var/RT in CI.known_rituals)
+			var/datum/ritual/R = all_rituals[RT]
 
 			if(!(R.category in cdata))
 				cdata.Add(R.category)
@@ -47,7 +47,7 @@
 						"group" = TRUE,
 						"name" = capitalize(R.name),
 						"desc" = R.desc,
-						"type" = "[RT]",
+						"type" = "[R.name]",
 					)
 
 					var/list/P = list()
@@ -113,15 +113,15 @@
 
 	if(href_list["say"] || href_list["say_group"])
 		var/incantation = ""
-		for(var/RT in CI.rituals)
+		for(var/RT in CI.known_rituals)
 
 			if("[RT]" == href_list["say"])
-				var/datum/ritual/R = new RT
+				var/datum/ritual/R = all_rituals[RT]
 				incantation = R.get_say_phrase()
 				break
-			if("[RT]" == href_list["say_group"] && ispath(RT, /datum/ritual/group))
+			if("[RT]" == href_list["say_group"])
 				var/ind = text2num(href_list["say_id"])
-				var/datum/ritual/group/R = new RT
+				var/datum/ritual/group/R = all_rituals[RT]
 				incantation = R.get_group_say_phrase(ind)
 				break
 		if (incantation != "")


### PR DESCRIPTION
Neotheology rituals are a horrible mess codewise.

How things currently work:
Just about any interaction with them generates a pile of new datums. 
The cruciform stores a list of typepaths for the rituals it can cast. Every time you open a book, it creates a new copy of each of those rituals to take some values from it.
Every time you speak a ritual, it creates a copy of each of them again to test it. This is especially galling with group rituals



I have changed things.

Now, all the ritual datums are held in a single global list. Only one copy of each ritual exists, ever.  The list is associative using the name as the key. Probably we should add some kind of ID instead but this works for now
The cruciform - and cruciform modules - each hold a list of ritual names, and get rituals by retrieving one from the all_rituals list using the name as the key.
Modules hold a list of typepaths for initialisation, and they generate their list of names by looking through the global list and finding subtypes of their whitelist.


This PR is by no means a final solution, but it's a giant step forward towards making this code be not so awful.
This may or may not fix the crashes with ritual books, but it will at least eliminate one possible cause