### PR TITLE
T Ray Scanner availability

### DIFF
--- a/code/modules/admin/bluespacetech.dm
+++ b/code/modules/admin/bluespacetech.dm
@@ -38,18 +38,15 @@ ADMIN_VERB_ADD(/client/proc/cmd_dev_bst, R_ADMIN|R_DEBUG, TRUE)
 	bst.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/utility/full/bst(bst), slot_belt)
 	bst.equip_to_slot_or_del(new /obj/item/clothing/gloves/color/white/bst(bst), slot_gloves)
 
-	if(istype(bst.backpack_setup.backpack, /decl/backpack_outfit/nothing))//depends on char's prefs
-		bst.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(bst), slot_r_hand)
-	else
-		bst.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(bst.back), slot_in_backpack)
-		bst.equip_to_slot_or_del(new /obj/item/device/t_scanner(bst.back), slot_in_backpack)
-		bst.equip_to_slot_or_del(new /obj/item/modular_computer/pda/captain(bst.back), slot_in_backpack)
+	bst.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(bst.back), slot_in_backpack)
+	bst.equip_to_slot_or_del(new /obj/item/device/t_scanner(bst.back), slot_in_backpack)
+	bst.equip_to_slot_or_del(new /obj/item/modular_computer/pda/captain(bst.back), slot_in_backpack)
 
-		var/obj/item/weapon/storage/box/pills = new /obj/item/weapon/storage/box(null, TRUE)
-		pills.name = "adminordrazine"
-		for(var/i = 1, i < 12, i++)
-			new /obj/item/weapon/reagent_containers/pill/adminordrazine(pills)
-		bst.equip_to_slot_or_del(pills, slot_in_backpack)
+	var/obj/item/weapon/storage/box/pills = new /obj/item/weapon/storage/box(null, TRUE)
+	pills.name = "adminordrazine"
+	for(var/i = 1, i < 12, i++)
+		new /obj/item/weapon/reagent_containers/pill/adminordrazine(pills)
+	bst.equip_to_slot_or_del(pills, slot_in_backpack)
 
 	//Sort out ID
 	var/obj/item/weapon/card/id/bst/id = new/obj/item/weapon/card/id/bst(bst)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -27,6 +27,8 @@
 	new /obj/item/weapon/tool/shovel(src)
 	new /obj/item/weapon/tool/pickaxe(src)
 	new /obj/item/weapon/tool/pickaxe/jackhammer(src)
+	new /obj/item/device/t_scanner(src)
+	new /obj/random/tool_upgrade(src)
 
 /******************************Lantern*******************************/
 

--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -22,7 +22,8 @@
 		/obj/item/weapon/circuitboard,
 		/obj/item/weapon/smes_coil,
 		/obj/item/device/assembly,//Primarily for making improved cameras, but opens many possibilities
-		/obj/item/weapon/computer_hardware
+		/obj/item/weapon/computer_hardware,
+		/obj/item/stack/tile //Repair floors yay
 		)
 
 	var/obj/item/wrapped = null // Item currently being held.

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -112,6 +112,12 @@ var/global/list/robot_modules = list(
 		T.degradation = 0 //We don't want robot tools breaking
 
 
+	for (var/obj/item/I in modules)
+		for (var/obj/item/weapon/cell/C in I)
+			C.charge = 999999999 //A quick hack to stop robot modules running out of power
+			//Later they'll be wired to the robot's central battery once we code functionality for that
+			//Setting it to infinity causes errors, so just a high number is fine
+
 /obj/item/weapon/robot_module/proc/Reset(var/mob/living/silicon/robot/R)
 	remove_camera_networks(R)
 	remove_languages(R)
@@ -258,6 +264,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/tool/crowbar/robotic(src)
 	src.modules += new /obj/item/device/scanner/healthanalyzer(src)
 	src.modules += new /obj/item/weapon/gripper(src)
+	src.modules += new /obj/item/device/t_scanner(src)
 	src.emag = new /obj/item/weapon/melee/energy/sword(src)
 
 	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(10000)
@@ -747,6 +754,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/device/lightreplacer(src)
 	src.modules += new /obj/item/weapon/reagent_containers/glass/bucket(src) // a hydroponist's bucket
 	src.modules += new /obj/item/weapon/matter_decompiler(src) // free drone remains for all
+	src.modules += new /obj/item/device/t_scanner(src)
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag.reagents.add_reagent("lube", 250)
 	src.emag.name = "Lube spray"
@@ -892,6 +900,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/storage/bag/sheetsnatcher/borg(src)
 	src.modules += new /obj/item/weapon/gripper/miner(src)
 	src.modules += new /obj/item/weapon/mining_scanner(src)
+	src.modules += new /obj/item/device/t_scanner(src)
 	//src.emag = new /obj/item/weapon/gun/energy/plasmacutter/mounted(src)
 	..(R)
 
@@ -1029,6 +1038,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/tool/crowbar/robotic(src)
 	src.modules += new /obj/item/weapon/tool/wirecutters/robotic(src)
 	src.modules += new /obj/item/weapon/tool/multitool/robotic(src)
+	src.modules += new /obj/item/device/t_scanner(src)
 	src.modules += new /obj/item/device/lightreplacer(src)
 	src.modules += new /obj/item/weapon/gripper(src)
 	src.modules += new /obj/item/weapon/soap(src)


### PR DESCRIPTION
This PR makes T-ray scanners more available to the people who need them:
A scanner is added to each miner equipment closet (also a single free toolmod)
Scanners are added to several robot modules, including drone

In addition this fixes a couple niggling issues:
Engineering grippers can now pickup floor tiles, so they can repair floors
Fixed a runtime error with BST backpacks

And one significant fix, i decided to implement a quick hack for the longstanding issue of robot items running out of power and breaking. For now, the charge of cells in their tools (which are unremovable and can't be recharged) is set to a really high value on initialize so it shouldn't run out.

This is a temporary fix until we (probably cups) gets around to coding a proper fix to wire them to the robot's central power cell