### PR TITLE
[QOL] Adding tactical reload and changes to chat lines.

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -54,25 +54,25 @@
 /obj/item/ammo_casing/attackby(obj/item/I, mob/user)
 	if(I.get_tool_type(usr, list(QUALITY_SCREW_DRIVING, QUALITY_CUTTING), src))
 		if(!BB)
-			user << "\blue There is no bullet in the casing to inscribe anything into."
+			to_chat(user, "\blue There is no bullet in the casing to inscribe anything into.")
 			return
 
 		var/tmp_label = ""
 		var/label_text = sanitizeSafe(input(user, "Inscribe some text into \the [initial(BB.name)]","Inscription",tmp_label), MAX_NAME_LEN)
 		if(length(label_text) > 20)
-			user << "\red The inscription can be at most 20 characters long."
+			to_chat(user, "\red The inscription can be at most 20 characters long.")
 		else if(!label_text)
-			user << "\blue You scratch the inscription off of [initial(BB)]."
+			to_chat(user, "\blue You scratch the inscription off of [initial(BB)].")
 			BB.name = initial(BB.name)
 		else
-			user << "\blue You inscribe \"[label_text]\" into \the [initial(BB.name)]."
+			to_chat(user, "\blue You inscribe \"[label_text]\" into \the [initial(BB.name)].")
 			BB.name = "[initial(BB.name)] (\"[label_text]\")"
 		return TRUE
 	else if(istype(I, /obj/item/ammo_casing))
 		var/obj/item/ammo_casing/merging_casing = I
 		if(isturf(src.loc))
 			if(merging_casing.amount == merging_casing.maxamount)
-				user << SPAN_WARNING("[merging_casing] is fully stacked!")
+				to_chat(user, SPAN_WARNING("[merging_casing] is fully stacked!"))
 				return FALSE
 			if(merging_casing.mergeCasing(src, null, user))
 				return TRUE
@@ -86,19 +86,19 @@
 		error("Passed no user to mergeCasing() when output messages is active.")
 	if(src.caliber != AC.caliber)
 		if(!noMessage)
-			user << SPAN_WARNING("Ammo are different calibers.")
+			to_chat(user, SPAN_WARNING("Ammo are different calibers."))
 		return FALSE
 	if(src.projectile_type != AC.projectile_type)
 		if(!noMessage)
-			user << SPAN_WARNING("Ammo are different types.")
+			to_chat(user, SPAN_WARNING("Ammo are different types."))
 		return FALSE
 	if(src.amount == src.maxamount)
 		if(!noMessage)
-			user << SPAN_WARNING("[src] is fully stacked!")
+			to_chat(user, SPAN_WARNING("[src] is fully stacked!"))
 		return FALSE
 	if((!src.BB && AC.BB) || (src.BB && !AC.BB))
 		if(!noMessage)
-			user << SPAN_WARNING("Fired and non-fired ammo wont stack.")
+			to_chat(user, SPAN_WARNING("Fired and non-fired ammo wont stack."))
 		return FALSE
 
 	var/mergedAmount
@@ -140,9 +140,9 @@
 
 /obj/item/ammo_casing/examine(mob/user)
 	..()
-	user << "There [(amount == 1)? "is" : "are"] [amount] round\s left!"
+	to_chat(user, "There [(amount == 1)? "is" : "are"] [amount] round\s left!")
 	if (!BB)
-		user << "[(amount == 1)? "This one is" : "These ones are"] spent."
+		to_chat(user, "[(amount == 1)? "This one is" : "These ones are"] spent.")
 
 //Gun loading types
 #define SINGLE_CASING 	1	//The gun only accepts ammo_casings. ammo_magazines should never have this as their mag_type.
@@ -206,19 +206,19 @@
 	if(istype(W, /obj/item/ammo_casing))
 		var/obj/item/ammo_casing/C = W
 		if(stored_ammo.len >= max_ammo)
-			user << SPAN_WARNING("[src] is full!")
+			to_chat(user, SPAN_WARNING("[src] is full!"))
 			return
 		if(C.caliber != caliber)
-			user << SPAN_WARNING("[C] does not fit into [src].")
+			to_chat(user, SPAN_WARNING("[C] does not fit into [src]."))
 			return
 		insertCasing(C)
 	else if(istype(W, /obj/item/ammo_magazine))
 		var/obj/item/ammo_magazine/other = W
 		if(!src.stored_ammo.len)
-			user << SPAN_WARNING("There is no ammo in [src]!")
+			to_chat(user, SPAN_WARNING("There is no ammo in [src]!"))
 			return
 		if(!do_after(user, src.reload_delay, src))
-			user << SPAN_WARNING("You stop loading ammo into [other]")
+			to_chat(user, SPAN_WARNING("You stop loading ammo into [other]"))
 			return
 		for(var/obj/item/ammo in src.stored_ammo)
 			if(other.stored_ammo.len >= other.max_ammo)
@@ -228,7 +228,7 @@
 				other.insertCasing(T)
 			else
 				break
-		user << SPAN_NOTICE("You're done here")
+		to_chat(user, SPAN_NOTICE("You're done here"))
 
 /obj/item/ammo_magazine/attack_hand(mob/user)
 	if(user.get_inactive_hand() == src && stored_ammo.len)
@@ -253,10 +253,10 @@
 	if(istype(W, /obj/item/ammo_casing))
 		var/obj/item/ammo_casing/C = W
 		if(stored_ammo.len >= max_ammo)
-			user << SPAN_WARNING("[src] is full!")
+			to_chat(user, SPAN_WARNING("[src] is full!"))
 			return
 		if(C.caliber != caliber)
-			user << SPAN_WARNING("[C] does not fit into [src].")
+			to_chat(user, SPAN_WARNING("[C] does not fit into [src]."))
 			return
 		if(stored_ammo.len)
 			var/obj/item/ammo_casing/T = removeCasing()
@@ -332,9 +332,9 @@
 		return
 
 	if(!stored_ammo.len)
-		usr << SPAN_NOTICE("[src] is already empty!")
+		to_chat(usr, SPAN_NOTICE("[src] is already empty!"))
 		return
-	usr << SPAN_NOTICE("You take out ammo from [src].")
+	to_chat(usr, SPAN_NOTICE("You take out ammo from [src]."))
 	for(var/i=1 to stored_ammo.len)
 		var/obj/item/ammo_casing/C = removeCasing()
 		C.forceMove(T)
@@ -354,7 +354,7 @@
 
 /obj/item/ammo_magazine/examine(mob/user)
 	..()
-	user << "There [(stored_ammo.len == 1)? "is" : "are"] [stored_ammo.len] round\s left!"
+	to_chat(user, "There [(stored_ammo.len == 1)? "is" : "are"] [stored_ammo.len] round\s left!")
 
 //magazine icon state caching
 /var/global/list/magazine_icondata_keys = list()

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -54,18 +54,18 @@
 /obj/item/ammo_casing/attackby(obj/item/I, mob/user)
 	if(I.get_tool_type(usr, list(QUALITY_SCREW_DRIVING, QUALITY_CUTTING), src))
 		if(!BB)
-			to_chat(user, "\blue There is no bullet in the casing to inscribe anything into.")
+			to_chat(user, SPAN_NOTICE("There is no bullet in the casing to inscribe anything into."))
 			return
 
 		var/tmp_label = ""
 		var/label_text = sanitizeSafe(input(user, "Inscribe some text into \the [initial(BB.name)]","Inscription",tmp_label), MAX_NAME_LEN)
 		if(length(label_text) > 20)
-			to_chat(user, "\red The inscription can be at most 20 characters long.")
+			to_chat(user, SPAN_WARNING("The inscription can be at most 20 characters long."))
 		else if(!label_text)
-			to_chat(user, "\blue You scratch the inscription off of [initial(BB)].")
+			to_chat(user, SPAN_NOTICE("You scratch the inscription off of [initial(BB)]."))
 			BB.name = initial(BB.name)
 		else
-			to_chat(user, "\blue You inscribe \"[label_text]\" into \the [initial(BB.name)].")
+			to_chat(user, SPAN_NOTICE("You inscribe \"[label_text]\" into \the [initial(BB.name)]."))
 			BB.name = "[initial(BB.name)] (\"[label_text]\")"
 		return TRUE
 	else if(istype(I, /obj/item/ammo_casing))

--- a/code/modules/projectiles/guns/Hatton.dm
+++ b/code/modules/projectiles/guns/Hatton.dm
@@ -56,7 +56,7 @@
 		user.put_in_hands(magazine)
 		magazine.update_icon()
 		magazine = null
-		user << SPAN_NOTICE("You pull the magazine out of \the [src]!")
+		to_chat(user, SPAN_NOTICE("You pull the magazine out of \the [src]!"))
 	update_icon()
 	return
 
@@ -85,21 +85,21 @@
 
 /obj/item/weapon/hatton/proc/Fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, params)
 	if (world.time < last_fired + fire_cooldown)
-		user << SPAN_WARNING("[src] is still cooling down, wait for [((last_fired + fire_cooldown) - world.time)*0.1] seconds")
+		to_chat(user, SPAN_WARNING("[src] is still cooling down, wait for [((last_fired + fire_cooldown) - world.time)*0.1] seconds"))
 		click_empty()
 		return
 
 	if(isliving(user))
 		var/mob/living/M = user
 		if (HULK in M.mutations)
-			M << SPAN_WARNING("Your meaty finger is much too large for the trigger guard!")
+			to_chat(M, SPAN_WARNING("Your meaty finger is much too large for the trigger guard!"))
 			return
 	if (!Adjacent(loc, target))
-		user << SPAN_WARNING("\red You're too far away to breach that!")
+		to_chat(user, SPAN_WARNING("\red You're too far away to breach that!"))
 		return
 	/*if(ishuman(user))
 		if(user.dna && user.dna.mutantrace == "adamantine")
-			user << "\red Your metal fingers don't fit in the trigger guard!"
+			to_chat(user, "\red Your metal fingers don't fit in the trigger guard!")
 			return*/
 
 	add_fingerprint(user)
@@ -109,7 +109,7 @@
 	if(isliving(user))
 		var/mob/living/M = user
 		if ((CLUMSY in M.mutations) && prob(50))
-			M << SPAN_DANGER("[src] blows up in your face.")
+			to_chat(user, SPAN_DANGER("[src] blows up in your face."))
 			M.drop_item()
 			Fire(get_turf(M))
 			del(src)

--- a/code/modules/projectiles/guns/Hatton.dm
+++ b/code/modules/projectiles/guns/Hatton.dm
@@ -95,7 +95,7 @@
 			to_chat(M, SPAN_WARNING("Your meaty finger is much too large for the trigger guard!"))
 			return
 	if (!Adjacent(loc, target))
-		to_chat(user, SPAN_WARNING("\red You're too far away to breach that!"))
+		to_chat(user, SPAN_WARNING("You're too far away to breach that!"))
 		return
 	/*if(ishuman(user))
 		if(user.dna && user.dna.mutantrace == "adamantine")

--- a/code/modules/projectiles/guns/alien.dm
+++ b/code/modules/projectiles/guns/alien.dm
@@ -31,14 +31,14 @@
 
 /obj/item/weapon/gun/launcher/spikethrower/examine(mob/user)
 	..(user)
-	user << "It has [spikes] spike\s remaining."
+	to_chat(user, "It has [spikes] spike\s remaining.")
 
 /obj/item/weapon/gun/launcher/spikethrower/update_icon()
 	icon_state = "spikethrower[spikes]"
 
 /obj/item/weapon/gun/launcher/spikethrower/special_check(user)
 	if(ishuman(user))
-		user << SPAN_WARNING("\The [src] does not respond to you!")
+		to_chat(user, SPAN_WARNING("\The [src] does not respond to you!"))
 		return 0
 	return ..()
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -108,15 +108,15 @@
 			cell = null
 			update_icon()
 	else
-		usr << SPAN_WARNING("[src] is a self-charging gun, its batteries cannot be removed!.")
+		to_chat(usr, SPAN_WARNING("[src] is a self-charging gun, its batteries cannot be removed!."))
 
 /obj/item/weapon/gun/energy/attackby(obj/item/C, mob/living/user)
 	if(self_recharge)
-		usr << SPAN_WARNING("[src] is a self-charging gun, it doesn't need more batteries.")
+		to_chat(usr, SPAN_WARNING("[src] is a self-charging gun, it doesn't need more batteries."))
 		return
 
 	if(cell)
-		usr << SPAN_WARNING("[src] is already loaded.")
+		to_chat(usr, SPAN_WARNING("[src] is already loaded."))
 		return
 
 	if(istype(C, suitable_cell) && insert_item(C, user))

--- a/code/modules/projectiles/guns/launcher.dm
+++ b/code/modules/projectiles/guns/launcher.dm
@@ -16,7 +16,7 @@
 
 //Override this to avoid a runtime with suicide handling.
 /obj/item/weapon/gun/launcher/handle_suicide(mob/living/user)
-	to_chat(user, "\red Shooting yourself with \a [src] is pretty tricky. You can't seem to manage it.")
+	to_chat(user, SPAN_WARNING("Shooting yourself with \a [src] is pretty tricky. You can't seem to manage it."))
 	return
 
 /obj/item/weapon/gun/launcher/proc/update_release_force(obj/item/projectile)

--- a/code/modules/projectiles/guns/launcher.dm
+++ b/code/modules/projectiles/guns/launcher.dm
@@ -16,7 +16,7 @@
 
 //Override this to avoid a runtime with suicide handling.
 /obj/item/weapon/gun/launcher/handle_suicide(mob/living/user)
-	user << "\red Shooting yourself with \a [src] is pretty tricky. You can't seem to manage it."
+	to_chat(user, "\red Shooting yourself with \a [src] is pretty tricky. You can't seem to manage it.")
 	return
 
 /obj/item/weapon/gun/launcher/proc/update_release_force(obj/item/projectile)

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -40,7 +40,7 @@
 
 /obj/item/weapon/arrow/rod/removed(mob/user)
 	if(throwforce == 15) // The rod has been superheated - we don't want it to be useable when removed from the bow.
-		user  << "[src] shatters into a scattering of overstressed metal shards as it leaves the crossbow."
+		to_chat(user, "[src] shatters into a scattering of overstressed metal shards as it leaves the crossbow.")
 		var/obj/item/weapon/material/shard/shrapnel/S = new()
 		S.loc = get_turf(src)
 		qdel(src)
@@ -70,7 +70,7 @@
 
 /obj/item/weapon/gun/launcher/crossbow/consume_next_projectile(mob/user=null)
 	if(tension <= 0)
-		user << SPAN_WARNING("\The [src] is not drawn back!")
+		to_chat(user, SPAN_WARNING("\The [src] is not drawn back!"))
 		return null
 	return bolt
 
@@ -98,7 +98,7 @@
 /obj/item/weapon/gun/launcher/crossbow/proc/draw(var/mob/user as mob)
 
 	if(!bolt)
-		user << "You don't have anything nocked to [src]."
+		to_chat(user, "You don't have anything nocked to [src].")
 		return
 
 	if(user.restrained())
@@ -124,7 +124,7 @@
 
 		if(tension >= max_tension)
 			tension = max_tension
-			usr << "[src] clunks as you draw the string to its maximum tension!"
+			to_chat(user, "[src] clunks as you draw the string to its maximum tension!")
 			return
 
 		user.visible_message("[usr] draws back the string of [src]!",SPAN_NOTICE("You continue drawing back the string of [src]!"))
@@ -159,19 +159,19 @@
 			user.drop_item()
 			cell = I
 			cell.loc = src
-			user << SPAN_NOTICE("You jam [cell] into [src] and wire it to the firing coil.")
+			to_chat(user, SPAN_NOTICE("You jam [cell] into [src] and wire it to the firing coil."))
 			superheat_rod(user)
 		else
-			user << SPAN_NOTICE("[src] already has a cell installed.")
+			to_chat(user, SPAN_NOTICE("[src] already has a cell installed."))
 
 	else if(I.get_tool_type(usr, list(QUALITY_SCREW_DRIVING), src))
 		if(cell)
 			var/obj/item/C = cell
 			C.loc = get_turf(user)
-			user << SPAN_NOTICE("You jimmy [cell] out of [src] with [I].")
+			to_chat(user, SPAN_NOTICE("You jimmy [cell] out of [src] with [I]."))
 			cell = null
 		else
-			user << SPAN_NOTICE("[src] doesn't have a cell installed.")
+			to_chat(user, SPAN_NOTICE("[src] doesn't have a cell installed."))
 
 	else
 		..()
@@ -182,7 +182,7 @@
 	if(bolt.throwforce >= 15) return
 	if(!istype(bolt,/obj/item/weapon/arrow/rod)) return
 
-	user << SPAN_NOTICE("[bolt] plinks and crackles as it begins to glow red-hot.")
+	to_chat(user, SPAN_NOTICE("[bolt] plinks and crackles as it begins to glow red-hot."))
 	bolt.throwforce = 15
 	bolt.icon_state = "metal-rod-superheated"
 	cell.use(500)
@@ -211,12 +211,12 @@
 /obj/item/weapon/crossbowframe/examine(mob/user)
 	..(user)
 	switch(buildstate)
-		if(0) user << "Some rods should work for a frame." 
-		if(1) user << "It has a loose rod frame in place. Welding it should secure it."
-		if(2) user << "It has a steel backbone welded in place. Will need some cables to attach the cell to."
-		if(3) user << "It has a steel backbone and a cell mount installed. Some plastic should flex enough for the lath."
-		if(4) user << "It has a steel backbone, plastic lath and a cell mount installed. Now some cables for the string."
-		if(5) user << "It has a steel cable loosely strung across the lath. And now to tighten it up with a screwdriver!"
+		if(0) to_chat(user, "Some rods should work for a frame." )
+		if(1) to_chat(user, "It has a loose rod frame in place. Welding it should secure it.")
+		if(2) to_chat(user, "It has a steel backbone welded in place. Will need some cables to attach the cell to.")
+		if(3) to_chat(user, "It has a steel backbone and a cell mount installed. Some plastic should flex enough for the lath.")
+		if(4) to_chat(user, "It has a steel backbone, plastic lath and a cell mount installed. Now some cables for the string.")
+		if(5) to_chat(user, "It has a steel cable loosely strung across the lath. And now to tighten it up with a screwdriver!")
 
 /obj/item/weapon/crossbowframe/attackby(obj/item/I, mob/user)
 
@@ -233,7 +233,7 @@
 		if(QUALITY_WELDING)
 			if(buildstate == 1)
 				if(I.use_tool(user, src, WORKTIME_NORMAL, tool_type, FAILCHANCE_VERY_EASY, required_stat = STAT_MEC))
-					user << SPAN_NOTICE("You weld the rods into place.")
+					to_chat(user, SPAN_NOTICE("You weld the rods into place."))
 					buildstate++
 					update_icon()
 					return
@@ -242,7 +242,7 @@
 		if(QUALITY_SCREW_DRIVING)
 			if(buildstate == 5)
 				if(I.use_tool(user, src, WORKTIME_NEAR_INSTANT, tool_type, FAILCHANCE_VERY_EASY, required_stat = STAT_MEC))
-					user << SPAN_NOTICE("You secure the crossbow's various parts.")
+					to_chat(user, SPAN_NOTICE("You secure the crossbow's various parts."))
 					new /obj/item/weapon/gun/launcher/crossbow(get_turf(src))
 					qdel(src)
 			return
@@ -254,41 +254,41 @@
 		if(buildstate == 0)
 			var/obj/item/stack/rods/R = I
 			if(R.use(3))
-				user << SPAN_NOTICE("You assemble a backbone of rods around the wooden stock.")
+				to_chat(user, SPAN_NOTICE("You assemble a backbone of rods around the wooden stock."))
 				buildstate++
 				update_icon()
 			else
-				user << SPAN_NOTICE("You need at least three rods to complete this task.")
+				to_chat(user, SPAN_NOTICE("You need at least three rods to complete this task."))
 			return
 
 	else if(istype(I,/obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/C = I
 		if(buildstate == 2)
 			if(C.use(5))
-				user << SPAN_NOTICE("You wire a crude cell mount into the top of the crossbow.")
+				to_chat(user, SPAN_NOTICE("You wire a crude cell mount into the top of the crossbow."))
 				buildstate++
 				update_icon()
 			else
-				user << SPAN_NOTICE("You need at least five segments of cable coil to complete this task.")
+				to_chat(user, SPAN_NOTICE("You need at least five segments of cable coil to complete this task."))
 			return
 		else if(buildstate == 4)
 			if(C.use(5))
-				user << SPAN_NOTICE("You string a steel cable across the crossbow's lath.")
+				to_chat(user, SPAN_NOTICE("You string a steel cable across the crossbow's lath."))
 				buildstate++
 				update_icon()
 			else
-				user << SPAN_NOTICE("You need at least five segments of cable coil to complete this task.")
+				to_chat(user, SPAN_NOTICE("You need at least five segments of cable coil to complete this task."))
 			return
 
 	else if(istype(I,/obj/item/stack/material) && I.get_material_name() == "plastic")
 		if(buildstate == 3)
 			var/obj/item/stack/material/P = I
 			if(P.use(3))
-				user << SPAN_NOTICE("You assemble and install a heavy plastic lath onto the crossbow.")
+				to_chat(user, SPAN_NOTICE("You assemble and install a heavy plastic lath onto the crossbow."))
 				buildstate++
 				update_icon()
 			else
-				user << SPAN_NOTICE("You need at least three plastic sheets to complete this task.")
+				to_chat(user, SPAN_NOTICE("You need at least three plastic sheets to complete this task."))
 			return
 
 	else

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -19,8 +19,8 @@
 	zoom_factor = 2.0
 
 //revolves the magazine, allowing players to choose between multiple grenade types
-/obj/item/weapon/gun/launcher/grenade/proc/pump(mob/M as mob)
-	playsound(M, 'sound/weapons/shotgunpump.ogg', 60, 1)
+/obj/item/weapon/gun/launcher/grenade/proc/pump(mob/user as mob)
+	playsound(user, 'sound/weapons/shotgunpump.ogg', 60, 1)
 
 	var/obj/item/weapon/grenade/next
 	if(grenades.len)
@@ -31,25 +31,25 @@
 	if(next)
 		grenades -= next //Remove grenade from loaded list.
 		chambered = next
-		M << SPAN_WARNING("Mechanism pumps [src], loading \a [next] into the chamber.")
+		to_chat(user, SPAN_WARNING("Mechanism pumps [src], loading \a [next] into the chamber."))
 	else
-		M << SPAN_WARNING("Mechanism pumps [src], but the magazine is empty.")
+		to_chat(user, SPAN_WARNING("Mechanism pumps [src], but the magazine is empty."))
 	update_icon()
 
 /obj/item/weapon/gun/launcher/grenade/examine(mob/user)
 	if(..(user, 2))
 		var/grenade_count = grenades.len + (chambered? 1 : 0)
-		user << "Has [grenade_count] grenade\s remaining."
+		to_chat(user, "Has [grenade_count] grenade\s remaining.")
 		if(chambered)
-			user << "\A [chambered] is chambered."
+			to_chat(user, "\A [chambered] is chambered.")
 
 /obj/item/weapon/gun/launcher/grenade/proc/load(obj/item/weapon/grenade/G, mob/user)
 	if(!G.loadable)
-		user << SPAN_WARNING("\The [G] doesn't seem to fit in \the [src]!")
+		to_chat(user, SPAN_WARNING("\The [G] doesn't seem to fit in \the [src]!"))
 		return
 
 	if(grenades.len >= max_grenades)
-		user << SPAN_WARNING("\The [src] is full.")
+		to_chat(user, SPAN_WARNING("\The [src] is full."))
 		return
 	user.remove_from_mob(G)
 	G.forceMove(src)
@@ -65,7 +65,7 @@
 		user.put_in_hands(G)
 		user.visible_message("\The [user] removes \a [G] from [src].", SPAN_NOTICE("You remove \a [G] from \the [src]."))
 	else
-		user << SPAN_WARNING("\The [src] is empty.")
+		to_chat(user, SPAN_WARNING("\The [src] is empty."))
 	update_icon()
 
 /obj/item/weapon/gun/launcher/grenade/attack_self(mob/user)
@@ -110,11 +110,11 @@
 //load and unload directly into chambered
 /obj/item/weapon/gun/launcher/grenade/underslung/load(obj/item/weapon/grenade/G, mob/user)
 	if(!G.loadable)
-		user << SPAN_WARNING("[G] doesn't seem to fit in the [src]!")
+		to_chat(user, SPAN_WARNING("[G] doesn't seem to fit in the [src]!"))
 		return
 
 	if(chambered)
-		user << SPAN_WARNING("\The [src] is already loaded.")
+		to_chat(user, SPAN_WARNING("\The [src] is already loaded."))
 		return
 	user.remove_from_mob(G)
 	G.forceMove(src)
@@ -127,7 +127,7 @@
 		user.visible_message("\The [user] removes \a [chambered] from \the[src].", SPAN_NOTICE("You remove \a [chambered] from \the [src]."))
 		chambered = null
 	else
-		user << SPAN_WARNING("\The [src] is empty.")
+		to_chat(user, SPAN_WARNING("\The [src] is empty."))
 
 /* Ironhammer stuff */
 

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -36,14 +36,14 @@
 	var/N = input("Percentage of tank used per shot:","[src]") as null|anything in possible_pressure_amounts
 	if (N)
 		pressure_setting = N
-		usr << "You dial the pressure valve to [pressure_setting]%."
+		to_chat(usr, "You dial the pressure valve to [pressure_setting]%.")
 
 /obj/item/weapon/gun/launcher/pneumatic/proc/eject_tank(mob/user) //Remove the tank.
 	if(!tank)
-		user << "There's no tank in [src]."
+		to_chat(user, "There's no tank in [src].")
 		return
 
-	user << "You twist the valve and pop the tank out of [src]."
+	to_chat(user, "You twist the valve and pop the tank out of [src].")
 	user.put_in_hands(tank)
 	tank = null
 	update_icon()
@@ -53,9 +53,9 @@
 		var/obj/item/removing = item_storage.contents[item_storage.contents.len]
 		item_storage.remove_from_storage(removing, src.loc)
 		user.put_in_hands(removing)
-		user << "You remove [removing] from the hopper."
+		to_chat(user, "You remove [removing] from the hopper.")
 	else
-		user << "There is nothing to remove in \the [src]."
+		to_chat(user, "There is nothing to remove in \the [src].")
 
 /obj/item/weapon/gun/launcher/pneumatic/attack_hand(mob/user as mob)
 	if(user.get_inactive_hand() == src)
@@ -79,7 +79,7 @@
 	if(!item_storage.contents.len)
 		return null
 	if (!tank)
-		user << "There is no gas tank in [src]!"
+		to_chat(user, SPAN_WARNING("There is no gas tank in [src]!"))
 		return null
 
 	var/environment_pressure = 10
@@ -91,7 +91,7 @@
 
 	fire_pressure = (tank.air_contents.return_pressure() - environment_pressure)*pressure_setting/100
 	if(fire_pressure < 10)
-		user << "There isn't enough gas in the tank to fire [src]."
+		to_chat(user, SPAN_WARNING("There isn't enough gas in the tank to fire [src]."))
 		return null
 
 	var/obj/item/launched = item_storage.contents[1]
@@ -101,11 +101,11 @@
 /obj/item/weapon/gun/launcher/pneumatic/examine(mob/user)
 	if(!..(user, 2))
 		return
-	user << "The valve is dialed to [pressure_setting]%."
+	to_chat(user, "The valve is dialed to [pressure_setting]%.")
 	if(tank)
-		user << "The tank dial reads [tank.air_contents.return_pressure()] kPa."
+		to_chat(user, "The tank dial reads [tank.air_contents.return_pressure()] kPa.")
 	else
-		user << "Nothing is attached to the tank valve!"
+		to_chat(user, SPAN_WARNING("Nothing is attached to the tank valve!"))
 
 /obj/item/weapon/gun/launcher/pneumatic/update_release_force(obj/item/projectile)
 	if(tank)
@@ -149,18 +149,18 @@
 /obj/item/weapon/cannonframe/examine(mob/user)
 	..(user)
 	switch(buildstate)
-		if(1) user << "It has a pipe segment installed."
-		if(2) user << "It has a pipe segment welded in place."
-		if(3) user << "It has an outer chassis installed."
-		if(4) user << "It has an outer chassis welded in place."
-		if(5) user << "It has a transfer valve installed."
+		if(1) to_chat(user, "It has a pipe segment installed.")
+		if(2) to_chat(user, "It has a pipe segment welded in place.")
+		if(3) to_chat(user, "It has an outer chassis installed.")
+		if(4) to_chat(user, "It has an outer chassis welded in place.")
+		if(5) to_chat(user, "It has a transfer valve installed.")
 
 /obj/item/weapon/cannonframe/attackby(obj/item/I, mob/user)
 	if(istype(I,/obj/item/pipe))
 		if(buildstate == 0)
 			user.drop_from_inventory(I)
 			qdel(I)
-			user << SPAN_NOTICE("You secure the piping inside the frame.")
+			to_chat(user, SPAN_NOTICE("You secure the piping inside the frame."))
 			buildstate++
 			update_icon()
 			return
@@ -168,34 +168,34 @@
 		if(buildstate == 2)
 			var/obj/item/stack/material/M = I
 			if(M.use(5))
-				user << SPAN_NOTICE("You assemble a chassis around the cannon frame.")
+				to_chat(user, SPAN_NOTICE("You assemble a chassis around the cannon frame."))
 				buildstate++
 				update_icon()
 			else
-				user << SPAN_NOTICE("You need at least five metal sheets to complete this task.")
+				to_chat(user, SPAN_NOTICE("You need at least five metal sheets to complete this task."))
 			return
 	else if(istype(I,/obj/item/device/transfer_valve))
 		if(buildstate == 4)
 			user.drop_from_inventory(I)
 			qdel(I)
-			user << SPAN_NOTICE("You install the transfer valve and connect it to the piping.")
+			to_chat(user, SPAN_NOTICE("You install the transfer valve and connect it to the piping."))
 			buildstate++
 			update_icon()
 			return
 	else if(QUALITY_WELDING in I.tool_qualities)
 		if(buildstate == 1)
 			if(I.use_tool(user, src, WORKTIME_FAST, QUALITY_WELDING, FAILCHANCE_EASY, required_stat = STAT_MEC))
-				user << SPAN_NOTICE("You weld the pipe into place.")
+				to_chat(user, SPAN_NOTICE("You weld the pipe into place."))
 				buildstate++
 				update_icon()
 		if(buildstate == 3)
 			if(I.use_tool(user, src, WORKTIME_FAST, QUALITY_WELDING, FAILCHANCE_EASY, required_stat = STAT_MEC))
-				user << SPAN_NOTICE("You weld the metal chassis together.")
+				to_chat(user, SPAN_NOTICE("You weld the metal chassis together."))
 				buildstate++
 				update_icon()
 		if(buildstate == 5)
 			if(I.use_tool(user, src, WORKTIME_FAST, QUALITY_WELDING, FAILCHANCE_EASY, required_stat = STAT_MEC))
-				user << SPAN_NOTICE("You weld the valve into place.")
+				to_chat(user, SPAN_NOTICE("You weld the valve into place."))
 				new /obj/item/weapon/gun/launcher/pneumatic(get_turf(src))
 				qdel(src)
 		return

--- a/code/modules/projectiles/guns/launcher/rocket.dm
+++ b/code/modules/projectiles/guns/launcher/rocket.dm
@@ -20,7 +20,7 @@
 /obj/item/weapon/gun/launcher/rocket/examine(mob/user)
 	if(!..(user, 2))
 		return
-	user << "\blue [rockets.len] / [max_rockets] rockets."
+	to_chat(user, "\blue [rockets.len] / [max_rockets] rockets.")
 
 /obj/item/weapon/gun/launcher/rocket/attackby(obj/item/I as obj, mob/user as mob)
 	if(istype(I, /obj/item/ammo_casing/rocket))
@@ -28,10 +28,10 @@
 			user.drop_item()
 			I.loc = src
 			rockets += I
-			user << "\blue You put the rocket in [src]."
-			user << "\blue [rockets.len] / [max_rockets] rockets."
+			to_chat(user, "\blue You put the rocket in [src].")
+			to_chat(user, "\blue [rockets.len] / [max_rockets] rockets.")
 		else
-			usr << "\red [src] cannot hold more rockets."
+			to_chat(user, SPAN_WARNING("[src] cannot hold more rockets."))
 
 /obj/item/weapon/gun/launcher/rocket/consume_next_projectile()
 	if(rockets.len)

--- a/code/modules/projectiles/guns/launcher/rocket.dm
+++ b/code/modules/projectiles/guns/launcher/rocket.dm
@@ -28,8 +28,8 @@
 			user.drop_item()
 			I.loc = src
 			rockets += I
-			to_chat(user, "\blue You put the rocket in [src].")
-			to_chat(user, "\blue [rockets.len] / [max_rockets] rockets.")
+			to_chat(user, SPAN_NOTICE("You put the rocket in [src]."))
+			to_chat(user, SPAN_NOTICE("[rockets.len] / [max_rockets] rockets."))
 		else
 			to_chat(user, SPAN_WARNING("[src] cannot hold more rockets."))
 

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -21,7 +21,7 @@
 /obj/item/weapon/syringe_cartridge/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/weapon/reagent_containers/syringe))
 		syringe = I
-		user << SPAN_NOTICE("You carefully insert [syringe] into [src].")
+		to_chat(user, SPAN_NOTICE("You carefully insert [syringe] into [src]."))
 		user.remove_from_mob(syringe)
 		syringe.loc = src
 		sharp = 1
@@ -30,7 +30,7 @@
 
 /obj/item/weapon/syringe_cartridge/attack_self(mob/user)
 	if(syringe)
-		user << SPAN_NOTICE("You remove [syringe] from [src].")
+		to_chat(user, SPAN_NOTICE("You remove [syringe] from [src]."))
 		user.put_in_hands(syringe)
 		syringe = null
 		sharp = initial(sharp)
@@ -111,10 +111,10 @@
 /obj/item/weapon/gun/launcher/syringe/attack_hand(mob/living/user as mob)
 	if(user.get_inactive_hand() == src)
 		if(!darts.len)
-			user << SPAN_WARNING("[src] is empty.")
+			to_chat(user, SPAN_WARNING("[src] is empty."))
 			return
 		if(next)
-			user << SPAN_WARNING("[src]'s cover is locked shut.")
+			to_chat(user, SPAN_WARNING("[src]'s cover is locked shut."))
 			return
 		var/obj/item/weapon/syringe_cartridge/C = darts[1]
 		darts -= C
@@ -127,7 +127,7 @@
 	if(istype(A, /obj/item/weapon/syringe_cartridge))
 		var/obj/item/weapon/syringe_cartridge/C = A
 		if(darts.len >= max_darts)
-			user << SPAN_WARNING("[src] is full!")
+			to_chat(user, SPAN_WARNING("[src] is full!"))
 			return
 		user.remove_from_mob(C)
 		C.loc = src

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -36,6 +36,7 @@
 	var/auto_eject = FALSE			//if the magazine should automatically eject itself when empty.
 	var/auto_eject_sound = null
 	var/ammo_mag = "default" // magazines + gun itself. if set to default, then not used
+	var/tac_reloads = TRUE	// Enables guns to eject mag and insert new magazine.
 
 /obj/item/weapon/gun/projectile/Destroy()
 	QDEL_NULL(chambered)
@@ -145,10 +146,13 @@
 		switch(method_for_this_load)
 			if(MAGAZINE)
 				if(AM.ammo_mag != ammo_mag && ammo_mag != "default")
-					user << SPAN_WARNING("[src] requires another magazine.") //wrong magazine
+					to_chat(user, SPAN_WARNING("[src] requires another magazine.")) //wrong magazine
 					return
-				if(ammo_magazine)
-					user << SPAN_WARNING("[src] already has a magazine loaded.") //already a magazine here
+				if(tac_reloads)
+					unload_ammo(user)	// ejects the magazine before inserting the new one.
+					to_chat(user, SPAN_NOTICE("You tactically reload your [src] with [AM]!"))
+				else if(ammo_magazine)
+					to_chat(user, SPAN_WARNING("[src] already has a magazine loaded.")) //already a magazine here
 					return
 				if(!(AM.mag_well & mag_well))
 					to_chat(user, SPAN_WARNING("[AM] won't fit into the magwell.")) //wrong magazine
@@ -162,11 +166,11 @@
 				update_firemode()
 			if(SPEEDLOADER)
 				if(loaded.len >= max_shells)
-					user << SPAN_WARNING("[src] is full!")
+					to_chat(user, SPAN_WARNING("[src] is full!"))
 					return
 				var/count = 0
 				if(AM.reload_delay)
-					user << SPAN_NOTICE("It takes some time to reload [src] with [AM]...")
+					to_chat(user, SPAN_NOTICE("It takes some time to reload [src] with [AM]..."))
 				if (do_after(user, AM.reload_delay, user))
 					for(var/obj/item/ammo_casing/C in AM.stored_ammo)
 						if(loaded.len >= max_shells)
@@ -187,7 +191,7 @@
 		if(!(load_method & SINGLE_CASING) || caliber != C.caliber)
 			return //incompatible
 		if(loaded.len >= max_shells)
-			user << SPAN_WARNING("[src] is full.")
+			to_chat(user, SPAN_WARNING("[src] is full."))
 			return
 
 		if(C.amount > 1)
@@ -243,7 +247,7 @@
 			user.visible_message("[user] removes \a [C] from [src].", SPAN_NOTICE("You remove \a [C] from [src]."))
 			if(bulletinsert_sound) playsound(src.loc, bulletinsert_sound, 75, 1)
 	else
-		user << SPAN_WARNING("[src] is empty.")
+		to_chat(user, SPAN_WARNING("[src] is empty."))
 	update_icon()
 
 /obj/item/weapon/gun/projectile/attackby(var/obj/item/A as obj, mob/user as mob)
@@ -285,8 +289,8 @@
 /obj/item/weapon/gun/projectile/examine(mob/user)
 	..(user)
 	if(ammo_magazine)
-		user << "It has \a [ammo_magazine] loaded."
-	user << "Has [get_ammo()] round\s remaining."
+		to_chat(user, "It has \a [ammo_magazine] loaded.")
+	to_chat(user, "Has [get_ammo()] round\s remaining.")
 	return
 
 /obj/item/weapon/gun/projectile/proc/get_ammo()

--- a/code/modules/projectiles/guns/projectile/automatic/IH_heavy.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/IH_heavy.dm
@@ -12,6 +12,7 @@
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_IH
 	magazine_type = /obj/item/ammo_magazine/ih762
+	tac_reloads = FALSE
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_STEEL = 20, MATERIAL_PLASTIC = 10)
 	price_tag = 4000
 	fire_sound = 'sound/weapons/guns/fire/ltrifle_fire.ogg'

--- a/code/modules/projectiles/guns/projectile/automatic/dallas.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/dallas.dm
@@ -12,6 +12,7 @@
 	origin_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 1)
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_SMG
+	auto_eject = 1
 	magazine_type = /obj/item/ammo_magazine/c10x24
 	matter = list(MATERIAL_PLASTEEL = 25, MATERIAL_PLASTIC = 15)
 	price_tag = 4500

--- a/code/modules/projectiles/guns/projectile/automatic/lmg.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/lmg.dm
@@ -1,18 +1,3 @@
-/obj/item/weapon/gun/projectile/automatic/lmg/l6_saw
-	name = "L6 SAW"
-	desc = "A rather traditionally made L6 SAW with a pleasantly lacquered wooden pistol grip. This one is unmarked."
-	icon_base = "l6"
-	icon_state = "l6closed-empty"
-	item_state = "l6closedmag"
-
-
-/obj/item/weapon/gun/projectile/automatic/lmg/pk
-	name = "Pulemyot Kalashnikova"
-	desc = "\"Kalashnikov's Machinegun\", a well preserved and maintained antique weapon of war."
-	icon_base = "pk"
-	icon_state = "pkclosed-empty"
-	item_state = "pkclosedmag"
-
 /obj/item/weapon/gun/projectile/automatic/lmg
 	w_class = ITEM_SIZE_HUGE
 	icon = 'icons/obj/weapons/lmg.dmi'
@@ -27,6 +12,7 @@
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_BOX
 	magazine_type = null //Magazine type is for preloaded spawning. This spawns empty
+	tac_reloads = FALSE
 	matter = list(MATERIAL_PLASTEEL = 40, MATERIAL_PLASTIC = 15, MATERIAL_WOOD = 5)
 	price_tag = 5000
 	unload_sound 	= 'sound/weapons/guns/interact/lmg_magout.ogg'
@@ -42,15 +28,31 @@
 
 	var/cover_open = 0
 
+/obj/item/weapon/gun/projectile/automatic/lmg/l6_saw
+	name = "L6 SAW"
+	desc = "A rather traditionally made L6 SAW with a pleasantly lacquered wooden pistol grip. This one is unmarked."
+	icon_base = "l6"
+	icon_state = "l6closed-empty"
+	item_state = "l6closedmag"
+
+
+/obj/item/weapon/gun/projectile/automatic/lmg/pk
+	name = "Pulemyot Kalashnikova"
+	desc = "\"Kalashnikov's Machinegun\", a well preserved and maintained antique weapon of war."
+	icon_base = "pk"
+	icon_state = "pkclosed-empty"
+	item_state = "pkclosedmag"
+
+
 /obj/item/weapon/gun/projectile/automatic/lmg/special_check(mob/user)
 	if(cover_open)
-		user << SPAN_WARNING("[src]'s cover is open! Close it before firing!")
+		to_chat(user, SPAN_WARNING("[src]'s cover is open! Close it before firing!"))
 		return 0
 	return ..()
 
 /obj/item/weapon/gun/projectile/automatic/lmg/proc/toggle_cover(mob/user)
 	cover_open = !cover_open
-	user << "<span class='notice'>You [cover_open ? "open" : "close"] [src]'s cover.</span>"
+	to_chat(user, SPAN_NOTICE("You [cover_open ? "open" : "close"] [src]'s cover."))
 	update_icon()
 
 /obj/item/weapon/gun/projectile/automatic/lmg/attack_self(mob/user as mob)
@@ -78,12 +80,12 @@
 
 /obj/item/weapon/gun/projectile/automatic/lmg/load_ammo(var/obj/item/A, mob/user)
 	if(!cover_open)
-		user << SPAN_WARNING("You need to open the cover to load [src].")
+		to_chat(user, SPAN_WARNING("You need to open the cover to load [src]."))
 		return
 	..()
 
 /obj/item/weapon/gun/projectile/automatic/lmg/unload_ammo(mob/user, var/allow_dump=1)
 	if(!cover_open)
-		user << SPAN_WARNING("You need to open the cover to unload [src].")
+		to_chat(user, SPAN_WARNING("You need to open the cover to unload [src]."))
 		return
 	..()

--- a/code/modules/projectiles/guns/projectile/automatic/maxim.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/maxim.dm
@@ -12,6 +12,7 @@ obj/item/weapon/gun/projectile/automatic/maxim
 	ammo_type = "/obj/item/ammo_casing/a762"
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_PAN
+	tac_reloads = FALSE
 	magazine_type = /obj/item/ammo_magazine/maxim
 	matter = list(MATERIAL_PLASTEEL = 42, MATERIAL_PLASTIC = 15, MATERIAL_WOOD = 5)
 	price_tag = 5000

--- a/code/modules/projectiles/guns/projectile/automatic/maxim.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/maxim.dm
@@ -42,6 +42,6 @@ obj/item/weapon/gun/projectile/automatic/maxim
 
 /obj/item/weapon/gun/projectile/automatic/maxim/special_check(mob/user)
 	if(!(user.get_active_hand() == src && user.get_inactive_hand() == null))
-		user << SPAN_WARNING("You can't fire \the [src] with [user.get_inactive_hand()] in the other hand.")
+		to_chat(user, SPAN_WARNING("You can't fire \the [src] with [user.get_inactive_hand()] in the other hand."))
 		return FALSE
 	return ..()

--- a/code/modules/projectiles/guns/projectile/automatic/sts35.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts35.dm
@@ -11,6 +11,7 @@
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_CIVI_RIFLE
 	magazine_type = /obj/item/ammo_magazine/c762
+	auto_eject = 1
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 12)
 	price_tag = 3500
 	fire_sound = 'sound/weapons/guns/fire/ltrifle_fire.ogg'

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -97,25 +97,25 @@
 	//	return
 	..()
 	if (beakers.len)
-		to_chat(user, "\blue [src] contains:")
+		to_chat(user, SPAN_NOTICE("[src] contains:"))
 		for(var/obj/item/weapon/reagent_containers/glass/beaker/B in beakers)
 			if(B.reagents && B.reagents.reagent_list.len)
 				for(var/datum/reagent/R in B.reagents.reagent_list)
-					to_chat(user, "\blue [R.volume] units of [R.name]")
+					to_chat(user, SPAN_NOTICE("[R.volume] units of [R.name]"))
 
 /obj/item/weapon/gun/projectile/dartgun/attackby(obj/item/I as obj, mob/user as mob)
 	if(istype(I, /obj/item/weapon/reagent_containers/glass))
 		if(!istype(I, beaker_type))
-			to_chat(user, "\blue [I] doesn't seem to fit into [src].")
+			to_chat(user, SPAN_NOTICE("[I] doesn't seem to fit into [src]."))
 			return
 		if(beakers.len >= max_beakers)
-			to_chat(user, "\blue [src] already has [max_beakers] beakers in it - another one isn't going to fit!")
+			to_chat(user, SPAN_NOTICE("[src] already has [max_beakers] beakers in it - another one isn't going to fit!"))
 			return
 		var/obj/item/weapon/reagent_containers/glass/beaker/B = I
 		user.drop_item()
 		B.loc = src
 		beakers += B
-		to_chat(user, "\blue You slot [B] into [src].")
+		to_chat(user, SPAN_NOTICE("You slot [B] into [src]."))
 		src.updateUsrDialog()
 		return 1
 	..()

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -6,7 +6,7 @@
 	embed = 1 //the dart is shot fast enough to pierce space suits, so I guess splintering inside the target can be a thing. Should be rare due to low damage.
 	var/reagent_amount = 15
 	kill_count = 15 //shorter range
-	
+
 	muzzle_type = null
 
 /obj/item/projectile/bullet/chemdart/New()
@@ -97,25 +97,25 @@
 	//	return
 	..()
 	if (beakers.len)
-		user << "\blue [src] contains:"
+		to_chat(user, "\blue [src] contains:")
 		for(var/obj/item/weapon/reagent_containers/glass/beaker/B in beakers)
 			if(B.reagents && B.reagents.reagent_list.len)
 				for(var/datum/reagent/R in B.reagents.reagent_list)
-					user << "\blue [R.volume] units of [R.name]"
+					to_chat(user, "\blue [R.volume] units of [R.name]")
 
 /obj/item/weapon/gun/projectile/dartgun/attackby(obj/item/I as obj, mob/user as mob)
 	if(istype(I, /obj/item/weapon/reagent_containers/glass))
 		if(!istype(I, beaker_type))
-			user << "\blue [I] doesn't seem to fit into [src]."
+			to_chat(user, "\blue [I] doesn't seem to fit into [src].")
 			return
 		if(beakers.len >= max_beakers)
-			user << "\blue [src] already has [max_beakers] beakers in it - another one isn't going to fit!"
+			to_chat(user, "\blue [src] already has [max_beakers] beakers in it - another one isn't going to fit!")
 			return
 		var/obj/item/weapon/reagent_containers/glass/beaker/B = I
 		user.drop_item()
 		B.loc = src
 		beakers += B
-		user << "\blue You slot [B] into [src]."
+		to_chat(user, "\blue You slot [B] into [src].")
 		src.updateUsrDialog()
 		return 1
 	..()
@@ -186,7 +186,7 @@
 		if(index <= beakers.len)
 			if(beakers[index])
 				var/obj/item/weapon/reagent_containers/glass/beaker/B = beakers[index]
-				usr << "You remove [B] from [src]."
+				to_chat(usr,  "You remove [B] from [src].")
 				mixing -= B
 				beakers -= B
 				B.loc = get_turf(src)

--- a/code/modules/projectiles/guns/projectile/pistol/handmade.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/handmade.dm
@@ -18,13 +18,13 @@
 
 /obj/item/weapon/gun/projectile/handmade_pistol/special_check(mob/user)
 	if(jammed)
-		user << SPAN_WARNING("[src] is jammed!")
+		to_chat(user, SPAN_WARNING("[src] is jammed!"))
 		return 0
 	else
 		if(loaded.len && prob(jam_chance)) //you know, when you try to shot and "aaaaawwwww fuk"
 			jammed = TRUE
 			playsound(src.loc, 'sound/weapons/guns/interact/hpistol_cock.ogg', 70, 1)
-			user << SPAN_DANGER("[src] is jammed!")
+			to_chat(user, SPAN_DANGER("[src] is jammed!"))
 			return 0
 	return ..()
 
@@ -32,7 +32,7 @@
 	if(!chamber_open)
 		if(istype(W, /obj/item/weapon/tool/screwdriver) || istype(W, /obj/item/weapon/material/kitchen/utensil) || W.sharp)
 			open_chamber()
-			user << SPAN_NOTICE("You force open chamber with [W].")
+			to_chat(user, SPAN_NOTICE("You force open chamber with [W]."))
 	..()
 
 /obj/item/weapon/gun/projectile/handmade_pistol/handle_post_fire(mob/user, atom/target, var/pointblank=0, var/reflex=0)
@@ -42,7 +42,7 @@
 /obj/item/weapon/gun/projectile/handmade_pistol/load_ammo(var/obj/item/A, mob/user)
 	if(istype(A, /obj/item/ammo_casing))
 		if(!chamber_open)
-			user << SPAN_WARNING("You need to open chamber first.")
+			to_chat(user, SPAN_WARNING("You need to open chamber first."))
 			return
 		..()
 		chamber_open = FALSE

--- a/code/modules/projectiles/guns/projectile/pistol/lamia.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/lamia.dm
@@ -9,6 +9,7 @@
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 4)
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_PISTOL
+	auto_eject = 1
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 8)
 	price_tag = 1800
 	unload_sound 	= 'sound/weapons/guns/interact/hpistol_magout.ogg'

--- a/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
@@ -40,7 +40,7 @@
 //this is largely hacky and bad :(	-Pete
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel/attackby(var/obj/item/A as obj, mob/user as mob)
 	if(QUALITY_SAWING in A.tool_qualities)
-		user << SPAN_NOTICE("You begin to shorten the barrel of \the [src].")
+		to_chat(user, SPAN_NOTICE("You begin to shorten the barrel of \the [src]."))
 		if(loaded.len)
 			for(var/i in 1 to max_shells)
 				afterattack(user, user)	//will this work? //it will. we call it twice, for twice the FUN
@@ -56,6 +56,6 @@
 			slot_flags |= (SLOT_BELT|SLOT_HOLSTER) //but you can wear it on your belt (poorly concealed under a trenchcoat, ideally) - or in a holster, why not.
 			name = "sawn-off shotgun"
 			desc = "Omar's coming!"
-			user << SPAN_WARNING("You shorten the barrel of \the [src]!")
+			to_chat(user, SPAN_WARNING("You shorten the barrel of \the [src]!"))
 	else
 		..()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -194,7 +194,7 @@
 
 	//hit messages
 	if(silenced)
-		target_mob << SPAN_DANGER("You've been hit in the [parse_zone(def_zone)] by \the [src]!")
+		to_chat(target_mob, SPAN_DANGER("You've been hit in the [parse_zone(def_zone)] by \the [src]!"))
 	else
 		visible_message(SPAN_DANGER("\The [target_mob] is hit by \the [src] in the [parse_zone(def_zone)]!"))//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
 


### PR DESCRIPTION
## General
All guns with magazine will have by default have their tactical reload enabled unless otherwise stated.
All machine guns does not have tactical reload.

## Changelog
🆑 TorinoFermic
rscadd: Tactical reload added for all magazine-type guns. Machine guns cannot use it.
tweak: No relevant to gameplay but changed from bunch lines to something sane in the code.
tweak: Lamia and Dallas does have the autoejection.
/🆑