### PR TITLE
Ammo loading/unloading fixes and tweaks

### DIFF
--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -15,6 +15,46 @@
 		if(collectAmmo(get_turf(A), user))
 			return TRUE
 	..()
+/obj/item/ammo_magazine/ammobox/attack_hand(mob/user)	
+	if(stored_ammo.len)
+		var/obj/item/ammo_casing/AC = removeCasing()
+		if(AC)
+			user.put_in_active_hand(AC)
+
+/obj/item/ammo_magazine/ammobox/attackby(obj/item/W as obj, mob/user as mob)
+	if(istype(W, /obj/item/ammo_casing))
+		var/obj/item/ammo_casing/C = W
+		if(stored_ammo.len >= max_ammo)
+			user << SPAN_WARNING("[src] is full!")
+			return
+		if(C.caliber != caliber)
+			user << SPAN_WARNING("[C] does not fit into [src].")
+			return
+		if(stored_ammo.len)
+			var/obj/item/ammo_casing/T = removeCasing()
+			if(T)
+				if(!C.attackby(T,user))
+					if(C.amount >= C.maxamount)
+						user << SPAN_WARNING("You cant hold more ammo.")
+					else if(T.desc != C.desc)
+						user << SPAN_WARNING("Inscribed ammo wont stack.")
+					insertCasing(T)
+		else
+			insertCasing(C)
+		return
+	..()
+
+/obj/item/ammo_magazine/ammobox/AltClick(var/mob/living/user)
+	var/obj/item/W = user.get_active_hand()
+	if(istype(W, /obj/item/ammo_casing))
+		var/obj/item/ammo_casing/C = W
+		if(stored_ammo.len >= max_ammo)
+			user << SPAN_WARNING("[src] is full!")
+			return
+		if(C.caliber != caliber)
+			user << SPAN_WARNING("[C] does not fit into [src].")
+			return
+		insertCasing(C)
 
 /obj/item/ammo_magazine/ammobox/proc/collectAmmo(var/turf/target, var/mob/user)
 	ASSERT(istype(target))
@@ -70,7 +110,7 @@
 	name = "ammunition box (.38)"
 	icon_state = "box38"
 	matter = list(MATERIAL_STEEL = 5)
-	caliber = "38"
+	caliber = ".38"
 	ammo_type = /obj/item/ammo_casing/c38
 	max_ammo = 30
 
@@ -83,7 +123,7 @@
 	name = "ammunition box (.32)"
 	icon_state = "box32"
 	matter = list(MATERIAL_STEEL = 5)
-	caliber = "38"
+	caliber = ".32"
 	ammo_type = /obj/item/ammo_casing/cl32
 	max_ammo = 40
 

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -15,46 +15,6 @@
 		if(collectAmmo(get_turf(A), user))
 			return TRUE
 	..()
-/obj/item/ammo_magazine/ammobox/attack_hand(mob/user)	
-	if(stored_ammo.len)
-		var/obj/item/ammo_casing/AC = removeCasing()
-		if(AC)
-			user.put_in_active_hand(AC)
-
-/obj/item/ammo_magazine/ammobox/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/ammo_casing))
-		var/obj/item/ammo_casing/C = W
-		if(stored_ammo.len >= max_ammo)
-			user << SPAN_WARNING("[src] is full!")
-			return
-		if(C.caliber != caliber)
-			user << SPAN_WARNING("[C] does not fit into [src].")
-			return
-		if(stored_ammo.len)
-			var/obj/item/ammo_casing/T = removeCasing()
-			if(T)
-				if(!C.attackby(T,user))
-					if(C.amount >= C.maxamount)
-						user << SPAN_WARNING("You cant hold more ammo.")
-					else if(T.desc != C.desc)
-						user << SPAN_WARNING("Inscribed ammo wont stack.")
-					insertCasing(T)
-		else
-			insertCasing(C)
-		return
-	..()
-
-/obj/item/ammo_magazine/ammobox/AltClick(var/mob/living/user)
-	var/obj/item/W = user.get_active_hand()
-	if(istype(W, /obj/item/ammo_casing))
-		var/obj/item/ammo_casing/C = W
-		if(stored_ammo.len >= max_ammo)
-			user << SPAN_WARNING("[src] is full!")
-			return
-		if(C.caliber != caliber)
-			user << SPAN_WARNING("[C] does not fit into [src].")
-			return
-		insertCasing(C)
 
 /obj/item/ammo_magazine/ammobox/proc/collectAmmo(var/turf/target, var/mob/user)
 	ASSERT(istype(target))

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -40,12 +40,12 @@
 
 /obj/item/ammo_casing/c38
 	desc = "A .38 bullet casing."
-	caliber = "38"
+	caliber = ".38"
 	projectile_type = /obj/item/projectile/bullet/c38
 
 /obj/item/ammo_casing/c38r
 	desc = "A .38 rubber bullet casing."
-	caliber = "38"
+	caliber = ".38"
 	projectile_type = /obj/item/projectile/bullet/c38r
 
 /obj/item/ammo_casing/cl44

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -10,7 +10,7 @@
 /obj/item/ammo_magazine/sl38
 	name = "speed loader (.38)"
 	icon_state = "38"
-	caliber = "38"
+	caliber = ".38"
 	matter = list(MATERIAL_STEEL = 3)
 	ammo_type = /obj/item/ammo_casing/c38
 	max_ammo = 6

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -201,7 +201,8 @@
 //attempts to unload src. If allow_dump is set to 0, the speedloader unloading method will be disabled
 /obj/item/weapon/gun/projectile/proc/unload_ammo(mob/user, var/allow_dump=1)
 	if(ammo_magazine)
-		user.put_in_hands(ammo_magazine)
+		if(!user.put_in_hands(ammo_magazine))
+			return
 
 		if(unload_sound) playsound(src.loc, unload_sound, 75, 1)
 		ammo_magazine.update_icon()
@@ -243,6 +244,11 @@
 		unload_ammo(user, allow_dump=0)
 	else
 		return ..()
+
+/obj/item/weapon/gun/projectile/MouseDrop(over_object, src_location, over_location)
+	..()
+	if(src.loc == usr && istype(over_object, /obj/screen/inventory/hand))
+		unload_ammo(usr, allow_dump=0)
 
 /obj/item/weapon/gun/projectile/afterattack(atom/A, mob/living/user)
 	..()

--- a/code/modules/projectiles/guns/projectile/pistol/handmade.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/handmade.dm
@@ -2,7 +2,7 @@
 	name = "handmade pistol"
 	desc = "Looks unreliable. May blow up in your hands. Due to a strange design, this one can be reload only after shot. Or with the use of a screwdriver."
 	icon_state = "hm_pistol"
-	caliber = "38"
+	caliber = ".38"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
 	load_method = SINGLE_CASING

--- a/code/modules/projectiles/guns/projectile/revolver/detective.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/detective.dm
@@ -5,7 +5,7 @@
 	drawChargeMeter = FALSE
 	w_class = ITEM_SIZE_SMALL
 	max_shells = 6
-	caliber = "38"
+	caliber = ".38"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	fire_sound = 'sound/weapons/Gunshot_light.ogg'
 	ammo_type = /obj/item/ammo_casing/c38


### PR DESCRIPTION
Loading magazines and ammoboxes is a little different now
You can load ammo in magazine by clicking on it with ammo in your hand
You can unload full stack from it by clicking on it with empty hand
You can unload one casing from it by alt clicking with ammo or empty hand on it
***
Stacking ammo from turf is easier now
***
Ammobox quick unload on selfclick is removed, click on turf for that
***
Magazines and ammo can be unloaded from guns by dragging gun in empty hand(just like removing battery)
***
Fixed 32 caliber not fitting in ammo box and a typo ".38"