### PR TITLE
Cloning activation fix

### DIFF
--- a/code/game/objects/items/weapons/implant/implant.dm
+++ b/code/game/objects/items/weapons/implant/implant.dm
@@ -22,7 +22,11 @@
 
 /obj/item/weapon/implant/proc/trigger(emote, mob/living/source)
 /obj/item/weapon/implant/proc/activate()
+	return TRUE
+
 /obj/item/weapon/implant/proc/deactivate()
+	return TRUE
+
 /obj/item/weapon/implant/proc/malfunction(var/severity)
 
 /obj/item/weapon/implant/proc/is_external()

--- a/code/modules/core_implant/core_implant.dm
+++ b/code/modules/core_implant/core_implant.dm
@@ -27,9 +27,6 @@
 /obj/item/weapon/implant/core_implant/New()
 	..()
 
-/obj/item/weapon/implant/core_implant/install(var/mob/M)
-	if(ishuman(M))
-		..(M)
 
 /obj/item/weapon/implant/core_implant/uninstall()
 	if(active)

--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -75,7 +75,8 @@ var/list/disciples = list()
 		for(var/datum/language/L in data.languages)
 			wearer.add_language(L.name)
 		update_data()
-		return TRUE
+		if (activate())
+			return TRUE
 
 /obj/item/weapon/implant/core_implant/cruciform/proc/remove_cyber()
 	if(!wearer)

--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -42,6 +42,7 @@ var/list/disciples = list()
 	add_module(new CRUCIFORM_COMMON)
 	update_data()
 	disciples |= wearer
+	return TRUE
 
 
 /obj/item/weapon/implant/core_implant/cruciform/deactivate()

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -123,6 +123,7 @@
 		fail("Soul transfer failed.", user, C)
 		return FALSE
 
+
 	return TRUE
 
 
@@ -168,9 +169,9 @@
 		fail("[H] must be undressed.", user, C)
 		return FALSE
 
-	CI.install(H)
 
-	if(CI.wearer != H)
+
+	if(!CI.install(H, BP_CHEST, user) || CI.wearer != H)
 		fail("Commitment failed.", user, C)
 		return FALSE
 


### PR DESCRIPTION
Fixes a nasty issue where the cruciform wouldn't properly activate when attached to a newly cloned person, resulting in them being unable to be targeted by rituals