### PR TITLE
Loadout fix

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -410,7 +410,7 @@ proc/EquipCustomLoadout(var/mob/living/carbon/human/H, var/datum/job/job)
 				var/permitted = 1
 				if(permitted)
 					if(G.allowed_roles)
-						if(job.type in G.allowed_roles)
+						if(job.title in G.allowed_roles)
 							permitted = 1
 						else
 							permitted = 0

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -188,7 +188,7 @@ var/list/gear_datums = list()
 				++ind
 				if(ind > 1)
 					entry += ", "
-				if(J.type in G.allowed_roles)
+				if(J.title in G.allowed_roles)
 					entry += "<font color=55cc55>[J.title]</font>"
 					good_job = 1
 				else

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -226,8 +226,8 @@
 					var/permitted = 0
 					if(G.allowed_roles && G.allowed_roles.len)
 						if(previewJob)
-							for(var/job_type in G.allowed_roles)
-								if(previewJob.type == job_type)
+							for(var/job_title in G.allowed_roles)
+								if(previewJob.title == job_title)
 									permitted = 1
 					else
 						permitted = 1


### PR DESCRIPTION
This fixes job-specific loadouts never being available for ANY job.

Loadout items have job titles in their allowed_roles ("Moebius Doctor"), while the check for eligibility checks the job type ("/datum/job/doctor"). This makes it so that the check is for the job title instead of the job type, fixing that loadout bug.