### PR TITLE
Overslot thingie

### DIFF
--- a/code/game/objects/items/_inventory.dm
+++ b/code/game/objects/items/_inventory.dm
@@ -21,17 +21,45 @@
 
 	SSinventory.update_mob(loc, slot, redraw_mob)
 
+
+/obj/item/proc/can_be_equipped(mob/user, slot, disable_warning = 0)
+	var/obj/item/equipped = user.get_equipped_item(slot)
+	if(equipped && equipped.overslot)
+		if (!disable_warning)
+			to_chat(user, "You are unable to wear \the [src] as [overslot_contents] in the way.")
+		return FALSE
+	return TRUE
+
+/obj/item/pre_attack(atom/a, mob/user, var/params)
+	if(overslot)
+		var/obj/item/clothing/i = a
+		if (i)
+			if(i.is_worn() && i.slot_flags == slot_flags)
+				user.equip_to_appropriate_slot(src)
+				return TRUE
+
+
 /obj/item/proc/pre_equip(var/mob/user, var/slot)
 	//Some inventory sounds.
 	//occurs when you equip something
 	if(item_flags & EQUIP_SOUNDS)
 		var/picked_sound = pick(w_class > ITEM_SIZE_NORMAL ? long_equipement_sound : short_equipement_sound)
 		playsound(src, picked_sound, 100, 1, 1)
+	if(overslot)
+		var/obj/item/equipped = user.get_equipped_item(slot)
+		if(equipped)
+			src.overslot_contents = equipped
+			user.drop_from_inventory(equipped)
+			equipped.forceMove(src)
+
+
 
 /obj/item/proc/equipped(var/mob/user, var/slot)
 	equip_slot = slot
 	if(user.pulling == src)
 		user.stop_pulling()
+	if(overslot && !is_worn())
+		remove_overslot_contents(user)
 
 
 
@@ -40,10 +68,17 @@
 	if(zoom) //binoculars, scope, etc
 		zoom()
 	remove_hud_actions(user)
+	if(overslot && is_held())
+		remove_overslot_contents(user)
 
 
-/obj/item/proc/can_be_equipped(mob/Mob, slot, disable_warning = FALSE)
-	return TRUE
+
+/obj/item/proc/remove_overslot_contents(mob/user)
+	if(overslot_contents)
+		if(!user.equip_to_appropriate_slot(overslot_contents))
+			overslot_contents.forceMove(get_turf(src))
+		overslot_contents = null
+
 
 
 /obj/item/proc/mob_can_unequip(mob/M, slot, disable_warning = 0)
@@ -116,4 +151,3 @@
 				H.put_in_l_hand(src)
 		src.add_fingerprint(usr)
 		return TRUE
-

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -30,6 +30,7 @@
 
 //Delayed equipping
 /obj/item/clothing/pre_equip(var/mob/user, var/slot)
+	..(user, slot)
 	if (equip_delay > 0)
 		//If its currently worn, we must be taking it off
 		if (is_worn())
@@ -113,7 +114,7 @@
 	var/other_slot = (slot == slot_l_ear) ? slot_r_ear : slot_l_ear
 	if(user.get_equipped_item(other_slot) != master_item || user.get_equipped_item(slot))
 		return FALSE
-	return TRUE
+	return ..()
 
 /obj/item/clothing/ears/earmuffs
 	name = "earmuffs"

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -4,17 +4,16 @@
 	icon_state = "magboots0"
 	species_restricted = null
 	force = 3
-	overshoes = 1
+	overslot = 1
 	var/magpulse = 0
 	var/mag_slow = 3
 	var/icon_base = "magboots"
 	action_button_name = "Toggle Magboots"
-	var/obj/item/clothing/shoes/shoes = null	//Undershoes
-	var/mob/living/carbon/human/wearer = null	//For shoe procs
 	armor = list(melee = 40, bullet = 30, laser = 30,energy = 25, bomb = 50, bio = 100, rad = 70)
 	//This armor only applies to legs
 
 /obj/item/clothing/shoes/magboots/proc/set_slowdown()
+	var/obj/item/clothing/shoes/shoes = overslot_contents
 	slowdown = shoes? max(SHOES_SLOWDOWN, shoes.slowdown): SHOES_SLOWDOWN	//So you can't put on magboots to make you walk faster.
 	if (magpulse)
 		slowdown += mag_slow
@@ -37,70 +36,6 @@
 	user.update_inv_shoes()	//so our mob-overlays update
 	user.update_action_buttons()
 	user.update_floating()
-
-
-//We want to allow the user to equip magboots even if they're already wearing shoes
-//As long as those shoes are not themselves magboots or similar overshoe-shoes
-/obj/item/clothing/shoes/magboots/can_be_equipped(mob/user, slot, disable_warning = 0)
-	if (slot == slot_shoes)
-		var/mob/living/carbon/human/H = user
-
-		if(H.shoes)
-			if (istype(H.shoes, /obj/item/clothing/shoes))
-				var/obj/item/clothing/shoes/S = H.shoes
-				if(S.overshoes)
-					if (!disable_warning)
-						user << "You are unable to wear \the [src] as \the [H.shoes] are in the way."
-					return 0
-		return 1
-
-
-	else
-		return ..()
-
-//When the magboots are used on worn boots, this indicates that we want to wear them.
-/obj/item/clothing/shoes/magboots/pre_attack(atom/a, mob/user)
-	if (istype(a, /obj/item))
-		var/obj/item/i = a
-		//Ensure that the thing you clicked on is a pair of shoes which are currently being worn
-		if (i.get_equip_slot() == slot_shoes)
-			//Start the equipping process. This will run through mob_can_equip and pre_equip
-			user.equip_to_slot_if_possible(src,slot_shoes)
-			return 1
-
-/obj/item/clothing/shoes/magboots/dropped()
-	..()
-	remove()
-
-/obj/item/clothing/shoes/magboots/equipped()
-	..()
-	if (is_held())
-		remove() //If the magboots are taken into hands, release the shoes
-	else if (is_worn())
-		wearer = loc
-
-//This proc handles sucking up the old shoes before we equip the magboots.
-/obj/item/clothing/shoes/magboots/pre_equip(mob/M, slot)
-	if (slot == slot_shoes)
-		var/mob/living/carbon/human/H = M
-
-		if(H.shoes)
-			shoes = H.shoes
-			H.drop_from_inventory(shoes)	//Remove the old shoes so you can put on the magboots.
-			shoes.forceMove(src) //Old shoes are sucked up inside the magboots, they'll be released when the magboots are removed
-	return 0
-
-
-
-//This proc releases any contained shoes back onto the wearer, then nulls all the relevant values.
-//It is called when the magboots are dropped from the mob, or taken to any non-worn slot (ie, the hands)
-/obj/item/clothing/shoes/magboots/proc/remove()
-	var/mob/living/carbon/human/H = wearer
-	if(shoes)
-		if(!H.equip_to_slot_if_possible(shoes, slot_shoes))
-			shoes.forceMove(get_turf(src))
-		shoes = null
-	wearer = null
 
 /obj/item/clothing/shoes/magboots/examine(mob/user)
 	..(user)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -222,7 +222,7 @@
 
 	// Seal toggling can be initiated by the suit AI, too
 	if(!wearer)
-		initiator << SPAN_DANGER("Cannot toggle suit: The suit is currently not being worn by anyone.")
+		to_chat(initiator, SPAN_DANGER("Cannot toggle suit: The suit is currently not being worn by anyone."))
 		return 0
 
 	if(!check_power_cost(wearer))
@@ -250,7 +250,7 @@
 		if(!instant)
 			wearer.visible_message("<font color='blue'>[wearer]'s suit emits a quiet hum as it begins to adjust its seals.</font>","<font color='blue'>With a quiet hum, the suit begins running checks and adjusting components.</font>")
 			if(seal_delay && !do_after(wearer,seal_delay, src))
-				if(wearer) wearer << SPAN_WARNING("You must remain still while the suit is adjusting the components.")
+				if(wearer) to_chat(wearer, SPAN_WARNING("You must remain still while the suit is adjusting the components."))
 				failed_to_seal = 1
 
 		if(!wearer)
@@ -267,7 +267,7 @@
 					continue
 
 				if(!istype(wearer) || !istype(piece) || !istype(compare_piece) || !msg_type)
-					if(wearer) wearer << SPAN_WARNING("You must remain still while the suit is adjusting the components.")
+					if(wearer) to_chat(wearer, SPAN_WARNING("You must remain still while the suit is adjusting the components."))
 					failed_to_seal = 1
 					break
 
@@ -279,16 +279,16 @@
 					piece.icon_state = "[initial(icon_state)][seal_target ? "_sealed" : ""]"
 					switch(msg_type)
 						if("boots")
-							wearer << "<font color='blue'>\The [piece] [seal_target ? "seal around your feet" : "relax their grip on your legs"].</font>"
+							to_chat(wearer, "<font color='blue'>\The [piece] [seal_target ? "seal around your feet" : "relax their grip on your legs"].</font>")
 							wearer.update_inv_shoes()
 						if("gloves")
-							wearer << "<font color='blue'>\The [piece] [seal_target ? "tighten around your fingers and wrists" : "become loose around your fingers"].</font>"
+							to_chat(wearer, "<font color='blue'>\The [piece] [seal_target ? "tighten around your fingers and wrists" : "become loose around your fingers"].</font>")
 							wearer.update_inv_gloves()
 						if("chest")
-							wearer << "<font color='blue'>\The [piece] [seal_target ? "cinches tight again your chest" : "releases your chest"].</font>"
+							to_chat(wearer, "<font color='blue'>\The [piece] [seal_target ? "cinches tight again your chest" : "releases your chest"].</font>")
 							wearer.update_inv_wear_suit()
 						if("helmet")
-							wearer << "<font color='blue'>\The [piece] hisses [seal_target ? "closed" : "open"].</font>"
+							to_chat(wearer, "<font color='blue'>\The [piece] hisses [seal_target ? "closed" : "open"].</font>")
 							wearer.update_inv_head()
 							if(helmet)
 								helmet.update_light(wearer)
@@ -321,10 +321,10 @@
 	// Success!
 	active = seal_target
 	canremove = !active
-	wearer << "<font color='blue'><b>Your entire suit [active ? "tightens around you as the components lock into place" : "loosens as the components relax"].</b></font>"
+	to_chat(wearer, "<font color='blue'><b>Your entire suit [active ? "tightens around you as the components lock into place" : "loosens as the components relax"].</b></font>")
 
 	if(wearer != initiator)
-		initiator << "<font color='blue'>Suit adjustment complete. Suit is now [active ? "unsealed" : "sealed"].</font>"
+		to_chat(initiator, "<font color='blue'>Suit adjustment complete. Suit is now [active ? "unsealed" : "sealed"].</font>")
 
 	if(canremove)
 		for(var/obj/item/rig_module/module in installed_modules)
@@ -351,58 +351,47 @@
 				M = piece.loc
 				M.drop_from_inventory(piece)
 			piece.forceMove(src)
-	//checks for aviability, proper user and place, proper cell.
-	if(!istype(wearer))
-		return 0
-	if(loc != wearer)
-		return 0
-	if(wearer.back != src)
-		return 0
-	if(canremove)
-		return 0
-	if(!cell)
-		return 0
 
-	if(cell.charge <= 0)
-		cell.charge = 0
-		if(electrified > 0)
-			electrified = 0
-		if(!offline)
-			if(!canremove)
-				if (offline_slowdown < 3)
-					wearer << SPAN_DANGER("Your suit beeps stridently, and suddenly goes dead.")
-				else
-					wearer << SPAN_DANGER("Your suit beeps stridently, and suddenly you're wearing a leaden mass of metal and plastic composites instead of a powered suit.")
-			if(offline_vision_restriction == 1)
-				wearer << SPAN_DANGER("The suit optics flicker and die, leaving you with restricted vision.")
-			else if(offline_vision_restriction == 2)
-				wearer << SPAN_DANGER("The suit optics drop out completely, drowning you in darkness.")
+	if(!istype(wearer) || loc != wearer || wearer.back != src || canremove || !cell || cell.charge <= 0)
+		if(!cell || cell.charge <= 0)
+			if(electrified > 0)
+				electrified = 0
+			if(!offline)
+				if(istype(wearer))
+					if(!canremove)
+						if (offline_slowdown < 3)
+							to_chat(wearer, SPAN_DANGER("Your suit beeps stridently, and suddenly goes dead."))
+						else
+							to_chat(wearer, SPAN_DANGER("Your suit beeps stridently, and suddenly you're wearing a leaden mass of metal and plastic composites instead of a powered suit."))
+					if(offline_vision_restriction == 1)
+						to_chat(wearer, SPAN_DANGER("The suit optics flicker and die, leaving you with restricted vision."))
+					else if(offline_vision_restriction == 2)
+						to_chat(wearer, SPAN_DANGER("The suit optics drop out completely, drowning you in darkness."))
 		if(!offline)
 			offline = 1
 	else
 		if(offline)
 			offline = 0
-			if(!wearer.wearing_rig)
+			if(istype(wearer) && !wearer.wearing_rig)
 				wearer.wearing_rig = src
 			chest.slowdown = initial(slowdown)
 
 	if(offline)
 		if(offline == 1)
 			for(var/obj/item/rig_module/module in installed_modules)
-				if(!istype(module, /obj/item/rig_module/power_sink))
-					module.deactivate()
+				module.deactivate()
 			offline = 2
 			chest.slowdown = offline_slowdown
-		//return
-	else
-		if(cell && cell.charge > 0 && electrified > 0)
-			electrified--
+		return
 
-		if(malfunction_delay > 0)
-			malfunction_delay--
-		else if(malfunctioning)
-			malfunctioning--
-			malfunction()
+	if(cell && cell.charge > 0 && electrified > 0)
+		electrified--
+
+	if(malfunction_delay > 0)
+		malfunction_delay--
+	else if(malfunctioning)
+		malfunctioning--
+		malfunction()
 
 	for(var/obj/item/rig_module/module in installed_modules)
 		cell.use(module.Process()*10)
@@ -430,7 +419,7 @@
 		fail_msg = SPAN_WARNING("Not enough stored power.")
 
 	if(fail_msg)
-		user << "[fail_msg]"
+		to_chat(user, fail_msg)
 		return 0
 
 	// This is largely for cancelling stealth and whatever.
@@ -550,11 +539,11 @@
 		if(user.back != src)
 			return 0
 		else if(!src.allowed(user))
-			user << SPAN_DANGER("Unauthorized user. Access denied.")
+			to_chat(user, SPAN_DANGER("Unauthorized user. Access denied."))
 			return 0
 
 	else if(!ai_override_enabled)
-		user << SPAN_DANGER("Synthetic access disabled. Please consult hardware provider.")
+		to_chat(user, SPAN_DANGER("Synthetic access disabled. Please consult hardware provider."))
 		return 0
 
 	return 1
@@ -578,10 +567,7 @@
 			var/obj/item/rig_module/module = installed_modules[module_index]
 			switch(href_list["module_mode"])
 				if("activate")
-					if(cell.charge >= module.use_power_cost)
-						module.activate()
-					else
-						to_chat(usr, SPAN_WARNING("Not enough power."))
+					module.activate()
 				if("deactivate")
 					module.deactivate()
 				if("engage")
@@ -684,7 +670,7 @@
 	if(use_obj)
 		if(check_slot == use_obj && deploy_mode != ONLY_DEPLOY)
 			if (active && !(use_obj.retract_while_active))
-				wearer << SPAN_DANGER("The [use_obj] is locked in place while [src] is active. You must deactivate it first!")
+				to_chat(wearer, SPAN_DANGER("The [use_obj] is locked in place while [src] is active. You must deactivate it first!"))
 				return
 
 			var/mob/living/carbon/human/holder
@@ -695,7 +681,9 @@
 					if(use_obj && check_slot == use_obj)
 						use_obj.canremove = 1
 						if (wearer.unEquip(use_obj, src))
-							wearer << SPAN_NOTICE("Your [use_obj.name] [use_obj.gender == PLURAL ? "retract" : "retracts"] swiftly.")
+							if(use_obj.overslot)
+								use_obj.remove_overslot_contents(wearer)
+							to_chat(wearer, "<font color='blue'><b>Your [use_obj.name] [use_obj.gender == PLURAL ? "retract" : "retracts"] swiftly.</b></font>")
 						use_obj.canremove = 0
 
 
@@ -706,10 +694,10 @@
 			if(!wearer.equip_to_slot_if_possible(use_obj, equip_to, TRUE)) //Disable_warning
 				use_obj.forceMove(src)
 				if(check_slot)
-					initiator << SPAN_DANGER("You are unable to deploy \the [piece] as \the [check_slot] [check_slot.gender == PLURAL ? "are" : "is"] in the way.")
+					to_chat(initiator, SPAN_DANGER("You are unable to deploy \the [piece] as \the [check_slot] [check_slot.gender == PLURAL ? "are" : "is"] in the way."))
 					return
 			else
-				wearer << SPAN_NOTICE("Your [use_obj.name] [use_obj.gender == PLURAL ? "deploy" : "deploys"] swiftly")
+				to_chat(wearer, SPAN_NOTICE("Your [use_obj.name] [use_obj.gender == PLURAL ? "deploy" : "deploys"] swiftly."))
 
 	if(piece == "helmet" && helmet)
 		helmet.update_light(wearer)

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -14,6 +14,7 @@
 /obj/item/clothing/gloves/rig
 	name = "gauntlets"
 	item_flags = THICKMATERIAL
+	overslot = 1
 	body_parts_covered = ARMS
 	heat_protection =    ARMS
 	cold_protection =    ARMS

--- a/code/modules/mob/inventory/equip.dm
+++ b/code/modules/mob/inventory/equip.dm
@@ -32,7 +32,7 @@
 //	proc will return TRUE if we succeded to equip item and FALSE otherwise
 //	put_in_storage - if TRUE will put replaced item into available storage or hands or drop if 'drop_if_unable_to_store' flag is TRUE, otherwise will delete it
 //	drop_if_unable_to_store - if TRUE will drop item on turf if failed to store it, otherwise will delete it
-//	skip_covering_check - if TRUE will ignore slot inaccessibleness for example helmet will prevent equip cause it covering slot 
+//	skip_covering_check - if TRUE will ignore slot inaccessibleness for example helmet will prevent equip cause it covering slot
 //	del_if_failed_to_equip - if TRUE will delete the item we attempting to replace with
 /mob/proc/replace_in_slot(obj/item/Item, slot, put_in_storage = FALSE, drop_if_unable_to_store = FALSE, skip_covering_check = FALSE, del_if_failed_to_equip = FALSE)
 	var/failed = FALSE
@@ -43,11 +43,11 @@
 			if(put_in_storage)	//trying to store item, if failed we delete it
 				var/obj/item/weapon/storage/S = equip_to_storage(old_item)
 				if(S)
-					src << SPAN_NOTICE("Storing your \the [old_item] into \the [S]!")
+					to_chat(src, SPAN_NOTICE("Storing your \the [old_item] into \the [S]!"))
 				else if (equip_to_slot_if_possible(old_item, slot_l_hand, disable_warning = TRUE))
-					src << SPAN_NOTICE("Putting your \the [old_item] into your left hand!")
+					to_chat(src, SPAN_NOTICE("Putting your \the [old_item] into your left hand!"))
 				else if (equip_to_slot_if_possible(old_item, slot_r_hand, disable_warning = TRUE))
-					src << SPAN_NOTICE("Putting your \the [old_item] into your right hand!")
+					to_chat(src, SPAN_NOTICE("Putting your \the [old_item] into your right hand!"))
 				else if (drop_if_unable_to_store)
 					var/turf/T = get_turf(src)
 					Item.forceMove(T)

--- a/code/modules/mob/inventory/helpers.dm
+++ b/code/modules/mob/inventory/helpers.dm
@@ -1,3 +1,7 @@
+/obj/item
+	var/overslot = 0
+	var/obj/item/overslot_contents = null
+
 /mob/proc/slot_is_accessible(var/slot, var/obj/item/Item, mob/user=null)
 	return TRUE
 
@@ -7,25 +11,30 @@
 	return Mob.can_equip(Item, slot, disable_warning) && Item.can_be_equipped(Mob, slot, disable_warning)
 
 /mob/proc/can_equip(obj/item/Item, slot, disable_warning = FALSE, skip_item_check = FALSE)
-	if(!skip_item_check && get_equipped_item(slot))
+	if(skip_item_check)
+		return TRUE
+	var/obj/item/equipped = get_equipped_item(slot)
+	if(equipped)
+		if(Item.overslot && !equipped.overslot)
+			return TRUE
 		if(!disable_warning)
-			src << SPAN_WARNING("You already has something equipped here!")
-		return FALSE
+			to_chat(src, SPAN_WARNING("You already has something equipped here!"))
+		return FALSE //Note, this one goes from if(equipped), not overslot check
 	return TRUE
 
 /mob/living/carbon/human/can_equip(obj/item/Item, slot, disable_warning = FALSE, skip_item_check = FALSE, skip_covering_check = FALSE)
 	if(!slot)
 		return FALSE
-		
+
 	if(!species.has_equip_slot(slot))
-		src << SPAN_WARNING("Your species can't wear that!")
+		to_chat(src, SPAN_WARNING("Your species can't wear that!"))
 		return FALSE
 
 	var/datum/inventory_slot/S = SSinventory.get_slot_datum(slot)
 	if(S && !S.can_equip(Item, src, disable_warning))
 		return FALSE
-	
+
 	if(!skip_covering_check && !slot_is_accessible(slot, Item, disable_warning? null : src))
 		return FALSE
-		
+
 	return ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -664,6 +664,7 @@
 
 	if(.)
 		if(statpanel("Status") && SSticker.current_state != GAME_STATE_PREGAME)
+			stat("Storyteller", "[master_storyteller]")
 			stat("Station Time", stationtime2text())
 			stat("Round Duration", roundduration2text())
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -664,7 +664,6 @@
 
 	if(.)
 		if(statpanel("Status") && SSticker.current_state != GAME_STATE_PREGAME)
-			stat("Storyteller", "[master_storyteller]")
 			stat("Station Time", stationtime2text())
 			stat("Round Duration", roundduration2text())
 


### PR DESCRIPTION
Closes #3177
* Added `overslot` mechanics all over equipable items.
Currently only magboots (hardsuit boots - too) have such feature, but it could be turned on to everything by VV. No checks on what type of thing we got under overslot item, besides it cannot be other item with overslot abilities.
Quite TODO thing, but you would be able to put space helmet under overslot helmet, so only magboots for now.

* Replaced << thingies to to_chat macro inside rig.dm
