### PR TITLE
Switch damage values of 10mm and .45

### DIFF
--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -12,7 +12,7 @@
 
 //Low-caliber pistols and SMGs
 #define ARMOR_PENETRATION_LOW_CALIBER_PISTOL 5
-#define DAMAGE_10MM 23
+#define DAMAGE_10MM 22
 #define DAMAGE_9MM 19
 #define DAMAGE_32 17
 #define DAMAGE_45 21.5

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -12,10 +12,10 @@
 
 //Low-caliber pistols and SMGs
 #define ARMOR_PENETRATION_LOW_CALIBER_PISTOL 5
-#define DAMAGE_10MM 21.5
+#define DAMAGE_10MM 23
 #define DAMAGE_9MM 19
 #define DAMAGE_32 17
-#define DAMAGE_45 22
+#define DAMAGE_45 21.5
 
 //Carbines and rifles
 #define DAMAGE_10X24 30


### PR DESCRIPTION
10mm is a bigger and more powerful cartridge than .45, so it makes little sense that .45 does more damage in game. This PR switches the values and makes 10mm do slightly more damage (as again, it is a very powerful cartridge).