### PR TITLE
Custom vendors now separate same-type items

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -444,7 +444,7 @@
 		return
 
 	for(var/datum/data/vending_product/R in product_records)
-		if(I.type == R.product_path)
+		if(I.type == R.product_path && I.name == R.product_name)
 			if (!locked || always_open || (panel_open && !custom_vendor))
 				stock(I, R, user)
 				return 1


### PR DESCRIPTION
Here comes the long awaited feature that everyone asked for but I always kept forgetting to actually do.

Custom vendors now generate a separate entry for items that have the same type but different names. This means you can label bottles or pills differently and they'll get their own entry on the product list.