### PR TITLE
Design Materials Refactor

### DIFF
--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -7,7 +7,7 @@
 	slot_flags = SLOT_BELT
 	var/flush = null
 	origin_tech = list(TECH_DATA = 4, TECH_MATERIAL = 4)
-
+	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	var/mob/living/silicon/ai/carded_ai
 
 /obj/item/device/aicard/attack(mob/living/silicon/decoy/M as mob, mob/user as mob)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -50,7 +50,7 @@
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	origin_tech = list(TECH_MAGNET = 3, TECH_MATERIAL = 2)
-	matter = list(MATERIAL_PLASTIC = 3)
+	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 
 	var/max_uses = 32
 	var/uses = 32

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -6,6 +6,7 @@
 	w_class = ITEM_SIZE_SMALL
 	slot_flags = SLOT_BELT
 	origin_tech = list(TECH_DATA = 2)
+	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	var/obj/item/device/radio/radio
 	var/looking_for_personality = 0
 	var/mob/living/silicon/pai/pai

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -5,6 +5,7 @@
 	item_state = "signaler"
 	var/code = "electronic"
 	origin_tech = list(TECH_BLUESPACE = 1)
+	matter = list (MATERIAL_STEEL = 3, MATERIAL_GLASS = 1)
 
 /obj/item/device/radio/beacon/hear_talk()
 	return

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -11,6 +11,7 @@
 	var/translate_hive = 0
 	var/syndie = 0
 	var/list/channels = list()
+	matter = list(MATERIAL_STEEL = 1)
 
 /obj/item/device/encryptionkey/attackby(obj/item/weapon/W as obj, mob/user as mob)
 

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -4,6 +4,7 @@
 	desc = "A tube of paste containing swarms of repair nanites. Very effective in repairing robotic machinery."
 	icon = 'icons/obj/nanopaste.dmi'
 	icon_state = "tube"
+	matter = list(MATERIAL_PLASTIC = 10)
 	origin_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
 	amount = 10
 

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -1,3 +1,6 @@
+/obj/item/weapon/disk
+	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_STEEL = 1)
+
 /obj/item/weapon/disk/autolathe_disk
 	name = "Design disk"
 	desc = "disk for autolathe designs."
@@ -8,7 +11,7 @@
 	flags = CONDUCT
 	force = WEAPON_FORCE_WEAK
 	throwforce = WEAPON_FORCE_WEAK
-	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
+
 
 	var/list/recipes = list()
 

--- a/code/game/objects/items/weapons/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/weapons/circuitboards/circuitboard.dm
@@ -10,7 +10,7 @@
 	icon_state = "id_mod"
 	item_state = "electronic"
 	origin_tech = list(TECH_DATA = 2)
-	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 3)
+	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_STEEL = 2)
 	matter_reagents = list("silicon" = 10)
 	density = 0
 	anchored = 0

--- a/code/game/objects/items/weapons/circuitboards/machinery/shieldgen.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/shieldgen.dm
@@ -6,6 +6,7 @@
 	name = T_BOARD("advanced shield generator")
 	board_type = "machine"
 	build_path = /obj/machinery/power/shield_generator
+	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GOLD = 1)
 	origin_tech = list(TECH_MAGNET = 3, TECH_POWER = 4)
 	req_components = list(
 							/obj/item/weapon/stock_parts/capacitor = 1,
@@ -26,6 +27,7 @@
 /obj/item/weapon/circuitboard/shieldwallgen
 	name = T_BOARD("shield wall generator")
 	board_type = "machine"
+	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GOLD = 1)
 	build_path = /obj/machinery/shieldwallgen
 	origin_tech = list(TECH_BLUESPACE = 3, TECH_MAGNET = 3)
 	req_components = list(

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -11,6 +11,7 @@
 	var/stage = 0
 	var/state = 0
 	var/path = 0
+	matter = list(MATERIAL_STEEL = 3)
 	var/obj/item/device/assembly_holder/detonator = null
 	var/list/beakers = new/list()
 	var/list/allowed_containers = list(/obj/item/weapon/reagent_containers/glass/beaker, /obj/item/weapon/reagent_containers/glass/bottle)
@@ -193,6 +194,7 @@
 	allowed_containers = list(/obj/item/weapon/reagent_containers/glass)
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
 	affected_area = 4
+	matter = list(MATERIAL_STEEL = 5)
 
 /obj/item/weapon/grenade/chem_grenade/metalfoam
 	name = "Asters \"Stop-Space\""

--- a/code/game/objects/items/weapons/implant/implant.dm
+++ b/code/game/objects/items/weapons/implant/implant.dm
@@ -7,6 +7,7 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "implant"
 	w_class = ITEM_SIZE_TINY
+	matter = list(MATERIAL_STEEL = 1, MATERIAL_GLASS = 1)
 	var/implanted = FALSE
 	var/mob/living/carbon/human/wearer = null
 	var/obj/item/organ/external/part = null

--- a/code/game/objects/items/weapons/implant/implantcase.dm
+++ b/code/game/objects/items/weapons/implant/implantcase.dm
@@ -10,6 +10,7 @@
 	throw_range = 5
 	w_class = ITEM_SIZE_TINY
 	var/obj/item/weapon/implant/implant = null
+	matter = list(MATERIAL_STEEL = 1, MATERIAL_GLASS = 3)
 
 /obj/item/weapon/implantcase/New()
 	..()

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -61,6 +61,7 @@
 	icon_state = "meb_b_nu"
 	autorecharging = TRUE
 	origin_tech = list(TECH_POWER = 6)
+	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 3, MATERIAL_SILVER = 3, MATERIAL_URANIUM = 6)
 	maxcharge = 13000
 
 //Meme cells - for fun and cancer
@@ -150,6 +151,7 @@
 	desc = "Moebius Laboratories branded rechargeable M-standardized power cell. This version able to recharge itself over time."
 	icon_state = "meb_m_nu"
 	autorecharging = TRUE
+	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2, MATERIAL_URANIUM = 4)
 	origin_tech = list(TECH_POWER = 6)
 	maxcharge = 1000
 
@@ -220,4 +222,5 @@
 	icon_state = "meb_s_nu"
 	autorecharging = TRUE
 	origin_tech = list(TECH_POWER = 6)
+	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_SILVER = 1, MATERIAL_URANIUM = 2)
 	maxcharge = 300

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -79,6 +79,7 @@
 	max_w_class = ITEM_SIZE_LARGE
 	max_storage_space = 100
 	storage_cost = 29
+	matter = list(MATERIAL_STEEL = 10, MATERIAL_GOLD = 10, MATERIAL_DIAMOND = 5, MATERIAL_URANIUM = 5)
 
 	attackby(obj/item/weapon/W as obj, mob/user as mob)
 		if(istype(W, /obj/item/weapon/storage/backpack/holding))

--- a/code/game/objects/items/weapons/storage/part_replacer.dm
+++ b/code/game/objects/items/weapons/storage/part_replacer.dm
@@ -13,4 +13,4 @@
 	display_contents_with_number = 1
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = 100
-
+	matter = list(MATERIAL_PLASTIC = 5, MATERIAL_STEEL = 2)

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -68,19 +68,19 @@
 
 // Metal. Common building material.
 /datum/export/stack/metal
-	cost = 5
+	cost = 2
 	message = "of metal"
 	export_types = list(/obj/item/stack/material/steel)
 
 // Glass. Common building material.
 /datum/export/stack/glass
-	cost = 5
+	cost = 2
 	message = "of glass"
 	export_types = list(/obj/item/stack/material/glass)
 
 // Plasteel. Lightweight, strong and contains some plasma too.
 /datum/export/stack/plasteel
-	cost = 85
+	cost = 10
 	message = "of plasteel"
 	export_types = list(/obj/item/stack/material/plasteel)
 
@@ -92,13 +92,13 @@
 
 // Wood. Quite expensive in the grim and dark 26 century.
 /datum/export/stack/wood
-	cost = 25
+	cost = 10
 	unit_name = "wood plank"
 	export_types = list(/obj/item/stack/material/wood)
 
 // Cardboard. Cheap.
 /datum/export/stack/cardboard
-	cost = 2
+	cost = 1
 	message = "of cardboard"
 	export_types = list(/obj/item/stack/material/cardboard)
 
@@ -127,13 +127,13 @@
 
 // Diamonds. Rare and expensive.
 /datum/export/stack/diamond
-	cost = 2500
+	cost = 30
 	export_types = list(/obj/item/stack/material/diamond)
 	message = "of diamonds"
 
 // Phoron. The oil of 26 century. The reason why you are here.
 /datum/export/stack/phoron
-	cost = 300
+	cost = 25
 	export_types = list(/obj/item/stack/material/plasma)
 	message = "of phoron"
 
@@ -144,19 +144,19 @@
 
 // Uranium. Still useful for both power generation and nuclear annihilation.
 /datum/export/stack/uranium
-	cost = 400
+	cost = 20
 	export_types = list(/obj/item/stack/material/diamond)
 	message = "of uranium"
 
 // Gold. Used in electronics and corrosion-resistant plating.
 /datum/export/stack/gold
-	cost = 250
+	cost = 25
 	export_types = list(/obj/item/stack/material/gold)
 	message = "of gold"
 
 // Silver.
 /datum/export/stack/silver
-	cost = 100
+	cost = 10
 	export_types = list(/obj/item/stack/material/silver)
 	message = "of silver"
 
@@ -168,7 +168,7 @@
 
 // Platinum.
 /datum/export/stack/platinum
-	cost = 1000
+	cost = 40
 	message = "of platinum"
 	export_types = list(/obj/item/stack/material/platinum)
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -473,29 +473,43 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	crate_name = "Replacement lights"
 	group = "Engineering"
 
-/datum/supply_pack/metal50
-	name = "50 metal sheets"
+/datum/supply_pack/metal120
+	name = "120 metal sheets"
 	contains = list(/obj/item/stack/material/steel)
-	amount = 50
-	cost = 1000
+	amount = 120
+	cost = 360
 	containertype = /obj/structure/closet/crate/secure
 	crate_name = "Metal sheets crate"
 	group = "Engineering"
 
-/datum/supply_pack/glass50
-	name = "50 glass sheets"
-	contains = list(/obj/item/stack/material/glass)
-	amount = 50
+
+/datum/supply_pack/metal480
+	name = "Bulk metal crate"
+	contains = list(/obj/item/stack/material/steel/full,
+	/obj/item/stack/material/steel/full,
+	/obj/item/stack/material/steel/full,
+	/obj/item/stack/material/steel/full)
 	cost = 1000
+	containertype = /obj/structure/largecrate
+	crate_name = "Bulk metal crate"
+	group = "Engineering"
+
+
+
+/datum/supply_pack/glass50
+	name = "120 glass sheets"
+	contains = list(/obj/item/stack/material/glass)
+	amount = 120
+	cost = 360
 	containertype = /obj/structure/closet/crate/secure
 	crate_name = "Glass sheets crate"
 	group = "Engineering"
 
 /datum/supply_pack/wood50
-	name = "50 wooden planks"
+	name = "120 wooden planks"
 	contains = list(/obj/item/stack/material/wood)
-	amount = 50
-	cost = 1000
+	amount = 120
+	cost = 1200
 	containertype = /obj/structure/closet/crate
 	crate_name = "Wooden planks crate"
 	group = "Engineering"
@@ -530,7 +544,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	containertype = /obj/structure/closet/crate
 	crate_name = "Mechanical maintenance crate"
 	group = "Engineering"
-	
+
 /datum/supply_pack/toolmods
 	contains = list(/obj/random/tool_upgrade,
 					/obj/random/tool_upgrade,
@@ -745,7 +759,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	crate_name = "Disposal Dispenser Crate"
 	group = "Engineering"
 	access = access_atmospherics
-	
+
 
 //----------------------------------------------
 //------------MEDICAL / SCIENCE-----------------
@@ -1286,7 +1300,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	crate_name = "Actor Costumes"
 	access = access_theatre
 	group = "Miscellaneous"
-	
+
 /datum/supply_pack/randomised/guns
 	num_contained = 2
 	contains = list(/obj/item/weapon/gun/projectile/automatic/ak47/fs,
@@ -1334,7 +1348,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	crate_name = "Surplus Crate"
 	containertype = /obj/structure/closet/crate/secure/weapon
 	group = "Security"
-	
+
 
 datum/supply_pack/randomised/spacesuit
 	num_contained = 1

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -5,6 +5,7 @@
 	prescription = TRUE
 	origin_tech = list(TECH_MAGNET = 3, TECH_BIO = 2)
 	var/list/icon/current = list() //the current hud icons
+	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1, MATERIAL_SILVER = 0.5)
 
 /obj/item/clothing/glasses/proc/process_hud(var/mob/M)
 	if(hud)

--- a/code/modules/clothing/glasses/meson.dm
+++ b/code/modules/clothing/glasses/meson.dm
@@ -10,6 +10,7 @@
 	vision_flags = SEE_TURFS
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
 	active = FALSE
+	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	var/tick_cost = 0.5
 	var/obj/item/weapon/cell/cell = null
 	var/suitable_cell = /obj/item/weapon/cell/small

--- a/code/modules/integrated/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated/integrated_electronics/core/assemblies.dm
@@ -7,6 +7,7 @@
 	w_class = ITEM_SIZE_SMALL
 	icon = 'icons/obj/electronic_assemblies.dmi'
 	icon_state = "setup_small"
+	matter = list(MATERIAL_STEEL = 4)
 	var/max_components = IC_COMPONENTS_BASE
 	var/max_complexity = IC_COMPLEXITY_BASE
 	var/opened = 0

--- a/code/modules/integrated/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated/integrated_electronics/core/integrated_circuit.dm
@@ -3,10 +3,15 @@
 a creative player the means to solve many problems.  Circuits are held inside an electronic assembly, and are wired using special tools.
 */
 
+/obj/item/integrated_circuit
+	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_STEEL = 1)
+	matter_reagents = list("silicon" = 5)
+
 /obj/item/integrated_circuit/examine(mob/user)
 	. = ..()
 	external_examine(user)
 	interact(user)
+
 
 // This should be used when someone is examining while the case is opened.
 /obj/item/integrated_circuit/proc/internal_examine(mob/user)

--- a/code/modules/integrated/integrated_electronics/core/tools.dm
+++ b/code/modules/integrated/integrated_electronics/core/tools.dm
@@ -16,6 +16,7 @@
 	w_class = ITEM_SIZE_SMALL
 	var/datum/integrated_io/selected_io = null
 	var/mode = WIRE
+	matter = list(MATERIAL_STEEL = 3, MATERIAL_GLASS = 1)
 
 /obj/item/device/integrated_electronics/wirer/update_icon()
 	icon_state = "wirer-[mode]"
@@ -114,6 +115,7 @@
 	w_class = ITEM_SIZE_SMALL
 	var/data_to_write = null
 	var/accepting_refs = 0
+	matter = list(MATERIAL_STEEL = 3, MATERIAL_GLASS = 1)
 
 /obj/item/device/integrated_electronics/debugger/attack_self(mob/user)
 	var/type_to_use = input("Please choose a type to use.","[src] type setting") as null|anything in list("string","number","ref", "null")

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -185,6 +185,10 @@
 	icon_state = "sheet-metal"
 	default_type = MATERIAL_STEEL
 
+//A stack which starts with the max amount
+/obj/item/stack/material/steel/full
+	amount = 120
+
 /obj/item/stack/material/steel/random
 	rand_min = 3
 	rand_max = 30

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -23,7 +23,7 @@
 	icon_state = "mmi_empty"
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_BIO = 3)
-
+	matter = list(MATERIAL_STEEL = 5, MATERIAL_GLASS = 3)
 	req_access = list(access_robotics)
 
 	//Revised. Brainmob is now contained directly within object of transfer. MMI in this case.

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -5,7 +5,7 @@
 	icon_state = "posibrain"
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2, TECH_DATA = 4)
-
+	matter = list(MATERIAL_STEEL = 5, MATERIAL_GLASS = 5, MATERIAL_SILVER = 5, MATERIAL_GOLD = 5)
 	var/searching = 0
 	var/askDelay = 10 * 60 * 1
 	req_access = list(access_robotics)

--- a/code/modules/modular_computers/hardware/_hardware.dm
+++ b/code/modules/modular_computers/hardware/_hardware.dm
@@ -2,6 +2,8 @@
 	name = "Hardware"
 	desc = "Unknown Hardware."
 	icon = 'icons/obj/modular_components.dmi'
+	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1)
+	matter_reagents = list("silicon" = 5)
 	var/obj/item/modular_computer/holder2 = null
 	var/power_usage = 0 			// If the hardware uses extra power, change this.
 	var/enabled = 1					// If the hardware is turned off set this to 0.

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -196,7 +196,7 @@
 	icon_state = "stunshell"
 	spent_icon = "stunshell-spent"
 	projectile_type = /obj/item/projectile/energy/electrode/stunshot
-	matter = list(MATERIAL_STEEL = 1, MATERIAL_SILVER = 1)
+	matter = list(MATERIAL_STEEL = 1, MATERIAL_SILVER = 0.5)
 	maxamount = 5
 
 /obj/item/ammo_casing/shotgun/stunshell/emp_act(severity)
@@ -212,7 +212,7 @@
 	desc = "A chemical shell used to signal distress or provide illumination."
 	icon_state = "fshell"
 	projectile_type = /obj/item/projectile/energy/flash/flare
-	matter = list(MATERIAL_STEEL = 1, MATERIAL_SILVER = 1)
+	matter = list(MATERIAL_STEEL = 1, MATERIAL_SILVER = 0.5)
 	maxamount = 5
 
 /obj/item/ammo_casing/shotgun/flash/prespawned

--- a/code/modules/projectiles/guns/energy/decloner.dm
+++ b/code/modules/projectiles/guns/energy/decloner.dm
@@ -7,3 +7,4 @@
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 4, TECH_POWER = 3)
 	projectile_type = /obj/item/projectile/energy/declone
 	charge_cost = 100
+	matter = list(MATERIAL_STEEL = 20)

--- a/code/modules/projectiles/guns/energy/floragun.dm
+++ b/code/modules/projectiles/guns/energy/floragun.dm
@@ -9,7 +9,7 @@
 	origin_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_POWER = 3)
 	modifystate = "floramut"
 	self_recharge = 1
-
+	matter = list(MATERIAL_STEEL = 20)
 	firemodes = list(
 		list(mode_name="induce mutations", projectile_type=/obj/item/projectile/energy/floramut, modifystate="floramut"),
 		list(mode_name="increase yield", projectile_type=/obj/item/projectile/energy/florayield, modifystate="florayield"),

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -57,6 +57,7 @@ obj/item/weapon/gun/energy/retro
 	projectile_type = /obj/item/projectile/beam/heavylaser
 	charge_cost = 250
 	fire_delay = 20
+	matter = list(MATERIAL_STEEL = 20)
 
 /obj/item/weapon/gun/energy/lasercannon/mounted
 	name = "mounted laser cannon"

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -7,6 +7,7 @@
 	force = WEAPON_FORCE_PAINFULL //looks heavier than a pistol
 	self_recharge = 1
 	modifystate = null
+	matter = list(MATERIAL_STEEL = 20, MATERIAL_URANIUM = 10)
 
 	firemodes = list(
 		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun, fire_sound='sound/weapons/Taser.ogg'),

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -8,7 +8,7 @@
 	charge_cost = 100
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 4, TECH_POWER = 3, TECH_MAGNET = 2)
 	slot_flags = SLOT_BELT|SLOT_BACK
-
+	matter = list(MATERIAL_STEEL = 20)
 	projectile_type = /obj/item/projectile/temp
 
 

--- a/code/modules/projectiles/guns/energy/toxgun.dm
+++ b/code/modules/projectiles/guns/energy/toxgun.dm
@@ -5,4 +5,5 @@
 	fire_sound = 'sound/effects/stealthoff.ogg'
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_COMBAT = 5, TECH_PLASMA = 4)
+	matter = list(MATERIAL_STEEL = 20, MATERIAL_PLASMA = 5)
 	projectile_type = /obj/item/projectile/energy/plasma

--- a/code/modules/reagents/reagent_containers/glass/beaker.dm
+++ b/code/modules/reagents/reagent_containers/glass/beaker.dm
@@ -16,7 +16,7 @@
 	name = "cryostasis beaker"
 	desc = "A cryostasis beaker that allows for chemical storage without reactions."
 	icon_state = "beakernoreact"
-	matter = list(MATERIAL_GLASS = 1)
+	matter = list(MATERIAL_GLASS = 1, MATERIAL_STEEL = 2)
 	volume = 60
 	amount_per_transfer_from_this = 10
 	flags = OPENCONTAINER | NOREACT
@@ -25,7 +25,7 @@
 	name = "bluespace beaker"
 	desc = "A bluespace beaker, powered by experimental bluespace technology."
 	icon_state = "beakerbluespace"
-	matter = list(MATERIAL_GLASS = 2)
+	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLASMA = 1)
 	volume = 300
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,25,30,60,120,300)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -154,6 +154,7 @@
 	item_state = "chemsprayer"
 	throwforce = 3
 	w_class = ITEM_SIZE_NORMAL
+	matter = list(MATERIAL_STEEL = 20, MATERIAL_PLASTIC = 4)
 	possible_transfer_amounts = null
 	volume = 600
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_ENGINEERING = 3)

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -84,7 +84,6 @@ other types of metals and chemistry for reagents).
 	desc = "Produce additional disks for storing device designs."
 	id = "design_disk"
 	req_tech = list(TECH_DATA = 1)
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/disk/design_disk
 	sort_string = "GAAAA"
 
@@ -93,7 +92,6 @@ other types of metals and chemistry for reagents).
 	desc = "Produce additional disks for storing technology data."
 	id = "tech_disk"
 	req_tech = list(TECH_DATA = 1)
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/disk/tech_disk
 	sort_string = "GAAAB"
 
@@ -111,105 +109,90 @@ other types of metals and chemistry for reagents).
 /datum/design/item/stock_part/basic_capacitor
 	id = "basic_capacitor"
 	req_tech = list(TECH_POWER = 1)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/capacitor
 	sort_string = "CAAAA"
 
 /datum/design/item/stock_part/adv_capacitor
 	id = "adv_capacitor"
 	req_tech = list(TECH_POWER = 3)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/capacitor/adv
 	sort_string = "CAAAB"
 
 /datum/design/item/stock_part/super_capacitor
 	id = "super_capacitor"
 	req_tech = list(TECH_POWER = 5, TECH_MATERIAL = 4)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/capacitor/super
 	sort_string = "CAAAC"
 
 /datum/design/item/stock_part/micro_mani
 	id = "micro_mani"
 	req_tech = list(TECH_MATERIAL = 1, TECH_DATA = 1)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/manipulator
 	sort_string = "CAABA"
 
 /datum/design/item/stock_part/nano_mani
 	id = "nano_mani"
 	req_tech = list(TECH_MATERIAL = 3, TECH_DATA = 2)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/manipulator/nano
 	sort_string = "CAABB"
 
 /datum/design/item/stock_part/pico_mani
 	id = "pico_mani"
 	req_tech = list(TECH_MATERIAL = 5, TECH_DATA = 2)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/manipulator/pico
 	sort_string = "CAABC"
 
 /datum/design/item/stock_part/basic_matter_bin
 	id = "basic_matter_bin"
 	req_tech = list(TECH_MATERIAL = 1)
-	materials = list(MATERIAL_PLASTIC = 3, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/matter_bin
 	sort_string = "CAACA"
 
 /datum/design/item/stock_part/adv_matter_bin
 	id = "adv_matter_bin"
 	req_tech = list(TECH_MATERIAL = 3)
-	materials = list(MATERIAL_PLASTIC = 3, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/matter_bin/adv
 	sort_string = "CAACB"
 
 /datum/design/item/stock_part/super_matter_bin
 	id = "super_matter_bin"
 	req_tech = list(TECH_MATERIAL = 5)
-	materials = list(MATERIAL_PLASTIC = 3, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/matter_bin/super
 	sort_string = "CAACC"
 
 /datum/design/item/stock_part/basic_micro_laser
 	id = "basic_micro_laser"
 	req_tech = list(TECH_MAGNET = 1)
-	materials = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/micro_laser
 	sort_string = "CAADA"
 
 /datum/design/item/stock_part/high_micro_laser
 	id = "high_micro_laser"
 	req_tech = list(TECH_MAGNET = 3)
-	materials = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/micro_laser/high
 	sort_string = "CAADB"
 
 /datum/design/item/stock_part/ultra_micro_laser
 	id = "ultra_micro_laser"
 	req_tech = list(TECH_MAGNET = 5, TECH_MATERIAL = 5)
-	materials = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/micro_laser/ultra
 	sort_string = "CAADC"
 
 /datum/design/item/stock_part/basic_sensor
 	id = "basic_sensor"
 	req_tech = list(TECH_MAGNET = 1)
-	materials = list(MATERIAL_PLASTIC = 3, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/scanning_module
 	sort_string = "CAAEA"
 
 /datum/design/item/stock_part/adv_sensor
 	id = "adv_sensor"
 	req_tech = list(TECH_MAGNET = 3)
-	materials = list(MATERIAL_PLASTIC = 3, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/scanning_module/adv
 	sort_string = "CAAEB"
 
 /datum/design/item/stock_part/phasic_sensor
 	id = "phasic_sensor"
 	req_tech = list(TECH_MAGNET = 5, TECH_MATERIAL = 3)
-	materials = list(MATERIAL_PLASTIC = 3, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/scanning_module/phasic
 	sort_string = "CAAEC"
 
@@ -218,7 +201,6 @@ other types of metals and chemistry for reagents).
 	desc = "Special mechanical module made to store, sort, and apply standard machine parts."
 	id = "rped"
 	req_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 3)
-	materials = list(MATERIAL_PLASTIC = 5, MATERIAL_STEEL = 2)
 	build_path = /obj/item/weapon/storage/part_replacer
 	sort_string = "CBAAA"
 
@@ -243,7 +225,6 @@ other types of metals and chemistry for reagents).
 	build_type = PROTOLATHE | MECHFAB
 	id = "basic_cell_b"
 	req_tech = list(TECH_POWER = 1)
-	materials = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 3, MATERIAL_SILVER = 3)
 	build_path = /obj/item/weapon/cell/large/moebius
 	category = "Misc"
 	sort_string = "DAAAA"
@@ -253,7 +234,6 @@ other types of metals and chemistry for reagents).
 	build_type = PROTOLATHE | MECHFAB
 	id = "high_cell_b"
 	req_tech = list(TECH_POWER = 2)
-	materials = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 3, MATERIAL_SILVER = 3)
 	build_path = /obj/item/weapon/cell/large/moebius/high
 	category = "Misc"
 	sort_string = "DAAAB"
@@ -262,7 +242,6 @@ other types of metals and chemistry for reagents).
 	name = "Moebius \"Power-Geyser 13000L\""
 	id = "super_cell_b"
 	req_tech = list(TECH_POWER = 3, TECH_MATERIAL = 2)
-	materials = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 3, MATERIAL_SILVER = 3)
 	build_path = /obj/item/weapon/cell/large/moebius/super
 	category = "Misc"
 	sort_string = "DAAAC"
@@ -271,7 +250,6 @@ other types of metals and chemistry for reagents).
 	name = "Moebius \"Power-Geyser 18000L\""
 	id = "hyper_cell_b"
 	req_tech = list(TECH_POWER = 5, TECH_MATERIAL = 4)
-	materials = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 3, MATERIAL_SILVER = 3)
 	build_path = /obj/item/weapon/cell/large/moebius/hyper
 	category = "Misc"
 	sort_string = "DAAAD"
@@ -281,7 +259,6 @@ other types of metals and chemistry for reagents).
 	build_type = PROTOLATHE | MECHFAB
 	id = "basic_cell_m"
 	req_tech = list(TECH_POWER = 1)
-	materials = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2)
 	build_path = /obj/item/weapon/cell/medium/moebius
 	category = "Misc"
 	sort_string = "DAAAF"
@@ -291,7 +268,6 @@ other types of metals and chemistry for reagents).
 	build_type = PROTOLATHE | MECHFAB
 	id = "high_cell_m"
 	req_tech = list(TECH_POWER = 2)
-	materials = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2)
 	build_path = /obj/item/weapon/cell/medium/moebius/high
 	category = "Misc"
 	sort_string = "DAAAI"
@@ -300,7 +276,6 @@ other types of metals and chemistry for reagents).
 	name = "Moebius \"Power-Geyser 1000M\""
 	id = "super_cell_m"
 	req_tech = list(TECH_POWER = 3, TECH_MATERIAL = 2)
-	materials = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2)
 	build_path = /obj/item/weapon/cell/medium/moebius/super
 	category = "Misc"
 	sort_string = "DAAAO"
@@ -309,7 +284,6 @@ other types of metals and chemistry for reagents).
 	name = "Moebius \"Power-Geyser 1300M\""
 	id = "hyper_cell_m"
 	req_tech = list(TECH_POWER = 5, TECH_MATERIAL = 4)
-	materials = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2)
 	build_path = /obj/item/weapon/cell/medium/moebius/hyper
 	category = "Misc"
 	sort_string = "DAAAP"
@@ -319,7 +293,6 @@ other types of metals and chemistry for reagents).
 	build_type = PROTOLATHE | MECHFAB
 	id = "basic_cell_s"
 	req_tech = list(TECH_POWER = 1)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_SILVER = 1)
 	build_path = /obj/item/weapon/cell/small/moebius
 	category = "Misc"
 	sort_string = "DAAAQ"
@@ -329,7 +302,6 @@ other types of metals and chemistry for reagents).
 	build_type = PROTOLATHE | MECHFAB
 	id = "high_cell_s"
 	req_tech = list(TECH_POWER = 2)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_SILVER = 1)
 	build_path = /obj/item/weapon/cell/small/moebius/high
 	category = "Misc"
 	sort_string = "DAAAZ"
@@ -338,7 +310,6 @@ other types of metals and chemistry for reagents).
 	name = "Moebius \"Power-Geyser 300S\""
 	id = "super_cell_s"
 	req_tech = list(TECH_POWER = 3, TECH_MATERIAL = 2)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_SILVER = 1)
 	build_path = /obj/item/weapon/cell/small/moebius/super
 	category = "Misc"
 	sort_string = "DAAAW"
@@ -347,7 +318,6 @@ other types of metals and chemistry for reagents).
 	name = "Moebius \"Power-Geyser 400S\""
 	id = "hyper_cell_s"
 	req_tech = list(TECH_POWER = 5, TECH_MATERIAL = 4)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_SILVER = 1)
 	build_path = /obj/item/weapon/cell/small/moebius/hyper
 	category = "Misc"
 	sort_string = "DAAAY"
@@ -356,7 +326,6 @@ other types of metals and chemistry for reagents).
 	name = "Moebius \"Atomcell 13000L\""
 	id = "nuke_cell_b"
 	req_tech = list(TECH_POWER = 5, TECH_MATERIAL = 4)
-	materials = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 3, MATERIAL_SILVER = 3, MATERIAL_URANIUM = 6)
 	build_path = /obj/item/weapon/cell/large/moebius/nuclear
 	category = "Misc"
 	sort_string = "DAAAZ"
@@ -365,7 +334,6 @@ other types of metals and chemistry for reagents).
 	name = "Moebius \"Atomcell 1000M\""
 	id = "nuke_cell_m"
 	req_tech = list(TECH_POWER = 5, TECH_MATERIAL = 4)
-	materials = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2, MATERIAL_URANIUM = 4)
 	build_path = /obj/item/weapon/cell/medium/moebius/nuclear
 	category = "Misc"
 	sort_string = "DAABA"
@@ -374,13 +342,10 @@ other types of metals and chemistry for reagents).
 	name = "Moebius \"Atomcell 300S\""
 	id = "nuke_cell_s"
 	req_tech = list(TECH_POWER = 5, TECH_MATERIAL = 4)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_SILVER = 1, MATERIAL_URANIUM = 2)
 	build_path = /obj/item/weapon/cell/small/moebius/nuclear
 	category = "Misc"
 	sort_string = "DAABB"
 
-/datum/design/item/hud
-	materials = list(MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 
 /datum/design/item/hud/AssembleDesignName()
 	..()
@@ -408,7 +373,6 @@ other types of metals and chemistry for reagents).
 	desc = "Using the meson-scanning technology those glasses allow you to see through walls, floor or anything else."
 	id = "mesons"
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
-	materials = list(MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/clothing/glasses/meson
 	sort_string = "GAAAC"
 
@@ -419,21 +383,18 @@ other types of metals and chemistry for reagents).
 /datum/design/item/weapon/mining/jackhammer
 	id = "jackhammer"
 	req_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2, TECH_ENGINEERING = 2)
-	materials = list(MATERIAL_STEEL = 5)
 	build_path = /obj/item/weapon/tool/pickaxe/jackhammer
 	sort_string = "KAAAA"
 
 /datum/design/item/weapon/mining/drill
 	id = "drill"
 	req_tech = list(TECH_MATERIAL = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
-	materials = list(MATERIAL_STEEL = 6) //expensive, but no need for miners.
 	build_path = /obj/item/weapon/tool/pickaxe/drill
 	sort_string = "KAAAB"
 
 /datum/design/item/weapon/mining/drill_diamond
 	id = "drill_diamond"
 	req_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 4)
-	materials = list(MATERIAL_STEEL = 6, MATERIAL_DIAMOND = 1)
 	build_path = /obj/item/weapon/tool/pickaxe/diamonddrill
 	sort_string = "KAAAC"
 ///////////////////////////////////
@@ -443,8 +404,6 @@ other types of metals and chemistry for reagents).
 	req_tech = list(TECH_BLUESPACE = 4, TECH_PLASMA = 3)
 	materials = list(MATERIAL_PLASTIC = 3, MATERIAL_GOLD = 1)
 
-/datum/design/item/medical
-	materials = list(MATERIAL_PLASTIC = 3, MATERIAL_GLASS = 1)
 
 /datum/design/item/medical/AssembleDesignName()
 	..()
@@ -454,14 +413,12 @@ other types of metals and chemistry for reagents).
 	desc = "A hand-held scanner able to diagnose robotic injuries."
 	id = "robot_scanner"
 	req_tech = list(TECH_MAGNET = 3, TECH_BIO = 2, TECH_ENGINEERING = 3)
-	materials = list(MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/device/robotanalyzer
 	sort_string = "MACFA"
 
 /datum/design/item/medical/mass_spectrometer
 	desc = "A device for analyzing chemicals in blood."
 	id = "mass_spectrometer"
-	req_tech = list(TECH_BIO = 2, TECH_MAGNET = 2)
 	build_path = /obj/item/device/scanner/mass_spectrometer
 	sort_string = "MACAA"
 
@@ -494,7 +451,6 @@ other types of metals and chemistry for reagents).
 	desc = "A cryostasis beaker that allows for chemical storage without reactions. Can hold up to 50 units."
 	id = "splitbeaker"
 	req_tech = list(TECH_MATERIAL = 2)
-	materials = list(MATERIAL_STEEL = 2)
 	build_path = /obj/item/weapon/reagent_containers/glass/beaker/noreact
 	sort_string = "MADAA"
 
@@ -503,7 +459,6 @@ other types of metals and chemistry for reagents).
 	desc = "A bluespace beaker, powered by experimental bluespace technology and Element Cuban combined with the Compound Pete. Can hold up to 300 units."
 	id = "bluespacebeaker"
 	req_tech = list(TECH_BLUESPACE = 2, TECH_MATERIAL = 6)
-	materials = list(MATERIAL_STEEL = 2)
 	build_path = /obj/item/weapon/reagent_containers/glass/beaker/bluespace
 	sort_string = "MADAB"
 
@@ -511,7 +466,6 @@ other types of metals and chemistry for reagents).
 	desc = "A tube of paste containing swarms of repair nanites. Very effective in repairing robotic machinery."
 	id = "nanopaste"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
-	materials = list(MATERIAL_STEEL = 3)
 	build_path = /obj/item/stack/nanopaste
 	sort_string = "MBAAA"
 
@@ -520,13 +474,10 @@ other types of metals and chemistry for reagents).
 	desc = "A scalpel augmented with a directed laser, for more precise cutting without blood entering the field."
 	id = "scalpel_laser1"
 	req_tech = list(TECH_BIO = 2, TECH_MATERIAL = 2, TECH_MAGNET = 2)
-	materials = list(MATERIAL_STEEL = 2)
 	build_path = /obj/item/weapon/tool/scalpel/laser
 	sort_string = "MBBAA"
 
 
-/datum/design/item/implant
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_GLASS = 1)
 
 /datum/design/item/implant/AssembleDesignName()
 	..()
@@ -560,14 +511,13 @@ other types of metals and chemistry for reagents).
 /datum/design/item/weapon/stunrevolver
 	id = "stunrevolver"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
-	materials = list(MATERIAL_STEEL = 10)
 	build_path = /obj/item/weapon/gun/energy/stunrevolver
 	sort_string = "TAAAA"
 
 /datum/design/item/weapon/nuclear_gun
 	id = "nuclear_gun"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 5, TECH_POWER = 3)
-	materials = list(MATERIAL_STEEL = 20, MATERIAL_URANIUM = 10)
+
 	build_path = /obj/item/weapon/gun/energy/gun/nuclear
 	sort_string = "TAAAB"
 
@@ -575,21 +525,18 @@ other types of metals and chemistry for reagents).
 	desc = "The lasing medium of this prototype is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core."
 	id = "lasercannon"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
-	materials = list(MATERIAL_STEEL = 20)
 	build_path = /obj/item/weapon/gun/energy/lasercannon
 	sort_string = "TAAAC"
 
 /datum/design/item/weapon/plasmapistol
 	id = "ppistol"
 	req_tech = list(TECH_COMBAT = 5, TECH_PLASMA = 4)
-	materials = list(MATERIAL_STEEL = 20)
 	build_path = /obj/item/weapon/gun/energy/toxgun
 	sort_string = "TAAAD"
 
 /datum/design/item/weapon/decloner
 	id = "decloner"
 	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
-	materials = list(MATERIAL_STEEL = 20)
 	build_path = /obj/item/weapon/gun/energy/decloner
 	sort_string = "TAAAE"
 
@@ -597,7 +544,6 @@ other types of metals and chemistry for reagents).
 	desc = "A stunning shell for a shotgun."
 	id = "stunshell"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
-	materials = list(MATERIAL_STEEL = 2)
 	build_path = /obj/item/ammo_casing/shotgun/stunshell
 	sort_string = "TAACB"
 
@@ -605,14 +551,12 @@ other types of metals and chemistry for reagents).
 	desc = "An advanced chem spraying device."
 	id = "chemsprayer"
 	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_BIO = 2)
-	materials = list(MATERIAL_PLASTIC = 3)
 	build_path = /obj/item/weapon/reagent_containers/spray/chemsprayer
 	sort_string = "TABAA"
 
 /datum/design/item/weapon/rapidsyringe
 	id = "rapidsyringe"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_BIO = 2)
-	materials = list(MATERIAL_PLASTIC = 3)
 	build_path = /obj/item/weapon/gun/launcher/syringe/rapid
 	sort_string = "TABAB"
 
@@ -620,70 +564,61 @@ other types of metals and chemistry for reagents).
 	desc = "A gun that shoots high-powered glass-encased energy temperature bullets."
 	id = "temp_gun"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 4, TECH_POWER = 3, TECH_MAGNET = 2)
-	materials = list(MATERIAL_STEEL = 20)
+
 	build_path = /obj/item/weapon/gun/energy/temperature
 	sort_string = "TABAC"
 
 /datum/design/item/weapon/large_grenade
 	id = "large_Grenade"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2)
-	materials = list(MATERIAL_STEEL = 4)
 	build_path = /obj/item/weapon/grenade/chem_grenade/large
 	sort_string = "TACAA"
 
 /datum/design/item/weapon/flora_gun
 	id = "flora_gun"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_POWER = 3)
-	materials = list(MATERIAL_STEEL = 20)
 	build_path = /obj/item/weapon/gun/energy/floragun
 	sort_string = "TBAAA"
 
 /datum/design/item/stock_part/subspace_ansible
 	id = "s-ansible"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/subspace/ansible
 	sort_string = "UAAAA"
 
 /datum/design/item/stock_part/hyperwave_filter
 	id = "s-filter"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 3)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/subspace/filter
 	sort_string = "UAAAB"
 
 /datum/design/item/stock_part/subspace_amplifier
 	id = "s-amplifier"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/subspace/amplifier
 	sort_string = "UAAAC"
 
 /datum/design/item/stock_part/subspace_treatment
 	id = "s-treatment"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 2, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/subspace/treatment
 	sort_string = "UAAAD"
 
 /datum/design/item/stock_part/subspace_analyzer
 	id = "s-analyzer"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/subspace/analyzer
 	sort_string = "UAAAE"
 
 /datum/design/item/stock_part/subspace_crystal
 	id = "s-crystal"
 	req_tech = list(TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/subspace/crystal
 	sort_string = "UAAAF"
 
 /datum/design/item/stock_part/subspace_transmitter
 	id = "s-transmitter"
 	req_tech = list(TECH_MAGNET = 5, TECH_MATERIAL = 5, TECH_BLUESPACE = 3)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/stock_parts/subspace/transmitter
 	sort_string = "UAAAG"
 
@@ -692,7 +627,6 @@ other types of metals and chemistry for reagents).
 	desc = "A device to automatically replace lights. Refill with working lightbulbs."
 	id = "light_replacer"
 	req_tech = list(TECH_MAGNET = 3, TECH_MATERIAL = 4)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/device/lightreplacer
 	sort_string = "VAAAH"
 
@@ -700,7 +634,6 @@ other types of metals and chemistry for reagents).
 	name = "'pAI', personal artificial intelligence device"
 	id = "paicard"
 	req_tech = list(TECH_DATA = 2)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/device/paicard
 	sort_string = "VABAI"
 
@@ -709,7 +642,6 @@ other types of metals and chemistry for reagents).
 	desc = "Allows for the construction of an intelliCard."
 	id = "intellicard"
 	req_tech = list(TECH_DATA = 4, TECH_MATERIAL = 4)
-	materials = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	build_path = /obj/item/device/aicard
 	sort_string = "VACAA"
 
@@ -718,7 +650,6 @@ other types of metals and chemistry for reagents).
 	id = "posibrain"
 	req_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 6, TECH_BLUESPACE = 2, TECH_DATA = 4)
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(MATERIAL_STEEL = 5, MATERIAL_GLASS = 5, MATERIAL_SILVER = 5, MATERIAL_GOLD = 5)
 	build_path = /obj/item/device/mmi/digital/posibrain
 	category = "Misc"
 	sort_string = "VACAB"
@@ -728,7 +659,6 @@ other types of metals and chemistry for reagents).
 	id = "mmi"
 	req_tech = list(TECH_DATA = 2, TECH_BIO = 3)
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(MATERIAL_STEEL = 5, MATERIAL_GLASS = 3)
 	build_path = /obj/item/device/mmi
 	category = "Misc"
 	sort_string = "VACBA"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1445,7 +1445,7 @@ CIRCUITS BELOW
 
 /datum/design/circuit/shield
 	req_tech = list(TECH_BLUESPACE = 4, TECH_PLASMA = 3)
-	materials = list(MATERIAL_GLASS = 2, MATERIAL_GOLD = 1)
+
 
 /datum/design/circuit/shield/AssembleDesignName()
 	name = "Shield generator circuit design ([name])"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -668,7 +668,6 @@ other types of metals and chemistry for reagents).
 	id = "mmi_radio"
 	req_tech = list(TECH_DATA = 2, TECH_BIO = 4)
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(MATERIAL_STEEL = 2)
 	build_path = /obj/item/device/mmi/radio_enabled
 	category = "Misc"
 	sort_string = "VACBB"
@@ -677,7 +676,6 @@ other types of metals and chemistry for reagents).
 	name = "Bluespace tracking beacon design"
 	id = "beacon"
 	req_tech = list(TECH_BLUESPACE = 1)
-	materials = list (MATERIAL_STEEL = 3, MATERIAL_GLASS = 1)
 	build_path = /obj/item/device/radio/beacon
 	sort_string = "VADAA"
 
@@ -686,7 +684,6 @@ other types of metals and chemistry for reagents).
 	desc = "Using localized pockets of bluespace this bag prototype offers incredible storage capacity with the contents weighting nothing. It's a shame the bag itself is pretty heavy."
 	id = "bag_holding"
 	req_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 6)
-	materials = list(MATERIAL_STEEL = 10, MATERIAL_GOLD = 10, MATERIAL_DIAMOND = 5, MATERIAL_URANIUM = 5)
 	build_path = /obj/item/weapon/storage/backpack/holding
 	sort_string = "VAEAA"
 
@@ -695,10 +692,11 @@ other types of metals and chemistry for reagents).
 	desc = "Allows for deciphering the binary channel on-the-fly."
 	id = "binaryencrypt"
 	req_tech = list(TECH_ILLEGAL = 2)
-	materials = list(MATERIAL_STEEL = 1)
 	build_path = /obj/item/device/encryptionkey/binary
 	sort_string = "VASAA"
 
+//Why is there a science design to craft a cardboard box full of things? That is not how this works
+/*
 /datum/design/item/chameleon
 	name = "Holographic equipment kit"
 	desc = "A kit of dangerous, high-tech equipment with changeable looks."
@@ -707,6 +705,7 @@ other types of metals and chemistry for reagents).
 	materials = list(MATERIAL_STEEL = 1)
 	build_path = /obj/item/weapon/storage/box/syndie_kit/chameleon
 	sort_string = "VASBA"
+*/
 
 // Modular computer components
 // Hard drives
@@ -715,7 +714,6 @@ other types of metals and chemistry for reagents).
 	id = "hdd_basic"
 	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
 	build_type = PROTOLATHE
-	materials = list(MATERIAL_STEEL = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/
 	sort_string = "VBAAA"
 
@@ -724,7 +722,6 @@ other types of metals and chemistry for reagents).
 	id = "hdd_advanced"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_type = PROTOLATHE
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/advanced
 	sort_string = "VBAAB"
 
@@ -733,7 +730,6 @@ other types of metals and chemistry for reagents).
 	id = "hdd_super"
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 3)
 	build_type = PROTOLATHE
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/super
 	sort_string = "VBAAC"
 
@@ -742,7 +738,6 @@ other types of metals and chemistry for reagents).
 	id = "hdd_cluster"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4)
 	build_type = PROTOLATHE
-	materials = list(MATERIAL_PLASTIC = 3, MATERIAL_GLASS = 2)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/cluster
 	sort_string = "VBAAD"
 
@@ -751,7 +746,6 @@ other types of metals and chemistry for reagents).
 	id = "hdd_small"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_type = PROTOLATHE
-	materials = list(MATERIAL_PLASTIC = 5, MATERIAL_GLASS = 3)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/small
 	sort_string = "VBAAE"
 
@@ -760,7 +754,6 @@ other types of metals and chemistry for reagents).
 	id = "hdd_micro"
 	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
 	build_type = PROTOLATHE
-	materials = list(MATERIAL_PLASTIC = 5, MATERIAL_GLASS = 3)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/micro
 	sort_string = "VBAAF"
 
@@ -770,7 +763,6 @@ other types of metals and chemistry for reagents).
 	id = "netcard_basic"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 1)
 	build_type = IMPRINTER
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	chemicals = list("sacid" = 20)
 	build_path = /obj/item/weapon/computer_hardware/network_card
 	sort_string = "VBAAG"
@@ -780,7 +772,6 @@ other types of metals and chemistry for reagents).
 	id = "netcard_advanced"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 2)
 	build_type = IMPRINTER
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	chemicals = list("sacid" = 20)
 	build_path = /obj/item/weapon/computer_hardware/network_card/advanced
 	sort_string = "VBAAH"
@@ -790,7 +781,6 @@ other types of metals and chemistry for reagents).
 	id = "netcard_wired"
 	req_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 3)
 	build_type = IMPRINTER
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	chemicals = list("sacid" = 20)
 	build_path = /obj/item/weapon/computer_hardware/network_card/wired
 	sort_string = "VBAAI"
@@ -801,7 +791,6 @@ other types of metals and chemistry for reagents).
 	id = "portadrive_basic"
 	req_tech = list(TECH_DATA = 1)
 	build_type = IMPRINTER
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	chemicals = list("sacid" = 20)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/portable
 	sort_string = "VBAAJ"
@@ -811,7 +800,6 @@ other types of metals and chemistry for reagents).
 	id = "portadrive_advanced"
 	req_tech = list(TECH_DATA = 2)
 	build_type = IMPRINTER
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	chemicals = list("sacid" = 20)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/portable/advanced
 	sort_string = "VBAAK"
@@ -821,7 +809,6 @@ other types of metals and chemistry for reagents).
 	id = "portadrive_super"
 	req_tech = list(TECH_DATA = 4)
 	build_type = IMPRINTER
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	chemicals = list("sacid" = 20)
 	build_path = /obj/item/weapon/computer_hardware/hard_drive/portable/super
 	sort_string = "VBAAL"
@@ -832,7 +819,6 @@ other types of metals and chemistry for reagents).
 	id = "cardslot"
 	req_tech = list(TECH_DATA = 2)
 	build_type = PROTOLATHE
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/computer_hardware/card_slot
 	sort_string = "VBAAM"
 
@@ -841,7 +827,6 @@ other types of metals and chemistry for reagents).
 	id = "cardbroadcaster"
 	req_tech = list(TECH_DATA = 2)
 	build_type = PROTOLATHE
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/computer_hardware/card_slot/broadcaster
 	sort_string = "VBAAN"
 
@@ -851,7 +836,6 @@ other types of metals and chemistry for reagents).
 	id = "nanoprinter"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_type = PROTOLATHE
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/computer_hardware/nano_printer
 	sort_string = "VBAAO"
 
@@ -861,7 +845,6 @@ other types of metals and chemistry for reagents).
 	id = "teslalink"
 	req_tech = list(TECH_DATA = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	build_type = PROTOLATHE
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/computer_hardware/tesla_link
 	sort_string = "VBAAP"
 
@@ -871,7 +854,6 @@ other types of metals and chemistry for reagents).
 	id = "bat_normal"
 	req_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 1)
 	build_type = PROTOLATHE
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/computer_hardware/battery_module
 	sort_string = "VBAAQ"
 
@@ -880,7 +862,6 @@ other types of metals and chemistry for reagents).
 	id = "bat_advanced"
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 2)
 	build_type = PROTOLATHE
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/advanced
 	sort_string = "VBAAR"
 
@@ -889,7 +870,6 @@ other types of metals and chemistry for reagents).
 	id = "bat_super"
 	req_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 3)
 	build_type = PROTOLATHE
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/super
 	sort_string = "VBAAS"
 
@@ -898,7 +878,6 @@ other types of metals and chemistry for reagents).
 	id = "bat_ultra"
 	req_tech = list(TECH_POWER = 5, TECH_ENGINEERING = 4)
 	build_type = PROTOLATHE
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/ultra
 	sort_string = "VBAAT"
 
@@ -907,7 +886,6 @@ other types of metals and chemistry for reagents).
 	id = "bat_nano"
 	req_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 1)
 	build_type = PROTOLATHE
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/nano
 	sort_string = "VBAAU"
 
@@ -916,7 +894,6 @@ other types of metals and chemistry for reagents).
 	id = "bat_micro"
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 2)
 	build_type = PROTOLATHE
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	build_path = /obj/item/weapon/computer_hardware/battery_module/micro
 	sort_string = "VBAAV"
 
@@ -925,7 +902,6 @@ other types of metals and chemistry for reagents).
 	id = "cpu_normal"
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 2)
 	build_type = IMPRINTER
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	chemicals = list("sacid" = 20)
 	build_path = /obj/item/weapon/computer_hardware/processor_unit
 	sort_string = "VBAAW"
@@ -935,7 +911,6 @@ other types of metals and chemistry for reagents).
 	id = "cpu_small"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_type = IMPRINTER
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	chemicals = list("sacid" = 20)
 	build_path = /obj/item/weapon/computer_hardware/processor_unit/small
 	sort_string = "VBAAX"
@@ -945,7 +920,6 @@ other types of metals and chemistry for reagents).
 	id = "pcpu_normal"
 	req_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 4)
 	build_type = IMPRINTER
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	chemicals = list("sacid" = 40)
 	build_path = /obj/item/weapon/computer_hardware/processor_unit/photonic
 	sort_string = "VBAAY"
@@ -955,7 +929,6 @@ other types of metals and chemistry for reagents).
 	id = "pcpu_small"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3)
 	build_type = IMPRINTER
-	materials = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	chemicals = list("sacid" = 20)
 	build_path = /obj/item/weapon/computer_hardware/processor_unit/photonic/small
 	sort_string = "VBAAZ"
@@ -966,8 +939,7 @@ CIRCUITS BELOW
 /datum/design/circuit
 	build_type = IMPRINTER
 	req_tech = list(TECH_DATA = 2)
-	materials = list(MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 2)
-	chemicals = list("sacid" = 20)
+	chemicals = list("sacid" = 20) //Acid is used for inscribing circuits, but intentionally not part of the final reagents
 	time = 5
 
 /datum/design/circuit/AssembleDesignName()

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -41,6 +41,7 @@ other types of metals and chemistry for reagents).
 /datum/design/proc/AssembleDesignInfo()
 	AssembleDesignName()
 	AssembleDesignDesc()
+	AssembleDesignMaterials()
 	return
 
 /datum/design/proc/AssembleDesignName()
@@ -54,6 +55,21 @@ other types of metals and chemistry for reagents).
 	if(!desc)								//Try to make up a nice description if we don't have one
 		desc = "Allows for the construction of \a [item_name]."
 	return
+
+//Extract matter and reagent requirements from the target object
+//Any materials specified in these designs are extras, added ontop of what is extracted
+/datum/design/proc/AssembleDesignMaterials()
+	if (ispath(build_path, /obj))
+		var/obj/O = new build_path
+		var/list/mats = O.matter
+		if (mats && mats.len)
+			for (var/a in mats)
+				LAZYAPLUS(materials, a, mats[a])
+		mats = O.matter_reagents
+		if (mats && mats.len)
+			for (var/a in mats)
+				LAZYAPLUS(chemicals, a, mats[a])
+		qdel(O)
 
 //Returns a new instance of the item for this design
 //This is to allow additional initialization to be performed, including possibly additional contructor arguments.

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1598,95 +1598,13 @@ CIRCUITS BELOW
 	build_path = /obj/item/device/pda
 	sort_string = "VAAAA"
 
-// Cartridges
-/datum/design/item/pda_cartridge
-	req_tech = list(TECH_ENGINEERING = 2, TECH_POWER = 3)
-	materials = list(MATERIAL_PLASTIC = 2)
 
-/datum/design/item/pda_cartridge/AssembleDesignName()
-	..()
-	name = "PDA accessory ([item_name])"
-
-/datum/design/item/pda_cartridge/cart_basic
-	id = "cart_basic"
-	build_path = /obj/item/weapon/cartridge
-	sort_string = "VBAAA"
-
-/datum/design/item/pda_cartridge/engineering
-	id = "cart_engineering"
-	build_path = /obj/item/weapon/cartridge/engineering
-	sort_string = "VBAAB"
-
-/datum/design/item/pda_cartridge/atmos
-	id = "cart_atmos"
-	build_path = /obj/item/weapon/cartridge/atmos
-	sort_string = "VBAAC"
-
-/datum/design/item/pda_cartridge/medical
-	id = "cart_medical"
-	build_path = /obj/item/weapon/cartridge/medical
-	sort_string = "VBAAD"
-
-/datum/design/item/pda_cartridge/chemistry
-	id = "cart_chemistry"
-	build_path = /obj/item/weapon/cartridge/chemistry
-	sort_string = "VBAAE"
-
-/datum/design/item/pda_cartridge/security
-	id = "cart_security"
-	build_path = /obj/item/weapon/cartridge/security
-	sort_string = "VBAAF"
-
-/datum/design/item/pda_cartridge/janitor
-	id = "cart_janitor"
-	build_path = /obj/item/weapon/cartridge/janitor
-	sort_string = "VBAAG"
-
-/datum/design/item/pda_cartridge/science
-	id = "cart_science"
-	build_path = /obj/item/weapon/cartridge/signal/science
-	sort_string = "VBAAH"
-
-/datum/design/item/pda_cartridge/quartermaster
-	id = "cart_quartermaster"
-	build_path = /obj/item/weapon/cartridge/quartermaster
-	sort_string = "VBAAI"
-
-/datum/design/item/pda_cartridge/hop
-	id = "cart_hop"
-	build_path = /obj/item/weapon/cartridge/hop
-	sort_string = "VBAAJ"
-
-/datum/design/item/pda_cartridge/hos
-	id = "cart_hos"
-	build_path = /obj/item/weapon/cartridge/hos
-	sort_string = "VBAAK"
-
-/datum/design/item/pda_cartridge/ce
-	id = "cart_ce"
-	build_path = /obj/item/weapon/cartridge/ce
-	sort_string = "VBAAL"
-
-/datum/design/item/pda_cartridge/cmo
-	id = "cart_cmo"
-	build_path = /obj/item/weapon/cartridge/cmo
-	sort_string = "VBAAM"
-
-/datum/design/item/pda_cartridge/rd
-	id = "cart_rd"
-	build_path = /obj/item/weapon/cartridge/rd
-	sort_string = "VBAAN"
-
-/datum/design/item/pda_cartridge/captain
-	id = "cart_captain"
-	build_path = /obj/item/weapon/cartridge/captain
-	sort_string = "VBAAO"
 
 /datum/design/item/wirer
 	name = "Custom wirer tool"
 	id = "wirer"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
-	materials = list(MATERIAL_STEEL = 3, MATERIAL_GLASS = 1)
+
 	build_path = /obj/item/device/integrated_electronics/wirer
 	sort_string = "VBVAA"
 
@@ -1694,7 +1612,6 @@ CIRCUITS BELOW
 	name = "Custom circuit debugger tool"
 	id = "debugger"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
-	materials = list(MATERIAL_STEEL = 3, MATERIAL_GLASS = 1)
 	build_path = /obj/item/device/integrated_electronics/debugger
 	sort_string = "VBVAB"
 
@@ -1705,7 +1622,6 @@ CIRCUITS BELOW
 	desc = "An customizable assembly for simple, small devices."
 	id = "assembly-small"
 	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 2, TECH_POWER = 2)
-	materials = list(MATERIAL_STEEL = 4)
 	build_path = /obj/item/device/electronic_assembly
 	sort_string = "VCAAA"
 
@@ -1714,7 +1630,6 @@ CIRCUITS BELOW
 	desc = "An customizable assembly suited for more ambitious mechanisms."
 	id = "assembly-medium"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3, TECH_POWER = 3)
-	materials = list(MATERIAL_STEEL = 5)
 	build_path = /obj/item/device/electronic_assembly/medium
 	sort_string = "VCAAB"
 
@@ -1723,7 +1638,6 @@ CIRCUITS BELOW
 	desc = "An customizable assembly optimized for autonomous devices."
 	id = "assembly-drone"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 4, TECH_POWER = 4)
-	materials = list(MATERIAL_STEEL = 6)
 	build_path = /obj/item/device/electronic_assembly/drone
 	sort_string = "VCAAC"
 
@@ -1732,7 +1646,6 @@ CIRCUITS BELOW
 	desc = "An customizable assembly for large machines."
 	id = "assembly-large"
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 4, TECH_POWER = 4)
-	materials = list(MATERIAL_STEEL = 8)
 	build_path = /obj/item/device/electronic_assembly/large
 	sort_string = "VCAAD"
 
@@ -1741,7 +1654,6 @@ CIRCUITS BELOW
 	desc = "An customizable assembly for very small devices, implanted into living entities."
 	id = "assembly-implant"
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 4, TECH_POWER = 3, TECH_BIO = 5)
-	materials = list(MATERIAL_STEEL = 2)
 	build_path = /obj/item/weapon/implant/integrated_circuit
 	sort_string = "VCAAE"
 

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -158,6 +158,14 @@ research holder datum.
 				else
 					D.req_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2)
 				D.build_path = IC.type
+				var/list/mats = IC.matter
+				if (mats && mats.len)
+					for (var/a in mats)
+						LAZYAPLUS(D.materials, a, mats[a])
+				mats = IC.matter_reagents
+				if (mats && mats.len)
+					for (var/a in mats)
+						LAZYAPLUS(D.chemicals, a, mats[a])
 				possible_designs += D
 
 

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -239,7 +239,6 @@ research holder datum.
 	icon_state = "blue"
 	item_state = "card-id"
 	w_class = ITEM_SIZE_SMALL
-	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	var/datum/tech/stored
 
 /obj/item/weapon/disk/tech_disk/New()
@@ -253,7 +252,6 @@ research holder datum.
 	icon_state = "yellow"
 	item_state = "card-id"
 	w_class = ITEM_SIZE_SMALL
-	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	var/datum/design/blueprint
 
 /obj/item/weapon/disk/design_disk/New()

--- a/html/changelogs/Nanako_Materials.yml
+++ b/html/changelogs/Nanako_Materials.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Majorly reworked how material costs are calculated for protolathe, autolathe and circuit imprinter designs. Some costs were adjusted in the process"
+  - tweak: "Made the prices of ordering materials in the guild far cheaper. Also added a bulk metal crate for large quantities of steel at once."


### PR DESCRIPTION
I hated doing this, but it needed to be done after some recent changes exposed flaws

This PR refactors all of the science designs to calculate their material costs the same way autolathes do - by reading them directly from the matter of the target object. And thus ensuring that a portion of the matter can be reclaimed by recycling it. 

With this, there should now be absolutely nothing in the game that can be printed, which can't also be recycled
A couple costs were manually changed, circuitboards now broadly require silicon (which, naturally, can be obtained by recycling other circuit boards)

Most of the costs weren't changed, but simply moved out of the design datum and onto the matter of the object instead. Hence the vast number of files changed.
Setting costs on the design datum is still allowed, and these are added to the matter costs. Costs on the design datum are now intended for use as "extra" costs associated with manufacture, but which don't show up in the finished product. The prime example being sulphuric acid

Finally, some small tweaks to cargo. Greatly reduced the cost of material crates, standardised prices of specific materials, and added a bulk metal crate to the guild ordering. will likely be used by robotics