### PR TITLE
Fixes for .32 lethal ammo

### DIFF
--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -391,6 +391,7 @@
 		/datum/autolathe/recipe/ammo/magazine_a556,
 		/datum/autolathe/recipe/ammo/shotgun,
 		/datum/autolathe/recipe/ammo/shotgun_pellet,
+		/datum/autolathe/recipe/ammo/mg_cl32_brute,
 		/datum/autolathe/recipe/ammo/sl_c138_brute,
 		/datum/autolathe/recipe/ammo/mg_cl44_brute,
 		/datum/autolathe/recipe/ammo/sl_cl44_brute,

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -24,8 +24,8 @@
 	projectile_type = /obj/item/projectile/bullet/a10mm
 
 /obj/item/ammo_casing/cl32
-	desc = "A .38 FS hollow point bullet casing."
-	caliber = ".38"
+	desc = "A .32 FS hollow point bullet casing."
+	caliber = ".32"
 	projectile_type = /obj/item/projectile/bullet/cl32
 
 /obj/item/ammo_casing/cl32r


### PR DESCRIPTION
Two bugs with .32 hollowpoints: The bullet's caliber is .38, and the magazines don't show up on the lethal ammo disk. This fixes both.

Fixes #2776