### PR TITLE
Bed dismantle runtime fix and tool quality standardization

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -102,7 +102,7 @@
 		return TRUE
 
 /obj/structure/bed/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/weapon/tool/wrench))
+	if(QUALITY_BOLT_TURNING in W.tool_qualities)
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		dismantle()
 		qdel(src)
@@ -133,7 +133,7 @@
 		add_padding(padding_type)
 		return
 
-	else if (istype(W, /obj/item/weapon/tool/wirecutters))
+	else if (QUALITY_WIRE_CUTTING in W.tool_qualities)
 		if(!padding_material)
 			user << "\The [src] has no padding to remove."
 			return
@@ -177,9 +177,11 @@
 	update_icon()
 
 /obj/structure/bed/proc/dismantle()
-	new material(loc, 5)
+	if(material)
+		material.place_sheet(get_turf(src))
 	if(padding_material)
 		padding_material.place_sheet(get_turf(src))
+	qdel(src)
 
 /obj/structure/bed/psych
 	name = "psychiatrist's couch"

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -102,10 +102,9 @@
 		return TRUE
 
 /obj/structure/bed/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(QUALITY_BOLT_TURNING in W.tool_qualities)
+	if(W.has_quality(QUALITY_BOLT_TURNING))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		dismantle()
-		qdel(src)
 	else if(istype(W,/obj/item/stack))
 		if(padding_material)
 			user << "\The [src] is already padded."
@@ -133,7 +132,7 @@
 		add_padding(padding_type)
 		return
 
-	else if (QUALITY_WIRE_CUTTING in W.tool_qualities)
+	else if (W.has_quality(QUALITY_WIRE_CUTTING))
 		if(!padding_material)
 			user << "\The [src] has no padding to remove."
 			return

--- a/html/changelogs/beddismantle.yml
+++ b/html/changelogs/beddismantle.yml
@@ -1,0 +1,5 @@
+author: Carbonhell
+delete-after: True
+changes: 
+  - bugfix: "Beds, chairs and all subtypes can now be dismantled again."
+  - tweak: "They can also be dismantled by any tool with the bolt turning quality, and the padding removed with the wirecutting quality."


### PR DESCRIPTION
Beds and subtypes were runtiming when dismantled due to the attempted creation of a /material (datum) type, this has been resolved and they now get dismantled properly, and drop some steel. Also, to dismantle/remove the padding, the checks now use tool qualities instead of strict type-checks for basic tools.
Addresses a tiny part of #2840 , might want to remove beds from the list