### PR TITLE
fixes being unable to look up in space

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1438,7 +1438,7 @@ var/list/rank_prefix = list(\
 			if(client.eye == shadow)
 				reset_view(0)
 				return
-			if(istype(above, /turf/simulated/open))
+			if(istype(above, /turf/simulated/open) || istype(above, /turf/space))
 				src << SPAN_NOTICE("You look up.")
 				if(client)
 					reset_view(shadow)


### PR DESCRIPTION
doesn't fix all tiles above you being fully white, since I'm not sure why that happens, but my guess would be  lighting atoms.