### PR TITLE
Fixes door.dm,420

### DIFF
--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -30,7 +30,7 @@
 	icon = 'icons/obj/doors/Door2x1metal.dmi'
 	assembly_type = /obj/structure/door_assembly/multi_tile
 
-/obj/machinery/door/airlock/multi_tile/metal/New()
+/obj/machinery/door/airlock/multi_tile/New()
 	..()
 	if(src.dir > 3)
 		f5 = new/obj/machinery/filler_object(src.loc)


### PR DESCRIPTION
No more `door.dm,420: Cannot execute null.set opacity().`
Glass multi-airlocks weren't properly initialized