### PR TITLE
Acid Plants Fix

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -41,11 +41,12 @@
 		return TRUE
 
 /turf/simulated/floor/New(var/newloc, var/floortype)
-	..(newloc)
 	if(!floortype && initial_flooring)
 		floortype = initial_flooring
 	if(floortype)
 		set_flooring(get_flooring_data(floortype), FALSE)
+	..(newloc)
+
 
 /turf/simulated/floor/Initialize()
 	turfs += src

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -133,7 +133,6 @@
 
 		// Some plants eat through plating.
 		if(islist(seed.chems) && !isnull(seed.chems["pacid"]))
-			world << "POLYACID SEED [jumplink(src)]"
 			var/turf/T = get_turf(src)
 			//Lets make acid plants not cause random breaches
 

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -21,7 +21,9 @@
 		if((locate(/obj/effect/plant) in zdest.contents) || (locate(/obj/effect/dead_plant) in zdest.contents) )
 
 			continue
-		if(floor.density)
+
+		//We dont want to melt external walls and cause breaches
+		if(!near_external && floor.density)
 			if(!isnull(seed.chems["pacid"]))
 				spawn(rand(5,25)) floor.ex_act(3)
 			continue


### PR DESCRIPTION
This PR does a couple tweaks to make it impossible for maintshrooms to cause breaches when they contain polyacid, while still allowing them to eat through parts of the ship that aren't exposed to space

In addition it includes a simple fix for a floor bug thats been bugging me
fixes #2407