### PR TITLE
Adminjump fix

### DIFF
--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -49,6 +49,7 @@ ADMIN_VERB_ADD(/client/proc/jumptomob, R_ADMIN|R_DEBUG, FALSE)
 	set category = "Admin"
 	set name = "Jump to Mob"
 
+
 	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
 		return
 
@@ -66,6 +67,7 @@ ADMIN_VERB_ADD(/client/proc/jumptomob, R_ADMIN|R_DEBUG, FALSE)
 				A << "This mob is not located in the game world."
 	else
 		alert("Admin jumping disabled")
+
 ADMIN_VERB_ADD(/client/proc/jumptocoord, R_ADMIN|R_DEBUG, FALSE)
 //we ghost and jump to a coordinate
 /client/proc/jumptocoord(tx as num, ty as num, tz as num)

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -344,9 +344,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return 0
 	return (T && T.holy) && (invisibility <= SEE_INVISIBLE_LIVING)
 
-/mob/observer/ghost/verb/jumptomob(target in getmobs()) //Moves the ghost instead of just changing the ghosts's eye -Nodrak
+/mob/observer/ghost/verb/jumptomob_ghost(target in getmobs()) //Moves the ghost instead of just changing the ghosts's eye -Nodrak
 	set category = "Ghost"
-	set name = "Jump to Mob"
+	set name = "Jump to a Mob"
 	set desc = "Teleport to a mob"
 
 	if(isghost(usr)) //Make sure they're an observer!


### PR DESCRIPTION
There were two verbs named jump to mob and they were interfering with each other

tweaked names and paths slightly to fix this