### PR TITLE
Fix for brig timers not working with flasher & doors

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -36,11 +36,11 @@
 	..()
 
 	spawn(20)
-		for(var/obj/machinery/door/window/brigdoor/M in SSmachines.machinery)
+		for(var/obj/machinery/door/window/brigdoor/M in world)
 			if (M.id == src.id)
 				targets += M
 
-		for(var/obj/machinery/flasher/F in SSmachines.machinery)
+		for(var/obj/machinery/flasher/F in world)
 			if(F.id == src.id)
 				targets += F
 


### PR DESCRIPTION
Okay so basically, the machinery subsystem gets initialized AFTER atoms, that means the list of machines is empty when the brig timer spawns. I think searching the whole world for the brig doors and flasher is a bit too much, but that's what it already did to look for the locker and shower.