### PR TITLE
Fixes lighting_turf.dm,63

### DIFF
--- a/code/modules/lighting/lighting_setup.dm
+++ b/code/modules/lighting/lighting_setup.dm
@@ -14,3 +14,5 @@
 			continue
 
 		new /atom/movable/lighting_overlay(T, TRUE)
+		if (!T.lighting_corners_initialised)
+			T.generate_missing_corners()


### PR DESCRIPTION
Runtime was caused by improper initialization - turfs without any light would get no `lightning_corner` datums