### PR TITLE
Fixes some bugs with audio files

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -218,6 +218,7 @@
 		recording = 0
 		audio_file.timestamp += audio_file.used_capacity
 		audio_file.storedinfo += "\[[time2text(audio_file.used_capacity*10,"mm:ss")]\] Recording stopped."
+		audio_file.stored_data = null
 		for(var/entry in audio_file.storedinfo)
 			audio_file.stored_data += "[entry]<br>"
 		if(show_message)

--- a/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
@@ -168,7 +168,9 @@
 		else
 			HDD = PRG.computer.hard_drive
 			file = HDD.find_file_by_name(PRG.open_file)
-			if(!istype(file))
+			if(file.filetype == "AUD")
+				data["error"] = "Software error: Please use a dedicated Audio Player program to read audio files."
+			else if(!istype(file))
 				data["error"] = "I/O ERROR: Unable to open file."
 			else
 				data["filedata"] = pencode2html(file.stored_data)


### PR DESCRIPTION
Fixes 2 bugs:
Stopping and starting a recording a second time made the first recording get repeated in the transcript.
You could read an audio file's transcript without transcribing it by opening it in the file manager.