### PR TITLE
Temporary patch for lobby image/login.dm runtime

### DIFF
--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -51,7 +51,7 @@
 			the_type = "(text)"
 		else if(isnum(lobby_image))
 			the_type = "(num)"
-		else if(isdatum(lobby_image))	//Already casted
+		else if(istype(lobby_image, /datum))	//Already casted
 			the_type = "[lobby_image.type]"
 		else
 			the_type = "(UNKNOWN)"

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -33,7 +33,6 @@
 		mind.current = src
 
 	loc = null
-	client.screen += lobby_image
 	my_client = client
 	sight |= SEE_TURFS
 	player_list |= src
@@ -41,3 +40,21 @@
 	new_player_panel()
 	if(client)
 		client.playtitlemusic()
+	
+	if(!istype(lobby_image, /obj/effect/lobby_image))
+		var/the_type
+		if(isnull(lobby_image))
+			the_type = "(null)"
+		else if(isicon(lobby_image))		//All of these should be impossible, just catching possibilities.
+			the_type = "/icon"
+		else if(istext(lobby_image))
+			the_type = "(text)"
+		else if(isnum(lobby_image))
+			the_type = "(num)"
+		else if(isdatum(lobby_image))	//Already casted
+			the_type = "[lobby_image.type]"
+		else
+			the_type = "(UNKNOWN)"
+		crash_with("WARNING: lobby_image global variable was the wrong type \[[the_type]\] instead of the proper /obj/effect/lobby_image!")
+		lobby_image = new /obj/effect/lobby_image			//Ensures it's the right type.
+	client.screen += lobby_image


### PR DESCRIPTION
I was unable to reproduce the bug on a windows host, and my best guess is it's somehow nulled out, and no one can check because it's not a managed global/there's no procs that can grab the value of a world.variable (unmanaged globals)/there's definitely no proc that directly grabs the value of this.
Adding a null to client.screen (along with things like text/numbers) will to my knowledge cause the runtime of wrong type for list.
This moves the erroring line below the important functions so it doesn't interrupt them when it crashes, and also adds a block of code to catch if it's the wrong type and report that.