### PR TITLE
Account Fix

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -307,11 +307,12 @@ SUBSYSTEM_DEF(job)
 		//var/list/custom_equip_leftovers = list()
 
 		//Equip job items and language stuff
+		job.setup_account(H)
 		job.equip(H, H.mind ? H.mind.role_alt_title : "")
 		job.add_stats(H)
 		job.add_additiional_language(H)
-		job.setup_account(H)
-		
+
+
 		job.apply_fingerprints(H)
 		spawn_in_storage = EquipCustomLoadout(H, job)
 		// EMAIL GENERATION

--- a/code/game/objects/structures/wire_splicing.dm
+++ b/code/game/objects/structures/wire_splicing.dm
@@ -63,7 +63,6 @@
 
 
 		loc = pick(candidates)
-		world << "Cable moved to [jumplink(loc)]"
 	messiness = rand (1,10)
 	icon_state = "wire_splicing[messiness]"
 

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -6,7 +6,7 @@
 	var/money = 0
 	var/list/transaction_log = list()
 	var/suspended = 0
-	var/security_level = 1	//0 - auto-identify from worn ID, require only account number
+	var/security_level = 0	//0 - auto-identify from worn ID, require only account number
 							//1 - require manual login / account number and pin
 							//2 - require card and manual login
 


### PR DESCRIPTION
Fixes being unable to buy anything with ID cards. This was caused by attempting to assign an account number to the card before the account was setup. Reversed the order of these operations

Removes account security, so you no longer need to type in a pin when buying things from a vendor. We can revisit this in future but for now its just a pain that serves no purpose

Removes a debug message from wire splices that i forgot