### PR TITLE
[TWEAK] Rebalance of agony for stun gameplay

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -13,8 +13,8 @@
 	origin_tech = list(TECH_COMBAT = 2)
 	attack_verb = list("beaten")
 	price_tag = 500
-	var/stunforce = 0
-	var/agonyforce = 60
+	var/stunforce = 10
+	var/agonyforce = 50
 	var/status = FALSE		//whether the thing is on or not
 	var/hitcost = 100
 	var/obj/item/weapon/cell/cell = null

--- a/code/modules/clothing/gloves/stungloves.dm
+++ b/code/modules/clothing/gloves/stungloves.dm
@@ -6,7 +6,7 @@
 	action_button_name = "Toggle Power Glove"
 	price_tag = 500
 	var/stunforce = 0
-	var/agonyforce = 60
+	var/agonyforce = 30
 	var/status = FALSE		//whether the thing is on or not
 	var/hitcost = 100
 	var/obj/item/weapon/cell/cell = null

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -45,8 +45,8 @@ meteor_act
 	agony_amount *= siemens_coeff
 
 	switch (def_zone)
-		if(BP_HEAD)
-			agony_amount *= 1.50
+		if(BP_CHEST)
+			agony_amount *= 0.80
 		if(BP_L_ARM, BP_R_ARM)
 			var/c_hand
 			if (def_zone == BP_L_ARM)


### PR DESCRIPTION
## General
That's up for discussion due many rounds where people are getting caught by IH way too easy.

## Changelog
🆑 TorinoFermic
tweak: Stuns and agony adjusted.
tweak: You can make the target drop the inhand item by aiming their arms and hitting with active stunbaton.
/🆑