### PR TITLE
Fixes blast door not opening when being drilled

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -137,10 +137,10 @@
 	return
 
 // Proc: open()
-// Parameters: None
+// Parameters: 1 (forced - if true, the checks will be skipped)
 // Description: Opens the door. Does necessary checks. Automatically closes if autoclose is true
-/obj/machinery/door/blast/open()
-	if (src.operating || (stat & BROKEN || stat & NOPOWER))
+/obj/machinery/door/blast/open(forced = FALSE)
+	if ((operating || (stat & BROKEN || stat & NOPOWER)) && !forced)
 		return
 	force_open()
 	if(autoclose)
@@ -149,10 +149,10 @@
 	return 1
 
 // Proc: close()
-// Parameters: None
+// Parameters: 1 (forced - if true, the checks will be skipped)
 // Description: Closes the door. Does necessary checks.
-/obj/machinery/door/blast/close()
-	if (src.operating || (stat & BROKEN || stat & NOPOWER))
+/obj/machinery/door/blast/close(forced = FALSE)
+	if ((operating || (stat & BROKEN || stat & NOPOWER)) && !forced)
 		return
 	force_close()
 	crush()


### PR DESCRIPTION
Fixes #2554 . Sometimes the doors may just disappear instead of being opened, but that's apparently intended, because the drill calls ex_act(2) on what it drills, and the default behaviour for doors is to either qdel themself immediately with a low chance, or take enough damage(300) to be force-opened.