### PR TITLE
Changes to traps

### DIFF
--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -142,14 +142,14 @@ Freeing yourself is much harder than freeing someone else. Calling for help is a
 		return
 	if (deployed)
 		user.visible_message(
-			"<span class='danger'>[user] starts to carefully disarm \the [src].</span>",
-			"<span class='danger'>You begin to carefully disarm \the [src].</span>"
+			SPAN_DANGER("[user] starts to carefully disarm \the [src]."),
+			SPAN_DANGER("You begin to carefully disarm \the [src].")
 			)
 
 		if (do_after(user, 25))
 			user.visible_message(
-				"<span class='danger'>[user] has disarmed \the [src].</span>",
-				"<span class='danger'>You have disarmed \the [src]!</span>"
+				SPAN_DANGER("[user] has disarmed \the [src]."),
+				SPAN_DANGER("You have disarmed \the [src]!")
 				)
 			deployed = FALSE
 			anchored = FALSE
@@ -335,7 +335,7 @@ Very rarely it might escape
 /obj/item/weapon/beartrap/examine(mob/user)
 	..()
 	if(deployed && isliving(user) && !("\ref[user]" in aware_mobs))
-		user << SPAN_NOTICE("You're aware of this trap, now. You won't set it off when walking carefully.")
+		to_chat(user, SPAN_NOTICE("You're aware of this trap, now. You won't set it off when walking carefully."))
 		aware_mobs |= "\ref[user]"
 
 

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -21,6 +21,7 @@
 	var/target_zone
 	var/min_size = 5 //Mobs smaller than this won't trigger the trap
 	var/struggle_prob = 2
+	var/list/aware_mobs = list() //List of mobs that examined this trap. Won't trigger it when walking.
 
 
 /obj/item/weapon/beartrap/Initialize()
@@ -139,6 +140,21 @@ Freeing yourself is much harder than freeing someone else. Calling for help is a
 	if (buckled_mob)
 		attempt_release(user)
 		return
+	if (deployed)
+		user.visible_message(
+			"<span class='danger'>[user] starts to carefully disarm \the [src].</span>",
+			"<span class='danger'>You begin to carefully disarm \the [src].</span>"
+			)
+
+		if (do_after(user, 25))
+			user.visible_message(
+				"<span class='danger'>[user] has disarmed \the [src].</span>",
+				"<span class='danger'>You have disarmed \the [src]!</span>"
+				)
+			deployed = FALSE
+			anchored = FALSE
+			update_icon()
+		return
 	.=..()
 
 /obj/item/weapon/beartrap/attack_generic(var/mob/user, var/damage)
@@ -196,6 +212,7 @@ Freeing yourself is much harder than freeing someone else. Calling for help is a
 				"You hear a latch click loudly."
 				)
 
+			aware_mobs = list()
 			deployed = 1
 			user.drop_from_inventory(src)
 			update_icon()
@@ -301,6 +318,8 @@ Very rarely it might escape
 /obj/item/weapon/beartrap/Crossed(AM as mob|obj)
 	if(deployed && isliving(AM))
 		var/mob/living/L = AM
+		if((L in aware_mobs) && MOVING_DELIBERATELY(L))
+			return ..()
 		L.visible_message(
 			"<span class='danger'>[L] steps on \the [src].</span>",
 			"<span class='danger'>You step on \the [src]!</span>",
@@ -313,7 +332,11 @@ Very rarely it might escape
 		update_icon()
 	..()
 
-
+/obj/item/weapon/beartrap/examine(mob/user)
+	..()
+	if(deployed && isliving(user) && !(user in aware_mobs))
+		user << SPAN_NOTICE("You're aware of this trap, now. You won't set it off when walking carefully.")
+		aware_mobs |= user
 
 
 /obj/item/weapon/beartrap/update_icon()

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -21,7 +21,7 @@
 	var/target_zone
 	var/min_size = 5 //Mobs smaller than this won't trigger the trap
 	var/struggle_prob = 2
-	var/list/aware_mobs = list() //List of mobs that examined this trap. Won't trigger it when walking.
+	var/list/aware_mobs = list() //List of refs of mobs that examined this trap. Won't trigger it when walking.
 
 
 /obj/item/weapon/beartrap/Initialize()
@@ -318,7 +318,7 @@ Very rarely it might escape
 /obj/item/weapon/beartrap/Crossed(AM as mob|obj)
 	if(deployed && isliving(AM))
 		var/mob/living/L = AM
-		if((L in aware_mobs) && MOVING_DELIBERATELY(L))
+		if(("\ref[L]" in aware_mobs) && MOVING_DELIBERATELY(L))
 			return ..()
 		L.visible_message(
 			"<span class='danger'>[L] steps on \the [src].</span>",
@@ -334,9 +334,9 @@ Very rarely it might escape
 
 /obj/item/weapon/beartrap/examine(mob/user)
 	..()
-	if(deployed && isliving(user) && !(user in aware_mobs))
+	if(deployed && isliving(user) && !("\ref[user]" in aware_mobs))
 		user << SPAN_NOTICE("You're aware of this trap, now. You won't set it off when walking carefully.")
-		aware_mobs |= user
+		aware_mobs |= "\ref[user]"
 
 
 /obj/item/weapon/beartrap/update_icon()

--- a/code/game/turfs/simulated/cleaning.dm
+++ b/code/game/turfs/simulated/cleaning.dm
@@ -17,9 +17,6 @@
 	addtimer(CALLBACK(src, .proc/unwet_floor, TRUE), rand(1 MINUTES, 1.5 MINUTES), TIMER_UNIQUE|TIMER_OVERRIDE)
 
 /turf/simulated/proc/unwet_floor(var/check_very_wet)
-	if(check_very_wet && wet >= 2)
-		return
-
 	wet = 0
 	if(wet_overlay)
 		overlays -= wet_overlay


### PR DESCRIPTION
You can no longer pick up deployed traps, you have to disarm them first.
When you examine a deployed trap, you become aware of it and won't trigger them when you WALK into them.

Fixed a bug where lubed floors would never get delubed.