### PR TITLE
storage and ammobox tweaks

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -127,7 +127,7 @@
 	src.hand = !( src.hand )
 	for (var/obj/screen/inventory/hand/H in src.HUDinventory)
 		H.update_icon()
-	return
+	return TRUE
 
 /mob/living/carbon/proc/activate_hand(var/selhand) //0 or "r" or "right" for right hand; 1 or "l" or "left" for left hand.
 

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -7,6 +7,34 @@
 	reload_delay = 30
 	ammo_mag = "box"
 
+/obj/item/ammo_magazine/ammobox/resolve_attackby(atom/A, mob/user)
+	if(isturf(A) && locate(/obj/item/ammo_casing) in A || istype(A, /obj/item/ammo_casing))
+		if(!do_after(user, src.reload_delay, src))
+			user << SPAN_WARNING("You stoped scooping ammo into [src].")
+			return
+		if(collectAmmo(get_turf(A), user))
+			return TRUE
+	..()
+
+/obj/item/ammo_magazine/ammobox/proc/collectAmmo(var/turf/target, var/mob/user)
+	ASSERT(istype(target))
+	. = FALSE
+	for(var/obj/item/ammo_casing/I in target)
+		if(stored_ammo.len >= max_ammo)
+			break
+		if(I.caliber == src.caliber)
+			for(var/j = 1 to I.amount)
+				if(stored_ammo.len >= max_ammo)
+					break
+				. |= TRUE
+				insertCasing(I)
+	if(user)
+		if(.)
+			user.visible_message(SPAN_NOTICE("[user] scoopes some ammo in [src]."),SPAN_NOTICE("You scoop some ammo in [src]."),SPAN_NOTICE("You hear metal clanging."))
+		else
+			user << SPAN_NOTICE("You fail to pick anything up with \the [src].")
+	update_icon()
+
 /obj/item/ammo_magazine/ammobox/c9mm
 	name = "ammunition box (9mm)"
 	icon_state = "box9mm"


### PR DESCRIPTION
Fixes #2558 
Fixes #2559 
Fixed storage gathering mode enabled on more types than intended
Tweaked how storage works
- On self click you now can open storage if your other hand is empty
- On tile click you will pickup item if there are gathering mode enabled and there are item to pick up if else it will empty storage if quick empty mode is avaliable
