### PR TITLE
Adjusts MedSpec & Inspector skills, gives medspec access to multiple Security roles.

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -18,7 +18,7 @@
 	access = list(
 		access_security, access_eva, access_sec_doors, access_brig, access_armory, access_medspec,
 		access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
-		access_moebius, access_engine, access_mining, access_moebius, access_construction, access_mailsorting,
+		access_moebius, access_engine, access_mining, access_construction, access_mailsorting,
 		access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway,
 		access_external_airlocks
 	)
@@ -50,11 +50,11 @@
 		Your second loyalty is to the name and reputation of the ironhammer company. You are often the captain's primary tool in keeping order and you must pride yourself on ensuring commands are carried out, threats extinguished and safety preserved. You may need to carry out unsavory orders like executions, and must balance your professional pride versus your conscience.<br>\
 		<br>\
 		Your third loyalty is to the crew. As the strongest military force on the ship, any mutiny attempt is likely at your mercy, and if unjustified, it will fall to you to put it down. If the captain has gone mad and a mutiny is justified, your support will be the difference between a peaceful arrest and a bloody civil war in the halls. Without your guns, an insane captain will usually be forced to surrender."
+
 /obj/landmark/join/start/ihc
 	name = "Ironhammer Commander"
 	icon_state = "player-blue-officer"
 	join_tag = /datum/job/ihc
-
 
 
 /datum/job/gunserg
@@ -74,7 +74,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/security/gunserg
 
 	access = list(
-		access_security, access_moebius, access_moebius, access_engine, access_mailsorting,
+		access_security, access_moebius, access_medspec, access_engine, access_mailsorting,
 		access_eva, access_sec_doors, access_brig, access_armory, access_maint_tunnels, access_morgue,
 		access_external_airlocks
 	)
@@ -87,7 +87,6 @@
 
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
 							 /datum/computer_file/program/camera_monitor)
-
 
 	description = "You are the Second-in-Command of the local Ironhammer regiment, and the defacto leader if the commander isn't around. <br>\
 	Within ironhammer you largely hold a desk job, your duties will rarely take you outside of the Ironhammer wing, and you are not expected to interact with civilians. You have enough to deal with as is, and are probably the hardest working member of Ironhammer.<br>\
@@ -121,16 +120,17 @@
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
 	also_known_languages = list(LANGUAGE_CYRILLIC = 50, LANGUAGE_SERBIAN = 50)
+
+	outfit_type = /decl/hierarchy/outfit/job/security/inspector
+
 	access = list(
-		access_security, access_moebius, access_moebius, access_engine, access_mailsorting,
+		access_security, access_moebius, access_medspec, access_engine, access_mailsorting,
 		access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels,
 		access_external_airlocks
 	)
 
-	outfit_type = /decl/hierarchy/outfit/job/security/inspector
-
 	stat_modifiers = list(
-		STAT_BIO = 20,
+		STAT_BIO = 15,
 		STAT_ROB = 15,
 		STAT_TGH = 15,
 		STAT_VIG = 25,
@@ -176,20 +176,20 @@
 	also_known_languages = list(LANGUAGE_CYRILLIC = 5)
 
 	outfit_type = /decl/hierarchy/outfit/job/security/medspec
+
 	access = list(
 		access_security, access_moebius, access_sec_doors, access_medspec, access_morgue, access_maint_tunnels, access_medical_equip
 	)
 
 	stat_modifiers = list(
-		STAT_BIO = 20,
+		STAT_BIO = 25,
 		STAT_TGH = 5,
-		STAT_VIG = 30,
+		STAT_VIG = 15,
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
 							 /datum/computer_file/program/suit_sensors,
 							 /datum/computer_file/program/camera_monitor)
-
 
 	description = "You are a highly trained specialist within Ironhammer. You were probably a medical student or inexperienced doctor when you joined Ironhammer, and you thusly have a combination of medical and military training. You are not quite as knowledgeable as a civilian career doctor, not quite as much of a fighter as a dedicated IH operative, but strike a balance inbetween. Balance is the nature of your existence.<br>\
 	<br>\
@@ -228,8 +228,8 @@
 	outfit_type = /decl/hierarchy/outfit/job/security/ihoper
 
 	access = list(
-		access_security, access_moebius, access_moebius, access_engine, access_mailsorting,
-		access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks
+		access_security, access_moebius, access_engine, access_mailsorting,access_eva,
+		access_sec_doors, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks
 	)
 
 	stat_modifiers = list(
@@ -251,7 +251,6 @@
 	<br>\
 	You have almost-total access to the ship in order to carry out your duties and reach threats quickly. Do not abuse this. It does not mean you can walk into anywhere you like, many areas are full of sensitive machinery and entering unnanounced can be harmful to your health. Do not steal from departments either. If it's not in the ironhammer wing, it doesn't belong to you. Stealing from the Guild is a good way to get shot in the back"
 
-
 	duties = "		Patrol the ship, provide a security presence, and look for trouble<br>\
 		Subdue and arrest criminals, terrorists, and other threats<br>\
 		Exterminate monsters, giant vermin and hostile xenos<br>\
@@ -263,7 +262,9 @@
 		Your second loyalty is to your fellow ironhammer brothers in arms. As long as the company takes care of you, you should follow orders. But if you start being sent on suicide missions and treated as expendable fodder, that should change.<br>\
 		<br>\
 		Your third loyalty is to humanity. You are still human under all that armour. If you're being ordered to slaughter civilians en masse, it may be time to start thinking for yourself."
+
 /obj/landmark/join/start/ihoper
 	name = "Ironhammer Operative"
 	icon_state = "player-blue"
 	join_tag = /datum/job/ihoper
+

--- a/html/changelogs/Kurgis-PR-SkillAdjustmentsMedSpec.yml
+++ b/html/changelogs/Kurgis-PR-SkillAdjustmentsMedSpec.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Kurgis
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Inspector stats adjusted to focus less on Biology skill. MedSpec stats adjusted to focus on Biology skill instead of Vigilance."
+  - tweak: "Gunnery Sergeant given MedSpec access, as it's essentially an extension of the Brig. Inspector given MedSpec access, as it's important for forensics."


### PR DESCRIPTION
Inspector stats adjusted to focus less on Biology skill. MedSpec stats adjusted to focus on Biology skill instead of Vigilance.

Gunnery Sergeant given MedSpec access, as it's essentially an extension of the Brig. Inspector given MedSpec access, as it's important for forensics.


Here's some reasoning for the stat changes, and some comparisons.
First, regarding the MedSpec's stat changes:
1. The MedSpec had the second highest VIG stat on the ship, higher than every role except the IH Commander.
2. The Inspector was inferior to the MedSpec, as they held both the same BIO stat, the MedSpec's higher VIG stat, and their lack of access to use forensic machinery.
3. MedSpec is support staff for the IronHammer Division, they shouldn't be able to operate on their own.

Second, regarding the Inspector's stat changes:
1. The Inspector's BIO stats are for performing autopsies, a stat of BIO 20 puts them on the level of the Paramedic. It also conflicts with the MedSpec's role as a Medical professional.


Now, lets compare three roles which are quite similar. The IronHammer Medical Specialist, IronHammer Inspector, and Moebius Paramedic. _Note, this PR does not change the Paramedic's stats, it's here for comparison purposes._
**Inspector:**
	STAT_BIO = 15,
	STAT_ROB = 15,
	STAT_TGH = 15,
	STAT_VIG = 25,

**IronHammer Medical Specialist:**
	STAT_BIO = 25,
	STAT_TGH = 5,
	STAT_VIG = 15,

**Moebius Paramedic:**
	STAT_BIO = 20,
	STAT_ROB = 10,
	STAT_TGH = 10,
	STAT_VIG = 10,

The IronHammer Medical Specialist has gone through a formal education for years, albeit of course not as long as Moebius Doctors, but has whatever the future's equivalent of a Master's is. They have also of course been given self-defense courses on how to use a firearm by IronHammer, but not a physical course like the Operatives. Unlike the Paramedic, the Medical Specialist isn't stabilizing prisoners to transfer over to MedBay, he has a fully stocked work station, and should be expected to be giving advanced treatment himself.

You may note the Medical Specialists lack of ROB and TGH stats, which are quite necessary when handling many Civilian prisoners who happen to have both stats in return. This is an intentional choice, not only because it separates them from the Paramedic, but because the MedSpec should be working with the Gunnery Sergeant or a Operative when handling prisoners.