### PR TITLE
Adds an inactive storyteller, and lets admins change storytellers midround.

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -540,6 +540,7 @@
 #include "code\game\gamemodes\storytellers\guide.dm"
 #include "code\game\gamemodes\storytellers\healer.dm"
 #include "code\game\gamemodes\storytellers\jester.dm"
+#include "code\game\gamemodes\storytellers\mime.dm"
 #include "code\game\gamemodes\storytellers\sleeper.dm"
 #include "code\game\gamemodes\storytellers\warrior.dm"
 #include "code\game\jobs\_access_defs.dm"

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -1,4 +1,5 @@
-var/list/storyteller_cache = list()
+
+GLOBAL_LIST_EMPTY(storyteller_cache)
 
 /datum/configuration
 	var/server_name = null				// server name (for world name / status)
@@ -210,7 +211,7 @@ var/list/storyteller_cache = list()
 		// their information, but it is the only way (at least that I know of).
 		var/datum/storyteller/S = new T()
 		if (S.config_tag)
-			storyteller_cache[S.config_tag] = S // So we don't instantiate them repeatedly.
+			GLOB.storyteller_cache[S.config_tag] = S // So we don't instantiate them repeatedly.
 			if(!(S.config_tag in storytellers))		// ensure each mode is added only once
 				log_misc("Adding storyteller [S.name] ([S.config_tag]) to configuration.")
 				src.storytellers += S.config_tag
@@ -726,15 +727,15 @@ var/list/storyteller_cache = list()
 /datum/configuration/proc/pick_storyteller(story_name)
 	// I wish I didn't have to instance the game modes in order to look up
 	// their information, but it is the only way (at least that I know of).
-	if(story_name in storyteller_cache)
-		return storyteller_cache[story_name]
+	if(story_name in GLOB.storyteller_cache)
+		return GLOB.storyteller_cache[story_name]
 
-	return storyteller_cache[STORYTELLER_BASE]
+	return GLOB.storyteller_cache[STORYTELLER_BASE]
 
 /datum/configuration/proc/get_storytellers()
 	var/list/runnable_storytellers = list()
-	for(var/storyteller in storyteller_cache)
-		var/datum/storyteller/S = storyteller_cache[storyteller]
+	for(var/storyteller in GLOB.storyteller_cache)
+		var/datum/storyteller/S = GLOB.storyteller_cache[storyteller]
 		if(S)
 			runnable_storytellers |= S
 	return runnable_storytellers

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -116,8 +116,8 @@ SUBSYSTEM_DEF(ticker)
 				Master.SetRunLevel(RUNLEVEL_LOBBY)
 
 		if(GAME_STATE_PLAYING)
-			storyteller.Process()
-			storyteller.process_events()
+			GLOB.storyteller.Process()
+			GLOB.storyteller.process_events()
 
 			var/game_finished = (evacuation_controller.round_over() || ship_was_nuked  || universe_has_ended)
 
@@ -151,24 +151,24 @@ SUBSYSTEM_DEF(ticker)
 /datum/controller/subsystem/ticker/proc/setup()
 	//Create and announce mode
 
-	if(!storyteller)
+	if(!GLOB.storyteller)
 		set_storyteller(announce = FALSE)
 
-	if(!storyteller)
+	if(!GLOB.storyteller)
 		world << "<span class='danger'>Serious error storyteller system!</span> Reverting to pre-game lobby."
 		return FALSE
 
 	SSjob.ResetOccupations()
 	SSjob.DivideOccupations() // Apparently important for new antagonist system to register specific job antags properly.
 
-	if(!storyteller.can_start(TRUE))
+	if(!GLOB.storyteller.can_start(TRUE))
 		world << "<B>Unable to start game.</B> Reverting to pre-game lobby."
-		//storyteller = null //Possibly bring this back in future if we have storytellers with differing requirements
+		//GLOB.storyteller = null //Possibly bring this back in future if we have storytellers with differing requirements
 		//story_vote_ended = FALSE
 		SSjob.ResetOccupations()
 		return FALSE
 
-	storyteller.announce()
+	GLOB.storyteller.announce()
 
 	setup_economy()
 	newscaster_announcements = pick(newscaster_standard_feeds)
@@ -187,7 +187,7 @@ SUBSYSTEM_DEF(ticker)
 	callHook("roundstart")
 
 	spawn(0)//Forking here so we dont have to wait for this to finish
-		storyteller.set_up()
+		GLOB.storyteller.set_up()
 		world << "<FONT color='blue'><B>Enjoy the game!</B></FONT>"
 		world << sound('sound/AI/welcome.ogg') // Skie
 		//Holiday Round-start stuff	~Carn
@@ -398,7 +398,7 @@ SUBSYSTEM_DEF(ticker)
 	if(dronecount)
 		world << "<b>There [dronecount>1 ? "were" : "was"] [dronecount] industrious maintenance [dronecount>1 ? "drones" : "drone"] at the end of this round.</b>"
 
-	storyteller.declare_completion()//To declare normal completion.
+	GLOB.storyteller.declare_completion()//To declare normal completion.
 
 	//Ask the event manager to print round end information
 	SSevent.RoundEnd()

--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -75,7 +75,7 @@
 		if(S.votable)
 			choices.Insert(index, CS)
 		else
-			qdel(S)
+			qdel(CS)
 
 	//After everything else is in, the guide is inserted at the top,
 	//so it will always be the first option in the poll

--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -59,9 +59,9 @@
 /datum/poll/storyteller/init_choices()
 	master_storyteller = null
 	var/datum/vote_choice/storyteller/base = null
-	for(var/ch in storyteller_cache)
+	for(var/ch in GLOB.storyteller_cache)
 		var/datum/vote_choice/storyteller/CS = new
-		var/datum/storyteller/S = storyteller_cache[ch]
+		var/datum/storyteller/S = GLOB.storyteller_cache[ch]
 		CS.text = S.name
 		CS.desc = S.description
 		CS.new_storyteller = ch
@@ -72,7 +72,10 @@
 			continue
 		//Storytellers are inserted at a random spot so they will be randomly sorted
 		var/index = rand(1, max(choices.len, 1))
-		choices.Insert(index, CS)
+		if(S.votable)
+			choices.Insert(index, CS)
+		else
+			qdel(S)
 
 	//After everything else is in, the guide is inserted at the top,
 	//so it will always be the first option in the poll

--- a/code/game/antagonist/antagonist_panel.dm
+++ b/code/game/antagonist/antagonist_panel.dm
@@ -154,7 +154,7 @@
 /datum/antagonist/proc/get_extra_panel_options()
 	return
 
-/* !TODO: This should be implemented in storyteller_print.dm (storyteller.antagonist_report())
+/* !TODO: This should be implemented in storyteller_print.dm (GLOB.storyteller.antagonist_report())
 /datum/antagonist/proc/get_check_antag_output(var/datum/admins/caller)
 
 	if(!current_antagonists || !current_antagonists.len)

--- a/code/game/gamemodes/roleset/roleset.dm
+++ b/code/game/gamemodes/roleset/roleset.dm
@@ -62,7 +62,7 @@
 		if(!(temp.bantype in candidate.current.client.prefs.be_special_role))
 			if (report) report << SPAN_NOTICE("Failure: [candidate] has special role [temp.bantype] disabled")
 			continue
-		if(storyteller && storyteller.one_role_per_player && candidate.antagonist.len)
+		if(GLOB.storyteller && GLOB.storyteller.one_role_per_player && candidate.antagonist.len)
 			if (report) report << SPAN_NOTICE("Failure: [candidate] is already a [candidate.antagonist[1]] and can't be two antags")
 			continue
 		if(player_is_antag_id(candidate,antag))

--- a/code/game/gamemodes/storyevent.dm
+++ b/code/game/gamemodes/storyevent.dm
@@ -106,8 +106,8 @@
 
 /datum/storyevent/proc/cancel(var/type, var/completion = 0.0)
 	//This proc refunds the cost of this event
-	if (storyteller)
-		storyteller.modify_points(get_cost(type)*(1 - completion), type)
+	if (GLOB.storyteller)
+		GLOB.storyteller.modify_points(get_cost(type)*(1 - completion), type)
 
 /datum/storyevent/proc/trigger_event(var/severity = EVENT_LEVEL_MUNDANE)
 	if (event_type)
@@ -131,17 +131,17 @@
 	return TRUE
 
 /datum/storyevent/proc/start_processing(var/announce = FALSE)
-	storyteller.add_processing(src)
+	GLOB.storyteller.add_processing(src)
 	if(announce)
 		announce()
 
 /datum/storyevent/proc/stop_processing(var/announce = FALSE)
-	storyteller.remove_processing(src)
+	GLOB.storyteller.remove_processing(src)
 	if(announce)
 		announce_end()
 
 /datum/storyevent/proc/is_processing()
-	return (src in storyteller.processing_events)
+	return (src in GLOB.storyteller.processing_events)
 
 /datum/storyevent/proc/announce()
 

--- a/code/game/gamemodes/storyteller.dm
+++ b/code/game/gamemodes/storyteller.dm
@@ -1,7 +1,4 @@
-var/datum/storyteller/storyteller = null
-
-
-
+GLOBAL_DATUM(storyteller, /datum/storyteller)
 
 /datum/storyteller
 	//Strings
@@ -22,7 +19,7 @@ var/datum/storyteller/storyteller = null
 	var/list/processing_events = list()
 	var/last_tick = 0
 	var/next_tick = 0
-	var/tick_interval = 60 SECONDS //Ticks once per second
+	var/tick_interval = 60 SECONDS //Ticks once per minute.
 
 	var/crew = 0
 	var/heads = 0
@@ -67,6 +64,9 @@ var/datum/storyteller/storyteller = null
 	//The maximum time between scheduling and firing an event
 	//Time is random between 1 decisecond to this
 
+	var/votable = TRUE
+	//whether or not the players can vote for it. If this is set to false, it can only be activated by being forced by admins.
+
 
 
 /********************************
@@ -106,7 +106,7 @@ var/datum/storyteller/storyteller = null
 	return FALSE
 
 /datum/storyteller/proc/announce()
-	world << "<b><font size=3>Storyteller is [src.name].</font> <br>[welcome]</b>"
+	world << "<b><font size=3>Storyteller is [name].</font> <br>[welcome]</b>"
 
 /datum/storyteller/proc/set_up()
 	build_event_pools()
@@ -199,8 +199,8 @@ var/datum/storyteller/storyteller = null
 
 
 /proc/storyteller_button()
-	if(storyteller)
-		return "<a href='?src=\ref[storyteller];panel=1'>\[STORY\]</a>"
+	if(GLOB.storyteller)
+		return "<a href='?src=\ref[GLOB.storyteller];panel=1'>\[STORY\]</a>"
 	else
 		return "<s>\[STORY\]</s>"
 

--- a/code/game/gamemodes/storyteller_helpers.dm
+++ b/code/game/gamemodes/storyteller_helpers.dm
@@ -6,8 +6,13 @@
 		newST = config.pick_storyteller(STORYTELLER_BASE) //This function is in code/controllers/configuration.dm
 
 	if (!istype(newST))
-		//Welp that failed
-		return
+		if(!istext(newST)) //Welp that failed
+			return
+
+		if(!GLOB.storyteller_cache[newST])
+			return
+		else
+			newST = GLOB.storyteller_cache[newST]
 
 	if (get_storyteller() == newST)
 		return //Nothing happens if we try to set to the storyteller we already have
@@ -16,23 +21,22 @@
 	//we cache it now so we can do that soon
 	var/datum/storyteller/oldST = get_storyteller()
 
-	//Finally, we set the new one
-	storyteller = newST
+	//Finally, we set the new one //and it's set globally.
+	GLOB.storyteller = newST
 
 	if (oldST != null)
-		storyteller.points.Cut()
-		storyteller.points.Add(oldST.points.Copy())//Transfer over points
+		GLOB.storyteller.points = oldST.points.Copy()//Transfer over points
 		//TODO: Cleanup and handover
 
 	//Configure the new storyteller
-	storyteller.set_up()
+	GLOB.storyteller.set_up()
 
 	if (announce)
-		storyteller.announce()
+		GLOB.storyteller.announce()
 
 
 /proc/get_storyteller()
-	return storyteller
+	return GLOB.storyteller
 
 /datum/storyteller/proc/update_crew_count()
 	if(debug_mode)

--- a/code/game/gamemodes/storyteller_print.dm
+++ b/code/game/gamemodes/storyteller_print.dm
@@ -63,7 +63,7 @@
 
 	data += "<b><a href='?src=\ref[src];panel=1'>\[UPDATE\]</a></b>"
 	data += "<table><tr><td>"
-	data += "[src.name] ([src.config_tag])"
+	data += "[src.name] (<A href='?src=\ref[src];c_mode=1'>Change</A>)"
 	data += "<br>Round duration: <b>[round(world.time / 36000)]:[add_zero(world.time / 600 % 60, 2)]:[world.time / 100 % 6][world.time / 100 % 10]</b>"
 	data += "<br>Debug mode: <b><a href='?src=\ref[src];toggle_debug=1'>\[[debug_mode?"ON":"OFF"]\]</a></b>"
 	data += "<br>One role per player: <b><a href='?src=\ref[src];toggle_orpp=1'>\[[one_role_per_player?"YES":"NO"]\]</a></b>"
@@ -269,7 +269,13 @@
 		var/pooltype = href_list["modify_points"]
 		var/add_points = input("Pool [pooltype] currently has [round(points[pooltype], 0.01)]. How many do you wish to add? Enter a negative value to subtract points","Altering Points",eng) as num
 		modify_points(add_points, pooltype)
+
 	storyteller_panel()
+
+	//anything below is placed there so it triggers after the storytellerpanel updates.
+
+	if(href_list["c_mode"])
+		. = usr.client.holder.Topic(href, href_list)
 
 /datum/storyteller/proc/topic_extra(href,href_list)
 	return

--- a/code/game/gamemodes/storytellers/mime.dm
+++ b/code/game/gamemodes/storytellers/mime.dm
@@ -1,0 +1,12 @@
+/datum/storyteller/mime
+	config_tag = "mime"
+	name = "The Mime"
+	welcome = "Welcome to CEV Eris! We hope you enjoy your stay!"
+	description = "A storyteller which will not do anything. Designed for admin events."
+	votable = FALSE //admin-only
+
+/datum/storyteller/mime/handle_points() //the mime does not run any events, and points are frozen while the mime is in charge.
+	return
+
+/datum/storyteller/mime/announce() //the mime does not talk.
+	return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -638,13 +638,13 @@
 		cmd_admin_mute(M, mute_type)
 	else if(href_list["check_antagonist"])
 		if(!check_rights(R_ADMIN))	return
-		storyteller.storyteller_panel()
+		GLOB.storyteller.storyteller_panel()
 
 	else if(href_list["c_mode"])
 		if(!check_rights(R_ADMIN))	return
 
-		if(get_storyteller())
-			return alert(usr, "The game has already started.", null, null, null, null)
+		/* if(get_storyteller())
+			return alert(usr, "The game has already started.", null, null, null, null) */ //this works fine even if the round has already started.
 		var/dat = {"<B>What storyteller do you wish to install?</B><HR>"}
 		for(var/mode in config.storytellers)
 			dat += {"<A href='?src=\ref[src];c_mode2=[mode]'>[config.storyteller_names[mode]]</A><br>"}
@@ -1073,7 +1073,7 @@
 	else if(href_list["traitor"])
 		if(!check_rights(R_ADMIN|R_MOD))	return
 
-		if(!storyteller)
+		if(!GLOB.storyteller)
 			alert("The game hasn't started yet!")
 			return
 


### PR DESCRIPTION
Adds an inactive storyteller, the mime, which will not trigger events or accrue points. This was designed for use in admin-events.

Also lets admins change the storyteller midround.

Both of these were requested by @GrayRachnid 

Moves both storyteller & storyteller_cache to GLOB, so they're easier to access & modify.