### PR TITLE
Ambiance Runtime Fix

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -238,7 +238,7 @@ var/list/mob/living/forced_ambiance_list = new
 
 /area/proc/play_ambience(var/mob/living/L)
     // Ambience goes down here -- make sure to list each area seperately for ease of adding things in later, thanks! Note: areas adjacent to each other should have the same sounds to prevent cutoff when possible.- LastyScratch
-	if(!(L && L.get_preference_value(/datum/client_preference/play_ambiance) == GLOB.PREF_YES))    return
+	if(!(L && L.client && L.get_preference_value(/datum/client_preference/play_ambiance) == GLOB.PREF_YES))    return
 
 	var/client/CL = L.client
 


### PR DESCRIPTION
Fixes a runtime error caused by npc mobs entering new areas.

Presumably this code was originally not designed for roaches that could travel around via burrows