### PR TITLE
Throwing mobs

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -273,6 +273,8 @@
 				M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been thrown by [usr.name] ([usr.ckey]) from [start_T_descriptor] with the target [end_T_descriptor]</font>")
 				usr.attack_log += text("\[[time_stamp()]\] <font color='red'>Has thrown [M.name] ([M.ckey]) from [start_T_descriptor] with the target [end_T_descriptor]</font>")
 				msg_admin_attack("[usr.name] ([usr.ckey]) has thrown [M.name] ([M.ckey]) from [start_T_descriptor] with the target [end_T_descriptor] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[usr.x];Y=[usr.y];Z=[usr.z]'>JMP</a>)")
+				item.throw_at(target, item.throw_range, item.throw_speed, src)
+				return
 
 	//Grab processing has a chance of returning null
 	if(item && src.unEquip(item, loc))


### PR DESCRIPTION
You gotta be kidding. 
There is cool if check in `/mob/living/carbon/throw_item(atom/target)` proc
https://github.com/discordia-space/CEV-Eris/blob/ddafebb29898d94125ac75f589e26766a696b367/code/modules/mob/living/carbon/carbon.dm#L278
Grab can't be unequipped, duh.

Sadly, it was there from 29.01.18 - https://github.com/discordia-space/CEV-Eris/commit/32114a9c4a7200e17d943fa55f152f49a9c6924c