### PR TITLE
Fixes lottery taking into account departments, and wild html tags

### DIFF
--- a/code/game/gamemodes/events/money_lotto.dm
+++ b/code/game/gamemodes/events/money_lotto.dm
@@ -24,8 +24,11 @@
 /datum/event/money_lotto/start()
 	winner_sum = pick(5000, 10000, 15000)
 	if(all_money_accounts.len)
-		var/datum/money_account/D = pick(all_money_accounts)
-		winner_name = D.owner_name
+		var/list/private_accounts = all_money_accounts.Copy()
+		for(var/i in department_accounts)
+			private_accounts.Remove(department_accounts[i])
+		var/datum/money_account/D = pick(private_accounts)
+		winner_name = D.get_name()
 		var/datum/transaction/T = new(winner_sum, "Nyx Daily Grand Slam -Stellar- Lottery", "Winner!", "Biesel TCD Terminal #[rand(111,333)]")
 		if(T.apply_to(D))
 			deposit_success = 1
@@ -34,7 +37,7 @@
 	var/author = "[company_name] Editor"
 	var/channel = "Nyx Daily"
 
-	var/body = "Nyx Daily wishes to congratulate <b>[winner_name]</b> for winning the Nyx Stellar Slam Lottery, and receiving the out of this world sum of [winner_sum] credits!"
+	var/body = "Nyx Daily wishes to congratulate [winner_name] for winning the Nyx Stellar Slam Lottery, and receiving the out of this world sum of [winner_sum] credits!"
 	if(!deposit_success)
 		body += "<br>Unfortunately, we were unable to verify the account details provided, so we were unable to transfer the money. Send a cheque containing the sum of 5000 credits to ND 'Stellar Slam' office on the Nyx gateway containing updated details, and your winnings'll be re-sent within the month."
 

--- a/html/changelogs/lottery.yml
+++ b/html/changelogs/lottery.yml
@@ -1,0 +1,4 @@
+author: Carbonhell
+delete-after: True
+changes: 
+  - bugfix: "The lottery cannot be win by departments anymore, and the output message has been fixed."

--- a/html/changelogs/lottery.yml
+++ b/html/changelogs/lottery.yml
@@ -1,4 +1,4 @@
 author: Carbonhell
 delete-after: True
 changes: 
-  - bugfix: "The lottery cannot be win by departments anymore, and the output message has been fixed."
+  - bugfix: "The lottery cannot be won by departments anymore, and the output message has been fixed."


### PR DESCRIPTION
Fixes #2832 and removes the chance for departments to be chosen as winners.