### PR TITLE
Examine Tcomms machinery to see damage

### DIFF
--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -14,6 +14,23 @@
 	var/temp = "" // output message
 	var/construct_op = 0
 
+/obj/machinery/telecomms/examine(mob/user)
+	..(user)
+	switch(integrity)
+		if(100)
+			user << SPAN_NOTICE("It's in perfect condition.")
+		if(85 to 99)
+			user << "It has some minor faults."
+		if(65 to 85)
+			user << "It's slightly damaged."
+		if(45 to 65)
+			user << SPAN_WARNING("It's badly damaged.")
+		if(25 to 45)
+			user << SPAN_WARNING("It's heavily damaged.")
+		else
+			user << SPAN_WARNING("It's falling apart.")
+	if(stat & BROKEN)
+		user << SPAN_DANGER("It's broken.")
 
 /obj/machinery/telecomms/attackby(obj/item/I, mob/user)
 
@@ -37,7 +54,7 @@
 					if(construct_op == 0)
 						user << "You unfasten the bolts."
 						construct_op ++
-					if(construct_op == 1)
+					else if(construct_op == 1)
 						user << "You fasten the bolts."
 						construct_op --
 					return

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -30,7 +30,7 @@
 		else
 			user << SPAN_WARNING("It's falling apart.")
 	if(stat & BROKEN)
-		user << SPAN_DANGER("It's broken.")
+		user << SPAN_DANGER("It's not working.")
 
 /obj/machinery/telecomms/attackby(obj/item/I, mob/user)
 


### PR DESCRIPTION
TComms machinery can now be examined to know if they are damaged or just unpowered. Different message depending on severity of damage.