### PR TITLE
Removes embedding for animals

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -25,7 +25,7 @@
 	apply_damage(effective_force, I.damtype, hit_zone, blocked, sharp=weapon_sharp, edge=weapon_edge, used_weapon=I)
 
 	//Melee weapon embedded object code.
-	if (I && I.damtype == BRUTE && !I.anchored && !is_robot_module(I))
+	if (I && I.damtype == BRUTE && !I.anchored && !is_robot_module(I) && !istype(src,/mob/living/carbon/superior_animal))
 		var/damage = effective_force
 		if (blocked)
 			damage /= blocked+1


### PR DESCRIPTION
So, since roaches and spiders are subtypes of carbon, they were susceptible to having weapons embed in them. This was problematic, since it's possible for a roach to have a weapon embed in it, and get gibbed during the same attack. No way of recovering the embedded weapon.

This PR disables embedding for animals, since I assume it was just an oversight.