### PR TITLE
Occupation Skills Redone

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -39,7 +39,6 @@ Your second loyalty is to your command officers. The heads of each faction. List
 		STAT_TGH = 15,
 		STAT_BIO = 15,
 		STAT_MEC = 15,
-		STAT_COG = 15
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
@@ -117,10 +116,9 @@ Act as the captain's sidekick, bodyguard, and last line of defense in a crisis o
 
 	stat_modifiers = list(
 		STAT_ROB = 10,
-		STAT_TGH = 10,
+		STAT_TGH = 15,
 		STAT_BIO = 10,
 		STAT_MEC = 10,
-		STAT_COG = 10
 	)
 
 /obj/landmark/join/start/hop

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -16,8 +16,12 @@
 	initial_balance	= 1600
 	wage = WAGE_NONE	//Bartender is unpaid, they make money selling drinks
 	stat_modifiers = list(
-		STAT_ROB = 10,
+		STAT_ROB = 15,
+		STAT_TGH = 10,
+		STAT_BIO = 5,
+		STAT_MEC = 10,
 	)
+
 	also_known_languages = list(LANGUAGE_JIVE = 80)
 
 	outfit_type = /decl/hierarchy/outfit/job/service/bartender
@@ -63,6 +67,12 @@
 	loyalties = LOYALTY_CIVILIAN
 	wage = WAGE_NONE	//Chef is unpaid, they make money selling food
 	initial_balance	= 1600
+		stat_modifiers = list(
+		STAT_ROB = 15,
+		STAT_TGH = 10,
+		STAT_BIO = 15,
+	)
+
 	description = "	Everyone's favourite person when they're hungry, you are the chef, maker of food and slayer of hunger. Everyone needs to eat, and you make sure they can. Your job is fairly simple, cook food for the crew. Your primary source of raw materials is the garden downstairs, you and the gardener should work closely together. <br>\
 	<br>\
 	You are a sole trader trying to make a profit here, so giving away your food for free is not adviseable unless times are desperate<br>\
@@ -95,9 +105,10 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/service/gardener
 	stat_modifiers = list(
-		STAT_BIO = 10,
+		STAT_ROB = 10,
 		STAT_TGH = 10,
-		STAT_ROB = 20,
+		STAT_BIO = 20,
+		STAT_MEC = 5,
 	)
 
 	description = "The green-fingered gnome working in the glorious viridian basement of Eris. You are the gardener, tender of plants.<br>\
@@ -139,9 +150,11 @@
 	outfit_type = /decl/hierarchy/outfit/job/service/actor/clown
 	wage = WAGE_LABOUR_DUMB	//Barely a retaining fee. Actor can busk for credits to keep themselves fed
 	stat_modifiers = list(
-		STAT_TGH = 10,
-		STAT_ROB = 20,
+		STAT_ROB = 10,
+		STAT_TGH = 20,
+		STAT-MECH = 5,
 	)
+
 
 	loyalties = LOYALTY_CIVILIAN
 
@@ -169,6 +182,9 @@
 
 	stat_modifiers = list(
 		STAT_ROB = 10,
+		STAT_TGH = 10,
+		STAT_BIO = 10,
+		STAT_MEC = 10,
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/camera_monitor)

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -16,8 +16,11 @@
 	outfit_type = /decl/hierarchy/outfit/job/chaplain
 
 	stat_modifiers = list(
-		STAT_TGH = 10,
+		STAT_ROB = 15,
+		STAT_TGH = 15,
+		STAT_MEC = 10,
 	)
+
 
 	software_on_spawn = list(/datum/computer_file/program/records,
 							 /datum/computer_file/program/reports)

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -24,9 +24,11 @@
 	)
 
 	stat_modifiers = list(
+		STAT_ROB = 10,
+		STAT_TGH = 10,
 		STAT_MEC = 40,
-		STAT_COG = 20,
 	)
+
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/ntnetmonitor,
@@ -72,9 +74,11 @@ Your second loyalty is to your clan. Ensure they are paid, fed and safe. Don't r
 	)
 
 	stat_modifiers = list(
+		STAT_ROB = 5,
+		STAT_TGH = 10,
 		STAT_MEC = 30,
-		STAT_COG = 15,
 	)
+
 
 	software_on_spawn = list(/datum/computer_file/program/power_monitor,
 							 /datum/computer_file/program/supermatter_monitor,

--- a/code/game/jobs/job/guild.dm
+++ b/code/game/jobs/job/guild.dm
@@ -17,6 +17,13 @@
 		access_heads, access_mining_station, access_RC_announce, access_keycard_auth, access_sec_doors,
 		access_eva, access_external_airlocks
 	)
+	stat_modifiers = list(
+		STAT_ROB = 15,
+		STAT_TGH = 15,
+		STAT_MEC = 10,
+		STAT_BIO = 10,
+
+	)
 	ideal_character_age = 40
 
 	description = "You are the head of the local branch of Asters Merchant Guild, and eris' guild representative<br>\
@@ -77,7 +84,9 @@ Your second loyalty is to the guild. Ensure it retains good relations with priva
 	stat_modifiers = list(
 		STAT_ROB = 10,
 		STAT_TGH = 10,
+		STAT_MEC = 20,
 	)
+
 
 	software_on_spawn = list(///datum/computer_file/program/supply,
 							 ///datum/computer_file/program/deck_management,
@@ -147,9 +156,10 @@ Character Expectations:<br>\
 
 
 	stat_modifiers = list(
-		STAT_ROB = 20,
+		STAT_ROB = 10,
 		STAT_TGH = 15,
-		STAT_MEC = 15
+		STAT_MEC = 10,
+		STAT_BIO = 5
 	)
 
 	software_on_spawn = list(///datum/computer_file/program/supply,

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -23,8 +23,11 @@
 	ideal_character_age = 50
 
 	stat_modifiers = list(
+		STAT_ROB = 10,
+		STAT_TGH = 10,
 		STAT_BIO = 40,
 	)
+
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/suit_sensors,
@@ -74,8 +77,11 @@ Your second loyalty is to your career with Moebius corp, and to your coworkers i
 	)
 
 	stat_modifiers = list(
+		STAT_ROB = 10,
+		STAT_TGH = 5,
 		STAT_BIO = 30,
 	)
+
 
 	software_on_spawn = list(/datum/computer_file/program/suit_sensors,
 							 /datum/computer_file/program/camera_monitor)
@@ -130,9 +136,11 @@ Your second loyalty is to your career with Moebius corp, and to your coworkers i
 	)
 
 	stat_modifiers = list(
-		STAT_COG = 10,
+		STAT_ROB = 10,
+		STAT_TGH = 5,
 		STAT_BIO = 30,
 	)
+
 
 	software_on_spawn = list(/datum/computer_file/program/scanner)
 
@@ -179,8 +187,11 @@ Your second loyalty is to your career with Moebius corp, and to your coworkers i
 	)
 
 	stat_modifiers = list(
-		STAT_BIO = 15,
+		STAT_ROB = 5,
+		STAT_TGH = 15,
+		STAT_BIO = 20,
 	)
+
 
 	software_on_spawn = list(/datum/computer_file/program/suit_sensors,
 							 /datum/computer_file/program/camera_monitor)
@@ -212,9 +223,9 @@ Your second loyalty is to your career with Moebius corp, and to your coworkers i
 	)
 
 	stat_modifiers = list(
+		STAT_ROB = 5,
+		STAT_TGH = 15,
 		STAT_BIO = 20,
-		STAT_ROB = 10,
-		STAT_TGH = 10,
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/suit_sensors,

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -25,10 +25,12 @@
 	ideal_character_age = 50
 
 	stat_modifiers = list(
-		STAT_MEC = 30,
-		STAT_COG = 40,
+		STAT_TGH = 10,
+		STAT_ROB = 10,
 		STAT_BIO = 30,
+		STAT_MEC = 30,
 	)
+
 
 	// TODO: enable after baymed
 	software_on_spawn = list(/datum/computer_file/program/comm,
@@ -75,9 +77,9 @@ Your second loyalty is to moebius corp. In order to ensure it can continue its m
 	)
 
 	stat_modifiers = list(
-		STAT_MEC = 20,
-		STAT_COG = 30,
+		STAT_TGH = 10,
 		STAT_BIO = 20,
+		STAT_MEC = 20,
 	)
 
 	description = "You are a scientist, standing at the frontier of human advancement. Here representing Moebius corp, to find new research opportunities in deep space. The science wing is located in the second section, starboard side, opposite medical, and your medical colleagues should be fast friends. The medical wing is part of Moebius too, and so you fully share access with each other, and are free to use each others' supplies.<br>\
@@ -129,9 +131,9 @@ Your second loyalty is to moebius corp. In order to ensure it can continue its m
 	) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 
 	stat_modifiers = list(
+		STAT_TGH = 10,
 		STAT_MEC = 30,
-		STAT_COG = 20,
-		STAT_BIO = 30,
+		STAT_BIO = 10,
 	)
 
 

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -24,9 +24,12 @@
 	)
 
 	stat_modifiers = list(
-		STAT_ROB = 30,
-		STAT_TGH = 20,
+		STAT_ROB = 20,
+		STAT_TGH = 25,
+		STAT_BIO = 10,
+		STAT_MEC = 10,
 	)
+
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/digitalwarrant,
@@ -81,7 +84,9 @@
 	stat_modifiers = list(
 		STAT_ROB = 20,
 		STAT_TGH = 20,
+		STAT_BIO = 10,
 	)
+
 
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
 							 /datum/computer_file/program/camera_monitor)
@@ -128,10 +133,12 @@
 	outfit_type = /decl/hierarchy/outfit/job/security/inspector
 
 	stat_modifiers = list(
+		STAT_ROB = 15,
+		STAT_TGH = 15,
 		STAT_BIO = 10,
-		STAT_ROB = 10,
-		STAT_TGH = 10,
+		STAT_MEC = 10,
 	)
+
 
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
 							 /datum/computer_file/program/audio,
@@ -178,8 +185,11 @@
 	)
 
 	stat_modifiers = list(
+		STAT_ROB = 15,
+		STAT_TGH = 15,
 		STAT_BIO = 20,
 	)
+
 
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
 							 /datum/computer_file/program/suit_sensors,
@@ -228,9 +238,11 @@
 	)
 
 	stat_modifiers = list(
-		STAT_ROB = 10,
+		STAT_ROB = 15,
 		STAT_TGH = 20,
+		STAT_BIO = 10,
 	)
+
 
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
 							 /datum/computer_file/program/camera_monitor)


### PR DESCRIPTION
So after a few hours, a little bit of math and my entire day gone. I have now fixed the job skills. Probably.

It's probably fixed.

This took a very long time, I had to ask a lot of people questions and there was a bit of tweaking outside of the number system I was using at the start. Specifically with Ironhammer, I wanted to give them job skills and still keep them combat efficient so they were boosted in that way. They aren't tougher now - but they can do things other then shoot people and eat lead. Like performing first aid or crowbarring doors open for crew.

The intention is to separate the roles into three categories of total allocated skill points. The differences between the roles in a department is less about their total power - and more about how it's distributed. Focusing on how they are different and less about how one is better than the other. Ideally with very few exceptions like IH / Command, any role you choose will have plenty of advantages to it.

Now the number of skills in things like Robust / Toughness, compared to Mechanics / Biology have different values. So an example is, it's easier to have really high non combat skills for a role but more difficult to have high combat ones. For that reason you will rarely see non security roles with a 15 in any Combat skill and if they do, they'll have little in the way of Mechanics / Bio.

I'm obviously open to changes down the road if my PR gets put in and understand, the server will be updated as time goes on. This at the very least, is like a very needed bandage for a wound that has been gushing for some time now. One that I will admit, as a Guild Miner with my 15+ in all skills, have been abusing ever since. I'm putting an end to my own bullshit.

Big Honchos - Captain, IH Commander.

Professionals - Head Roles and IH Personnel.

The Other Guys - Every other occupational role, including Clowns and Guild Miners.