### PR TITLE
Change : You can use radios with . in addition to :

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -1,19 +1,34 @@
 var/list/department_radio_keys = list(
-	"r" = "right ear",
-	"l" = "left ear",
-	"i" = "intercom",
-	"h" = "department",
-	"+" = "special",		//activate radio-specific special functions
-	"c" = "Command",
-	"n" = "Science",
-	"m" = "Medical",
-	"e" = "Engineering",
-	"s" = "Security",
-	"w" = "whisper",
-	"t" = "Mercenary",
-	"u" = "Supply",
-	"v" = "Service",
-	"p" = "AI Private"
+	":r" = "right ear",	".r" = "right ear",
+	":l" = "left ear",	".l" = "left ear",
+	":i" = "intercom",	".i" = "intercom",
+	":h" = "department",	".h" = "department",
+	":+" = "special",		".+" = "special", //activate radio-specific special functions
+	":c" = "Command",		".c" = "Command",
+	":n" = "Science",		".n" = "Science",
+	":m" = "Medical",		".m" = "Medical",
+	":e" = "Engineering", ".e" = "Engineering",
+	":s" = "Security",	".s" = "Security",
+	":w" = "whisper",		".w" = "whisper",
+	":t" = "Mercenary",	".t" = "Mercenary",
+	":u" = "Supply",		".u" = "Supply",
+	":v" = "Service",		".v" = "Service",
+	":p" = "AI Private",	".p" = "AI Private",
+
+	//kinda localization -- rastaf0
+	//same keys as above, but on russian keyboard layout. This file uses cp1251 as encoding.
+	":ê" = "right ear",	".ê" = "right ear",
+	":ä" = "left ear",	".ä" = "left ear",
+	":ø" = "intercom",	".ø" = "intercom",
+	":ð" = "department",	".ð" = "department",
+	":ñ" = "Command",		".ñ" = "Command",
+	":ò" = "Science",		".ò" = "Science",
+	":ü" = "Medical",		".ü" = "Medical",
+	":ó" = "Engineering",	".ó" = "Engineering",
+	":û" = "Security",	".û" = "Security",
+	":ö" = "whisper",		".ö" = "whisper",
+	":å" = "Mercenary",	".å" = "Mercenary",
+	":é" = "Supply",	".é" = "Supply"
 )
 
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -153,8 +153,8 @@
 	if(length(message) >= 1 && copytext(message,1,2) == get_prefix_key(/decl/prefix/radio_main_channel))
 		return standard_mode
 
-	if(length(message) >= 2 && copytext(message, 1, 2) == get_prefix_key(/decl/prefix/radio_channel_selection))
-		var/channel_prefix =  sanitize_key(copytext(message, 2, 3))
+	if(length(message) >= 2)
+		var/channel_prefix =  sanitize_key(copytext(message, 1, 3))
 		return department_radio_keys[channel_prefix]
 
 	return null


### PR DESCRIPTION
## General
Code is ported from Baystation12
Also, the code handles with Russian letters, whispering.

Fixes #2714

## Changelog
🆑 TorinoFermic
fix: Radios has been augmented to use "." or ":" and you can whisper with ".w" or ":w". Just like all other servers.
/🆑
