### PR TITLE
Fixes guns not dropping bullet casings

### DIFF
--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -85,6 +85,8 @@
 		if(EJECT_CASINGS) //eject casing onto ground.
 			chambered.loc = get_turf(src)
 			for(var/obj/item/ammo_casing/temp_casing in chambered.loc)
+				if(temp_casing == chambered)
+					continue
 				if((temp_casing.desc == chambered.desc) && !temp_casing.BB)
 					var/temp_amount = temp_casing.amount + chambered.amount
 					if(temp_amount > chambered.maxamount)


### PR DESCRIPTION
What it says on the tin.

Basically, bullet pile code went wrong. It deleted the ejected bullet casing while trying to pile the bullet with itself. Fiiixed.

Fixes #2757