### PR TITLE
Fixes borg module duplication

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -279,6 +279,8 @@
 	"[modtype] module", "Yes", "No"))
 		if("No")
 			//They changed their mind, abort, abort!
+			if(module)
+				return
 			QDEL_NULL(RM)
 			modtype = null
 			spawn()
@@ -286,6 +288,8 @@
 			return //And abort out of this
 		if ("Yes")
 			//This time spawn the real module
+			if(module)
+				return
 			QDEL_NULL(RM)
 			new module_type(src)
 


### PR DESCRIPTION
Fixes #3036
Expanding on the issue - queuing up the borg module change prompt would allow multiple concurrent module changes, allowing the module items pools to be drawn from at will. Also messed up the HUD with ghost item sprites.  Adds checks in the alert switch statement to prevent this.

