### PR TITLE
Fix for printing vendomat boards in autolathe

### DIFF
--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -204,7 +204,7 @@
 		/datum/autolathe/recipe/circuit/powermodule,
 		/datum/autolathe/recipe/circuit/autolathe,
 		/datum/autolathe/recipe/circuit/autolathe_disk_cloner,
-		/datum/autolathe/recipe/circuit/autolathe,
+		/datum/autolathe/recipe/circuit/vending,
 		/datum/autolathe/recipe/circuit/arcade_battle,
 		/datum/autolathe/recipe/circuit/arcade_orion_trail,
 		/datum/autolathe/recipe/circuit/teleporter,


### PR DESCRIPTION
Accidentally put in the path for the autolathe board a second time instead of the path for the custom vendomat. Whoops.