### PR TITLE
Make the config disabling AI in working order

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -54,7 +54,7 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 	var/list/storytellers = list()				// allowed modes
 	var/humans_need_surnames = 0
 	var/allow_random_events = 0			// enables random events mid-round when set to 1
-	var/allow_ai = 1					// allow ai job
+	var/allow_ai = 0					// allow ai job
 	var/hostedby = null
 	var/respawn_delay = 30
 	var/guest_jobban = 1


### PR DESCRIPTION
For future config edit. Current AI still work after PR has merged until the config file has been modified to remove the line "ALLOW_AI" which is present in default config.