### PR TITLE
Fix for cyborg recharger screw/prying interaction

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -127,28 +127,8 @@
 		user << SPAN_NOTICE("You cant do anything with [src] while someone inside of it.")
 		return
 
-	var/tool_type = I.get_tool_type(user, I, list(QUALITY_PRYING, QUALITY_SCREW_DRIVING))
-	switch(tool_type)
-
-		if(QUALITY_PRYING)
-			if(!panel_open)
-				user << SPAN_NOTICE("You cant get to the components of \the [src], remove the cover.")
-				return
-			if(I.use_tool(user, src, WORKTIME_NORMAL, tool_type, FAILCHANCE_HARD, required_stat = STAT_MEC))
-				user << SPAN_NOTICE("You remove the components of \the [src] with [I].")
-				dismantle()
-				return
-
-		if(QUALITY_SCREW_DRIVING)
-			var/used_sound = panel_open ? 'sound/machines/Custom_screwdriveropen.ogg' :  'sound/machines/Custom_screwdriverclose.ogg'
-			if(I.use_tool(user, src, WORKTIME_NEAR_INSTANT, tool_type, FAILCHANCE_VERY_EASY, required_stat = STAT_MEC, instant_finish_tier = 30, forced_sound = used_sound))
-				panel_open = !panel_open
-				user << SPAN_NOTICE("You [panel_open ? "open" : "close"] the maintenance hatch of \the [src] with [I].")
-				update_icon()
-				return
-
-		if(ABORT_CHECK)
-			return
+	if(default_deconstruction(I, user))
+		return
 
 	if(default_part_replacement(I, user))
 		return


### PR DESCRIPTION
Formerly, trying to open maintenance hatches on cyborg rechargers ends up with you hitting the recharger with the screwdriver. This fixes that.

Honestly I have no idea what exactly changed. I just made it so that cyborg rechargers had similar interaction as autolathes, and now it works.