### PR TITLE
Weging crowbars: RE

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1,3 +1,5 @@
+GLOBAL_LIST_EMPTY(wedge_icon_cache)
+
 /obj/machinery/door/airlock
 	name = "Airlock"
 	icon = 'icons/obj/doors/Doorint.dmi'
@@ -40,6 +42,7 @@
 	var/open_sound_unpowered = 'sound/machines/airlock_creaking.ogg'
 	var/_wifi_id
 	var/datum/wifi/receiver/button/door/wifi_receiver
+	var/obj/item/wedged_item
 
 /obj/machinery/door/airlock/attack_generic(var/mob/user, var/damage)
 	if(stat & (BROKEN|NOPOWER))
@@ -417,7 +420,7 @@ There are 9 wires.
 
 
 
-/obj/machinery/door/airlock/bumpopen(mob/living/user as mob) //Airlocks now zap you when you 'bump' them open when they're electrified. --NeoFite
+/obj/machinery/door/airlock/bumpopen(mob/living/user) //Airlocks now zap you when you 'bump' them open when they're electrified. --NeoFite
 	if(!issilicon(usr))
 		if(src.isElectrified())
 			if(!src.justzap)
@@ -433,10 +436,7 @@ There are 9 wires.
 			user.halloss += 10
 			user.stunned += 10
 			return
-	..(user)
-
-/obj/machinery/door/airlock/bumpopen(mob/living/simple_animal/user as mob)
-	..(user)
+	..()
 
 /obj/machinery/door/airlock/proc/isElectrified()
 	if(src.electrified_until != 0)
@@ -570,10 +570,87 @@ There are 9 wires.
 	else
 		return 0
 
+/obj/machinery/door/airlock/proc/force_wedge_item(obj/item/weapon/tool/T)
+	T.forceMove(src)
+	wedged_item = T
+	update_icon()
+	verbs -= /obj/machinery/door/airlock/proc/try_wedge_item
+	verbs += /obj/machinery/door/airlock/proc/take_out_wedged_item
+
+/obj/machinery/door/airlock/proc/try_wedge_item(mob/living/user)
+	set name = "Wedge item"
+	set category = "Object"
+	set src in view(1)
+
+	if(!user)
+		user = usr
+
+	var/obj/item/weapon/tool/T = user.get_active_hand()
+	if(istype(T) && T.w_class >= ITEM_SIZE_NORMAL) // We do the checks before proc call, because see "proc overhead".
+		if(!density)
+			user.drop_item()
+			force_wedge_item(T)
+			to_chat(user, SPAN_NOTICE("You wedge [T] into [src]."))
+		else
+			to_chat(user, SPAN_NOTICE("[T] can't be wedged into [src], while [src] is open."))
+
+/obj/machinery/door/airlock/proc/take_out_wedged_item(mob/living/user)
+	set name = "Remove Blockage"
+	set category = "Object"
+	set src in view(1)
+
+	if(!user)
+		user = usr
+
+	if(wedged_item)
+		if(user && !wedged_item.use_tool(user, src, WORKTIME_NEAR_INSTANT, QUALITY_PRYING, FAILCHANCE_ZERO, STAT_ROB))
+			return
+		wedged_item.forceMove(loc)
+		if(user)
+			user.put_in_hands(wedged_item)
+			to_chat(user, SPAN_NOTICE("You took [wedged_item] out of [src]."))
+		wedged_item = null
+		verbs -= /obj/machinery/door/airlock/proc/take_out_wedged_item
+		verbs += /obj/machinery/door/airlock/proc/try_wedge_item
+		update_icon()
+
+/obj/machinery/door/airlock/AltClick(mob/user)
+	if(Adjacent(user))
+		try_wedge_item(user)
+
+/obj/machinery/door/airlock/MouseDrop(obj/over_object)
+	if(ishuman(usr) && usr == over_object && !usr.incapacitated() && Adjacent(usr))
+		take_out_wedged_item(usr)
+		return
+	return ..()
+
+/obj/machinery/door/airlock/examine(mob/user)
+	..()
+	if(wedged_item)
+		to_chat(user, "You can see \icon[wedged_item] [wedged_item] wedged into it.")
+
+/obj/machinery/door/airlock/proc/generate_wedge_overlay()
+	var/cache_string = "[wedged_item.icon]||[wedged_item.icon_state]||[wedged_item.overlays.len]||[wedged_item.underlays.len]"
+
+	if(!GLOB.wedge_icon_cache[cache_string])
+		var/icon/I = getFlatIcon(wedged_item, SOUTH, always_use_defdir = TRUE)
+
+		// #define COOL_LOOKING_SHIFT_USING_CROWBAR_RIGHT 14, #define COOL_LOOKING_SHIFT_USING_CROWBAR_DOWN 6 - throw a rock at me if this looks less magic.
+		I.Shift(SOUTH, 6) // These numbers I got by sticking the crowbar in and looking what will look good.
+		I.Shift(EAST, 14)
+		I.Turn(45)
+
+		GLOB.wedge_icon_cache[cache_string] = I
+		underlays += I
+	else
+		underlays += GLOB.wedge_icon_cache[cache_string]
 
 /obj/machinery/door/airlock/update_icon()
 	set_light(0)
-	if(overlays) overlays.Cut()
+	if(overlays.len)
+		overlays.Cut()
+	if(underlays.len)
+		underlays.Cut()
 	if(density)
 		if(locked && lights && src.arePowerSystemsOn())
 			icon_state = "door_locked"
@@ -597,12 +674,14 @@ There are 9 wires.
 		icon_state = "door_open"
 		if((stat & BROKEN) && !(stat & NOPOWER))
 			overlays += image(icon, "sparks_open")
-	return
+	if(wedged_item)
+		generate_wedge_overlay()
 
 /obj/machinery/door/airlock/do_animate(animation)
 	switch(animation)
 		if("opening")
-			if(overlays) overlays.Cut()
+			if(overlays.len)
+				overlays.Cut()
 			if(p_open)
 				flick("o_door_opening", src)  //can not use flick due to BYOND bug updating overlays right before flicking
 				update_icon()
@@ -610,7 +689,8 @@ There are 9 wires.
 				flick("door_opening", src)//[stat ? "_stat":]
 				update_icon()
 		if("closing")
-			if(overlays) overlays.Cut()
+			if(overlays.len)
+				overlays.Cut()
 			if(p_open)
 				flick("o_door_closing", src)
 				update_icon()
@@ -783,6 +863,10 @@ There are 9 wires.
 				visible_message(SPAN_WARNING("[user] headbutts the airlock. Good thing they're wearing a helmet."))
 			return
 	**/
+
+	if(user.a_intent == I_GRAB && wedged_item && !user.get_active_hand())
+		take_out_wedged_item(user)
+		return
 
 	if(src.p_open)
 		user.set_machine(src)
@@ -1018,12 +1102,16 @@ There are 9 wires.
 
 /obj/machinery/door/airlock/can_close(var/forced=0)
 	if(locked || welded)
-		return 0
+		return FALSE
+
+	if(wedged_item)
+		wedged_item.airlock_crush(DOOR_CRUSH_DAMAGE)
+		return FALSE
 
 	if(!forced)
 		//despite the name, this wire is for general door control.
 		if(!arePowerSystemsOn() || isWireCut(AIRLOCK_WIRE_OPEN_DOOR))
-			return	0
+			return FALSE
 
 	return ..()
 
@@ -1056,13 +1144,19 @@ There are 9 wires.
 	health -= crush_damage
 	healthcheck()
 
-
 /obj/structure/closet/airlock_crush(var/crush_damage)
 	..()
 	damage(crush_damage)
 	for(var/atom/movable/AM in src)
 		AM.airlock_crush()
 	return 1
+
+/obj/item/weapon/tool/airlock_crush(crush_damage)
+	. = ..() // Perhaps some function to this was planned, however currently this proc's return is not used anywhere, how peculiar. ~Luduk
+	// #define MAGIC_NANAKO_CONSTANT 0.4
+	unreliability += crush_damage * degradation * (1 - get_tool_quality(QUALITY_PRYING) * 0.01) * 0.4
+	if(prob(unreliability))
+		handle_failure(null, src)
 
 /mob/living/airlock_crush(var/crush_damage)
 	. = ..()
@@ -1094,6 +1188,22 @@ There are 9 wires.
 						next_beep_at = world.time + SecondsToTicks(10)
 					close_door_at = world.time + 6
 					return
+				if(istype(AM, /obj/item/weapon/tool))
+					var/obj/item/weapon/tool/T = AM
+					if(T.w_class >= ITEM_SIZE_NORMAL)
+						operating = TRUE
+						density = TRUE
+						do_animate("closing")
+						sleep(7)
+						force_wedge_item(AM)
+						playsound(loc, 'sound/machines/airlock_creaking.ogg', 75, 1)
+						shake_animation(12)
+						sleep(7)
+						playsound(loc, 'sound/machines/buzz-two.ogg', 30, 1, -1)
+						density = FALSE
+						do_animate("opening")
+						operating = FALSE
+						return
 
 	for(var/turf/turf in locs)
 		for(var/atom/movable/AM in turf)
@@ -1186,6 +1296,7 @@ There are 9 wires.
 			if(A.closeOtherId == src.closeOtherId && A != src)
 				src.closeOther = A
 				break
+	verbs += /obj/machinery/door/airlock/proc/try_wedge_item
 	. = ..()
 
 /obj/machinery/door/airlock/Destroy()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1105,6 +1105,7 @@ There are 9 wires.
 		return FALSE
 
 	if(wedged_item)
+		shake_animation(12)
 		wedged_item.airlock_crush(DOOR_CRUSH_DAMAGE)
 		return FALSE
 

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -191,7 +191,6 @@
 //Simple form ideal for basic use. That proc will return TRUE only when everything was done right, and FALSE if something went wrong, ot user was unlucky.
 //Editionaly, handle_failure proc will be called for a critical failure roll.
 /obj/item/proc/use_tool(var/mob/living/user, var/atom/target, var/base_time, var/required_quality, var/fail_chance, var/required_stat, var/instant_finish_tier = 110, forced_sound = null, var/sound_repeat = 2.5)
-
 	var/obj/item/weapon/tool/T
 	if (istool(src))
 		T = src
@@ -362,32 +361,34 @@
 		return
 
 	//This list initially contains the fail types that are always valid, even for robots
-	var/list/failtypes = list("slip" = 2, "swing" = 1)
+	var/list/failtypes = list()
 
 	if(T && T.use_fuel_cost)
 		//Robots can do this one too
 		failtypes["burn"] = 0.5
 
-	if(ishuman(user))
-		if (canremove)
+	if(canremove)
+		failtypes["throw"] = 1
 
-			failtypes["drop"] = 2
-			failtypes["throw"] = 1
+		if(T && T.degradation)
+			failtypes["damage"] = 2.5
+			if(T.unreliability >= 3)
+				failtypes["break"] = T.unreliability * 0.1 // Damaged tools are more likely to break.
+		else
+			failtypes["break"] = 0.5
 
-			if (T && T.degradation)
-				failtypes["damage"] = 2.5
-				if (T.unreliability >= 3)
-					failtypes["break"] = T.unreliability*0.1 //Damaged tools are more likely to break
-			else
-				failtypes["break"] = 0.5
-		if (sharp)
-			failtypes["stab"] = 1
+	if(user)
+		failtypes["slip"] = 2
+		failtypes["swing"] = 1
+		if(ishuman(user))
+			if(canremove)
+				failtypes["drop"] = 2
+			if (sharp)
+				failtypes["stab"] = 1
 
-		//This one is limited to humans only since robots often can't remove/replace their device cells
-		if (locate(/obj/item/weapon/cell) in contents)
-			failtypes["overload"] = 0.5
-
-
+			//This one is limited to humans only since robots often can't remove/replace their device cells
+			if(locate(/obj/item/weapon/cell) in contents)
+				failtypes["overload"] = 0.5
 
 	if(prob(crit_fail_chance))
 		var/fail_type = pickweight(failtypes)
@@ -395,14 +396,21 @@
 		switch(fail_type)
 			//Drop the tool on the floor
 			if("damage")
-				user << SPAN_DANGER("Your hand slips and you damage [src] a bit.")
+				if(user)
+					user << SPAN_DANGER("Your hand slips and you damage [src] a bit.")
 				T.unreliability += 5
 				return
 
 			//Drop the tool on the floor
 			if("drop")
-				user << SPAN_DANGER("You drop [src] on the floor.")
-				user.drop_from_inventory(src)
+				if(user)
+					user << SPAN_DANGER("You drop [src] on the floor.")
+					user.drop_from_inventory(src)
+				else if(istype(loc, /obj/machinery/door/airlock))
+					var/obj/machinery/door/airlock/AD = loc
+					AD.take_out_wedged_item()
+				else
+					forceMove(get_turf(src))
 				return
 
 			//Hit yourself
@@ -430,11 +438,20 @@
 
 			//Throw the tool in a random direction
 			if("throw")
-				var/mob/living/carbon/human/H = user
-				var/throw_target = pick(trange(6, user))
-				user << SPAN_DANGER("Your [src] flies away!")
-				H.unEquip(src)
-				src.throw_at(throw_target, src.throw_range, src.throw_speed, H)
+				if(user)
+					var/mob/living/carbon/human/H = user
+					var/throw_target = pick(trange(6, user))
+					user << SPAN_DANGER("Your [src] flies away!")
+					H.unEquip(src)
+					throw_at(throw_target, src.throw_range, src.throw_speed, H)
+					return
+				if(istype(loc, /obj/machinery/door/airlock))
+					var/obj/machinery/door/airlock/AD = loc
+					AD.take_out_wedged_item()
+				else
+					forceMove(get_turf(src))
+				var/throw_target = pick(trange(6, src))
+				throw_at(throw_target, src.throw_range, src.throw_speed)
 				return
 
 			//Stab yourself in the hand so hard your tool embeds
@@ -446,14 +463,22 @@
 
 			//The tool completely breaks, permanantly gone
 			if("break")
-				user << SPAN_DANGER("Your [src] broke beyond repair!")
-				new /obj/item/weapon/material/shard/shrapnel(user.loc)
+				if(user)
+					user << SPAN_DANGER("Your [src] broke beyond repair!")
+					new /obj/item/weapon/material/shard/shrapnel(user.loc)
+				else
+					new /obj/item/weapon/material/shard/shrapnel(get_turf(src))
 
 				//To encourage using makeshift tools, upgrades are preserved if the tool breaks
 				if (T)
 					for (var/obj/item/weapon/tool_upgrade/A in T.upgrades)
 						A.forceMove(get_turf(src))
 						A.holder = null
+
+				if(istype(loc, /obj/machinery/door/airlock))
+					var/obj/machinery/door/airlock/AD = loc
+					AD.take_out_wedged_item()
+
 				qdel(src)
 				return
 
@@ -477,7 +502,8 @@
 					C = locate(/obj/item/weapon/cell) in contents
 
 
-				user << SPAN_DANGER("You overload the cell in the [src]!")
+				if(user)
+					user << SPAN_DANGER("You overload the cell in the [src]!")
 				C.explode()
 				if (T)
 					T.cell = null


### PR DESCRIPTION
closes #2617

The title sums it all up pretty neatly.

![image](https://user-images.githubusercontent.com/17705613/51607559-a688b300-1f1d-11e9-823f-3cb9c8602fc9.png)

* It may look derpy with tools that are not crowbar.

You wedge a tool in by holding it in hand, and in right-click dropdown menu of airlock clicking "Wedge item", or by putting it on the same tile as the airlock.

![2019-01-24_13-30-25](https://user-images.githubusercontent.com/17705613/51675403-4442b780-1fdc-11e9-8eaf-590554133b9b.gif)

You take the tool out in one of three ways: dropdown menu "Take out wedged item", grab intent-click, mousedroping the airlock onto you.