### PR TITLE
[FIX] Excelsior implants's role removal works now.

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/excelsior.dm
+++ b/code/game/objects/items/weapons/implant/implants/excelsior.dm
@@ -26,7 +26,7 @@
 	implant = /obj/item/weapon/implant/excelsior
 
 /obj/item/weapon/implanter/excelsior
-	name = "broken implanter-complant"
+	name = "implanter-complant"
 	implant = /obj/item/weapon/implant/excelsior
 
 /obj/item/weapon/implant/excelsior/broken

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -211,8 +211,8 @@
 					obj.update_icon()
 					if(istype(obj,/obj/item/weapon/implant))
 						var/obj/item/weapon/implant/imp = obj
-						imp.wearer = null
-						imp.implanted = 0
+						imp.uninstall()
+						
 				playsound(target.loc, 'sound/effects/squelch1.ogg', 50, 1)
 			else
 				user.visible_message("\blue [user] removes \the [tool] from [target]'s [affected.name].", \


### PR DESCRIPTION
## General
All implants should be calling uninstall() when removing these implants by surgery or by cruciform.

Fixes #3308

## Changelog
🆑 TorinoFermic
fix: Excelsior role removal works now when removing the excelsior implant via surgery.
/🆑
