### PR TITLE
Hitting cameras with melee

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -182,7 +182,7 @@
 		interact(user)
 
 	// OTHER
-	else if (can_use() && isliving(user))
+	else if (can_use() && isliving(user) && user.a_intent != I_HURT)
 		var/mob/living/U = user
 		var/list/mob/viewers = list()
 		if(last_shown_time < world.time)


### PR DESCRIPTION
You can now hit security cameras with melee if your intent is set to harm.

Fixes #2822