### PR TITLE
Modify Move Downwards verb name

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -340,7 +340,7 @@ var/list/ai_verbs_default = list(
 
 /mob/living/silicon/ai/proc/ai_movement_down()
 	set category = "Silicon Commands"
-	set name = "Move Downwards"
+	set name = "Move Down"
 	zMove(DOWN)
 
 /mob/living/silicon/ai/proc/pick_icon()

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -22,7 +22,7 @@
  * Verb for the mob to move down a z-level if possible.
  */
 /mob/verb/down()
-	set name = "Move Downwards"
+	set name = "Move Down"
 	set category = "IC"
 
 	if(zMove(DOWN))
@@ -265,6 +265,6 @@
 	zMove(UP)
 
 /mob/observer/ghost/verb/movedown()
-	set name = "Move Downwards"
+	set name = "Move Down"
 	set category = "Ghost"
 	zMove(DOWN)


### PR DESCRIPTION
`Move Downwards` is `Move Down` in most SS13 code bases - the naming
difference can break binds players have set up from other servers.

----------------

Examples:

- [Bay](https://github.com/Baystation12/Baystation12/blob/e700ba17d98d00b30575e360992b63faa4007233/code/modules/multiz/movement.dm#L9)
- [Aurora](https://github.com/Aurorastation/Aurora.3/blob/0e09deafea9967f5b161724dc5e9cf42f4d10b02/code/modules/multiz/movement.dm#L19)
 - [TG](https://github.com/tgstation/tgstation/blob/1b24b13d802db601eac34497467a22d8e74cd6ae/code/modules/mob/mob_movement.dm#L382)
  - [Polaris](https://github.com/PolarisSS13/Polaris/blob/3155d5829f689d5127decdf4730115a4e405f312/code/modules/multiz/movement.dm#L9)