### PR TITLE
Cyrofeed structure made solid to avoid trapping arrival players.

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -144,6 +144,7 @@
 	desc = "A bewildering tangle of machinery and pipes."
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "cryo_rear"
+	density = 1
 	anchored = 1
 	dir = WEST
 


### PR DESCRIPTION
## General
Cryopods creators forgot to set one critical part to solid form.

## Changelog
🆑 TorinoFermic
fix: You won't wake up at wrong side and getting stuck.
/🆑
