### PR TITLE
Headphones fix

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -96,7 +96,7 @@
 	name = "Other ear"
 	w_class = ITEM_SIZE_HUGE
 	icon = 'icons/mob/screen1_Midnight.dmi'
-	icon_state = "block"
+	icon_state = "blocked"
 	slot_flags = SLOT_EARS | SLOT_TWOEARS
 	var/obj/item/master_item = null
 
@@ -105,6 +105,7 @@
 	desc = O.desc
 	icon = O.icon
 	icon_state = O.icon_state
+	w_class = O.w_class
 	set_dir(O.dir)
 	master_item = O
 

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -232,13 +232,25 @@ This saves us from having to call add_fingerprint() any time something is put in
 			src.l_ear = W
 			if(l_ear.slot_flags & SLOT_TWOEARS)
 				var/obj/item/clothing/ears/offear/O = new(W)
-				equip_to_slot_if_possible(O, slot_r_ear, TRUE, FALSE, FALSE)
+				O.loc = src
+				src.r_ear = O
+				O.screen_loc = "4,3"
+				O.layer = ABOVE_HUD_LAYER
+				O.plane = ABOVE_HUD_PLANE
+				if(client)
+					client.screen |= O
 
 		if(slot_r_ear)
 			src.r_ear = W
 			if(r_ear.slot_flags & SLOT_TWOEARS)
 				var/obj/item/clothing/ears/offear/O = new(W)
-				equip_to_slot_if_possible(O, slot_l_ear, TRUE, FALSE, FALSE)
+				O.loc = src
+				src.l_ear = O
+				O.screen_loc = "4,2"
+				O.layer = ABOVE_HUD_LAYER
+				O.plane = ABOVE_HUD_PLANE
+				if(client)
+					client.screen |= O
 		if(slot_glasses)
 			src.glasses = W
 		if(slot_gloves)


### PR DESCRIPTION
Makes headphones & earmuffs actually work the way they should. They now block both ears, so you can't have a headset and headphones on at the same time.

The code related to earmuffs & headphones is pretty bad, honestly. The part where it deleted the imaginary offear item is called by attack_hand instead of something that would only get called when it's being unequipped. There's still a bug where if you try to strip headphones from someone, they stay stuck with that imaginary offear which you can't strip. I'm leaving fixing that to someone else, since it doesn't sound like a priority issue.