### PR TITLE
Attack Log viewer

### DIFF
--- a/code/datums/topic/admin.dm
+++ b/code/datums/topic/admin.dm
@@ -1151,6 +1151,14 @@
 	var/mob/M = locate(input["subtlemessage"])
 	usr.client.cmd_admin_subtle_message(M)
 
+/datum/admin_topic/viewlogs
+	keyword = "viewlogs"
+	require_perms = list(R_MOD|R_ADMIN)
+
+/datum/admin_topic/viewlogs/Run(list/input)
+	var/mob/M = locate(input["viewlogs"])
+	source.view_log_panel(M)
+
 
 /datum/admin_topic/traitor
 	keyword = "traitor"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -31,6 +31,32 @@ proc/admin_notice(var/message, var/rights)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////Panels
 
+/datum/admins/proc/view_log_panel(mob/M)
+	if(!M)
+		to_chat(usr, "That mob doesn't seem to exist! Something went wrong.")
+		return 
+
+	if (!istype(src, /datum/admins))
+		src = usr.client.holder
+	if (!istype(src, /datum/admins))
+		usr << "Error: you are not an admin!"
+		return
+
+	var/body = "<html><head><title>Log Panel of [M.real_name]</title></head>"
+	body += "<body><center>Logs of <b>[M]</b><br>"
+	body += "<a href='?src=\ref[src];viewlogs=\ref[M]'>REFRESH</a></center><br>"
+
+
+	var/i = length(M.attack_log)
+	while(i > 0)
+		body += M.attack_log[i] + "<br>"
+		i--
+
+	usr << browse(body, "window=\ref[M]logs;size=500x500")
+
+	
+
+
 ADMIN_VERB_ADD(/datum/admins/proc/show_player_panel, null, TRUE)
 //shows an interface for individual players, with various links (links require additional flags
 /datum/admins/proc/show_player_panel(var/mob/M in SSmobs.mob_list)
@@ -76,7 +102,8 @@ ADMIN_VERB_ADD(/datum/admins/proc/show_player_panel, null, TRUE)
 		<a href='?src=\ref[src];traitor=\ref[M]'>TP</a> -
 		<a href='?src=\ref[usr];priv_msg=\ref[M]'>PM</a> -
 		<a href='?src=\ref[src];subtlemessage=\ref[M]'>SM</a> -
-		[admin_jump_link(M, src)]\] <br>
+		[admin_jump_link(M, src)] - 
+		<a href='?src=\ref[src];viewlogs=\ref[M]'>LOGS</a>\] <br>
 		<b>Mob type</b> = [M.type]<br><br>
 		<A href='?src=\ref[src];boot2=\ref[M]'>Kick</A> |
 		<A href='?_src_=holder;warn=[M.ckey]'>Warn</A> |

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -81,6 +81,7 @@
 					body += "<a href='?src=\ref[src];traitor="+ref+"'>TP</a> - "
 					body += "<a href='?src=\ref[usr];priv_msg=\ref"+ref+"'>PM</a> - "
 					body += "<a href='?src=\ref[src];subtlemessage="+ref+"'>SM</a> - "
+					body += "<a href='?src=\ref[src];viewlogs="+ref+"'>LOGS</a> - "
 					body += "<a href='?src=\ref[src];adminplayerobservejump="+ref+"'>JMP</a><br>"
 					if(antagonist > 0)
 						body += "<font size='2'><a href='?src=\ref[src];check_antagonist=1'><font color='red'><b>Antagonist</b></font></a></font>";


### PR DESCRIPTION

![pic](https://user-images.githubusercontent.com/15747030/54492811-f9516c00-48c9-11e9-9e20-0847a37fdde1.png)

Can reach it from the player panel, as well as the bigger list of players (which is also incidentally called Player Panel?). No more clicking through VV to read those ugly logs.

I considered adding a search function, but disappearing logs would be annoying as hell. You can ctrl+f in there anyway.