### PR TITLE
Craft menu now opens code-predefined tab.

### DIFF
--- a/code/controllers/subsystems/craft.dm
+++ b/code/controllers/subsystems/craft.dm
@@ -2,8 +2,8 @@ SUBSYSTEM_DEF(craft)
 	name = "Craft"
 	init_order = INIT_ORDER_CRAFT
 	flags = SS_NO_FIRE
-	var/list/categories
-	var/list/cat_names
+	var/list/categories //list of craft_recipe objects(datums)
+	var/list/cat_names //list of strings from craft_recipe.category
 
 	var/global/list/current_category = list()
 	var/global/list/current_item = list()

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -49,5 +49,4 @@
 
 
 /obj/item/stack/rods/attack_self(mob/living/user)
-
-	user.craft_menu()//this now calls craft window, do building stuff there
+	user.open_craft_menu("Tiles")//see menu.dm


### PR DESCRIPTION
Now you can choose which tab you want to see when open craft menu by calling `open_craft_menu(arg)` .
Just see item's categories in `/datums/craft/craft_recipe.category` (or see SScraft) and give it's name as argument to
`open_craft_menu(arg)`. 
Opens NanoUi interface with predefined tab, after closing last selected tab remains.