### PR TITLE
Cryopods can be exited by pressing movement keys after sleeping timer.

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -502,6 +502,10 @@
 
 	return
 
+/obj/machinery/cryopod/relaymove(var/mob/user)
+	..()
+	go_out()
+
 /obj/machinery/cryopod/proc/go_out()
 
 	if(!occupant)


### PR DESCRIPTION
## General
Makes the game start life more bearable.

## Changelog
🆑 TorinoFermic
change: You can exit cyropods with movement keys like sleepers.
/🆑