### PR TITLE
Robot tool upgrading

### DIFF
--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -122,7 +122,7 @@
 
 		if (C.use_tool(user = user, target =  src, base_time = WORKTIME_SLOW, required_quality = QUALITY_SCREW_DRIVING, fail_chance = FAILCHANCE_CHALLENGING, required_stat = STAT_MEC))
 			//If you pass the check, then you manage to remove the upgrade intact
-			user << SPAN_NOTICE("You successfully remove the [toremove] intact.")
+			user << SPAN_NOTICE("You successfully remove [toremove] while leaving it intact.")
 			upgrades -= toremove
 			toremove.forceMove(get_turf(src))
 			toremove.holder = null
@@ -132,7 +132,7 @@
 			//You failed the check, lets see what happens
 			if (prob(50))
 				//50% chance to break the upgrade and remove it
-				user << SPAN_DANGER("You successfully remove the [toremove], but destroy it in the process.")
+				user << SPAN_DANGER("You successfully remove [toremove], but destroy it in the process.")
 				upgrades -= toremove
 				toremove.forceMove(get_turf(src))
 				toremove.holder = null
@@ -140,9 +140,9 @@
 					QDEL_NULL(toremove)
 				refresh_upgrades()
 				return 1
-			else
+			else if (degradation) //Because robot tools are unbreakable
 				//otherwise, damage the host tool a bit, and give you another try
-				user << SPAN_DANGER("You only managed to damage the [src], but you can retry.")
+				user << SPAN_DANGER("You only managed to damage [src], but you can retry.")
 				unreliability += 10*degradation
 				refresh_upgrades()
 				return 1

--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -89,6 +89,14 @@
 
 
 /obj/item/weapon/tool_upgrade/proc/can_apply(var/obj/item/weapon/tool/T, var/mob/user)
+	if (isrobot(T))
+		var/mob/living/silicon/robot/R = T
+		if (R.module_active && istool(R.module_active))
+			try_apply(R.module_active,user)
+		else
+			user << SPAN_WARNING("[src] needs to be wielding a compatible tool.")
+		return
+
 	if (!istool(T))
 		user << SPAN_WARNING("This can only be applied to a tool!")
 		return

--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -91,10 +91,18 @@
 /obj/item/weapon/tool_upgrade/proc/can_apply(var/obj/item/weapon/tool/T, var/mob/user)
 	if (isrobot(T))
 		var/mob/living/silicon/robot/R = T
-		if (R.module_active && istool(R.module_active))
-			try_apply(R.module_active,user)
+		if(!R.opened)
+			user << SPAN_WARNING("You need to open [R]'s panel to access its tools.")
+		var/list/robotools = list()
+		for(var/obj/item/weapon/tool/robotool in R.module.modules)
+			robotools.Add(robotool)
+		if(robotools.len)
+			var/obj/item/weapon/tool/chosen_tool = input(user,"Which tool are you trying to modify?","Tool Modification","Cancel") in robotools + "Cancel"
+			if(chosen_tool == "Cancel")
+				return
+			try_apply(chosen_tool,user)
 		else
-			user << SPAN_WARNING("[src] needs to be wielding a compatible tool.")
+			user << SPAN_WARNING("[R] has no modifiable tools.")
 		return
 
 	if (!istool(T))

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -30,6 +30,8 @@
 		if(UNCONSCIOUS)		msg += "<span class='warning'>It doesn't seem to be responding.</span>\n"
 		if(DEAD)			msg += "<span class='deadsay'>It's completely broken, but looks repairable.</span>\n" //TODO: add no_soul status or flag
 		//msg += "<span class='deadsay'>It looks completely unsalvageable.</span>\n"
+	if(module_active)
+		msg += "It is wielding \icon[module_active] [module_active].\n"
 	msg += "*---------*"
 
 	if(print_flavor_text()) msg += "\n[print_flavor_text()]\n"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -620,15 +620,24 @@
 					wiresexposed = !wiresexposed
 					user << SPAN_NOTICE("The wires have been [wiresexposed ? "exposed" : "unexposed"]")
 					updateicon()
-			else if (module_active && istool(module_active))
-				var/obj/item/weapon/tool/T = module_active
-				T.attackby(I,user)
-			else if (opened && cell)
-				if(!radio)
-					user << SPAN_WARNING("Unable to locate a radio.")
-				if(I.use_tool(user, src, WORKTIME_FAST, tool_type, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
-					radio.attackby(I,user)//Push it to the radio to let it handle everything
-					updateicon()
+			switch(alert(user,"What are you trying to interact with?",,"Tools","Radio"))
+				if("Tools")
+					var/list/robotools = list()
+					for(var/obj/item/weapon/tool/robotool in src.module.modules)
+						robotools.Add(robotool)
+					if(robotools.len)
+						var/obj/item/weapon/tool/chosen_tool = input(user,"Which tool are you trying to modify?","Tool Modification","Cancel") in robotools + "Cancel"
+						if(chosen_tool == "Cancel")
+							return
+						chosen_tool.attackby(I,user)
+					else
+						user << SPAN_WARNING("[src] has no modifiable tools.")
+				if("Radio")
+					if(!radio)
+						user << SPAN_WARNING("Unable to locate a radio.")
+					if(I.use_tool(user, src, WORKTIME_FAST, tool_type, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
+						radio.attackby(I,user)//Push it to the radio to let it handle everything
+						updateicon()
 			return
 
 		if(ABORT_CHECK)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -615,19 +615,20 @@
 			return
 
 		if(QUALITY_SCREW_DRIVING)
-			if(opened && !cell)
+			if (opened && !cell)
 				if(I.use_tool(user, src, WORKTIME_FAST, tool_type, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
 					wiresexposed = !wiresexposed
 					user << SPAN_NOTICE("The wires have been [wiresexposed ? "exposed" : "unexposed"]")
 					updateicon()
-					return
-			if(opened && cell)
+			else if (module_active && istool(module_active))
+				var/obj/item/weapon/tool/T = module_active
+				T.attackby(I,user)
+			else if (opened && cell)
 				if(!radio)
 					user << SPAN_WARNING("Unable to locate a radio.")
 				if(I.use_tool(user, src, WORKTIME_FAST, tool_type, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
 					radio.attackby(I,user)//Push it to the radio to let it handle everything
 					updateicon()
-					return
 			return
 
 		if(ABORT_CHECK)
@@ -712,6 +713,9 @@
 				U.loc = src
 			else
 				usr << "Upgrade error!"
+
+	else if (istype(I,/obj/item/weapon/tool_upgrade)) //Upgrading is handled in _upgrades.dm
+		return
 
 	else
 		if( !(istype(I, /obj/item/device/robotanalyzer) || istype(I, /obj/item/device/scanner/healthanalyzer)) )


### PR DESCRIPTION
Robot tools can now be modded by an external user. Robot has to be wielding a valid tool. User will attempt to install the tool upgrade by using the upgrade on the robot.

Robot can uninstall mods by itself if it has a screwdriver, or an external user can uninstall by using a crowbar with the robot's panel being open.

I also made it so that the robot's active module is visible on examine.