### PR TITLE
Splicings interaction

### DIFF
--- a/code/game/objects/structures/wire_splicing.dm
+++ b/code/game/objects/structures/wire_splicing.dm
@@ -109,3 +109,8 @@
 			if(!shock(user, 100))
 				user << SPAN_NOTICE("You remove the splicing.")
 				qdel(src)
+
+	if(istype(I, /obj/item/stack/cable_coil))
+		var/obj/item/stack/cable_coil/coil = I
+		if(coil.amount >= 1)
+			world << "TODO: ADD DEM MOAR WIRES"

--- a/code/game/objects/structures/wire_splicing.dm
+++ b/code/game/objects/structures/wire_splicing.dm
@@ -71,6 +71,10 @@
 	if (messiness > 2)
 		layer = LOW_OBJ_LAYER  // I wont do such stuff on splicing "reinforcement". Take it as nasty feature
 
+/obj/structure/wire_splicing/examine(mob/user)
+	..()
+	to_chat(user, "It has [messiness] wire[messiness > 1?"s":""] dangling around")
+
 /obj/structure/wire_splicing/Crossed(AM as mob|obj)
 	if(isliving(AM))
 		var/mob/living/L = AM
@@ -117,22 +121,21 @@
 		// keep goin!
 		var/obj/item/stack/cable_coil/coil = I
 		if(coil.get_amount() >= 1)
-			to_chat(user, SPAN_NOTICE("You started to adding more to this pile of wires..."))
+			to_chat(user, SPAN_NOTICE("You started to wire to this pile of wires..."))
 			if(shock(user)) //check if he got his insulation gloves
 				return 		//he didn't
-			if(do_after(user, 20))
+			if(do_after(src, 20))
 				if(shock(user)) //check if he got his insulation gloves. Again.
 					return
-				var/fail_chance = FAILCHANCE_NORMAL - user.stats.getStat(STAT_MEC)
+				var/fail_chance = FAILCHANCE_HARD - user.stats.getStat(STAT_MEC) // 72 for assistant
 				if(prob(fail_chance))
-					to_chat(user, SPAN_WARNING("You failed to finish your task with [src.name]!"))
-					shock(user, FALSE) //why not
+					if(!shock(user, FALSE)) //why not
+						to_chat(user, SPAN_WARNING("You failed to finish your task with [src.name]! There was a [fail_chance]% chance to screw this up."))
 					return
-
-				//all safe
+				if(messiness >= 10)
+					messiness = 10
+				//all clear, update things
 				coil.use(1)
-				if(coil.get_amount() == 0)
-					qdel(coil)
 				messiness += 1
 				icon_state = "wire_splicing[messiness]"
-				to_chat(user, SPAN_NOTICE("You added one more to this pile of wires."))
+				to_chat(user, SPAN_NOTICE("You added one more wire."))

--- a/code/game/objects/structures/wire_splicing.dm
+++ b/code/game/objects/structures/wire_splicing.dm
@@ -69,8 +69,7 @@
 	//At messiness of 2 or below, triggering when walking on a catwalk is impossible
 	//Above that it becomes possible, so we will change the layer to make it poke through catwalks
 	if (messiness > 2)
-		layer = LOW_OBJ_LAYER
-
+		layer = LOW_OBJ_LAYER  // I wont do such stuff on splicing "reinforcement". Take it as nasty feature
 
 /obj/structure/wire_splicing/Crossed(AM as mob|obj)
 	if(isliving(AM))
@@ -110,7 +109,30 @@
 				user << SPAN_NOTICE("You remove the splicing.")
 				qdel(src)
 
-	if(istype(I, /obj/item/stack/cable_coil))
+	if(istype(I, /obj/item/stack/cable_coil) && user.a_intent == I_HURT)
+		if(messiness >= 10)
+			messiness = 10
+			to_chat(user, SPAN_WARNING("Enough."))
+			return
+		// keep goin!
 		var/obj/item/stack/cable_coil/coil = I
-		if(coil.amount >= 1)
-			world << "TODO: ADD DEM MOAR WIRES"
+		if(coil.get_amount() >= 1)
+			to_chat(user, SPAN_NOTICE("You started to adding more to this pile of wires..."))
+			if(shock(user)) //check if he got his insulation gloves
+				return 		//he didn't
+			if(do_after(user, 20))
+				if(shock(user)) //check if he got his insulation gloves. Again.
+					return
+				var/fail_chance = FAILCHANCE_NORMAL - user.stats.getStat(STAT_MEC)
+				if(prob(fail_chance))
+					to_chat(user, SPAN_WARNING("You failed to finish your task with [src.name]!"))
+					shock(user, FALSE) //why not
+					return
+
+				//all safe
+				coil.use(1)
+				if(coil.get_amount() == 0)
+					qdel(coil)
+				messiness += 1
+				icon_state = "wire_splicing[messiness]"
+				to_chat(user, SPAN_NOTICE("You added one more to this pile of wires."))

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -4,7 +4,6 @@
 	icon_state = "galoshes"
 	permeability_coefficient = 0.05
 	siemens_coefficient = 0 // DAMN BOI
-	overslot = 1
 	item_flags = NOSLIP
 	slowdown = SHOES_SLOWDOWN+1
 	species_restricted = null

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -16,7 +16,7 @@
 	item_state = "jackboots"
 	force = WEAPON_FORCE_WEAK
 	armor = list(melee = 30, bullet = 20, laser = 20, energy = 15, bomb = 20, bio = 0, rad = 0)
-	siemens_coefficient = 0.7
+	siemens_coefficient = 0.6
 	can_hold_knife = 1
 
 /obj/item/clothing/shoes/reinforced
@@ -26,7 +26,7 @@
 	item_state = "reinforced"
 	force = 2
 	armor = list(melee = 30, bullet = 25, laser = 25, energy = 5, bomb = 0, bio = 0, rad = 0)
-	siemens_coefficient = 0.7
+	siemens_coefficient = 0.5
 
 /obj/item/clothing/shoes/workboots
 	name = "workboots"
@@ -34,5 +34,5 @@
 	icon_state = "workboots"
 	item_state = "workboots"
 	armor = list(melee = 40, bullet = 25, laser = 25, energy = 15, bomb = 20, bio = 0, rad = 20)
-	siemens_coefficient = 0.7
+	siemens_coefficient = 0
 	can_hold_knife = 1

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -3,6 +3,8 @@
 	name = "galoshes"
 	icon_state = "galoshes"
 	permeability_coefficient = 0.05
+	siemens_coefficient = 0 // DAMN BOI
+	overslot = 1
 	item_flags = NOSLIP
 	slowdown = SHOES_SLOWDOWN+1
 	species_restricted = null

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -10,6 +10,7 @@
 	var/icon_base = "magboots"
 	action_button_name = "Toggle Magboots"
 	armor = list(melee = 40, bullet = 30, laser = 30,energy = 25, bomb = 50, bio = 100, rad = 70)
+	siemens_coefficient = 0 // DAMN BOI
 	//This armor only applies to legs
 
 /obj/item/clothing/shoes/magboots/proc/set_slowdown()

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -53,12 +53,14 @@
 	icon_state = "wizard"
 	species_restricted = null
 	body_parts_covered = 0
+	siemens_coefficient = 0
 
 /obj/item/clothing/shoes/sandal/marisa
 	desc = "A pair of magic, black shoes."
 	name = "magic shoes"
 	icon_state = "black"
 	body_parts_covered = LEGS
+	siemens_coefficient = 0
 
 /obj/item/clothing/shoes/clown_shoes
 	desc = "The prankster's standard-issue clowning shoes. Damn they're huge!"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -7,7 +7,7 @@
 	item_flags = NOSLIP | SILENT
 	origin_tech = list(TECH_ILLEGAL = 3)
 	var/list/clothing_choices = list()
-	siemens_coefficient = 0.8
+	siemens_coefficient = 0 // DAMN BOI
 	species_restricted = null
 
 /obj/item/clothing/shoes/mime
@@ -40,7 +40,7 @@
 	force = WEAPON_FORCE_WEAK
 	armor = list(melee = 80, bullet = 60, laser = 50,energy = 25, bomb = 50, bio = 10, rad = 0)
 	item_flags = NOSLIP
-	siemens_coefficient = 0.6
+	siemens_coefficient = 0.4
 
 	cold_protection = LEGS
 	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -320,13 +320,24 @@
 	//If following checks determine user is protected we won't alarm for long.
 	if(PN)
 		PN.trigger_warning(5)
+
+	var/body_part = null
+
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.species.siemens_coefficient == 0)
 			return
+		var/obj/item/clothing/cloth
 		if(hands && H.gloves)
-			var/obj/item/clothing/gloves/G = H.gloves
-			if(G.siemens_coefficient == 0)	return 0		//to avoid spamming with insulated glvoes on
+			cloth = H.gloves
+			body_part = M.hand ? BP_L_ARM : BP_R_ARM
+		else if(H.shoes) // hand or legs for now
+			cloth = H.shoes
+			body_part = pick(BP_L_LEG, BP_R_LEG)
+		if(cloth)
+			siemens_coeff = cloth.siemens_coefficient
+		if(siemens_coeff == 0)	return 0
+		//TODO: ask for overslot contents checks
 
 
 	//Checks again. If we are still here subject will be shocked, trigger standard 20 tick warning
@@ -349,7 +360,8 @@
 	else
 		power_source = cell
 		shock_damage = cell_damage
-	var/drained_hp = M.electrocute_act(shock_damage, source, siemens_coeff) //zzzzzzap!
+
+	var/drained_hp = M.electrocute_act(shock_damage, source, siemens_coeff, body_part) //zzzzzzap!
 	var/drained_energy = drained_hp*20
 
 	if (source_area)


### PR DESCRIPTION
- Added `proc/electrocute_mob ` ability to damage legs
- Made `proc/electrocute_mob` actually use insulation coefficients for gloves/shoes
- Added "reinforcement" for wire splicing: use cable coil with `harm` intent.
It would try to zap your hands and legs, use some insulation
- Tweaked insulation coefficients for some shoes.
Magboots, antag shoes from uplink and galoshes are fully insulated now.
- Added ability to make splicing from current wiring. Any wiring on floor.
Use cable coil with 'harm' intent.
- Added ability to spawn splicing on tools failure.