### PR TITLE
[BALANCE] HE grenade damage application

### DIFF
--- a/code/game/objects/items/weapons/grenades/explosive.dm
+++ b/code/game/objects/items/weapons/grenades/explosive.dm
@@ -52,10 +52,10 @@
 	icon_state = "explosive"
 
 	fragment_type = /obj/item/projectile/bullet/pellet/fragment/invisible
-	spread_range = 1
-	num_fragments = 2
-	fragment_damage = 40
-	damage_step = 30
+	spread_range = 4
+	num_fragments = 4
+	fragment_damage = 30
+	damage_step = 20
 
 	devastation_range = -1
 	heavy_range = 1

--- a/code/game/objects/items/weapons/grenades/explosive.dm
+++ b/code/game/objects/items/weapons/grenades/explosive.dm
@@ -53,9 +53,9 @@
 
 	fragment_type = /obj/item/projectile/bullet/pellet/fragment/invisible
 	spread_range = 1
-	num_fragments = 1
-	fragment_damage = 20
-	damage_step = 20
+	num_fragments = 2
+	fragment_damage = 40
+	damage_step = 30
 
 	devastation_range = -1
 	heavy_range = 1


### PR DESCRIPTION
## General
Adjusting the damage to make useful these HE grenades, discussions might be needed to decide the damage numbers since the damage also vary wildly from no-crit to holy-fuck-I-need-medic.

Damage can range from 50 to 201 from just one HE grenade atop a prone guy, being prone reduces the damage.

## Changelog
🆑 TorinoFermic
tweak: HE grenades's damage upped to compensate the changes of shrapnel. They never embed.
/🆑