### PR TITLE
Fixes station_levels list

### DIFF
--- a/code/modules/multiz/map_data.dm
+++ b/code/modules/multiz/map_data.dm
@@ -18,6 +18,7 @@
 
 	for(var/shift in 1 to height)
 		var/z_level_r = original_level + shift - 1
+		z_level = z_level_r
 		name = "[original_name] stage [shift]"
 		maps_data.registrate(src)
 


### PR DESCRIPTION
It was being populated with the original zlevel and not the actual z_level
With this fix, NTnet works again for PDAs 