### PR TITLE
[BALANCE] Excelsior antag won't be given to Heads or Ironhammer.

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -11,8 +11,9 @@
 
 	var/flags = 0                           // Various runtime options.
 
-	var/list/restricted_jobs =     list()   // Jobs that technically cannot be this antagonist (like AI-changeling)
-	var/list/protected_jobs =      list()   // As above, but this jobs are rewstricted ideologically (like Security Officer-traitor)
+	var/list/restricted_jobs =	list()	// Jobs that technically cannot be this antagonist (like AI-changeling)
+	var/list/protected_jobs =	list()	// As above, but this jobs are rewstricted ideologically (like Security Officer-traitor)
+	var/list/story_ineligible =	list()	// Denies the job from getting the antag status by story teller itself but allows become antag via different means.
 
 	// Strings.
 	var/welcome_text = "Cry havoc and let slip the dogs of war!"

--- a/code/game/antagonist/station/revolutionary/excelsior.dm
+++ b/code/game/antagonist/station/revolutionary/excelsior.dm
@@ -1,6 +1,5 @@
 /datum/antagonist/excelsior
 	id = ROLE_EXCELSIOR_REV
-	protected_jobs = list(JOBS_SECURITY, JOBS_COMMAND)
 	role_text = "Excelsior Infiltrator"
 	role_text_plural = "Infiltrators"
 	bantype = ROLE_BANTYPE_EXCELSIOR

--- a/code/game/antagonist/station/revolutionary/excelsior.dm
+++ b/code/game/antagonist/station/revolutionary/excelsior.dm
@@ -1,5 +1,6 @@
 /datum/antagonist/excelsior
 	id = ROLE_EXCELSIOR_REV
+	protected_jobs = list(JOBS_SECURITY, JOBS_COMMAND)
 	role_text = "Excelsior Infiltrator"
 	role_text_plural = "Infiltrators"
 	bantype = ROLE_BANTYPE_EXCELSIOR

--- a/code/game/antagonist/station/revolutionary/excelsior.dm
+++ b/code/game/antagonist/station/revolutionary/excelsior.dm
@@ -9,6 +9,8 @@
 	faction_id = FACTION_EXCELSIOR
 	allow_neotheology = FALSE //Implant causes head asplode
 
+	story_ineligible = list(JOBS_SECURITY, JOBS_COMMAND)
+
 /datum/antagonist/excelsior/equip()
 	.=..()
 

--- a/code/game/gamemodes/roleset/faction/excelsior.dm
+++ b/code/game/gamemodes/roleset/faction/excelsior.dm
@@ -12,11 +12,3 @@
 
 	req_crew = 6
 	leaders = -1 //Every excelsior spawned directly is a leader. Non leaders are those recruited during gameplay
-
-	story_ineligible = list(JOBS_SECURITY, JOBS_COMMAND)
-
-// Code to prevent a role from being picked by the storyteller.
-/datum/storyevent/roleset/faction/excelsior/antagonist_suitable(var/datum/mind/player, var/datum/antagonist/antag)
-	if(player.assigned_role in story_ineligible)
-		return FALSE
-	return TRUE

--- a/code/game/gamemodes/roleset/faction/excelsior.dm
+++ b/code/game/gamemodes/roleset/faction/excelsior.dm
@@ -13,4 +13,10 @@
 	req_crew = 6
 	leaders = -1 //Every excelsior spawned directly is a leader. Non leaders are those recruited during gameplay
 
+	story_ineligible = list(JOBS_SECURITY, JOBS_COMMAND)
 
+// Code to prevent a role from being picked by the storyteller.
+/datum/storyevent/roleset/faction/excelsior/antagonist_suitable(var/datum/mind/player, var/datum/antagonist/antag)
+	if(player.assigned_role in story_ineligible)
+		return FALSE
+	return TRUE

--- a/code/game/gamemodes/roleset/faction/roleset_faction.dm
+++ b/code/game/gamemodes/roleset/faction/roleset_faction.dm
@@ -9,6 +9,9 @@
 	//The type of the faction we'll create if we can't find one
 	var/faction_type = null
 
+	//Denies the role from being picked by the storyteller
+	var/story_ineligible = list()
+
 
 //This is a copypaste of roleset/trigger_event, with some new features added
 /datum/storyevent/roleset/faction/trigger_event()

--- a/code/game/gamemodes/roleset/faction/roleset_faction.dm
+++ b/code/game/gamemodes/roleset/faction/roleset_faction.dm
@@ -9,10 +9,6 @@
 	//The type of the faction we'll create if we can't find one
 	var/faction_type = null
 
-	//Denies the role from being picked by the storyteller
-	var/story_ineligible = list(JOBS_SECURITY, JOBS_COMMAND)
-
-
 //This is a copypaste of roleset/trigger_event, with some new features added
 /datum/storyevent/roleset/faction/trigger_event()
 	calc_target_quantity()
@@ -89,6 +85,6 @@
 
 // Code to prevent a role from being picked by the storyteller.
 /datum/storyevent/roleset/faction/antagonist_suitable(var/datum/mind/player, var/datum/antagonist/antag)
-	if(player.assigned_role in story_ineligible)
+	if(player.assigned_role in antag.story_ineligible)
 		return FALSE
 	return TRUE

--- a/code/game/gamemodes/roleset/faction/roleset_faction.dm
+++ b/code/game/gamemodes/roleset/faction/roleset_faction.dm
@@ -10,7 +10,7 @@
 	var/faction_type = null
 
 	//Denies the role from being picked by the storyteller
-	var/story_ineligible = list()
+	var/story_ineligible = list(JOBS_SECURITY, JOBS_COMMAND)
 
 
 //This is a copypaste of roleset/trigger_event, with some new features added
@@ -86,3 +86,9 @@
 		if (success_quantity > 1)
 			success_percent = success_quantity / target_quantity
 		cancel(severity, success_percent)
+
+// Code to prevent a role from being picked by the storyteller.
+/datum/storyevent/roleset/faction/antagonist_suitable(var/datum/mind/player, var/datum/antagonist/antag)
+	if(player.assigned_role in story_ineligible)
+		return FALSE
+	return TRUE

--- a/code/game/gamemodes/roleset/roleset.dm
+++ b/code/game/gamemodes/roleset/roleset.dm
@@ -56,7 +56,7 @@
 		if(!temp.can_become_antag(candidate, report))
 			if (report) report << SPAN_NOTICE("Failure: [candidate] can't become this antag")
 			continue
-		if(!antagonist_suitable(candidate,temp))
+		if(!antagonist_suitable(candidate, temp))
 			if (report) report << SPAN_NOTICE("Failure: [candidate] is not antagonist suitable")
 			continue
 		if(!(temp.bantype in candidate.current.client.prefs.be_special_role))


### PR DESCRIPTION
## General
Changed so the antag Excelsior won't apply to heads of staff by the storyteller.
Excelsiors can forcefully implant heads or IH just fine.

## Changelog
🆑 TorinoFermic
tweak: Excelsior will not apply to head of staff or Ironhammer for the storyteller picking.
/🆑