### PR TITLE
Embedding Fixes

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -62,7 +62,7 @@
 
 	//Damage vars
 	var/force = 0	//How much damage the weapon deals
-
+	var/embed_mult = 0.5 //Multiplier for the chance of embedding in mobs. Set to zero to completely disable embedding
 	var/structure_damage_factor = STRUCTURE_DAMAGE_NORMAL	//Multiplier applied to the damage when attacking structures and machinery
 	//Does not affect damage dealt to mobs
 

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -81,6 +81,7 @@
 	desc = "A sharp, metal hook what sticks into things."
 	icon_state = "hook_knife"
 	item_state = "hook_knife"
+	embed_mult = 1.5 //This is designed for embedding
 
 /obj/item/weapon/material/knife/ritual
 	name = "ritual knife"

--- a/code/game/objects/items/weapons/material/thrown.dm
+++ b/code/game/objects/items/weapons/material/thrown.dm
@@ -8,6 +8,7 @@
 	throw_range = 15
 	sharp = 1
 	edge =  1
+	embed_mult = 5 //We want these to embed
 
 /obj/item/weapon/material/star/New()
 	..()

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -88,6 +88,7 @@
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	applies_material_colour = 0
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
+	embed_mult = 1 //Axes cut deep, and their hooked shape catches on things
 
 /obj/item/weapon/material/twohanded/fireaxe/afterattack(atom/A as mob|obj|turf|area, mob/user as mob, proximity)
 	if(!proximity) return
@@ -117,3 +118,4 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "poked", "jabbed", "torn", "gored")
 	default_material = MATERIAL_GLASS
+	embed_mult = 1.5

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -9,6 +9,7 @@
 	flags = NOBLOODY
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
 	heat = 3800
+	embed_mult = 0 //No physical matter to catch onto things
 
 /obj/item/weapon/melee/energy/is_hot()
 	if (active)

--- a/code/game/objects/items/weapons/tools/pickaxe.dm
+++ b/code/game/objects/items/weapons/tools/pickaxe.dm
@@ -15,6 +15,7 @@
 	sharp = 1
 	structure_damage_factor = 3 //Drills and picks are made for getting through hard materials
 	//They are the best anti-structure melee weapons
+	embed_mult = 1.2 //Digs deep
 
 /obj/item/weapon/tool/pickaxe/jackhammer
 	name = "jackhammer"

--- a/code/game/objects/items/weapons/tools/saws.dm
+++ b/code/game/objects/items/weapons/tools/saws.dm
@@ -14,6 +14,7 @@
 	sharp = TRUE
 	edge = TRUE
 	tool_qualities = list(QUALITY_SAWING = 30, QUALITY_CUTTING = 20, QUALITY_WIRE_CUTTING = 20)
+	embed_mult = 1 //Serrated blades catch on bone more easily
 
 /obj/item/weapon/tool/saw/improvised
 	name = "choppa"

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -226,7 +226,7 @@
 
 //To be called from things that spill objects on the floor.
 //Makes an object move around randomly for a couple of tiles
-/obj/proc/tumble(var/dist)
+/obj/proc/tumble(var/dist = 2)
 	if (dist >= 1)
 		spawn()
 			dist += rand(0,1)

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -18,7 +18,10 @@
 	flick(anim, animation)
 	if(do_gibs) gibs(loc, dna)
 
+
+
 	spawn(15)
+		drop_embedded()
 		if(animation)	qdel(animation)
 		if(src)			qdel(src)
 
@@ -45,8 +48,11 @@
 	flick(anim, animation)
 	new remains(loc)
 
+
+
 	dead_mob_list -= src
 	spawn(15)
+		drop_embedded()
 		if(animation)	qdel(animation)
 		if(src)			qdel(src)
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -309,21 +309,22 @@ meteor_act
 					msg_admin_attack("[src.name] ([src.ckey]) was hit by a [O], thrown by [M.name] ([assailant.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
 
 		//thrown weapon embedded object code.
-		if(dtype == BRUTE && istype(O,/obj/item))
+		if(istype(O,/obj/item))
 			var/obj/item/I = O
-			if (!is_robot_module(I))
-				var/sharp = is_sharp(I)
+			if (I && I.damtype == BRUTE && !I.anchored && !is_robot_module(I))
 				var/damage = throw_damage
+				var/sharp = is_sharp(I)
+
 				if (armor)
 					damage /= armor+1
 
 				//blunt objects should really not be embedding in things unless a huge amount of force is involved
-				var/embed_chance = sharp? damage/I.w_class : damage/(I.w_class*3)
-				var/embed_threshold = sharp? 5*I.w_class : 15*I.w_class
 
-				//Sharp objects will always embed if they do enough damage.
-				//Thrown sharp objects have some momentum already and have a small chance to embed even if the damage is below the threshold
-				if((sharp && prob(damage/(10*I.w_class)*100)) || (damage > embed_threshold && prob(embed_chance)))
+				var/embed_threshold = sharp? 3*I.w_class : 9*I.w_class
+
+
+				var/embed_chance = (damage - embed_threshold)*I.embed_mult
+				if (embed_chance > 0 && prob(embed_chance))
 					affecting.embed(I)
 
 		// Begin BS12 momentum-transfer code.

--- a/code/modules/mob/living/carbon/superior_animal/defense.dm
+++ b/code/modules/mob/living/carbon/superior_animal/defense.dm
@@ -1,6 +1,7 @@
 /mob/living/carbon/superior_animal/proc/harvest(var/mob/user)
 	var/actual_meat_amount = max(1,(meat_amount/2))
 	if(meat_type && actual_meat_amount>0 && (stat == DEAD))
+		drop_embedded()
 		for(var/i=0;i<actual_meat_amount;i++)
 			var/obj/item/meat = new meat_type(get_turf(src))
 			meat.name = "[src.name] [meat.name]"

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -212,6 +212,7 @@
 			return
 	O.forceMove(src)
 	src.embedded += O
+	src.visible_message("<span class='danger'>\The [O] embeds in the [src]!</span>")
 	src.verbs += /mob/proc/yank_out_object
 
 //This is called when the mob is thrown into a dense turf

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -616,3 +616,11 @@ proc/is_blind(A)
 		return
 	var/list/hands = list(M.l_hand, M.r_hand)
 	return hands
+
+/mob/proc/drop_embedded()
+	//Embedded list is defined at mob level so we can have this here too
+	for(var/obj/A in embedded)
+		if (A.loc == src)
+			A.forceMove(loc)
+			A.tumble()
+	embedded = list()


### PR DESCRIPTION
This issue has become troublesome, time to prioritise it

This PR fixes several issues with embedding and rebalances a little. Notable changes:
There's now some text in chat when a weapon embeds into a nonhuman enemy
Embedded items are now dropped instead of deleted, when a creature is gibbed, dusted or butchered

Balance wise, reworked how embed chance is calculated, and notably factored robustness stat into it. If you're stronger, you can more easily pull the weapon out on the follow through, so higher robustness increases the embed damage threshold, and thusly allows you to more capably handle large weapons.