### PR TITLE
Unpickable beartrap bug fix

### DIFF
--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -266,6 +266,7 @@ Very rarely it might escape
 	//If its dead or gone, stop processing
 	//Also stop if a player took control of it, they can try to free themselves
 	if (QDELETED(L) || L.stat == DEAD || L.loc != loc || L.client)
+		release_mob()		// Reset the trap properly if the roach was gibbed during the processing.
 		return PROCESS_KILL
 
 	if (L.incapacitated())


### PR DESCRIPTION
## General

If the roach got gibbed by this bear trap, you cannot pick it for some time until the process() managed to free invisible mob ( buckled_mob ) from his trap.

## Changelog
🆑 TorinoFermic
fix: Bear traps can be picked again right now after a mob has gibbed on the trap.
/🆑