### PR TITLE
Mining Changes

### DIFF
--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -43,7 +43,7 @@
 		return 1
 
 	if(href_list["change_stack"])
-		var/choice = input("What would you like to set the stack amount to?") as null|anything in list(1,5,10,20,50)
+		var/choice = input("What would you like to set the stack amount to?") as null|anything in list(1,5,10,20,50,120)
 		if(!choice) return
 		machine.stack_amt = choice
 
@@ -68,7 +68,7 @@
 	var/input_dir = null
 	var/output_dir = null
 	var/list/stack_storage
-	var/stack_amt = 50; // Amount to stack before releassing
+	var/stack_amt = 120 // Amount to stack before releassing
 
 /obj/machinery/mineral/stacking_machine/New()
 	stack_storage = new

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -20,6 +20,7 @@
 	new /obj/item/clothing/shoes/black(src)
 	new /obj/item/weapon/cell/medium(src)
 	new /obj/item/weapon/cell/medium(src)
+	new /obj/item/weapon/cell/small(src)
 	new /obj/item/weapon/tool_upgrade/augment/fuel_tank(src)
 	new /obj/item/device/scanner/analyzer(src)
 	new /obj/item/weapon/storage/bag/ore(src)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -16,19 +16,18 @@
 	new /obj/item/device/radio/headset/headset_cargo(src)
 	new /obj/item/clothing/under/rank/miner(src)
 	new /obj/item/clothing/gloves/thick(src)
+	new /obj/item/clothing/glasses/meson(src)
 	new /obj/item/clothing/shoes/black(src)
 	new /obj/item/weapon/cell/medium(src)
 	new /obj/item/weapon/cell/medium(src)
 	new /obj/item/weapon/tool_upgrade/augment/fuel_tank(src)
-	new /obj/item/weapon/tool_upgrade/augment/fuel_tank(src)
 	new /obj/item/device/scanner/analyzer(src)
 	new /obj/item/weapon/storage/bag/ore(src)
-	new /obj/item/device/lighting/toggleable/lantern(src)
+	new /obj/item/device/lighting/toggleable/flashlight/heavy(src)
 	new /obj/item/weapon/tool/shovel(src)
 	new /obj/item/weapon/tool/pickaxe(src)
-	new /obj/item/weapon/tool/pickaxe/jackhammer(src)
+	new /obj/item/weapon/tool/pickaxe/drill(src)
 	new /obj/item/device/t_scanner(src)
-	new /obj/random/tool_upgrade(src)
 
 /******************************Lantern*******************************/
 


### PR DESCRIPTION
A redo of the last PR that doesn't have anything to do with the map. Gives miners a slight QoL change.

**tweak:** stacking machine defaults sheet stacks to 120 and now has the option in its stacking console
**tweak:** removed one of the fuel tank attachments and the random tool attachment spawn in the locker to give miners optical meson glasses, a heavy duty flashlight, a drill instead of a jackhammer, and a small cell for their mesons.