### PR TITLE
Robot items plane fix

### DIFF
--- a/code/modules/multiz/planes.dm
+++ b/code/modules/multiz/planes.dm
@@ -21,7 +21,10 @@
 		return min(32767,((z-LD.original_level)*PLANES_PER_Z_LEVEL) + original_plane)
 
 /atom/proc/update_plane()	//Updates plane using local z-coordinate
-	plane = calculate_plane(z,original_plane)
+	if(z > 0)
+		plane = calculate_plane(z,original_plane)
+	else
+		plane = ABOVE_HUD_PLANE
 
 /atom/proc/get_relative_plane(var/plane)
 	return calculate_plane(z,plane)


### PR DESCRIPTION
This should fix a lot of similar cases.
If an object z = 0, this object is either in the nullspace, or in the other object contents and invisible. 
If object is on the screen, it should be on the above_hud plane.