### PR TITLE
Excelsior Fixes

### DIFF
--- a/code/datums/autolathe/parts.dm
+++ b/code/datums/autolathe/parts.dm
@@ -58,3 +58,15 @@
 /datum/autolathe/recipe/part/diamondblade
 	name = "Asters \"Gleaming Edge\": Diamond blade"
 	path = /obj/item/weapon/tool_upgrade/productivity/diamond_blade
+
+/datum/autolathe/recipe/part/subspace_transmitter
+	name = "subspace transmitter"
+	path = /obj/item/weapon/stock_parts/subspace/transmitter
+
+/datum/autolathe/recipe/part/subspace_crystal
+	name = "ansible crystal"
+	path = /obj/item/weapon/stock_parts/subspace/crystal
+
+/datum/autolathe/recipe/part/subspace_amplifier
+	name = "subspace amplifier"
+	path = /obj/item/weapon/stock_parts/subspace/amplifier

--- a/code/game/antagonist/station/revolutionary/excelsior.dm
+++ b/code/game/antagonist/station/revolutionary/excelsior.dm
@@ -10,5 +10,5 @@
 
 /datum/antagonist/excelsior/equip()
 	.=..()
-	var/obj/item/weapon/implant/excelsior/implant = new(owner.current)
-	implant.install(owner.current)
+	var/obj/item/weapon/implant/excelsior/leader/implant = new(owner.current)
+	implant.install(owner.current, BP_HEAD)

--- a/code/game/gamemodes/storyteller_meta.dm
+++ b/code/game/gamemodes/storyteller_meta.dm
@@ -13,7 +13,11 @@ var/global/list/storyevents = list()
 var/global/list/scheduled_events = list()
 
 /proc/fill_storyevents_list()
-	for(var/type in typesof(/datum/storyevent)-/datum/storyevent-/datum/storyevent/roleset)
+	var/list/base_types = list(/datum/storyevent,
+	/datum/storyevent/roleset,
+	/datum/storyevent/roleset/faction)
+
+	for(var/type in typesof(/datum/storyevent)-base_types)
 		storyevents.Add(new type)
 
 

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -407,11 +407,17 @@
 		/datum/autolathe/recipe/ammo/ak47,
 		/datum/autolathe/recipe/ammo/box_a762,
 		/datum/autolathe/recipe/device/excelsiormine,
+		/datum/autolathe/recipe/sec/beartrap,
+		/datum/autolathe/recipe/clothing/excelsior_armor,
+		/datum/autolathe/recipe/clothing/excelsior_helmet,
+		/datum/autolathe/recipe/part/manipulator,
+		/datum/autolathe/recipe/part/subspace_amplifier,
+		/datum/autolathe/recipe/part/subspace_crystal,
+		/datum/autolathe/recipe/part/subspace_transmitter,
 		/datum/autolathe/recipe/part/igniter,
 		/datum/autolathe/recipe/part/signaler,
 		/datum/autolathe/recipe/part/sensor_prox,
-		/datum/autolathe/recipe/sec/beartrap,
-		/datum/autolathe/recipe/clothing/excelsior_armor,
-		/datum/autolathe/recipe/clothing/excelsior_helmet
+		/datum/autolathe/recipe/part/capacitor,
+		/datum/autolathe/recipe/part/camera_assembly
 	)
 	..()

--- a/code/game/objects/items/weapons/implant/implant.dm
+++ b/code/game/objects/items/weapons/implant/implant.dm
@@ -29,6 +29,7 @@
 
 //return TRUE for implanter icon update.
 /obj/item/weapon/implant/proc/install(var/mob/living/target, var/organ, var/mob/user)
+	world << "Implant installing"
 	var/obj/item/organ/external/affected
 	if (ishuman(target))
 		var/mob/living/carbon/human/H = target
@@ -42,14 +43,17 @@
 
 		if(!affected)
 			user << SPAN_WARNING("[H] is missing that body part!.")
+			world << "Fail missing bodypart"
 			return
 
 		if(allowed_organs && allowed_organs.len && !(organ in allowed_organs))
 			user << SPAN_WARNING("[src] cannot be implanted in this limb.")
+			world << "Fail not allowed"
 			return
 
 	if(!can_install(target, affected))
 		user << SPAN_WARNING("You can't install [src].")
+		world << "Fail caninstall"
 		return
 
 	forceMove(target)
@@ -61,6 +65,7 @@
 
 	on_install(target, affected)
 	wearer.update_implants()
+	world << "success"
 	return TRUE
 
 /obj/item/weapon/implant/proc/can_install(var/mob/living/target, var/obj/item/organ/external/E)

--- a/code/game/objects/items/weapons/implant/implant.dm
+++ b/code/game/objects/items/weapons/implant/implant.dm
@@ -42,17 +42,14 @@
 
 		if(!affected)
 			user << SPAN_WARNING("[H] is missing that body part!.")
-			world << "Fail missing bodypart"
 			return
 
 		if(allowed_organs && allowed_organs.len && !(organ in allowed_organs))
 			user << SPAN_WARNING("[src] cannot be implanted in this limb.")
-			world << "Fail not allowed"
 			return
 
 	if(!can_install(target, affected))
 		user << SPAN_WARNING("You can't install [src].")
-		world << "Fail caninstall"
 		return
 
 	forceMove(target)
@@ -64,7 +61,6 @@
 
 	on_install(target, affected)
 	wearer.update_implants()
-	world << "success"
 	return TRUE
 
 /obj/item/weapon/implant/proc/can_install(var/mob/living/target, var/obj/item/organ/external/E)

--- a/code/game/objects/items/weapons/implant/implant.dm
+++ b/code/game/objects/items/weapons/implant/implant.dm
@@ -29,7 +29,6 @@
 
 //return TRUE for implanter icon update.
 /obj/item/weapon/implant/proc/install(var/mob/living/target, var/organ, var/mob/user)
-	world << "Implant installing"
 	var/obj/item/organ/external/affected
 	if (ishuman(target))
 		var/mob/living/carbon/human/H = target

--- a/code/game/objects/items/weapons/implant/implants/excelsior.dm
+++ b/code/game/objects/items/weapons/implant/implants/excelsior.dm
@@ -74,3 +74,16 @@
 	if(prob(66))
 		wearer.adjustBrainLoss(200)
 		part.droplimb(FALSE, DROPLIMB_BLUNT)
+
+//The leader version of the implant is the one given to antags spawned by the storyteller.
+//It has no special gameplay properties and is not attainable in normal gameplay, it just exists to
+//prevent buggy behaviour.
+/obj/item/weapon/implant/excelsior/leader
+
+//Caninstall returns true, so it wont fail when inserted into someone who was already made an antag
+/obj/item/weapon/implant/excelsior/leader/can_install()
+	return TRUE
+
+//On install is short circuited, so that it doesnt spam them with double greeting
+/obj/item/weapon/implant/excelsior/leader/on_install()
+	return TRUE


### PR DESCRIPTION
Fixes excelsior implants not being properly setup when spawned by storyteller, resulting in their own turrets shooting them
Fixes storyteller having a defunct "roleset" option in the roleset pool which wasted antag points
Adds many parts to the excelsior disk so they can actually create shield generators