### PR TITLE
Expands uses of the resistance value.

### DIFF
--- a/code/__defines/weapons.dm
+++ b/code/__defines/weapons.dm
@@ -2,24 +2,26 @@
 
 //Weapon Force: Provides the base damage for melee weapons.
 //These are due for a review and overhaul, generally too powerful
-#define WEAPON_FORCE_HARMLESS    3
-#define WEAPON_FORCE_WEAK        7
-#define WEAPON_FORCE_NORMAL      10
-#define WEAPON_FORCE_PAINFUL    15
-#define WEAPON_FORCE_DANGEROUS   20
-#define WEAPON_FORCE_ROBUST      26
-#define WEAPON_FORCE_LETHAL      51
+#define WEAPON_FORCE_HARMLESS		3
+#define WEAPON_FORCE_WEAK			7
+#define WEAPON_FORCE_NORMAL			10
+#define WEAPON_FORCE_PAINFUL		15
+#define WEAPON_FORCE_DANGEROUS		20
+#define WEAPON_FORCE_ROBUST			26
+#define WEAPON_FORCE_LETHAL			51
 
 
-//Resistance values, used on floors, windows, airlocks, girders, and similar hard targets
+//Resistance values, used on floors, windows, airlocks, girders, and similar hard targets.
+//Resistance value is also used on simple animals.
 //Reduces the damage they take by flat amounts
+#define RESISTANCE_NONE 				0
 #define RESISTANCE_FRAGILE 				4
 #define RESISTANCE_AVERAGE 				8
 #define RESISTANCE_IMPROVED 			12
-#define RESISTANCE_TOUGH 				15
+#define RESISTANCE_TOUGH 				16
 #define RESISTANCE_ARMOURED 			20
-#define RESISTANCE_HEAVILY_ARMOURED 	25
-#define RESISTANCE_VAULT 				30
+#define RESISTANCE_HEAVILY_ARMOURED 	24
+#define RESISTANCE_VAULT 				32
 #define RESISTANCE_UNBREAKABLE 			100
 
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -100,10 +100,9 @@ GLOBAL_LIST_EMPTY(wedge_icon_cache)
 	name = "Glass Airlock"
 	icon = 'icons/obj/doors/Doorglass.dmi'
 	hitsound = 'sound/effects/Glasshit.ogg'
-
 	maxhealth = 300
-	explosion_resistance = 5
 	resistance = RESISTANCE_AVERAGE
+	explosion_resistance = 5
 	opacity = 0
 	glass = 1
 
@@ -152,6 +151,7 @@ GLOBAL_LIST_EMPTY(wedge_icon_cache)
 	icon = 'icons/obj/doors/Doorcomglass.dmi'
 	hitsound = 'sound/effects/Glasshit.ogg'
 	maxhealth = 300
+	resistance = RESISTANCE_AVERAGE
 	explosion_resistance = 5
 	opacity = 0
 	assembly_type = /obj/structure/door_assembly/door_assembly_com
@@ -162,6 +162,7 @@ GLOBAL_LIST_EMPTY(wedge_icon_cache)
 	icon = 'icons/obj/doors/Doorengglass.dmi'
 	hitsound = 'sound/effects/Glasshit.ogg'
 	maxhealth = 300
+	resistance = RESISTANCE_AVERAGE
 	explosion_resistance = 5
 	opacity = 0
 	assembly_type = /obj/structure/door_assembly/door_assembly_eng
@@ -172,6 +173,7 @@ GLOBAL_LIST_EMPTY(wedge_icon_cache)
 	icon = 'icons/obj/doors/Doorsecglass.dmi'
 	hitsound = 'sound/effects/Glasshit.ogg'
 	maxhealth = 300
+	resistance = RESISTANCE_AVERAGE
 	explosion_resistance = 5
 	opacity = 0
 	assembly_type = /obj/structure/door_assembly/door_assembly_sec
@@ -182,6 +184,7 @@ GLOBAL_LIST_EMPTY(wedge_icon_cache)
 	icon = 'icons/obj/doors/Doormedglass.dmi'
 	hitsound = 'sound/effects/Glasshit.ogg'
 	maxhealth = 300
+	resistance = RESISTANCE_AVERAGE
 	explosion_resistance = 5
 	opacity = 0
 	assembly_type = /obj/structure/door_assembly/door_assembly_med
@@ -207,6 +210,7 @@ GLOBAL_LIST_EMPTY(wedge_icon_cache)
 	icon = 'icons/obj/doors/Doorresearchglass.dmi'
 	hitsound = 'sound/effects/Glasshit.ogg'
 	maxhealth = 300
+	resistance = RESISTANCE_AVERAGE
 	explosion_resistance = 5
 	opacity = 0
 	assembly_type = /obj/structure/door_assembly/door_assembly_research
@@ -218,6 +222,7 @@ GLOBAL_LIST_EMPTY(wedge_icon_cache)
 	icon = 'icons/obj/doors/Doorminingglass.dmi'
 	hitsound = 'sound/effects/Glasshit.ogg'
 	maxhealth = 300
+	resistance = RESISTANCE_AVERAGE
 	explosion_resistance = 5
 	opacity = 0
 	assembly_type = /obj/structure/door_assembly/door_assembly_min
@@ -228,6 +233,7 @@ GLOBAL_LIST_EMPTY(wedge_icon_cache)
 	icon = 'icons/obj/doors/Dooratmoglass.dmi'
 	hitsound = 'sound/effects/Glasshit.ogg'
 	maxhealth = 300
+	resistance = RESISTANCE_AVERAGE
 	explosion_resistance = 5
 	opacity = 0
 	assembly_type = /obj/structure/door_assembly/door_assembly_atmo
@@ -363,6 +369,8 @@ GLOBAL_LIST_EMPTY(wedge_icon_cache)
 /obj/machinery/door/airlock/glass_science
 	name = "Glass Airlocks"
 	icon = 'icons/obj/doors/Doorsciglass.dmi'
+	maxhealth = 300
+	resistance = RESISTANCE_AVERAGE
 	opacity = 0
 	assembly_type = /obj/structure/door_assembly/door_assembly_science
 	glass = 1

--- a/code/game/machinery/doors/showcase.dm
+++ b/code/game/machinery/doors/showcase.dm
@@ -4,7 +4,7 @@
 	icon_state = "closed"
 	health = 100
 	maxhealth = 100
-	resistance = 0
+	resistance = RESISTANCE_NONE
 	opacity = 0
 	layer = 4.2
 	var/have_glass = TRUE

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -23,7 +23,7 @@
 	var/raising= 0			//if the turret is currently opening or closing its cover
 	var/health = 80			//the turret's health
 	var/maxhealth = 80		//turrets maximal health.
-	var/resistance = 5 		//reduction on incoming damage
+	var/resistance = RESISTANCE_FRAGILE 		//reduction on incoming damage
 	var/auto_repair = 0		//if 1 the turret slowly repairs itself.
 	var/locked = 1			//if the turret's behaviour control access is locked
 	var/controllock = 0		//if the turret responds to control panels

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -107,6 +107,7 @@
 	name = "spear"
 	desc = "A haphazardly-constructed yet still deadly weapon of ancient design."
 	force = WEAPON_FORCE_PAINFUL
+	structure_damage_factor = STRUCTURE_DAMAGE_WEAK
 	w_class = ITEM_SIZE_LARGE
 	slot_flags = SLOT_BACK
 	force_divisor = 0.33          // 22 when wielded with hardness 15 (glass)

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -6,6 +6,7 @@
 	item_state = "toolbox_red"
 	flags = CONDUCT
 	force = WEAPON_FORCE_PAINFUL
+	structure_damage_factor = STRUCTURE_DAMAGE_BLUNT
 	throwforce = WEAPON_FORCE_NORMAL
 	throw_speed = 1
 	throw_range = 7

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -8,7 +8,7 @@
 	anchored = 1.0
 	flags = ON_BORDER
 	var/maxhealth = 20
-	var/resistance = 0	//Incoming damage is reduced by this flat amount before being subtracted from health
+	var/resistance = RESISTANCE_NONE	//Incoming damage is reduced by this flat amount before being subtracted from health. Defines found in code\__defines\weapons.dm
 	var/maximal_heat = T0C + 100 		// Maximal heat before this window begins taking damage from fire
 	var/damage_per_fire_tick = 2.0 		// Amount of damage per fire tick. Regular windows are not fireproof so they might as well break quickly.
 	var/health
@@ -518,7 +518,7 @@
 	maximal_heat = T0C + 200	// Was 100. Spaceship windows surely surpass coffee pots.
 	damage_per_fire_tick = 3.0	// Was 2. Made weaker than rglass per tick.
 	maxhealth = 15
-	resistance = 0
+	resistance = RESISTANCE_NONE
 
 /obj/structure/window/basic/full
 	dir = SOUTH|EAST
@@ -526,7 +526,7 @@
 	icon_state = "fwindow"
 	alpha = 120
 	maxhealth = 40
-	resistance = 2
+	resistance = RESISTANCE_NONE
 
 /obj/structure/window/plasmabasic
 	name = "plasma window"
@@ -538,7 +538,7 @@
 	maximal_heat = T0C + 5227  // Safe use temperature at 5500 kelvin. Easy to remember.
 	damage_per_fire_tick = 1.5 // Lowest per-tick damage so overheated supermatter chambers have some time to respond to it. Will still shatter before a delam.
 	maxhealth = 150
-	resistance = 8
+	resistance = RESISTANCE_AVERAGE
 
 /obj/structure/window/plasmabasic/full
 	dir = SOUTH|EAST
@@ -546,7 +546,7 @@
 	icon_state = "plasmawindow_mask"
 	alpha = 150
 	maxhealth = 200
-	resistance = 10
+	resistance = RESISTANCE_AVERAGE
 
 /obj/structure/window/reinforced
 	name = "reinforced window"
@@ -559,7 +559,7 @@
 	glasstype = /obj/item/stack/material/glass/reinforced
 
 	maxhealth = 50
-	resistance = 4
+	resistance = RESISTANCE_FRAGILE
 
 /obj/structure/window/New(Loc, constructed=0)
 	..()
@@ -574,7 +574,7 @@
 	icon_state = "fwindow"
 	alpha = 150
 	maxhealth = 80
-	resistance = 6
+	resistance = RESISTANCE_FRAGILE
 
 /obj/structure/window/reinforced/plasma
 	name = "reinforced plasma window"
@@ -586,7 +586,7 @@
 	maximal_heat = T0C + 5453 // Safe use temperature at 6000 kelvin.
 	damage_per_fire_tick = 1.5
 	maxhealth = 200
-	resistance = 10
+	resistance = RESISTANCE_IMPROVED
 
 /obj/structure/window/reinforced/plasma/full
 	dir = SOUTH|EAST
@@ -594,7 +594,7 @@
 	icon_state = "plasmarwindow_mask"
 	alpha = 150
 	maxhealth = 250
-	resistance = 12
+	resistance = RESISTANCE_IMPROVED
 
 /obj/structure/window/reinforced/tinted
 	name = "tinted window"
@@ -616,7 +616,7 @@
 	icon_state = "window"
 	basestate = "window"
 	maxhealth = 300
-	resistance = 12
+	resistance = RESISTANCE_IMPROVED
 	reinf = 1
 	basestate = "w"
 	dir = 5


### PR DESCRIPTION
Windows now use the defines set out in defines weapons.

Slightly tweaks said define values.

Fixes most glass airlocks having an incorrect resistance value, making them stronger than regular airlocks.