### PR TITLE
More fixes

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -10,6 +10,8 @@
 		return
 	if(!Adjacent(usr) || !over.Adjacent(usr)) // should stop you from dragging through windows
 		return
+	if(usr.stat == DEAD)
+		return
 
 	spawn(0)
 		over.MouseDrop_T(src, usr, src_location, over_location, src_control, over_control, params)

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -100,7 +100,7 @@
 // Space movement
 /datum/movement_handler/mob/space/DoMove(var/direction, var/mob/mover)
 	if(!mob.check_gravity())
-		var/allowmove = mob.allow_spacemove(0)
+		var/allowmove = mob.allow_spacemove()
 		if(!allowmove)
 			return MOVEMENT_HANDLED
 		else if(allowmove == -1 && mob.handle_spaceslipping()) //Check to see if we slipped
@@ -113,7 +113,7 @@
 		return MOVEMENT_PROCEED
 
 	if(!mob.check_gravity())
-		if(!mob.allow_spacemove(0))
+		if(!mob.allow_spacemove())
 			return MOVEMENT_STOP
 	return MOVEMENT_PROCEED
 

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -136,10 +136,10 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 		var/mob/living/L = usr
 		if(CanUse(L) && href_list["action"])
 			var/obj/item/I = L.get_active_hand()
-			if (!istype(I))
-				return
 			holder.add_hiddenprint(L)
 			if(href_list["cut"]) // Toggles the cut/mend status
+				if (!istype(I))
+					return
 				var/tool_type = null
 				if(QUALITY_CUTTING in I.tool_qualities)
 					tool_type = QUALITY_CUTTING
@@ -151,23 +151,25 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 						add_log_entry(L, "has [IsColourCut(colour) ? "mended" : "cut"] the <font color='[colour]'>[capitalize(colour)]</font> wire")
 						CutWireColour(colour)
 				else
-					L << "<span class='error'>You need something that can cut!</span>"
+					to_chat(L, SPAN_ERROR("You need something that can cut!"))
 
 			else if(href_list["pulse"])
+				if (!istype(I))
+					return
 				if(I.get_tool_type(usr, list(QUALITY_PULSING), holder))
 					if(I.use_tool(L, holder, WORKTIME_INSTANT, QUALITY_PULSING, FAILCHANCE_ZERO))
 						var/colour = href_list["pulse"]
 						add_log_entry(L, "has pulsed the <font color='[colour]'>[capitalize(colour)]</font> wire")
 						PulseColour(colour)
 				else
-					L << "<span class='error'>You need a multitool!</span>"
+					to_chat(L, SPAN_ERROR("You need a multitool!"))
 
 			else if(href_list["attach"])
 				var/colour = href_list["attach"]
 				// Detach
 				if(IsAttached(colour))
 					var/obj/item/O = Detach(colour)
-					add_log_entry(L, "has detched [O] from the <font color='[colour]'>[capitalize(colour)]</font> wire")
+					add_log_entry(L, "has detached [O] from the <font color='[colour]'>[capitalize(colour)]</font> wire")
 					if(O)
 						L.put_in_hands(O)
 
@@ -178,7 +180,7 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 						add_log_entry(L, "has attached [I] to the <font color='[colour]'>[capitalize(colour)]</font> wire")
 						Attach(colour, I)
 					else
-						L << "<span class='error'>You need a remote signaller!</span>"
+						to_chat(L, SPAN_ERROR("You need a remote signaller!"))
 
 
 

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -151,7 +151,7 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 						add_log_entry(L, "has [IsColourCut(colour) ? "mended" : "cut"] the <font color='[colour]'>[capitalize(colour)]</font> wire")
 						CutWireColour(colour)
 				else
-					to_chat(L, SPAN_ERROR("You need something that can cut!"))
+					to_chat(L, SPAN_WARNING("You need something that can cut!"))
 
 			else if(href_list["pulse"])
 				if (!istype(I))
@@ -162,7 +162,7 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 						add_log_entry(L, "has pulsed the <font color='[colour]'>[capitalize(colour)]</font> wire")
 						PulseColour(colour)
 				else
-					to_chat(L, SPAN_ERROR("You need a multitool!"))
+					to_chat(L, SPAN_WARNING("You need a multitool!"))
 
 			else if(href_list["attach"])
 				var/colour = href_list["attach"]
@@ -180,7 +180,7 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 						add_log_entry(L, "has attached [I] to the <font color='[colour]'>[capitalize(colour)]</font> wire")
 						Attach(colour, I)
 					else
-						to_chat(L, SPAN_ERROR("You need a remote signaller!"))
+						to_chat(L, SPAN_WARNING("You need a remote signaller!"))
 
 
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -293,7 +293,7 @@ var/list/mob/living/forced_ambiance_list = new
 	for(var/mob/M in src)
 		if(has_gravity)
 			thunk(M)
-		M.update_floating( M.check_dense_object() )
+		M.update_floating()
 
 //This thunk should probably not be an area proc.
 //TODO: Make it a mob proc

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -20,7 +20,7 @@
 	var/stored_matter = 0
 	var/working = 0
 	var/mode = 1
-	var/list/modes = list("Floor & Walls","Airlock","Deconstruct")
+	var/list/modes = list("Floor & Walls","Low wall", "Airlock","Deconstruct")
 	var/canRwall = 1
 	var/disabled = 0
 
@@ -64,8 +64,8 @@
 
 /obj/item/weapon/rcd/attack_self(mob/user)
 	//Change the mode
-	if(++mode > 3) mode = 1
-	user << SPAN_NOTICE("Changed mode to '[modes[mode]]'")
+	if(++mode > modes.len) mode = 1
+	to_chat(user, SPAN_NOTICE("Changed mode to '[modes[mode]]'"))
 	playsound(src.loc, 'sound/effects/pop.ogg', 50, 0)
 	if(prob(20)) src.spark_system.start()
 
@@ -75,7 +75,7 @@
 		return 0
 	if(istype(get_area(A),/area/shuttle)||istype(get_area(A),/turf/space/transit))
 		return 0
-	return alter_turf(A,user,(mode == 3))
+	return alter_turf(A,user)
 
 /obj/item/weapon/rcd/proc/useResource(var/amount, var/mob/user, var/checkOnly)
 	if(stored_matter < amount)
@@ -85,57 +85,90 @@
 		update_icon()	//Updates the ammo counter if ammo is succesfully used
 	return 1
 
-/obj/item/weapon/rcd/proc/alter_turf(var/turf/T,var/mob/user,var/deconstruct)
+/obj/item/weapon/rcd/proc/alter_turf(var/T,var/mob/user,var/deconstruct)
 
 	var/build_cost = 0
 	var/build_type
 	var/build_turf
+	var/build_object
 	var/build_delay
-	var/build_other
 
 	if(working == 1)
 		return 0
+	var/turf/local_turf = T
+	if(!T)
+		local_turf = get_turf(T)
+	var/gotFloor = istype(local_turf,/turf/simulated/floor)
+	var/gotSpace = (istype(local_turf,/turf/space) || istype(local_turf,get_base_turf(local_turf.z)))
+	var/gotBlocked = (istype(T, /obj/machinery/door/airlock) || istype(T, /obj/structure/low_wall))
 
-	if(mode == 3 && istype(T,/obj/machinery/door/airlock))
-		build_cost =  10
-		build_delay = 50
-		build_type = "airlock"
-	else if(mode == 2 && !deconstruct && istype(T,/turf/simulated/floor))
-		build_cost =  10
-		build_delay = 50
-		build_type = "airlock"
-		build_other = /obj/machinery/door/airlock
-	else if(!deconstruct && (istype(T,/turf/space) || istype(T,get_base_turf(T.z))))
-		build_cost =  1
-		build_type =  "floor"
-		build_turf =  /turf/simulated/floor/airless
-	else if(deconstruct && istype(T,/turf/simulated/wall))
-		var/turf/simulated/wall/W = T
-		build_delay = deconstruct ? (W.reinf_material) ? 150 : 50 : 40
-		build_cost =  (W.reinf_material) ? 10 : 5
-		build_type =  (!canRwall && W.reinf_material) ? null : "wall"
-		build_turf =  /turf/simulated/floor
-	else if(istype(T,/turf/simulated/floor))
-		build_delay = deconstruct ? 50 : 20
-		build_cost =  deconstruct ? 10 : 3
-		build_type =  deconstruct ? "floor" : "wall"
-		build_turf =  deconstruct ? get_base_turf(T.z) : /turf/simulated/wall
-	else
-		return 0
+	switch(mode)
+		if(1)
+			if(gotSpace)
+				build_cost =  1
+				build_type =  "floor"
+				build_turf =  /turf/simulated/floor/airless
+			if(gotFloor)
+				build_delay = 40
+				build_cost =  5
+				build_type =  "wall"
+				build_turf =  /turf/simulated/wall
+		if(2)
+			if(!gotBlocked)
+				build_type = "low wall"
+				build_object = /obj/structure/low_wall
+				if(gotSpace)
+					build_delay = 30
+					build_cost = 6
+					build_turf = /turf/simulated/floor/airless //there is always floor under low wall
+				if(gotFloor)
+					build_delay = 30
+					build_cost =  5
+
+		if(3)
+			if(!gotBlocked)
+				build_type = "airlock"
+				build_object = /obj/machinery/door/airlock
+				if(gotSpace)
+					build_cost =  11
+					build_delay = 50
+					build_turf =  /turf/simulated/floor/airless
+				if(gotFloor)
+					build_cost =  10
+					build_delay = 40
+
+		if(4)
+			build_type =  "destroy"
+			if(gotFloor)
+				build_cost =  10
+				build_delay = 50
+				build_turf = get_base_turf(local_turf.z)
+			if(istype(T,/obj/structure/low_wall))
+				build_delay = 40
+				build_cost =  5
+			if(istype(T,/turf/simulated/wall))
+				var/turf/simulated/wall/W = T
+				build_delay = deconstruct ? (W.reinf_material) ? 150 : 50 : 40
+				build_cost =  (W.reinf_material) ? 10 : 5
+				build_type =  (!canRwall && W.reinf_material) ? null : "destroy"
+				build_turf =  /turf/simulated/floor
+			if(istype(T,/obj/machinery/door/airlock))
+				build_cost =  10
+				build_delay = 50
 
 	if(!build_type)
 		working = 0
 		return 0
 
 	if(!useResource(build_cost, user, 1))
-		user << "The \'Low Ammo\' light on the device blinks yellow."
+		to_chat(user, "The \'Low Ammo\' light on the device blinks yellow.")
 		flick("[icon_state]-empty", src)
 		return 0
 
 	playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 
 	working = 1
-	user << "[(deconstruct ? "Deconstructing" : "Building")] [build_type]..."
+	to_chat(user, "[(mode==modes.len ? "Deconstructing" : "Building [build_type]")]...")
 
 	if(build_delay && !do_after(user, build_delay, src))
 		working = 0
@@ -146,15 +179,16 @@
 		return 0
 
 	if(!useResource(build_cost, user))
-		user << "The \'Low Ammo\' light on the device blinks yellow."
+		to_chat(user, "The \'Low Ammo\' light on the device blinks yellow.")
 		flick("[icon_state]-empty", src)
 		return 0
 
 	if(build_turf)
-		T.ChangeTurf(build_turf)
-	else if(build_other)
-		new build_other(T)
-	else
+		local_turf.ChangeTurf(build_turf)
+	if(build_object)
+		new build_object(local_turf)
+
+	if(build_type == "destroy")
 		qdel(T)
 
 	playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -85,7 +85,7 @@
 		update_icon()	//Updates the ammo counter if ammo is succesfully used
 	return 1
 
-/obj/item/weapon/rcd/proc/alter_turf(var/T,var/mob/user,var/deconstruct)
+/obj/item/weapon/rcd/proc/alter_turf(var/T,var/mob/user)
 
 	var/build_cost = 0
 	var/build_type
@@ -138,7 +138,7 @@
 					build_delay = 40
 
 		if(4)
-			build_type =  "destroy"
+			build_type =  "deconstruct"
 			if(gotFloor)
 				build_cost =  10
 				build_delay = 50
@@ -148,7 +148,7 @@
 				build_cost =  5
 			if(istype(T,/turf/simulated/wall))
 				var/turf/simulated/wall/W = T
-				build_delay = deconstruct ? (W.reinf_material) ? 150 : 50 : 40
+				build_delay = 40
 				build_cost =  (W.reinf_material) ? 10 : 5
 				build_type =  (!canRwall && W.reinf_material) ? null : "destroy"
 				build_turf =  /turf/simulated/floor
@@ -188,7 +188,7 @@
 	if(build_object)
 		new build_object(local_turf)
 
-	if(build_type == "destroy")
+	if(build_type == "deconstruct")
 		qdel(T)
 
 	playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -140,12 +140,16 @@
 	if (occupant && occupant.mind && occupant.mind.key && occupant.stat == DEAD)
 		//Whoever inhabited this body is long gone, we need some black magic to find where and who they are now
 		var/mob/M = key2mob(occupant.mind.key)
-		if (!(M.get_respawn_bonus("CORPSE_HANDLING")))
-			//We send a message to the occupant's current mob - probably a ghost, but who knows.
-			M << SPAN_NOTICE("Your remains have been collected and properly stored. Your crew respawn time is reduced by 8 minutes.")
-			M << 'sound/effects/magic/blind.ogg' //Play this sound to a player whenever their respawn time gets reduced
+		if (!M)
+			return
+		if (M.stat != DEAD)
+			return // no more bonuses for alive mobs
+		if (M.get_respawn_bonus("CORPSE_HANDLING"))
+			return // we got this one already
+		//We send a message to the occupant's current mob - probably a ghost, but who knows.
+		to_chat(M, SPAN_NOTICE("Your remains have been collected and properly stored. Your crew respawn time is reduced by 8 minutes."))
+		M << 'sound/effects/magic/blind.ogg' //Play this sound to a player whenever their respawn time gets reduced
 
-		//Going safely to cryo will allow the patient to respawn more quickly
 		M.set_respawn_bonus("CORPSE_HANDLING", 8 MINUTES)
 
 

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -93,12 +93,6 @@
 				for(var/i = 0;i<slip_dist;i++)
 					step(M, M.dir)
 					sleep(1)
-		/*
-			else
-				M.inertia_dir = 0
-		else
-			M.inertia_dir = 0
-			*/
 
 	..()
 

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -93,10 +93,12 @@
 				for(var/i = 0;i<slip_dist;i++)
 					step(M, M.dir)
 					sleep(1)
+		/*
 			else
 				M.inertia_dir = 0
 		else
 			M.inertia_dir = 0
+			*/
 
 	..()
 

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -99,11 +99,13 @@
 	..()
 	if ((!(A) || src != A.loc))	return
 
-	inertial_drift(A)
+	//inertial_drift(A)
 
 	// Okay, so let's make it so that people can travel z levels
 	if (A.x <= TRANSITIONEDGE || A.x >= (world.maxx - TRANSITIONEDGE + 1) || A.y <= TRANSITIONEDGE || A.y >= (world.maxy - TRANSITIONEDGE + 1))
 		A.touch_map_edge()
+
+	..()
 
 /turf/space/proc/Sandbox_Spacemove(atom/movable/A as mob|obj)
 	var/cur_x

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -156,7 +156,7 @@ var/const/enterloopsanity = 100
 		if(M.check_gravity() || M.incorporeal_move)
 			M.inertia_dir = 0
 		else
-			var/allow_spacemove = M.allow_spacemove(1)
+			var/allow_spacemove = M.allow_spacemove()
 			if(allow_spacemove == TRUE)
 				M.inertia_dir = 0
 				M.update_floating(FALSE)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -151,15 +151,17 @@ var/const/enterloopsanity = 100
 
 	if(ismob(A))
 		var/mob/M = A
+
+		M.update_floating()
 		if(M.check_gravity() || M.incorporeal_move)
 			M.inertia_dir = 0
 		else
-			if(!M.allow_spacemove())
-				inertial_drift(M)
-			else
+			var/allow_spacemove = M.allow_spacemove(1)
+			if(allow_spacemove == TRUE)
 				M.inertia_dir = 0
-
-		M.update_floating() // no check_dense_object() proc in arg because it will make this line more costly for almost zero reward in my opinion.
+				M.update_floating(FALSE)
+			else if(!M.check_dense_object())
+				inertial_drift(M)
 		if(isliving(M))
 			var/mob/living/L = M
 			L.handle_footstep(src)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -156,12 +156,15 @@ var/const/enterloopsanity = 100
 		if(M.check_gravity() || M.incorporeal_move)
 			M.inertia_dir = 0
 		else
-			var/allow_spacemove = M.allow_spacemove()
-			if(allow_spacemove == TRUE)
-				M.inertia_dir = 0
-				M.update_floating(FALSE)
-			else if(!M.check_dense_object())
+			if(!M.allow_spacemove())
 				inertial_drift(M)
+			else
+				if(M.allow_spacemove() == TRUE)
+					M.update_floating(FALSE)
+					M.inertia_dir = 0
+				else if(M.check_dense_object())
+					M.inertia_dir = 0
+
 		if(isliving(M))
 			var/mob/living/L = M
 			L.handle_footstep(src)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -188,7 +188,7 @@ var/const/enterloopsanity = 100
 	if(!(A.last_move))	return
 	if((istype(A, /mob/) && src.x > 2 && src.x < (world.maxx - 1) && src.y > 2 && src.y < (world.maxy-1)))
 		var/mob/M = A
-		if(M.allow_spacemove())
+		if(M.allow_spacemove() == TRUE)
 			M.inertia_dir  = 0
 			return
 		spawn(5)

--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -67,7 +67,7 @@ var/list/disciples = list()
 	if(wearer.dna.unique_enzymes == data.dna.unique_enzymes)
 		for(var/mob/M in GLOB.player_list)
 			if(M.ckey == data.ckey)
-				if(!isghost(M) && !isangel(M))
+				if(M.stat != DEAD)
 					return FALSE
 		var/datum/mind/MN = data.mind
 		if(!istype(MN, /datum/mind))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -279,7 +279,7 @@
 		src.visible_message("\red [src] has thrown [item].")
 		if(incorporeal_move)
 			inertia_dir = 0
-		else if(!check_gravity() && !src.allow_spacemove(1)) // spacemove would return one with magboots, -1 with adjacent tiles
+		else if(!check_gravity() && !src.allow_spacemove()) // spacemove would return one with magboots, -1 with adjacent tiles
 			src.inertia_dir = get_dir(target, src)
 			step(src, inertia_dir)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -279,17 +279,9 @@
 		src.visible_message("\red [src] has thrown [item].")
 		if(incorporeal_move)
 			inertia_dir = 0
-		else if(!check_gravity() && !src.allow_spacemove()) // spacemove would return one with magboots, -1 with adjacent tiles
+		else if(!check_gravity() && !src.allow_spacemove(1)) // spacemove would return one with magboots, -1 with adjacent tiles
 			src.inertia_dir = get_dir(target, src)
 			step(src, inertia_dir)
-
-
-/*
-		if(istype(src.loc, /turf/space) || (src.flags & NOGRAV)) //they're in space, move em one space in the opposite direction
-			src.inertia_dir = get_dir(target, src)
-			step(src, inertia_dir)
-*/
-
 
 		item.throw_at(target, item.throw_range, item.throw_speed, src)
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -51,9 +51,7 @@
 			return -1
 
 	//If no working jetpack then use the other checks
-	. = ..()
-
-
+	return ..()
 
 /mob/living/carbon/human/slip_chance(var/prob_slip = 5)
 	if(!..())

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -48,11 +48,9 @@
 		//The cost for stabilization is paid later
 		if (check_drift)
 			if (thrust.stabilization_on)
-				inertia_dir = 0
 				return TRUE
 			return FALSE
 		else if(thrust.allow_thrust(JETPACK_MOVE_COST, src))
-			inertia_dir = 0
 			return TRUE
 
 	//If no working jetpack then use the other checks

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -37,7 +37,7 @@
 	return tally
 
 
-/mob/living/carbon/human/allow_spacemove(var/check_drift = 0)
+/mob/living/carbon/human/allow_spacemove()
 	//Can we act?
 	if(restrained())	return 0
 
@@ -45,11 +45,9 @@
 	var/obj/item/weapon/tank/jetpack/thrust = get_jetpack()
 
 	if(thrust)
-		//The cost for stabilization is paid later
-		if (check_drift)
+		if(thrust.allow_thrust(JETPACK_MOVE_COST, src))
 			if (thrust.stabilization_on)
 				return TRUE
-		if(thrust.allow_thrust(JETPACK_MOVE_COST, src))
 			return -1
 
 	//If no working jetpack then use the other checks

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -49,9 +49,8 @@
 		if (check_drift)
 			if (thrust.stabilization_on)
 				return TRUE
-			return FALSE
-		else if(thrust.allow_thrust(JETPACK_MOVE_COST, src))
-			return TRUE
+		if(thrust.allow_thrust(JETPACK_MOVE_COST, src))
+			return -1
 
 	//If no working jetpack then use the other checks
 	. = ..()

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -149,7 +149,7 @@
 	..()
 
 /mob/living/carbon/slime/allow_spacemove()
-	return 2
+	return -1
 
 /mob/living/carbon/slime/Stat()
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -3,16 +3,17 @@
 		return 0
 	..(prob_slip)
 
-/mob/living/silicon/robot/allow_spacemove(var/check_drift = 0)
+/mob/living/silicon/robot/allow_spacemove()
 
 	//Do we have a working jetpack?
 	var/obj/item/weapon/tank/jetpack/thrust = get_jetpack()
 
 	if(thrust)
 		//The cost for stabilization is paid later
-		if (thrust.stabilization_on)
-			return TRUE
+
 		if(thrust.allow_thrust(JETPACK_MOVE_COST, src))
+			if (thrust.stabilization_on)
+				return TRUE
 			return -1
 
 	//If no working jetpack then use the other checks

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -10,14 +10,10 @@
 
 	if(thrust)
 		//The cost for stabilization is paid later
-		if (check_drift)
-			if (thrust.stabilization_on)
-				inertia_dir = 0
-				return TRUE
-			return FALSE
-		else if(thrust.allow_thrust(JETPACK_MOVE_COST, src))
-			inertia_dir = 0
+		if (thrust.stabilization_on)
 			return TRUE
+		if(thrust.allow_thrust(JETPACK_MOVE_COST, src))
+			return -1
 
 	//If no working jetpack then use the other checks
 	if (is_component_functioning("actuator"))

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -9,8 +9,6 @@
 	var/obj/item/weapon/tank/jetpack/thrust = get_jetpack()
 
 	if(thrust)
-		//The cost for stabilization is paid later
-
 		if(thrust.allow_thrust(JETPACK_MOVE_COST, src))
 			if (thrust.stabilization_on)
 				return TRUE
@@ -18,7 +16,7 @@
 
 	//If no working jetpack then use the other checks
 	if (is_component_functioning("actuator"))
-		. = ..()
+		return ..()
 
 
 

--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -41,7 +41,7 @@
 	if(istype(L))
 		owner = L
 
-/mob/living/simple_animal/hostile/scarybat/allow_spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/scarybat/allow_spacemove()
 	return ..()	//No drifting in space for space carp!	//original comments do not steal
 
 /mob/living/simple_animal/hostile/scarybat/FindTarget()

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -109,7 +109,7 @@
 	..()
 
 /mob/living/simple_animal/hostile/bear/allow_spacemove()
-	return	//No drifting in space for space bears!
+	return ..()//No drifting in space for space bears!
 
 /mob/living/simple_animal/hostile/bear/FindTarget()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -108,7 +108,7 @@
 		target_mob = M
 	..()
 
-/mob/living/simple_animal/hostile/bear/allow_spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/bear/allow_spacemove()
 	return	//No drifting in space for space bears!
 
 /mob/living/simple_animal/hostile/bear/FindTarget()

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -36,7 +36,7 @@
 
 	faction = "carp"
 
-/mob/living/simple_animal/hostile/carp/allow_spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/carp/allow_spacemove()
 	return 1	//No drifting in space for space carp!	//original comments do not steal
 
 /mob/living/simple_animal/hostile/carp/FindTarget()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -59,7 +59,7 @@
 	trail.set_up(src)
 	trail.start()
 
-/mob/living/simple_animal/hostile/retaliate/malf_drone/allow_spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/retaliate/malf_drone/allow_spacemove()
 	return 1
 
 /mob/living/simple_animal/hostile/retaliate/malf_drone/ListTargets()

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -96,7 +96,7 @@
 	corpse = /obj/landmark/corpse/syndicatecommando
 	speed = 0
 
-/mob/living/simple_animal/hostile/syndicate/melee/space/allow_spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/syndicate/melee/space/allow_spacemove()
 	return
 
 /mob/living/simple_animal/hostile/syndicate/ranged
@@ -124,7 +124,7 @@
 	corpse = /obj/landmark/corpse/syndicatecommando
 	speed = 0
 
-/mob/living/simple_animal/hostile/syndicate/ranged/space/allow_spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/syndicate/ranged/space/allow_spacemove()
 	return
 
 

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -97,7 +97,7 @@
 	speed = 0
 
 /mob/living/simple_animal/hostile/syndicate/melee/space/allow_spacemove()
-	return
+	return ..()
 
 /mob/living/simple_animal/hostile/syndicate/ranged
 	ranged = 1
@@ -125,7 +125,7 @@
 	speed = 0
 
 /mob/living/simple_animal/hostile/syndicate/ranged/space/allow_spacemove()
-	return
+	return ..()
 
 
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -172,7 +172,7 @@
 //Return true for safe movement
 //Return -1 for movement with possibility of slipping
 //Return false for no movement
-/mob/proc/allow_spacemove(var/check_drift = 0)
+/mob/proc/allow_spacemove()
 	//First up, check for magboots or other gripping capability
 	//If we have some, then check the ground under us
 	if (incorporeal_move)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -175,18 +175,13 @@
 /mob/proc/allow_spacemove(var/check_drift = 0)
 	//First up, check for magboots or other gripping capability
 	//If we have some, then check the ground under us
-	if(incorporeal_move)
-		update_floating(!check_gravity())
+	if (incorporeal_move)
 		return TRUE
 	if (check_shoegrip() && check_solid_ground())
-		update_floating(FALSE)
 		return TRUE
-
-	update_floating(TRUE)
-	if(check_dense_object())
+	if (check_dense_object())
 		return -1
 	return FALSE
-
 
 //return 1 if slipped, 0 otherwise
 /mob/proc/handle_spaceslipping()
@@ -215,6 +210,8 @@
 //This proc is only called if we have grip, ie magboots
 /mob/proc/check_solid_ground()
 	if (istype(loc, /turf/simulated))
+		if(istype(loc, /turf/simulated/open))
+			return FALSE //open spess was fogotten
 		return TRUE //We're standing on a simulated floor
 	else
 		//We're probably in space

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -217,56 +217,59 @@
 	if(istype(W, suitable_cell) || istype(W, /obj/item/weapon/computer_hardware))
 		try_install_component(user, W)
 
-	var/list/usable_qualities = list(QUALITY_SCREW_DRIVING, QUALITY_WELDING, QUALITY_BOLT_TURNING)
 
-	var/tool_type = W.get_tool_type(user, usable_qualities, src)
-	switch(tool_type)
-		if(QUALITY_BOLT_TURNING)
-			var/list/components = get_all_components()
-			if(components.len)
-				to_chat(user, "Remove all components from \the [src] before disassembling it.")
-				return
-			if(W.use_tool(user, src, WORKTIME_SLOW, QUALITY_BOLT_TURNING, FAILCHANCE_VERY_EASY, required_stat = STAT_COG))
-				new /obj/item/stack/material/steel( get_turf(src.loc), steel_sheet_cost )
-				src.visible_message("\The [src] has been disassembled by [user].")
-				qdel(src)
-				return
 
-		if(QUALITY_WELDING)
-			if(!damage)
-				to_chat(user, "\The [src] does not require repairs.")
-				return
-			if(W.use_tool(user, src, WORKTIME_SLOW, QUALITY_WELDING, FAILCHANCE_HARD, required_stat = STAT_COG))
-				damage = 0
-				to_chat(user, "You repair \the [src].")
-				return
-
-		if(QUALITY_SCREW_DRIVING)
-			var/list/all_components = get_all_components()
-			if(!all_components.len)
-				to_chat(user, "This device doesn't have any components installed.")
-				return
-			var/list/component_names = list()
-			for(var/obj/item/weapon/H in all_components)
-				component_names.Add(H.name)
-			var/list/options = list()
-			for(var/i in component_names)
-				for(var/X in all_components)
-					var/obj/item/weapon/TT = X
-					if(TT.name == i)
-						options[i] = image(icon = TT.icon, icon_state = TT.icon_state)
-			var/choice
-			choice = show_radial_menu(user, src, options, radius = 32)
-			if(!choice)
-				return
-			if(!Adjacent(usr))
-				return
-			if(W.use_tool(user, src, WORKTIME_FAST, QUALITY_SCREW_DRIVING, FAILCHANCE_VERY_EASY, required_stat = STAT_COG))
-				var/obj/item/weapon/computer_hardware/H = find_hardware_by_name(choice)
-				if(!H)
+	var/obj/item/weapon/tool/tool = W
+	if(tool)
+		var/list/usable_qualities = list(QUALITY_SCREW_DRIVING, QUALITY_WELDING, QUALITY_BOLT_TURNING)
+		var/tool_type = tool.get_tool_type(user, usable_qualities, src)
+		switch(tool_type)
+			if(QUALITY_BOLT_TURNING)
+				var/list/components = get_all_components()
+				if(components.len)
+					to_chat(user, "Remove all components from \the [src] before disassembling it.")
 					return
-				uninstall_component(user, H)
-				return
+				if(tool.use_tool(user, src, WORKTIME_SLOW, QUALITY_BOLT_TURNING, FAILCHANCE_VERY_EASY, required_stat = STAT_COG))
+					new /obj/item/stack/material/steel( get_turf(src.loc), steel_sheet_cost )
+					src.visible_message("\The [src] has been disassembled by [user].")
+					qdel(src)
+					return
+
+			if(QUALITY_WELDING)
+				if(!damage)
+					to_chat(user, "\The [src] does not require repairs.")
+					return
+				if(tool.use_tool(user, src, WORKTIME_SLOW, QUALITY_WELDING, FAILCHANCE_HARD, required_stat = STAT_COG))
+					damage = 0
+					to_chat(user, "You repair \the [src].")
+					return
+
+			if(QUALITY_SCREW_DRIVING)
+				var/list/all_components = get_all_components()
+				if(!all_components.len)
+					to_chat(user, "This device doesn't have any components installed.")
+					return
+				var/list/component_names = list()
+				for(var/obj/item/weapon/H in all_components)
+					component_names.Add(H.name)
+				var/list/options = list()
+				for(var/i in component_names)
+					for(var/X in all_components)
+						var/obj/item/weapon/TT = X
+						if(TT.name == i)
+							options[i] = image(icon = TT.icon, icon_state = TT.icon_state)
+				var/choice
+				choice = show_radial_menu(user, src, options, radius = 32)
+				if(!choice)
+					return
+				if(!Adjacent(usr))
+					return
+				if(tool.use_tool(user, src, WORKTIME_FAST, QUALITY_SCREW_DRIVING, FAILCHANCE_VERY_EASY, required_stat = STAT_COG))
+					var/obj/item/weapon/computer_hardware/H = find_hardware_by_name(choice)
+					if(!H)
+						return
+					uninstall_component(user, H)
+					return
 	..()
 
 /obj/item/modular_computer/examine(var/mob/user)

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -117,6 +117,8 @@
 	var/obj/item/weapon/card/id/id_card
 	if (computer.card_slot)
 		id_card = computer.card_slot.stored_card
+	if (!user_id_card)
+		return
 
 	var/datum/nano_module/program/card_mod/module = NM
 	switch(href_list["action"])

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -150,6 +150,7 @@
 
 // Humans and borgs have jetpacks which allows them to override gravity! Or rather,
 // they can have them. So we override and check.
+/* Maybe next time.
 /mob/living/carbon/human/CanAvoidGravity()
 	if (!restrained())
 		var/obj/item/weapon/tank/jetpack/thrust = get_jetpack()
@@ -166,6 +167,7 @@
 		return TRUE
 
 	return ..()
+*/
 
 /**
  * An overridable proc used by SSfalling to determine whether or not an atom
@@ -217,10 +219,7 @@
 /mob/living/carbon/human/can_fall(turf/below, turf/simulated/open/dest = src.loc)
 	// Special condition for jetpack mounted folk!
 	if (!restrained())
-		var/obj/item/weapon/tank/jetpack/thrust = get_jetpack()
-
-		if (thrust && thrust.stabilization_on &&\
-			!lying && thrust.allow_thrust(0.01, src))
+		if (CanAvoidGravity())
 			return FALSE
 
 	return ..()
@@ -232,9 +231,7 @@
 	return FALSE
 
 /mob/living/silicon/robot/can_fall(turf/below, turf/simulated/open/dest = src.loc)
-	var/obj/item/weapon/tank/jetpack/thrust = get_jetpack()
-
-	if (thrust && thrust.stabilization_on && thrust.allow_thrust(0.02, src))
+	if (CanAvoidGravity())
 		return FALSE
 
 	return ..()

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -72,7 +72,7 @@
 		to_chat(src, SPAN_WARNING("You can't leave this place in this direction."))
 		return FALSE
 	if(!destination.CanZPass(mover, (direction == UP ? DOWN : UP) ))
-		to_chat(src, SPAN_WARNING("\The [destination] has something on your way."))
+		to_chat(src, SPAN_WARNING("\The [destination] blocks you."))
 		return FALSE
 
 	// Check for blocking atoms at the destination.

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -13,7 +13,7 @@ see multiz/movement.dm for some info.
 		if(z == A.z)
 			if(direction == DOWN)
 				return 0
-		if(direction == UP)
+		else if(direction == UP)
 			return 0
 	return 1
 
@@ -23,9 +23,12 @@ see multiz/movement.dm for some info.
 		if(z == A.z)
 			if(direction == DOWN)
 				return 0
-		if(direction == UP)
+		else if(direction == UP)
 			return 0
 	return 1
+
+/turf/simulated/floor/CanZPass(atom/A, direction)
+	return direction != DOWN
 /////////////////////////////////////
 
 /turf/simulated/open

--- a/code/modules/multiz/ztravel/zmethod.dm
+++ b/code/modules/multiz/ztravel/zmethod.dm
@@ -192,11 +192,19 @@
 /datum/vertical_travel_method/proc/finish()
 	animating = FALSE
 	reset_values()
+
+	//this is bullshit, but animation is always halted on z change. Vars such as floating remain the same
+	//So we gotta "prepare" it right after successful zmove
+	var/mob/mob = M
+	if(mob)
+		mob.stop_floating()
+		mob.update_floating()
+	// end_of_dirty_bullshit.dm
+
 	M.forceMove(destination)
 	if (prob(slip_chance))
 		slip()
 	announce_end()
-
 
 /datum/vertical_travel_method/proc/get_destination()
 	destination = (direction == UP) ? GetAbove(origin) : GetBelow(origin)


### PR DESCRIPTION
- Morgue respawn bonus
There always was message about your corpse properly handled with morgue tray. Even when you respawned already. Also, fixes related runtime on morgue  non-mob storing event.
- RCD supports low walls now. (Closes #2915)
It would be built without windows, if you would need windows - ping me.
- Signaler could be detached with bare hands now (Closes #3194)
- [NT] Cloning with reincarnation is possible with ghost sitting in old body (Closes #3201)
- Proper zero-g behaviour around simulated open space tiles and some animation fixes. Also removed some dublicated calls
Animations are quite inconsistent, so expect floating bodies in area with gravity still. You can get your mob floating, but all its vars would state that mob wasn't animated. Joy.
- Fix about console runtime, trying to get your ID when you got only PDA. Maybe realted to #3385, but really not sure about it.
- Fix around drag'n'drop feature that could be aboosed by dead mobs
- Jetpack nerf and proper inertia stuff. Praise be.