### PR TITLE
Crew sensors improve and some organ refactor

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -88,11 +88,12 @@
 #define BP_ALL_LIMBS list(BP_CHEST, BP_GROIN, BP_HEAD, BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG)
 #define BP_BY_DEPTH list(BP_HEAD, BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_GROIN, BP_CHEST)
 
-// Prosthetic helpers.
-#define BP_IS_ROBOTIC(org)  (org.status & ORGAN_ROBOTIC)
-#define BP_IS_ASSISTED(org) (org.status & ORGAN_ASSISTED)
-#define BP_IS_BRITTLE(org)  (org.status & ORGAN_BRITTLE)
-#define BP_IS_CRYSTAL(org)  (org.status & ORGAN_CRYSTAL)
+// Organs helpers.
+#define BP_IS_ORGANIC(org)  (org.nature & MODIFICATION_ORGANIC)
+#define BP_IS_ROBOTIC(org) (org.nature & MODIFICATION_SILICON)
+#define BP_IS_REMOVED(org) (org.nature & MODIFICATION_REMOVED)
+#define BP_IS_ASSISTED(org) (org.nature & MODIFICATION_ASSISTED)
+#define BP_IS_LIFELIKE(org) (org.nature & MODIFICATION_LIFELIKE)
 
 
 // Organ defines.
@@ -108,9 +109,11 @@
 #define DROPLIMB_BLUNT 1
 #define DROPLIMB_BURN 2
 
-#define ORGAN_ASSISTED 1 // Like pacemakers, not robotic
-#define ORGAN_ROBOT    2 // Fully robotic, no organic parts
-#define ORGAN_LIFELIKE 3 // Robotic, made to appear organic
+#define MODIFICATION_ORGANIC 0	// Organic
+#define MODIFICATION_ASSISTED 1 // Like pacemakers, not robotic
+#define MODIFICATION_SILICON 2	// Fully robotic, no organic parts
+#define MODIFICATION_LIFELIKE 3	// Robotic, made to appear organic
+#define MODIFICATION_REMOVED 4	// Removed completly
 
 #define ORGAN_PROCESS_ACCURACY 10
 
@@ -124,6 +127,3 @@
 #define INFECTION_LEVEL_ONE   100
 #define INFECTION_LEVEL_TWO   500
 #define INFECTION_LEVEL_THREE 1000
-
-//plug before baymed
-#define BP_IS_ROBOTIC(org)  (org.status & ORGAN_ROBOT)

--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -89,11 +89,12 @@
 #define BP_BY_DEPTH list(BP_HEAD, BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_GROIN, BP_CHEST)
 
 // Organs helpers.
-#define BP_IS_ORGANIC(org)  (org.nature & MODIFICATION_ORGANIC)
-#define BP_IS_ROBOTIC(org) (org.nature & MODIFICATION_SILICON)
-#define BP_IS_REMOVED(org) (org.nature & MODIFICATION_REMOVED)
-#define BP_IS_ASSISTED(org) (org.nature & MODIFICATION_ASSISTED)
-#define BP_IS_LIFELIKE(org) (org.nature & MODIFICATION_LIFELIKE)
+#define BP_IS_ORGANIC(org)  (org.nature == MODIFICATION_ORGANIC)
+#define BP_IS_ROBOTIC(org) (org.nature == MODIFICATION_SILICON || org.nature == MODIFICATION_LIFELIKE)
+#define BP_IS_SILICON(org) (org.nature == MODIFICATION_SILICON)	// Prothetics that are obvious
+#define BP_IS_REMOVED(org) (org.nature == MODIFICATION_REMOVED)
+#define BP_IS_ASSISTED(org) (org.nature == MODIFICATION_ASSISTED)
+#define BP_IS_LIFELIKE(org) (org.nature == MODIFICATION_LIFELIKE)
 
 
 // Organ defines.

--- a/code/datums/repositories/crew/crew.dm
+++ b/code/datums/repositories/crew/crew.dm
@@ -54,11 +54,17 @@ var/global/datum/repository/crew/crew_repository = new()
 		if(C.has_sensor && pos && pos.z == z_level && C.sensor_mode != SUIT_SENSOR_OFF)
 			if(istype(C.loc, /mob/living/carbon/human))
 				var/mob/living/carbon/human/H = C.loc
+
 				if(H.w_uniform != C)
 					continue
 
 				var/list/crewmemberData = list("sensor_type"=C.sensor_mode, "stat"=H.stat, "area"="", "x"=-1, "y"=-1, "z"=-1, "ref"="\ref[H]")
 				if(!(run_queues(H, C, pos, crewmemberData) & MOD_SUIT_SENSORS_REJECTED))
+					var/datum/computer_file/report/crew_record/CR = get_crewmember_record(crewmemberData["name"])
+					if(CR)
+						// We wont include sensors of deceased people
+						if(CR.get_status() == "Deceased")
+							continue
 					crewmembers[++crewmembers.len] = crewmemberData
 					if (crewmemberData["alert"])
 						cache_data_alert[num2text(z_level)] = TRUE

--- a/code/datums/repositories/crew/general.dm
+++ b/code/datums/repositories/crew/general.dm
@@ -3,6 +3,11 @@
 	crew_data["name"] = H.get_authentification_name(if_no_id="Unknown")
 	crew_data["rank"] = H.get_authentification_rank(if_no_id="Unknown", if_no_job="No Job")
 	crew_data["assignment"] = H.get_assignment(if_no_id="Unknown", if_no_job="No Job")
+
+	var/datum/computer_file/report/crew_record/CR = get_crewmember_record(crew_data["name"])		
+	if(CR)
+		if(CR.get_criminalStatus() == "*Arrest*" || CR.get_criminalStatus() == "Incarcerated")
+			crew_data["isCriminal"] = TRUE
 	return ..()
 
 /* Jamming */

--- a/code/datums/repositories/crew/vital.dm
+++ b/code/datums/repositories/crew/vital.dm
@@ -67,6 +67,10 @@
 					crew_data["pulse_span"] = "average"
 				if(PULSE_THREADY)
 					crew_data["pulse_span"] = "bad"
+		else if(BP_IS_ROBOTIC(O))
+			crew_data["true_pulse"] = -1
+			crew_data["pulse_span"] = "highlight"
+			crew_data["pulse"] = "synthetic"
 
 	crew_data["pressure"] = "N/A"
 	crew_data["true_oxygenation"] = -1

--- a/code/datums/repositories/crew/vital.dm
+++ b/code/datums/repositories/crew/vital.dm
@@ -56,6 +56,7 @@
 			crew_data["pulse"] = H.get_pulse(1)
 			switch(crew_data["true_pulse"])
 				if(PULSE_NONE)
+					crew_data["alert"] = TRUE
 					crew_data["pulse_span"] = "bad"
 				if(PULSE_SLOW)
 					crew_data["pulse_span"] = "average"
@@ -66,11 +67,14 @@
 				if(PULSE_2FAST)
 					crew_data["pulse_span"] = "average"
 				if(PULSE_THREADY)
+					crew_data["alert"] = TRUE
 					crew_data["pulse_span"] = "bad"
 		else if(BP_IS_ROBOTIC(O))
-			crew_data["true_pulse"] = -1
 			crew_data["pulse_span"] = "highlight"
 			crew_data["pulse"] = "synthetic"
+	else
+		crew_data["pulse_span"] = "highlight"
+		crew_data["pulse"] = "synthetic"
 
 	crew_data["pressure"] = "N/A"
 	crew_data["true_oxygenation"] = -1
@@ -81,9 +85,11 @@
 		crew_data["true_oxygenation"] = H.getOxyLoss()
 		switch (crew_data["true_oxygenation"])
 			if(40 to INFINITY)
+				crew_data["alert"] = TRUE
 				crew_data["oxygenation"] = "extremely low"
 				crew_data["oxygenation_span"] = "bad"
 			if(20 to 40)
+				crew_data["alert"] = TRUE
 				crew_data["oxygenation"] = "very low"
 				crew_data["oxygenation_span"] = "bad"
 			if(10 to 20)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -318,11 +318,10 @@
 			bled = "Bleeding:"
 		if(e.status & ORGAN_BROKEN)
 			AN = "[e.broken_description]:"
-		switch(e.robotic)
-			if(ORGAN_ASSISTED)
-				robot = "Assisted:"
-			if(ORGAN_ROBOT)
-				robot = "Prosthetic:"
+		if(BP_IS_ASSISTED(e))
+			robot = "Assisted:"
+		if(BP_IS_ROBOTIC(e))
+			robot = "Prosthetic:"
 		if(e.open)
 			open = "Open:"
 
@@ -365,11 +364,10 @@
 	for(var/obj/item/organ/I in occ["internal_organs"])
 
 		var/mech = ""
-		switch(I.robotic)
-			if(ORGAN_ASSISTED)
-				mech = "Assisted:"
-			if(ORGAN_ROBOT)
-				mech = "Mechanical:"
+		if(BP_IS_ASSISTED(I))
+			mech = "Assisted:"
+		if(BP_IS_ROBOTIC(I))
+			mech = "Prosthetic:"
 
 		var/infection = "None"
 		switch (I.germ_level)

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -48,7 +48,7 @@
 		var/obj/item/organ/O = new new_organ(get_turf(src))
 
 		if(prints_prosthetics)
-			O.robotic = ORGAN_ROBOT
+			O.nature = MODIFICATION_SILICON
 		else if(loaded_dna)
 			visible_message("<span class='notice'>The printer injects the stored DNA into the biomass.</span>.")
 			O.transplant_data = list()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -296,7 +296,7 @@
 		eyes.damage += rand(3,4)
 		if(eyes.damage >= eyes.min_bruised_damage)
 			if(M.stat != DEAD)
-				if(eyes.robotic <= ORGAN_ASSISTED) //robot eyes bleeding might be a bit silly
+				if(BP_IS_ORGANIC(eyes) || BP_IS_ASSISTED(eyes)) //robot eyes bleeding might be a bit silly
 					M << SPAN_DANGER("Your eyes start to bleed profusely!")
 			if(prob(50))
 				if(M.stat != DEAD)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -123,7 +123,7 @@ REAGENT SCANNER
 			for(var/obj/item/organ/external/org in damaged)
 				user.show_message(text("<span class='notice'>     [][]: [][] - []</span>",
 				capitalize(org.name),
-				(BP_IS_ROBOTIC(org) || BP_IS_LIFELIKE(org)) ? "(Cybernetic)" : "",
+				(BP_IS_ROBOTIC(org)) ? "(Cybernetic)" : "",
 				(org.brute_dam > 0) ? SPAN_WARNING("[org.brute_dam]") : 0,
 				(org.status & ORGAN_BLEEDING)?SPAN_DANGER("\[Bleeding\]"):"",
 				(org.burn_dam > 0) ? "<font color='#FFA500'>[org.burn_dam]</font>" : 0), 1)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -123,7 +123,7 @@ REAGENT SCANNER
 			for(var/obj/item/organ/external/org in damaged)
 				user.show_message(text("<span class='notice'>     [][]: [][] - []</span>",
 				capitalize(org.name),
-				(org.robotic >= ORGAN_ROBOT) ? "(Cybernetic)" : "",
+				(BP_IS_ROBOTIC(org) || BP_IS_LIFELIKE(org)) ? "(Cybernetic)" : "",
 				(org.brute_dam > 0) ? SPAN_WARNING("[org.brute_dam]") : 0,
 				(org.status & ORGAN_BLEEDING)?SPAN_DANGER("\[Bleeding\]"):"",
 				(org.burn_dam > 0) ? "<font color='#FFA500'>[org.burn_dam]</font>" : 0), 1)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -38,7 +38,25 @@
 				user << SPAN_WARNING("You can't apply [src] through [H.wear_suit]!")
 				return 1
 
-		if(BP_IS_ROBOTIC(affecting) || BP_IS_LIFELIKE(affecting))
+		if(BP_IS_ROBOTIC(affecting))
+			// user is clueless
+			if(BP_IS_LIFELIKE(affecting) && user.stats.getStat(STAT_BIO) < STAT_LEVEL_BASIC)
+				user.visible_message( \
+				SPAN_NOTICE("[user] starts applying [src] to [M]."), \
+				SPAN_NOTICE("You start applying [src] to [M].") \
+				)
+				if (do_after(user, 30, M))
+					if(prob(10 + user.stats.getStat(STAT_BIO)))
+						user << SPAN_NOTICE("You have managed to waste less [src].")
+					else
+						use(1)
+					user.visible_message( \
+						SPAN_NOTICE("[M] starts has been applied with [src] by [user]."), \
+						SPAN_NOTICE("You apply [src] to [M].") \
+					)
+				M.updatehealth()
+				return 1
+				
 			user << SPAN_WARNING("This isn't useful at all on a robotic limb.")
 			return 1
 
@@ -107,7 +125,6 @@
 					if(!do_mob(user, M, W.damage/5))
 						user << SPAN_NOTICE("You must stand still to bandage wounds.")
 						break
-
 					if (W.current_stage <= W.max_bleeding_stage)
 						user.visible_message(
 							SPAN_NOTICE("\The [user] bandages \a [W.desc] on [M]'s [affecting.name]."),
@@ -125,6 +142,16 @@
 							SPAN_NOTICE("You place a bandaid over \a [W.desc] on [M]'s [affecting.name].")
 						)
 					W.bandage()
+					// user's stat check that causing pain if they are amateurs
+					if(user && user.stats.getStat(STAT_BIO) < STAT_LEVEL_BASIC)
+						if(prob(affecting.get_damage() - user.stats.getStat(STAT_BIO)))
+							var/pain = rand(min(30,affecting.get_damage()), max(affecting.get_damage() + 30,60) - user.stats.getStat(STAT_BIO))
+							H.pain(affecting, pain)
+							if(user != H)
+								to_chat(H, "<span class='[pain > 50 ? "danger" : "warning"]'>\The [user]'s amateur actions caused you [pain > 50 ? "alot of " : ""]pain.</span>")
+								to_chat(user, SPAN_WARNING("Your amateur actions caused [H] [pain > 50 ? "alot of " : ""]pain."))
+							else
+								to_chat(user, "<span class='[pain > 50 ? "danger" : "warning"]'>Your amateur actions caused you [pain > 50 ? "alot of " : ""]pain.</span>")
 					if(prob(10 + user.stats.getStat(STAT_BIO)))
 						user << SPAN_NOTICE("You have managed to waste less [src].")
 					else
@@ -191,6 +218,16 @@
 				else
 					use(1)
 				affecting.salve()
+				// user's stat check that causing pain if they are amateurs
+				if(user && user.stats.getStat(STAT_BIO) < STAT_LEVEL_BASIC)
+					if(prob(affecting.get_damage() - user.stats.getStat(STAT_BIO)))
+						var/pain = rand(min(30,affecting.get_damage()), max(affecting.get_damage() + 30,60) - user.stats.getStat(STAT_BIO))
+						H.pain(affecting, pain)
+						if(user != H)
+							to_chat(H, "<span class='[pain > 50 ? "danger" : "warning"]'>\The [user]'s amateur actions caused you [pain > 50 ? "alot of " : ""]pain.</span>")
+							to_chat(user, SPAN_WARNING("Your amateur actions caused [H] [pain > 50 ? "alot of " : ""]pain."))
+						else
+							to_chat(user, "<span class='[pain > 50 ? "danger" : "warning"]'>Your amateur actions caused you [pain > 50 ? "alot of " : ""]pain.</span>")
 		else
 			if (can_operate(H))        //Checks if mob is lying down on table for surgery
 				if (do_surgery(H,user,src))
@@ -263,6 +300,16 @@
 				else
 					used++
 			affecting.update_damages()
+			// user's stat check that causing pain if they are amateurs
+			if(user && user.stats.getStat(STAT_BIO) < STAT_LEVEL_BASIC)
+				if(prob(affecting.get_damage() - user.stats.getStat(STAT_BIO)))
+					var/pain = rand(min(30,affecting.get_damage()), max(affecting.get_damage() + 30,60) - user.stats.getStat(STAT_BIO))
+					H.pain(affecting, pain)
+					if(user != H)
+						to_chat(H, "<span class='[pain > 50 ? "danger" : "warning"]'>\The [user]'s amateur actions caused you [pain > 50 ? "alot of " : ""]pain.</span>")
+						to_chat(user, SPAN_WARNING("Your amateur actions caused [H] [pain > 50 ? "alot of " : ""]pain."))
+					else
+						to_chat(user, "<span class='[pain > 50 ? "danger" : "warning"]'>Your amateur actions caused you [pain > 50 ? "alot of " : ""]pain.</span>")
 			if(used == amount)
 				if(affecting.is_bandaged())
 					user << SPAN_WARNING("\The [src] is used up.")
@@ -319,6 +366,16 @@
 				else
 					use(1)
 				affecting.salve()
+				// user's stat check that causing pain if they are amateurs
+				if(user && user.stats.getStat(STAT_BIO) < STAT_LEVEL_BASIC)
+					if(prob(affecting.get_damage() - user.stats.getStat(STAT_BIO)))
+						var/pain = rand(min(30,affecting.get_damage()), max(affecting.get_damage() + 30,60) - user.stats.getStat(STAT_BIO))
+						H.pain(affecting, pain)
+						if(user != H)
+							to_chat(H, "<span class='[pain > 50 ? "danger" : "warning"]'>\The [user]'s amateur actions caused you [pain > 50 ? "alot of " : ""]pain.</span>")
+							to_chat(user, SPAN_WARNING("Your amateur actions caused [H] [pain > 50 ? "alot of " : ""]pain."))
+						else
+							to_chat(user, "<span class='[pain > 50 ? "danger" : "warning"]'>Your amateur actions caused you [pain > 50 ? "alot of " : ""]pain.</span>")
 		else
 			if (can_operate(H))        //Checks if mob is lying down on table for surgery
 				if (do_surgery(H,user,src))

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -38,7 +38,7 @@
 				user << SPAN_WARNING("You can't apply [src] through [H.wear_suit]!")
 				return 1
 
-		if(affecting.robotic >= ORGAN_ROBOT)
+		if(BP_IS_ROBOTIC(affecting) || BP_IS_LIFELIKE(affecting))
 			user << SPAN_WARNING("This isn't useful at all on a robotic limb.")
 			return 1
 

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -34,7 +34,7 @@
 		var/obj/item/organ/external/S = H.get_organ(user.targeted_organ)
 
 		if(S && S.open == 1)
-			if(BP_IS_ROBOTIC(S) || BP_IS_LIFELIKE(S))
+			if(BP_IS_ROBOTIC(S))
 				if(S.get_damage())
 					user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 					S.heal_damage(15, 15, robo_repair = 1)

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -34,7 +34,7 @@
 		var/obj/item/organ/external/S = H.get_organ(user.targeted_organ)
 
 		if(S && S.open == 1)
-			if(S.robotic >= ORGAN_ROBOT)
+			if(BP_IS_ROBOTIC(S) || BP_IS_LIFELIKE(S))
 				if(S.get_damage())
 					user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 					S.heal_damage(15, 15, robo_repair = 1)

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -162,7 +162,7 @@
 				var/picked = pick(check)
 				var/obj/item/organ/external/affecting = H.get_organ(picked)
 				if(affecting)
-					if(affecting.robotic >= ORGAN_ROBOT)
+					if(BP_IS_ROBOTIC(affecting) || BP_IS_LIFELIKE(affecting))
 						return
 					if(affecting.take_damage(5, 0))
 						H.UpdateDamageIcon()

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -162,7 +162,7 @@
 				var/picked = pick(check)
 				var/obj/item/organ/external/affecting = H.get_organ(picked)
 				if(affecting)
-					if(BP_IS_ROBOTIC(affecting) || BP_IS_LIFELIKE(affecting))
+					if(BP_IS_ROBOTIC(affecting))
 						return
 					if(affecting.take_damage(5, 0))
 						H.UpdateDamageIcon()

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -862,7 +862,7 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.organs_by_name[user.targeted_organ]
 
-		if (!istype(S) || !(BP_IS_ROBOTIC(S) || BP_IS_LIFELIKE(S)))
+		if (!istype(S) || !BP_IS_ROBOTIC(S))
 			return ..()
 
 		if (get_tool_type(user, list(QUALITY_WELDING), H)) //Prosthetic repair

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -862,7 +862,7 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.organs_by_name[user.targeted_organ]
 
-		if (!istype(S) || S.robotic < ORGAN_ROBOT)
+		if (!istype(S) || !(BP_IS_ROBOTIC(S) || BP_IS_LIFELIKE(S)))
 			return ..()
 
 		if (get_tool_type(user, list(QUALITY_WELDING), H)) //Prosthetic repair

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -91,6 +91,7 @@
 	icon_state = "stethoscope"
 
 /obj/item/clothing/accessory/stethoscope/attack(mob/living/carbon/human/M, mob/living/user)
+	// TODO: baymed, rework this to use something like get_heartbeat()
 	if(ishuman(M) && isliving(user))
 		if(user.a_intent == I_HELP)
 			var/body_part = parse_zone(user.targeted_organ)
@@ -105,7 +106,7 @@
 				var/heartbeat = 0
 				if(M.species && M.species.has_organ[BP_HEART])
 					var/obj/item/organ/internal/heart/heart = M.internal_organs_by_name[BP_HEART]
-					if(heart && !(BP_IS_ROBOTIC(heart) || BP_IS_LIFELIKE(heart)))
+					if(heart && !BP_IS_ROBOTIC(heart))
 						heartbeat = 1
 				if(M.stat == DEAD || (M.status_flags&FAKEDEATH))
 					sound_strength = "cannot hear"

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -105,7 +105,7 @@
 				var/heartbeat = 0
 				if(M.species && M.species.has_organ[BP_HEART])
 					var/obj/item/organ/internal/heart/heart = M.internal_organs_by_name[BP_HEART]
-					if(heart && !heart.robotic)
+					if(heart && !(BP_IS_ROBOTIC(heart) || BP_IS_LIFELIKE(heart)))
 						heartbeat = 1
 				if(M.stat == DEAD || (M.status_flags&FAKEDEATH))
 					sound_strength = "cannot hear"

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -85,13 +85,11 @@
 /obj/item/organ/internal/brain/slime
 	name = "slime core"
 	desc = "A complex, organic knot of jelly and crystalline particles."
-	robotic = 2
 	icon = 'icons/mob/slimes.dmi'
 	icon_state = "green slime extract"
 
 /obj/item/organ/internal/brain/golem
 	name = "chem"
 	desc = "A tightly furled roll of paper, covered with indecipherable runes."
-	robotic = 2
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "scroll"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -240,7 +240,7 @@
 
 	for(var/obj/item/organ/external/temp in organs)
 		if(temp)
-			if(temp.robotic >= ORGAN_ROBOT)
+			if(BP_IS_ROBOTIC(temp) || BP_IS_LIFELIKE(temp))
 				if(!(temp.brute_dam + temp.burn_dam))
 					wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] [T.has] a robot [temp.name]!</span>\n"
 					continue

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -240,7 +240,7 @@
 
 	for(var/obj/item/organ/external/temp in organs)
 		if(temp)
-			if(BP_IS_ROBOTIC(temp) || BP_IS_LIFELIKE(temp))
+			if(BP_IS_SILICON(temp))
 				if(!(temp.brute_dam + temp.burn_dam))
 					wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] [T.has] a robot [temp.name]!</span>\n"
 					continue

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1247,7 +1247,6 @@ var/list/rank_prefix = list(\
 
 /mob/living/carbon/human/can_inject(var/mob/user, var/error_msg, var/target_zone)
 	. = 1
-
 	if(!target_zone)
 		if(user)
 			target_zone = user.targeted_organ
@@ -1264,7 +1263,7 @@ var/list/rank_prefix = list(\
 	if(!affecting)
 		. = 0
 		fail_msg = "They are missing that limb."
-	else if (BP_IS_ROBOTIC(affecting) || BP_IS_LIFELIKE(affecting))
+	else if (BP_IS_ROBOTIC(affecting))
 		. = 0
 		fail_msg = "That limb is robotic."
 	else
@@ -1276,7 +1275,9 @@ var/list/rank_prefix = list(\
 				if(wear_suit && wear_suit.item_flags & THICKMATERIAL)
 					. = 0
 	if(!. && error_msg && user)
-		if(!fail_msg)
+		if(BP_IS_LIFELIKE(affecting) && user.stats.getStat(STAT_BIO) < STAT_LEVEL_BASIC)
+			fail_msg = "Skin is tough and inelastic."
+		else if(!fail_msg)
 			fail_msg = "There is no exposed flesh or thin material [target_zone == BP_HEAD ? "on their head" : "on their body"] to inject into."
 		to_chat(user, SPAN_WARNING(fail_msg))
 
@@ -1467,11 +1468,11 @@ var/list/rank_prefix = list(\
 	else if(organ_check in list(BP_LIVER, BP_KIDNEYS))
 		affecting = organs_by_name[BP_GROIN]
 
-	if(affecting && (BP_IS_ROBOTIC(affecting) || BP_IS_LIFELIKE(affecting)))
+	if(affecting && (BP_IS_ROBOTIC(affecting)))
 		return FALSE
 	return (species && species.has_organ[organ_check])
 
-/mob/living/carbon/human/has_appendage(var/appendage_check)	//returns TRUE if found, 2 or 3 if limb is robotic, FALSE if not found
+/mob/living/carbon/human/has_appendage(var/appendage_check)	//returns TRUE if found, type of organ modification if limb is robotic, FALSE if not found
 
 	if (appendage_check == BP_CHEST)
 		return TRUE
@@ -1480,8 +1481,7 @@ var/list/rank_prefix = list(\
 	appendage = organs_by_name[appendage_check]
 
 	if(appendage && !appendage.is_stump())
-		if(BP_IS_ROBOTIC(appendage) || BP_IS_LIFELIKE(appendage))
-			// CHECK THIS RETURN
+		if(BP_IS_ROBOTIC(appendage))
 			return appendage.nature
 		else return TRUE
 	return FALSE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1255,7 +1255,7 @@ var/list/rank_prefix = list(\
 			// Pick an existing non-robotic limb, if possible.
 			for(target_zone in BP_ALL_LIMBS)
 				var/obj/item/organ/external/affecting = get_organ(target_zone)
-				if(affecting && affecting.robotic < ORGAN_ROBOT)
+				if(affecting && BP_IS_ORGANIC(affecting) || BP_IS_ASSISTED(affecting))
 					break
 
 
@@ -1264,7 +1264,7 @@ var/list/rank_prefix = list(\
 	if(!affecting)
 		. = 0
 		fail_msg = "They are missing that limb."
-	else if (affecting.robotic >= ORGAN_ROBOT)
+	else if (BP_IS_ROBOTIC(affecting) || BP_IS_LIFELIKE(affecting))
 		. = 0
 		fail_msg = "That limb is robotic."
 	else
@@ -1467,7 +1467,7 @@ var/list/rank_prefix = list(\
 	else if(organ_check in list(BP_LIVER, BP_KIDNEYS))
 		affecting = organs_by_name[BP_GROIN]
 
-	if(affecting && (affecting.robotic >= ORGAN_ROBOT))
+	if(affecting && (BP_IS_ROBOTIC(affecting) || BP_IS_LIFELIKE(affecting)))
 		return FALSE
 	return (species && species.has_organ[organ_check])
 
@@ -1480,8 +1480,9 @@ var/list/rank_prefix = list(\
 	appendage = organs_by_name[appendage_check]
 
 	if(appendage && !appendage.is_stump())
-		if(appendage.robotic >= ORGAN_ROBOT)
-			return appendage.robotic
+		if(BP_IS_ROBOTIC(appendage) || BP_IS_LIFELIKE(appendage))
+			// CHECK THIS RETURN
+			return appendage.nature
 		else return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -8,7 +8,7 @@
 	var/total_burn  = 0
 	var/total_brute = 0
 	for(var/obj/item/organ/external/O in organs)	//hardcoded to streamline things a bit
-		if((O.robotic >= ORGAN_ROBOT) && !O.vital)
+		if((BP_IS_ROBOTIC(O) || BP_IS_LIFELIKE(O)) && !O.vital)
 			continue //*non-vital* robot limbs don't count towards shock and crit
 		total_brute += O.brute_dam
 		total_burn  += O.burn_dam
@@ -70,7 +70,7 @@
 /mob/living/carbon/human/getBruteLoss()
 	var/amount = 0
 	for(var/obj/item/organ/external/O in organs)
-		if(O.robotic >= ORGAN_ROBOT)
+		if(BP_IS_ROBOTIC(O) || BP_IS_LIFELIKE(O))
 			continue //robot limbs don't count towards shock and crit
 		amount += O.brute_dam
 	return amount
@@ -78,7 +78,7 @@
 /mob/living/carbon/human/getFireLoss()
 	var/amount = 0
 	for(var/obj/item/organ/external/O in organs)
-		if(O.robotic >= ORGAN_ROBOT)
+		if(BP_IS_ROBOTIC(O) || BP_IS_LIFELIKE(O))
 			continue //robot limbs don't count towards shock and crit
 		amount += O.burn_dam
 	return amount
@@ -109,7 +109,7 @@
 			O.take_damage(amount, 0, sharp=is_sharp(damage_source), edge=has_edge(damage_source), used_weapon=damage_source)
 		else
 			//if you don't want to heal robot organs, they you will have to check that yourself before using this proc.
-			O.heal_damage(-amount, 0, internal=0, robo_repair=(O.robotic >= ORGAN_ROBOT))
+			O.heal_damage(-amount, 0, internal=0, robo_repair=(BP_IS_ROBOTIC(O) || BP_IS_LIFELIKE(O)))
 
 	BITSET(hud_updateflag, HEALTH_HUD)
 
@@ -122,7 +122,7 @@
 			O.take_damage(0, amount, sharp=is_sharp(damage_source), edge=has_edge(damage_source), used_weapon=damage_source)
 		else
 			//if you don't want to heal robot organs, they you will have to check that yourself before using this proc.
-			O.heal_damage(0, -amount, internal=0, robo_repair=(O.robotic >= ORGAN_ROBOT))
+			O.heal_damage(0, -amount, internal=0, robo_repair=(BP_IS_ROBOTIC(O) || BP_IS_LIFELIKE(O)))
 
 	BITSET(hud_updateflag, HEALTH_HUD)
 

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -8,7 +8,7 @@
 	var/total_burn  = 0
 	var/total_brute = 0
 	for(var/obj/item/organ/external/O in organs)	//hardcoded to streamline things a bit
-		if((BP_IS_ROBOTIC(O) || BP_IS_LIFELIKE(O)) && !O.vital)
+		if(BP_IS_ROBOTIC(O) && !O.vital)
 			continue //*non-vital* robot limbs don't count towards shock and crit
 		total_brute += O.brute_dam
 		total_burn  += O.burn_dam
@@ -70,7 +70,7 @@
 /mob/living/carbon/human/getBruteLoss()
 	var/amount = 0
 	for(var/obj/item/organ/external/O in organs)
-		if(BP_IS_ROBOTIC(O) || BP_IS_LIFELIKE(O))
+		if(BP_IS_ROBOTIC(O))
 			continue //robot limbs don't count towards shock and crit
 		amount += O.brute_dam
 	return amount
@@ -78,7 +78,7 @@
 /mob/living/carbon/human/getFireLoss()
 	var/amount = 0
 	for(var/obj/item/organ/external/O in organs)
-		if(BP_IS_ROBOTIC(O) || BP_IS_LIFELIKE(O))
+		if(BP_IS_ROBOTIC(O))
 			continue //robot limbs don't count towards shock and crit
 		amount += O.burn_dam
 	return amount
@@ -109,7 +109,7 @@
 			O.take_damage(amount, 0, sharp=is_sharp(damage_source), edge=has_edge(damage_source), used_weapon=damage_source)
 		else
 			//if you don't want to heal robot organs, they you will have to check that yourself before using this proc.
-			O.heal_damage(-amount, 0, internal=0, robo_repair=(BP_IS_ROBOTIC(O) || BP_IS_LIFELIKE(O)))
+			O.heal_damage(-amount, 0, internal=0, robo_repair=(BP_IS_ROBOTIC(O)))
 
 	BITSET(hud_updateflag, HEALTH_HUD)
 
@@ -122,7 +122,7 @@
 			O.take_damage(0, amount, sharp=is_sharp(damage_source), edge=has_edge(damage_source), used_weapon=damage_source)
 		else
 			//if you don't want to heal robot organs, they you will have to check that yourself before using this proc.
-			O.heal_damage(0, -amount, internal=0, robo_repair=(BP_IS_ROBOTIC(O) || BP_IS_LIFELIKE(O)))
+			O.heal_damage(0, -amount, internal=0, robo_repair=(BP_IS_ROBOTIC(O)))
 
 	BITSET(hud_updateflag, HEALTH_HUD)
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -58,7 +58,7 @@ meteor_act
 				msg_admin_attack("[src.name] ([src.ckey]) was disarmed by a stun effect")
 
 				drop_from_inventory(c_hand)
-				if (affected.robotic >= ORGAN_ROBOT)
+				if (BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected))
 					emote("pain", 1, "drops what they were holding, their [affected.name] malfunctioning!")
 				else
 					var/emote_scream = pick("screams in pain and ", "lets out a sharp cry and ", "cries out and ")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -58,7 +58,7 @@ meteor_act
 				msg_admin_attack("[src.name] ([src.ckey]) was disarmed by a stun effect")
 
 				drop_from_inventory(c_hand)
-				if (BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected))
+				if (BP_IS_ROBOTIC(affected))
 					emote("pain", 1, "drops what they were holding, their [affected.name] malfunctioning!")
 				else
 					var/emote_scream = pick("screams in pain and ", "lets out a sharp cry and ", "cries out and ")

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
@@ -23,7 +23,7 @@
 		var/mob/living/carbon/human/H = target
 		if(prob(poison_per_bite))
 			var/obj/item/organ/external/O = safepick(H.organs)
-			if(O && !(BP_IS_ROBOTIC(O) || BP_IS_LIFELIKE(O)))
+			if(O && !BP_IS_ROBOTIC(O))
 				var/eggs = new /obj/effect/spider/eggcluster(O, src)
 				O.implants += eggs
 

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
@@ -23,7 +23,7 @@
 		var/mob/living/carbon/human/H = target
 		if(prob(poison_per_bite))
 			var/obj/item/organ/external/O = safepick(H.organs)
-			if(O && !(O.robotic >= ORGAN_ROBOT))
+			if(O && !(BP_IS_ROBOTIC(O) || BP_IS_LIFELIKE(O)))
 				var/eggs = new /obj/effect/spider/eggcluster(O, src)
 				O.implants += eggs
 

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -83,7 +83,7 @@
 			var/organ_found
 			if(H.internal_organs.len)
 				for(var/obj/item/organ/external/E in H.organs)
-					if(!(E.robotic >= ORGAN_ROBOT))
+					if(!(BP_IS_ROBOTIC(E) || BP_IS_LIFELIKE(E)))
 						continue
 					organ_found = 1
 					user << "[E.name]: <font color='red'>[E.brute_dam]</font> <font color='#FFA500'>[E.burn_dam]</font>"
@@ -94,7 +94,7 @@
 			organ_found = null
 			if(H.internal_organs.len)
 				for(var/obj/item/organ/O in H.internal_organs)
-					if(!(O.robotic >= ORGAN_ROBOT))
+					if(!(BP_IS_ROBOTIC(O) || BP_IS_LIFELIKE(O)))
 						continue
 					organ_found = 1
 					user << "[O.name]: <font color='red'>[O.damage]</font>"

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -83,7 +83,7 @@
 			var/organ_found
 			if(H.internal_organs.len)
 				for(var/obj/item/organ/external/E in H.organs)
-					if(!(BP_IS_ROBOTIC(E) || BP_IS_LIFELIKE(E)))
+					if(!BP_IS_ROBOTIC(E))
 						continue
 					organ_found = 1
 					user << "[E.name]: <font color='red'>[E.brute_dam]</font> <font color='#FFA500'>[E.burn_dam]</font>"
@@ -94,7 +94,7 @@
 			organ_found = null
 			if(H.internal_organs.len)
 				for(var/obj/item/organ/O in H.internal_organs)
-					if(!(BP_IS_ROBOTIC(O) || BP_IS_LIFELIKE(O)))
+					if(!BP_IS_ROBOTIC(O))
 						continue
 					organ_found = 1
 					user << "[O.name]: <font color='red'>[O.damage]</font>"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -17,7 +17,7 @@
 /mob/living/carbon/human/isSynthetic()
 	// If they are 100% robotic, they count as synthetic.
 	for(var/obj/item/organ/external/E in organs)
-		if(!BP_IS_ROBOTIC(E) || !BP_IS_LIFELIKE(E))
+		if(!BP_IS_ROBOTIC(E))
 			return FALSE
 	return TRUE
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -17,7 +17,7 @@
 /mob/living/carbon/human/isSynthetic()
 	// If they are 100% robotic, they count as synthetic.
 	for(var/obj/item/organ/external/E in organs)
-		if(E.robotic < ORGAN_ROBOT)
+		if(!BP_IS_ROBOTIC(E) || !BP_IS_LIFELIKE(E))
 			return FALSE
 	return TRUE
 

--- a/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
+++ b/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
@@ -50,13 +50,18 @@
 				AI.ai_actual_track(H)
 		return 1
 
-/datum/nano_module/crew_monitor/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = NANOUI_FOCUS, var/datum/topic_state/state = GLOB.default_state)
+/datum/nano_module/crew_monitor/ui_data(mob/user)
 	var/list/data = host.initial_data()
 
 	data["isAI"] = isAI(user)
 	data["crewmembers"] = list()
 	for(var/z_level in maps_data.station_levels)
 		data["crewmembers"] += crew_repository.health_data(z_level)
+	data["crewmembers"] = sortByKey(data["crewmembers"], "name")
+	return data
+
+/datum/nano_module/crew_monitor/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = NANOUI_FOCUS, var/datum/topic_state/state = GLOB.default_state)
+	var/list/data = ui_data(user)
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)

--- a/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
+++ b/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
@@ -34,6 +34,8 @@
 	name = "Crew monitor"
 	var/list/ddata
 	var/list/crew
+	//for search
+	var/search = ""
 
 /datum/nano_module/crew_monitor/proc/has_alerts()
 	for(var/z_level in maps_data.station_levels)
@@ -51,6 +53,15 @@
 			if(hassensorlevel(H, SUIT_SENSOR_TRACKING))
 				AI.ai_actual_track(H)
 		return 1
+	if(href_list["search"])
+		var/new_search = sanitize(input("Enter the value for search for.") as null|text)
+		if(!new_search || new_search == "")
+			search = ""
+			return
+		search = new_search
+		return 1
+
+
 
 /datum/nano_module/crew_monitor/ui_data(mob/user)
 	var/list/data = host.initial_data()
@@ -66,10 +77,11 @@
 	
 	for(var/i = 1, i <=crewmembers.len, i++)
 		var/list/entry = crewmembers[i]
-		if(entry["alert"] || entry["isCriminal"])
-			crewmembers_problematic += list(entry)
-		else
-			crewmembers_goodbois += list(entry)
+		if(!search || findtext(entry["name"],search))
+			if(entry["alert"] || entry["isCriminal"])
+				crewmembers_problematic += list(entry)
+			else
+				crewmembers_goodbois += list(entry)
 	data["crewmembers"] = list()
 	if(crewmembers_problematic.len)
 		data["crewmembers"] += crewmembers_problematic
@@ -77,6 +89,7 @@
 		data["crewmembers"] += crewmembers_goodbois
 	ddata = data
 	crew = crewmembers_problematic
+	data["search"] = search ? search : "Search"
 	return data
 
 /datum/nano_module/crew_monitor/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = NANOUI_FOCUS, var/datum/topic_state/state = GLOB.default_state)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -50,7 +50,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 40
 	//Bleeding out
 	var/blood_max = 0
 	for(var/obj/item/organ/external/temp in organs)
-		if(!(temp.status & ORGAN_BLEEDING) || (temp.robotic >= ORGAN_ROBOT))
+		if(!(temp.status & ORGAN_BLEEDING) || (BP_IS_ROBOTIC(temp) || BP_IS_LIFELIKE(temp)))
 			continue
 		for(var/datum/wound/W in temp.wounds) if(W.bleeding())
 			blood_max += W.damage * WOUND_BLEED_MULTIPLIER

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -50,7 +50,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 40
 	//Bleeding out
 	var/blood_max = 0
 	for(var/obj/item/organ/external/temp in organs)
-		if(!(temp.status & ORGAN_BLEEDING) || (BP_IS_ROBOTIC(temp) || BP_IS_LIFELIKE(temp)))
+		if(!(temp.status & ORGAN_BLEEDING) || BP_IS_ROBOTIC(temp))
 			continue
 		for(var/datum/wound/W in temp.wounds) if(W.bleeding())
 			blood_max += W.damage * WOUND_BLEED_MULTIPLIER

--- a/code/modules/organs/body_modifications.dm
+++ b/code/modules/organs/body_modifications.dm
@@ -1,7 +1,3 @@
-#define MODIFICATION_ORGANIC 1
-#define MODIFICATION_SILICON 2
-#define MODIFICATION_REMOVED 3
-
 var/global/list/body_modifications = list()
 var/global/list/modifications_types = list(
 	BP_CHEST = "",  "chest2" = "", BP_HEAD = "",   BP_GROIN = "",
@@ -182,7 +178,7 @@ var/global/list/modifications_types = list(
 
 /datum/body_modification/organ/assisted/create_organ(var/mob/living/carbon/holder, var/O, var/color)
 	var/obj/item/organ/I = ..(holder,O,color)
-	I.robotic = ORGAN_ASSISTED
+	I.nature = MODIFICATION_ASSISTED
 	I.min_bruised_damage = 15
 	I.min_broken_damage = 35
 	return I
@@ -198,7 +194,7 @@ var/global/list/modifications_types = list(
 
 /datum/body_modification/organ/robotize_organ/create_organ(var/mob/living/carbon/holder, O, color)
 	var/obj/item/organ/I = ..(holder,O,color)
-	I.robotic = ORGAN_ROBOT
+	I.nature = MODIFICATION_SILICON
 	if(istype(I, /obj/item/organ/internal/eyes))
 		var/obj/item/organ/internal/eyes/E = I
 		E.robo_color = iscolor(color) ? color : "#FFFFFF"
@@ -256,7 +252,3 @@ var/global/list/modifications_types = list(
 	var/obj/item/organ/internal/eyes/heterohromia/E = new(holder,organ_type,color)
 	E.second_color = color
 	return E
-
-#undef MODIFICATION_REMOVED
-#undef MODIFICATION_ORGANIC
-#undef MODIFICATION_SILICON

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -198,7 +198,7 @@
 		module.activate(owner, src)
 
 /obj/item/organ/external/emp_act(severity)
-	if(robotic < ORGAN_ROBOT)
+	if(!(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)))
 		return
 	switch (severity)
 		if (1)
@@ -301,7 +301,7 @@
 		owner.verbs -= /mob/living/carbon/human/proc/undislocate
 
 /obj/item/organ/external/proc/setBleeding()
-	if(robotic >= ORGAN_ROBOT || owner.species.flags & NO_BLOOD)
+	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src) || owner.species.flags & NO_BLOOD)
 		return FALSE
 	status |= ORGAN_BLEEDING
 	return TRUE
@@ -350,7 +350,7 @@ This function completely restores a damaged organ to perfect condition.
 	// (because of the return)
 	//Possibly trigger an internal wound, too.
 	var/local_damage = brute_dam + burn_dam + damage
-	if(damage > 15 && type != BURN && local_damage > 30 && prob(damage) && robotic < ORGAN_ROBOT)
+	if(damage > 15 && type != BURN && local_damage > 30 && prob(damage) && !(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)))
 		var/datum/wound/internal_bleeding/I = new (min(damage - 15, 15))
 		wounds += I
 		owner.custom_pain("You feel something rip in your [name]!", 1)
@@ -368,7 +368,7 @@ This function completely restores a damaged organ to perfect condition.
 				var/datum/wound/W = pick(compatible_wounds)
 				W.open_wound(damage)
 				if(prob(25))
-					if(robotic >= ORGAN_ROBOT)
+					if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
 						owner.visible_message(
 							SPAN_DANGER("The damage to [owner.name]'s [name] worsens."),
 							SPAN_DANGER("The damage to your [name] worsens."),
@@ -410,7 +410,7 @@ This function completely restores a damaged organ to perfect condition.
 /obj/item/organ/external/proc/need_process()
 	if(status & (ORGAN_CUT_AWAY|ORGAN_BLEEDING|ORGAN_BROKEN|ORGAN_DESTROYED|ORGAN_SPLINTED|ORGAN_DEAD|ORGAN_MUTATED))
 		return 1
-	if((brute_dam || burn_dam) && (robotic < ORGAN_ROBOT)) //Robot limbs don't autoheal and thus don't need to process when damaged
+	if((brute_dam || burn_dam) && !(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))) //Robot limbs don't autoheal and thus don't need to process when damaged
 		return 1
 	if(last_dam != brute_dam + burn_dam) // Process when we are fully healed up.
 		last_dam = brute_dam + burn_dam
@@ -465,7 +465,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 /obj/item/organ/external/proc/update_germs()
 
 	//Robotic limbs shouldn't be infected, nor should nonexistant limbs.
-	if(robotic >= ORGAN_ROBOT || (owner.species && owner.species.flags & IS_PLANT))
+	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src) || (owner.species && owner.species.flags & IS_PLANT))
 		germ_level = 0
 		return
 
@@ -526,12 +526,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 		//spread the infection to child and parent organs
 		if (children)
 			for (var/obj/item/organ/external/child in children)
-				if (child.germ_level < germ_level && child.robotic<ORGAN_ROBOT)
+				if (child.germ_level < germ_level && !(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)))
 					if (child.germ_level < INFECTION_LEVEL_ONE*2 || prob(30))
 						child.germ_level++
 
 		if (parent)
-			if (parent.germ_level < germ_level && parent.robotic < ORGAN_ROBOT)
+			if (parent.germ_level < germ_level && !(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)))
 				if (parent.germ_level < INFECTION_LEVEL_ONE*2 || prob(30))
 					parent.germ_level++
 
@@ -547,7 +547,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 //Updating wounds. Handles wound natural I had some free spachealing, internal bleedings and infections
 /obj/item/organ/external/proc/update_wounds()
 
-	if(robotic >= ORGAN_ROBOT) //Robotic limbs don't heal or get worse.
+	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) //Robotic limbs don't heal or get worse.
 		for(var/datum/wound/W in wounds) //Repaired wounds disappear though
 			if(W.damage <= 0)        //and they disappear right away
 				wounds -= W      //TODO: robot wounds for robot limbs
@@ -633,7 +633,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		src.setBleeding()
 
 	//Bone fractures
-	if(config.bones_can_break && brute_dam > min_broken_damage * ORGAN_HEALTH_MULTIPLIER && robotic < ORGAN_ROBOT)
+	if(config.bones_can_break && brute_dam > min_broken_damage * ORGAN_HEALTH_MULTIPLIER && !(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)))
 		src.fracture()
 
 //Returns 1 if damage_state changed
@@ -683,20 +683,20 @@ Note that amputating the affected organ does in fact remove the infection from t
 	switch(disintegrate)
 		if(DROPLIMB_EDGE)
 			if(!clean)
-				var/gore_sound = "[(robotic >= ORGAN_ROBOT) ? "tortured metal" : "ripping tendons and flesh"]"
+				var/gore_sound = "[(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? "tortured metal" : "ripping tendons and flesh"]"
 				owner.visible_message(
 					SPAN_DANGER("\The [owner]'s [src.name] flies off in an arc!"),\
 					"<span class='moderate'><b>Your [src.name] goes flying off!</b></span>",\
 					SPAN_DANGER("You hear a terrible sound of [gore_sound]."))
 		if(DROPLIMB_BURN)
-			var/gore = "[(robotic >= ORGAN_ROBOT) ? "": " of burning flesh"]"
+			var/gore = "[(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? "": " of burning flesh"]"
 			owner.visible_message(
 				SPAN_DANGER("\The [owner]'s [src.name] flashes away into ashes!"),\
 				"<span class='moderate'><b>Your [src.name] flashes away into ashes!</b></span>",\
 				SPAN_DANGER("You hear a crackling sound[gore]."))
 		if(DROPLIMB_BLUNT)
-			var/gore = "[(robotic >= ORGAN_ROBOT) ? "": " in shower of gore"]"
-			var/gore_sound = "[(robotic >= ORGAN_ROBOT) ? "rending sound of tortured metal" : "sickening splatter of gore"]"
+			var/gore = "[(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? "": " in shower of gore"]"
+			var/gore_sound = "[(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? "rending sound of tortured metal" : "sickening splatter of gore"]"
 			owner.visible_message(
 				SPAN_DANGER("\The [owner]'s [src.name] explodes[gore]!"),\
 				"<span class='moderate'><b>Your [src.name] explodes[gore]!</b></span>",\
@@ -848,7 +848,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return rval
 
 /obj/item/organ/external/proc/fracture()
-	if(robotic >= ORGAN_ROBOT)
+	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
 		return	//ORGAN_BROKEN doesn't have the same meaning for robot limbs
 	if((status & ORGAN_BROKEN) || cannot_break)
 		return
@@ -890,7 +890,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return
 
 /obj/item/organ/external/proc/mend_fracture()
-	if(robotic >= ORGAN_ROBOT)
+	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
 		return 0	//ORGAN_BROKEN doesn't have the same meaning for robot limbs
 	if(brute_dam > min_broken_damage * ORGAN_HEALTH_MULTIPLIER)
 		return 0	//will just immediately fracture again
@@ -899,7 +899,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return 1
 
 /obj/item/organ/external/proc/mutate()
-	if(src.robotic >= ORGAN_ROBOT)
+	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
 		return
 	src.status |= ORGAN_MUTATED
 	if(owner) owner.update_body()
@@ -921,7 +921,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return !is_dislocated() && !(status & (ORGAN_MUTATED|ORGAN_DEAD))
 
 /obj/item/organ/external/proc/is_malfunctioning()
-	return ((robotic >= ORGAN_ROBOT) && (brute_dam + burn_dam) >= 10 && prob(brute_dam + burn_dam))
+	return ((BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) && (brute_dam + burn_dam) >= 10 && prob(brute_dam + burn_dam))
 
 /obj/item/organ/external/proc/embed(var/obj/item/weapon/W, var/silent = 0)
 	if(!owner || loc != owner)
@@ -957,7 +957,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	disfigured = 1
 
 /obj/item/organ/external/proc/get_wounds_desc()
-	if(robotic >= ORGAN_ROBOT)
+	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
 		var/list/descriptors = list()
 		if(brute_dam)
 			switch(brute_dam)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -198,7 +198,7 @@
 		module.activate(owner, src)
 
 /obj/item/organ/external/emp_act(severity)
-	if(!(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)))
+	if(!BP_IS_ROBOTIC(src))
 		return
 	switch (severity)
 		if (1)
@@ -301,7 +301,7 @@
 		owner.verbs -= /mob/living/carbon/human/proc/undislocate
 
 /obj/item/organ/external/proc/setBleeding()
-	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src) || owner.species.flags & NO_BLOOD)
+	if(BP_IS_ROBOTIC(src) || owner.species.flags & NO_BLOOD)
 		return FALSE
 	status |= ORGAN_BLEEDING
 	return TRUE
@@ -350,7 +350,7 @@ This function completely restores a damaged organ to perfect condition.
 	// (because of the return)
 	//Possibly trigger an internal wound, too.
 	var/local_damage = brute_dam + burn_dam + damage
-	if(damage > 15 && type != BURN && local_damage > 30 && prob(damage) && !(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)))
+	if(damage > 15 && type != BURN && local_damage > 30 && prob(damage) && !BP_IS_ROBOTIC(src))
 		var/datum/wound/internal_bleeding/I = new (min(damage - 15, 15))
 		wounds += I
 		owner.custom_pain("You feel something rip in your [name]!", 1)
@@ -368,7 +368,7 @@ This function completely restores a damaged organ to perfect condition.
 				var/datum/wound/W = pick(compatible_wounds)
 				W.open_wound(damage)
 				if(prob(25))
-					if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
+					if(BP_IS_ROBOTIC(src))
 						owner.visible_message(
 							SPAN_DANGER("The damage to [owner.name]'s [name] worsens."),
 							SPAN_DANGER("The damage to your [name] worsens."),
@@ -410,7 +410,7 @@ This function completely restores a damaged organ to perfect condition.
 /obj/item/organ/external/proc/need_process()
 	if(status & (ORGAN_CUT_AWAY|ORGAN_BLEEDING|ORGAN_BROKEN|ORGAN_DESTROYED|ORGAN_SPLINTED|ORGAN_DEAD|ORGAN_MUTATED))
 		return 1
-	if((brute_dam || burn_dam) && !(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))) //Robot limbs don't autoheal and thus don't need to process when damaged
+	if((brute_dam || burn_dam) && !BP_IS_ROBOTIC(src)) //Robot limbs don't autoheal and thus don't need to process when damaged
 		return 1
 	if(last_dam != brute_dam + burn_dam) // Process when we are fully healed up.
 		last_dam = brute_dam + burn_dam
@@ -465,7 +465,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 /obj/item/organ/external/proc/update_germs()
 
 	//Robotic limbs shouldn't be infected, nor should nonexistant limbs.
-	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src) || (owner.species && owner.species.flags & IS_PLANT))
+	if(BP_IS_ROBOTIC(src) || (owner.species && owner.species.flags & IS_PLANT))
 		germ_level = 0
 		return
 
@@ -526,12 +526,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 		//spread the infection to child and parent organs
 		if (children)
 			for (var/obj/item/organ/external/child in children)
-				if (child.germ_level < germ_level && !(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)))
+				if (child.germ_level < germ_level && !BP_IS_ROBOTIC(src))
 					if (child.germ_level < INFECTION_LEVEL_ONE*2 || prob(30))
 						child.germ_level++
 
 		if (parent)
-			if (parent.germ_level < germ_level && !(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)))
+			if (parent.germ_level < germ_level && !BP_IS_ROBOTIC(src))
 				if (parent.germ_level < INFECTION_LEVEL_ONE*2 || prob(30))
 					parent.germ_level++
 
@@ -547,7 +547,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 //Updating wounds. Handles wound natural I had some free spachealing, internal bleedings and infections
 /obj/item/organ/external/proc/update_wounds()
 
-	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) //Robotic limbs don't heal or get worse.
+	if(BP_IS_ROBOTIC(src)) //Robotic limbs don't heal or get worse.
 		for(var/datum/wound/W in wounds) //Repaired wounds disappear though
 			if(W.damage <= 0)        //and they disappear right away
 				wounds -= W      //TODO: robot wounds for robot limbs
@@ -633,7 +633,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		src.setBleeding()
 
 	//Bone fractures
-	if(config.bones_can_break && brute_dam > min_broken_damage * ORGAN_HEALTH_MULTIPLIER && !(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)))
+	if(config.bones_can_break && brute_dam > min_broken_damage * ORGAN_HEALTH_MULTIPLIER && !BP_IS_ROBOTIC(src))
 		src.fracture()
 
 //Returns 1 if damage_state changed
@@ -683,20 +683,20 @@ Note that amputating the affected organ does in fact remove the infection from t
 	switch(disintegrate)
 		if(DROPLIMB_EDGE)
 			if(!clean)
-				var/gore_sound = "[(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? "tortured metal" : "ripping tendons and flesh"]"
+				var/gore_sound = "[BP_IS_ROBOTIC(src) ? "tortured metal" : "ripping tendons and flesh"]"
 				owner.visible_message(
 					SPAN_DANGER("\The [owner]'s [src.name] flies off in an arc!"),\
 					"<span class='moderate'><b>Your [src.name] goes flying off!</b></span>",\
 					SPAN_DANGER("You hear a terrible sound of [gore_sound]."))
 		if(DROPLIMB_BURN)
-			var/gore = "[(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? "": " of burning flesh"]"
+			var/gore = "[BP_IS_ROBOTIC(src) ? "": " of burning flesh"]"
 			owner.visible_message(
 				SPAN_DANGER("\The [owner]'s [src.name] flashes away into ashes!"),\
 				"<span class='moderate'><b>Your [src.name] flashes away into ashes!</b></span>",\
 				SPAN_DANGER("You hear a crackling sound[gore]."))
 		if(DROPLIMB_BLUNT)
-			var/gore = "[(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? "": " in shower of gore"]"
-			var/gore_sound = "[(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? "rending sound of tortured metal" : "sickening splatter of gore"]"
+			var/gore = "[BP_IS_ROBOTIC(src) ? "": " in shower of gore"]"
+			var/gore_sound = "[BP_IS_ROBOTIC(src) ? "rending sound of tortured metal" : "sickening splatter of gore"]"
 			owner.visible_message(
 				SPAN_DANGER("\The [owner]'s [src.name] explodes[gore]!"),\
 				"<span class='moderate'><b>Your [src.name] explodes[gore]!</b></span>",\
@@ -848,7 +848,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return rval
 
 /obj/item/organ/external/proc/fracture()
-	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
+	if(BP_IS_ROBOTIC(src))
 		return	//ORGAN_BROKEN doesn't have the same meaning for robot limbs
 	if((status & ORGAN_BROKEN) || cannot_break)
 		return
@@ -890,7 +890,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return
 
 /obj/item/organ/external/proc/mend_fracture()
-	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
+	if(BP_IS_ROBOTIC(src))
 		return 0	//ORGAN_BROKEN doesn't have the same meaning for robot limbs
 	if(brute_dam > min_broken_damage * ORGAN_HEALTH_MULTIPLIER)
 		return 0	//will just immediately fracture again
@@ -899,7 +899,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return 1
 
 /obj/item/organ/external/proc/mutate()
-	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
+	if(BP_IS_ROBOTIC(src))
 		return
 	src.status |= ORGAN_MUTATED
 	if(owner) owner.update_body()
@@ -921,7 +921,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return !is_dislocated() && !(status & (ORGAN_MUTATED|ORGAN_DEAD))
 
 /obj/item/organ/external/proc/is_malfunctioning()
-	return ((BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) && (brute_dam + burn_dam) >= 10 && prob(brute_dam + burn_dam))
+	return (BP_IS_ROBOTIC(src) && (brute_dam + burn_dam) >= 10 && prob(brute_dam + burn_dam))
 
 /obj/item/organ/external/proc/embed(var/obj/item/weapon/W, var/silent = 0)
 	if(!owner || loc != owner)
@@ -957,7 +957,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	disfigured = 1
 
 /obj/item/organ/external/proc/get_wounds_desc()
-	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
+	if(BP_IS_ROBOTIC(src))
 		var/list/descriptors = list()
 		if(brute_dam)
 			switch(brute_dam)

--- a/code/modules/organs/external/damage.dm
+++ b/code/modules/organs/external/damage.dm
@@ -31,7 +31,7 @@
 	if(used_weapon)
 		add_autopsy_data("[used_weapon]", brute + burn)
 
-	var/can_cut = (prob(brute*2) || sharp) && robotic < ORGAN_ROBOT
+	var/can_cut = (prob(brute*2) || sharp) && !(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
 
 	// If the limbs can break, make sure we don't exceed the maximum damage a limb can take before breaking
 	// Non-vital organs are limited to max_damage. You can't kill someone by bludeonging their arm all the way to 200 -- you can
@@ -113,7 +113,7 @@
 	return update_damstate()
 
 /obj/item/organ/external/proc/heal_damage(brute, burn, internal = 0, robo_repair = 0)
-	if(robotic >= ORGAN_ROBOT && !robo_repair)
+	if((BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) && !robo_repair)
 		return
 
 	//Heal damage on the individual wounds

--- a/code/modules/organs/external/damage.dm
+++ b/code/modules/organs/external/damage.dm
@@ -31,7 +31,7 @@
 	if(used_weapon)
 		add_autopsy_data("[used_weapon]", brute + burn)
 
-	var/can_cut = (prob(brute*2) || sharp) && !(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
+	var/can_cut = (prob(brute*2 || sharp) && !BP_IS_ROBOTIC(src))
 
 	// If the limbs can break, make sure we don't exceed the maximum damage a limb can take before breaking
 	// Non-vital organs are limited to max_damage. You can't kill someone by bludeonging their arm all the way to 200 -- you can
@@ -113,7 +113,7 @@
 	return update_damstate()
 
 /obj/item/organ/external/proc/heal_damage(brute, burn, internal = 0, robo_repair = 0)
-	if((BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) && !robo_repair)
+	if(BP_IS_ROBOTIC(src) && !robo_repair)
 		return
 
 	//Heal damage on the individual wounds

--- a/code/modules/organs/external/stump.dm
+++ b/code/modules/organs/external/stump.dm
@@ -14,8 +14,8 @@
 	..(holder, null)
 	if(istype(limb))
 		max_damage = limb.max_damage
-		if((limb.robotic >= ORGAN_ROBOT) && (!parent || (parent.robotic >= ORGAN_ROBOT)))
-			robotic = ORGAN_ROBOT
+		if((BP_IS_ROBOTIC(limb) || BP_IS_LIFELIKE(limb)) && (!parent || (BP_IS_ROBOTIC(parent) || BP_IS_LIFELIKE(parent))))
+			nature = MODIFICATION_SILICON
 
 /obj/item/organ/external/stump/get_tally()
 	return 4

--- a/code/modules/organs/external/stump.dm
+++ b/code/modules/organs/external/stump.dm
@@ -14,7 +14,7 @@
 	..(holder, null)
 	if(istype(limb))
 		max_damage = limb.max_damage
-		if((BP_IS_ROBOTIC(limb) || BP_IS_LIFELIKE(limb)) && (!parent || (BP_IS_ROBOTIC(parent) || BP_IS_LIFELIKE(parent))))
+		if(BP_IS_ROBOTIC(limb) && (!parent || BP_IS_ROBOTIC(parent)))
 			nature = MODIFICATION_SILICON
 
 /obj/item/organ/external/stump/get_tally()

--- a/code/modules/organs/external/subtypes/robotic.dm
+++ b/code/modules/organs/external/subtypes/robotic.dm
@@ -4,7 +4,7 @@
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	dislocated = -1
 	cannot_break = 1
-	robotic = ORGAN_ROBOT
+	nature = MODIFICATION_SILICON
 	brute_mod = 0.8
 	burn_mod = 0.8
 	var/list/forced_children = null

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -12,11 +12,11 @@
 /obj/item/organ/internal/eyes/proc/get_icon()
 	var/icon/eyes_icon = new/icon('icons/mob/human_face.dmi', "eye_l[owner.body_build.index]")
 	eyes_icon.Blend(icon('icons/mob/human_face.dmi', "eye_r[owner.body_build.index]"), ICON_OVERLAY)
-	eyes_icon.Blend(robotic ? robo_color : eyes_color, ICON_ADD)
+	eyes_icon.Blend((BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? robo_color : eyes_color, ICON_ADD)
 	return eyes_icon
 
 /obj/item/organ/internal/eyes/proc/get_cache_key()
-	return "[cache_key][robotic ? robo_color : eyes_color]"
+	return "[cache_key][(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? robo_color : eyes_color]"
 
 /obj/item/organ/internal/eyes/replaced(var/mob/living/carbon/human/target)
 
@@ -56,7 +56,7 @@
 /obj/item/organ/internal/eyes/oneeye/get_icon()
 	var/icon/eyes_icon
 	eyes_icon = icon('icons/mob/human_face.dmi', "[icon_state][owner.body_build.index]")
-	eyes_icon.Blend(robotic ? robo_color : eyes_color, ICON_ADD)
+	eyes_icon.Blend((BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? robo_color : eyes_color, ICON_ADD)
 	return eyes_icon
 
 /obj/item/organ/internal/eyes/oneeye/right
@@ -68,11 +68,11 @@
 	cache_key = "heterohromia"
 
 /obj/item/organ/internal/eyes/heterohromia/get_cache_key()
-	return "[cache_key][robotic ? robo_color : eyes_color]&[second_color]"
+	return "[cache_key][(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? robo_color : eyes_color]&[second_color]"
 
 /obj/item/organ/internal/eyes/heterohromia/get_icon()
 	var/icon/eyes_icon = icon('icons/mob/human_face.dmi', "eye_l[owner.body_build.index]")
-	eyes_icon.Blend(robotic ? robo_color : eyes_color, ICON_ADD)
+	eyes_icon.Blend((BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? robo_color : eyes_color, ICON_ADD)
 
 	var/icon/right_eye = icon('icons/mob/human_face.dmi', "eye_r[owner.body_build.index]")
 	right_eye.Blend(second_color, ICON_ADD)

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -12,11 +12,11 @@
 /obj/item/organ/internal/eyes/proc/get_icon()
 	var/icon/eyes_icon = new/icon('icons/mob/human_face.dmi', "eye_l[owner.body_build.index]")
 	eyes_icon.Blend(icon('icons/mob/human_face.dmi', "eye_r[owner.body_build.index]"), ICON_OVERLAY)
-	eyes_icon.Blend((BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? robo_color : eyes_color, ICON_ADD)
+	eyes_icon.Blend(BP_IS_ROBOTIC(src) ? robo_color : eyes_color, ICON_ADD)
 	return eyes_icon
 
 /obj/item/organ/internal/eyes/proc/get_cache_key()
-	return "[cache_key][(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? robo_color : eyes_color]"
+	return "[cache_key][BP_IS_ROBOTIC(src) ? robo_color : eyes_color]"
 
 /obj/item/organ/internal/eyes/replaced(var/mob/living/carbon/human/target)
 
@@ -56,7 +56,7 @@
 /obj/item/organ/internal/eyes/oneeye/get_icon()
 	var/icon/eyes_icon
 	eyes_icon = icon('icons/mob/human_face.dmi', "[icon_state][owner.body_build.index]")
-	eyes_icon.Blend((BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? robo_color : eyes_color, ICON_ADD)
+	eyes_icon.Blend(BP_IS_ROBOTIC(src) ? robo_color : eyes_color, ICON_ADD)
 	return eyes_icon
 
 /obj/item/organ/internal/eyes/oneeye/right
@@ -68,11 +68,11 @@
 	cache_key = "heterohromia"
 
 /obj/item/organ/internal/eyes/heterohromia/get_cache_key()
-	return "[cache_key][(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? robo_color : eyes_color]&[second_color]"
+	return "[cache_key][BP_IS_ROBOTIC(src) ? robo_color : eyes_color]&[second_color]"
 
 /obj/item/organ/internal/eyes/heterohromia/get_icon()
 	var/icon/eyes_icon = icon('icons/mob/human_face.dmi', "eye_l[owner.body_build.index]")
-	eyes_icon.Blend((BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) ? robo_color : eyes_color, ICON_ADD)
+	eyes_icon.Blend(BP_IS_ROBOTIC(src) ? robo_color : eyes_color, ICON_ADD)
 
 	var/icon/right_eye = icon('icons/mob/human_face.dmi', "eye_r[owner.body_build.index]")
 	right_eye.Blend(second_color, ICON_ADD)

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -17,7 +17,7 @@
 	..()
 
 /obj/item/organ/internal/heart/proc/handle_pulse()
-	if(owner.stat == DEAD || robotic >= ORGAN_ROBOT)
+	if(owner.stat == DEAD || BP_IS_ROBOTIC(src))
 		pulse = PULSE_NONE	//that's it, you're dead (or your metal heart is), nothing can influence your pulse
 		return
 	if(owner.life_tick % 5 == 0)//update pulse every 5 life ticks (~1 tick/sec, depending on server load)

--- a/code/modules/organs/internal/machine.dm
+++ b/code/modules/organs/internal/machine.dm
@@ -5,7 +5,7 @@
 	icon_state = "scell"
 	organ_tag = BP_CELL
 	parent_organ = BP_CHEST
-	robotic = ORGAN_ROBOT
+	nature = MODIFICATION_SILICON
 	vital = TRUE
 
 /obj/item/organ/cell/replaced()
@@ -19,7 +19,7 @@
 	name = "optical sensor"
 	organ_tag = "optics"
 	parent_organ = BP_HEAD
-	robotic = ORGAN_ROBOT
+	nature = MODIFICATION_SILICON
 	icon = 'icons/obj/robot_component.dmi'
 	icon_state = "camera"
 	dead_icon = "camera_broken"
@@ -62,7 +62,7 @@
 			owner.visible_message(SPAN_DANGER("\The [owner] twitches visibly!"))
 
 /obj/item/organ/mmi_holder/posibrain
-	robotic = ORGAN_ROBOT
+	nature = MODIFICATION_SILICON
 
 /obj/item/organ/mmi_holder/posibrain/New()
 	stored_mmi = new /obj/item/device/mmi/digital/posibrain(src)

--- a/code/modules/organs/internal/xenos/eggsac.dm
+++ b/code/modules/organs/internal/xenos/eggsac.dm
@@ -45,7 +45,7 @@
 		return
 
 	var/obj/item/organ/affecting = M.get_organ(BP_CHEST)
-	if(!affecting || (BP_IS_ROBOTIC(affecting) || BP_IS_LIFELIKE(affecting)))
+	if(!affecting || BP_IS_ROBOTIC(affecting))
 		owner << SPAN_WARNING("This form is not compatible with our physiology.")
 		return
 
@@ -57,7 +57,7 @@
 		return
 
 	//TODO: instead affecting.robotic use M.isSyntetic()
-	if(M.species.get_bodytype() == "Xenomorph" || !isnull(M.internal_organs_by_name[BP_HIVE]) || !affecting || (BP_IS_ROBOTIC(affecting) || BP_IS_LIFELIKE(affecting)))
+	if(M.species.get_bodytype() == "Xenomorph" || !isnull(M.internal_organs_by_name[BP_HIVE]) || !affecting || BP_IS_ROBOTIC(affecting))
 		return
 
 	if(!check_alien_ability(500, TRUE))

--- a/code/modules/organs/internal/xenos/eggsac.dm
+++ b/code/modules/organs/internal/xenos/eggsac.dm
@@ -45,7 +45,7 @@
 		return
 
 	var/obj/item/organ/affecting = M.get_organ(BP_CHEST)
-	if(!affecting || (affecting.robotic >= ORGAN_ROBOT))
+	if(!affecting || (BP_IS_ROBOTIC(affecting) || BP_IS_LIFELIKE(affecting)))
 		owner << SPAN_WARNING("This form is not compatible with our physiology.")
 		return
 
@@ -57,7 +57,7 @@
 		return
 
 	//TODO: instead affecting.robotic use M.isSyntetic()
-	if(M.species.get_bodytype() == "Xenomorph" || !isnull(M.internal_organs_by_name[BP_HIVE]) || !affecting || (affecting.robotic >= ORGAN_ROBOT))
+	if(M.species.get_bodytype() == "Xenomorph" || !isnull(M.internal_organs_by_name[BP_HIVE]) || !affecting || (BP_IS_ROBOTIC(affecting) || BP_IS_LIFELIKE(affecting)))
 		return
 
 	if(!check_alien_ability(500, TRUE))

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -12,7 +12,9 @@
 	var/status = 0                    // Various status flags
 	var/vital                         // Lose a vital limb, die immediately.
 	var/damage = 0                    // Current damage to the organ
-	var/robotic = 0
+
+	// Type of modification, (If you ever need to apply several types make this a bit flag)
+	var/nature = MODIFICATION_ORGANIC 
 
 	// Reference data.
 	var/mob/living/carbon/human/owner // Current mob owning the organ.
@@ -86,7 +88,7 @@
 		species = all_species[new_dna.species]
 
 /obj/item/organ/proc/die()
-	if(robotic >= ORGAN_ROBOT)
+	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
 		return
 	damage = max_damage
 	status |= ORGAN_DEAD
@@ -115,7 +117,7 @@
 	if(istype(loc,/obj/structure/closet/body_bag/cryobag) || istype(loc,/obj/structure/closet/crate/freezer) || istype(loc,/obj/item/weapon/storage/box/freezer))
 		return
 	//Process infections
-	if ((robotic >= ORGAN_ROBOT) || (owner && owner.species && (owner.species.flags & IS_PLANT)))
+	if ((BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) || (owner && owner.species && (owner.species.flags & IS_PLANT)))
 		germ_level = 0
 		return
 
@@ -239,7 +241,7 @@
 
 //Note: external organs have their own version of this proc
 /obj/item/organ/proc/take_damage(amount, var/silent=0)
-	if(src.robotic >= ORGAN_ROBOT)
+	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
 		src.damage = between(0, src.damage + (amount * 0.8), max_damage)
 	else
 		src.damage = between(0, src.damage + amount, max_damage)
@@ -254,7 +256,7 @@
 	damage = max(damage, min_bruised_damage)
 
 /obj/item/organ/emp_act(severity)
-	if(robotic < ORGAN_ROBOT)
+	if(!(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)))
 		return
 	switch (severity)
 		if (1)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -88,7 +88,7 @@
 		species = all_species[new_dna.species]
 
 /obj/item/organ/proc/die()
-	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
+	if(BP_IS_ROBOTIC(src))
 		return
 	damage = max_damage
 	status |= ORGAN_DEAD
@@ -117,7 +117,7 @@
 	if(istype(loc,/obj/structure/closet/body_bag/cryobag) || istype(loc,/obj/structure/closet/crate/freezer) || istype(loc,/obj/item/weapon/storage/box/freezer))
 		return
 	//Process infections
-	if ((BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)) || (owner && owner.species && (owner.species.flags & IS_PLANT)))
+	if (BP_IS_ROBOTIC(src) || (owner && owner.species && (owner.species.flags & IS_PLANT)))
 		germ_level = 0
 		return
 
@@ -241,7 +241,7 @@
 
 //Note: external organs have their own version of this proc
 /obj/item/organ/proc/take_damage(amount, var/silent=0)
-	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
+	if(BP_IS_ROBOTIC(src))
 		src.damage = between(0, src.damage + (amount * 0.8), max_damage)
 	else
 		src.damage = between(0, src.damage + amount, max_damage)
@@ -256,7 +256,7 @@
 	damage = max(damage, min_bruised_damage)
 
 /obj/item/organ/emp_act(severity)
-	if(!(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)))
+	if(!BP_IS_ROBOTIC(src))
 		return
 	switch (severity)
 		if (1)

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -16,7 +16,7 @@ var/global/list/limb_icon_cache = list()
 	skin_tone = null
 	skin_col = null
 	hair_col = null
-	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
+	if(BP_IS_ROBOTIC(src))
 		return
 	if(species && human.species && species.name != human.species.name)
 		return
@@ -30,7 +30,7 @@ var/global/list/limb_icon_cache = list()
 	skin_tone = null
 	skin_col = null
 	hair_col = null
-	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
+	if(BP_IS_ROBOTIC(src))
 		return
 	if(!isnull(dna.GetUIValue(DNA_UI_SKIN_TONE)) && (species.appearance_flags & HAS_SKIN_TONE))
 		skin_tone = dna.GetUIValue(DNA_UI_SKIN_TONE)
@@ -44,7 +44,7 @@ var/global/list/limb_icon_cache = list()
 	if(!appearance_test.get_species_sprite)
 		part_key += "forced"
 	else
-		if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
+		if(BP_IS_ROBOTIC(src))
 			part_key += "ROBOTIC"
 		else if(status & ORGAN_MUTATED)
 			part_key += "Mutated"
@@ -95,7 +95,7 @@ var/global/list/limb_icon_cache = list()
 		var/icon/lip_icon = new/icon('icons/mob/human_face.dmi', "lips[owner.lip_style][owner.body_build.index]")
 		mob_icon.Blend(lip_icon, ICON_OVERLAY)
 
-	if(!(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)))
+	if(!BP_IS_ROBOTIC(src))
 		if(owner.f_style)
 			var/datum/sprite_accessory/facial_hair_style = GLOB.facial_hair_styles_list[owner.f_style]
 			if(facial_hair_style && facial_hair_style.species_allowed && (species.get_bodytype() in facial_hair_style.species_allowed))
@@ -137,7 +137,7 @@ var/global/list/limb_icon_cache = list()
 			icon = src.force_icon
 		else if(!dna)
 			icon = 'icons/mob/human_races/r_human.dmi'
-		else if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
+		else if(BP_IS_ROBOTIC(src))
 			icon = 'icons/mob/human_races/robotic.dmi'
 		else if(status & ORGAN_MUTATED)
 			icon = species.deform

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -16,7 +16,7 @@ var/global/list/limb_icon_cache = list()
 	skin_tone = null
 	skin_col = null
 	hair_col = null
-	if(robotic >= ORGAN_ROBOT)
+	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
 		return
 	if(species && human.species && species.name != human.species.name)
 		return
@@ -30,7 +30,7 @@ var/global/list/limb_icon_cache = list()
 	skin_tone = null
 	skin_col = null
 	hair_col = null
-	if(robotic >= ORGAN_ROBOT)
+	if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
 		return
 	if(!isnull(dna.GetUIValue(DNA_UI_SKIN_TONE)) && (species.appearance_flags & HAS_SKIN_TONE))
 		skin_tone = dna.GetUIValue(DNA_UI_SKIN_TONE)
@@ -44,7 +44,7 @@ var/global/list/limb_icon_cache = list()
 	if(!appearance_test.get_species_sprite)
 		part_key += "forced"
 	else
-		if(robotic >= ORGAN_ROBOT)
+		if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
 			part_key += "ROBOTIC"
 		else if(status & ORGAN_MUTATED)
 			part_key += "Mutated"
@@ -95,7 +95,7 @@ var/global/list/limb_icon_cache = list()
 		var/icon/lip_icon = new/icon('icons/mob/human_face.dmi', "lips[owner.lip_style][owner.body_build.index]")
 		mob_icon.Blend(lip_icon, ICON_OVERLAY)
 
-	if(robotic < ORGAN_ROBOT)
+	if(!(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src)))
 		if(owner.f_style)
 			var/datum/sprite_accessory/facial_hair_style = GLOB.facial_hair_styles_list[owner.f_style]
 			if(facial_hair_style && facial_hair_style.species_allowed && (species.get_bodytype() in facial_hair_style.species_allowed))
@@ -137,7 +137,7 @@ var/global/list/limb_icon_cache = list()
 			icon = src.force_icon
 		else if(!dna)
 			icon = 'icons/mob/human_races/r_human.dmi'
-		else if(robotic >= ORGAN_ROBOT)
+		else if(BP_IS_ROBOTIC(src) || BP_IS_LIFELIKE(src))
 			icon = 'icons/mob/human_races/robotic.dmi'
 		else if(status & ORGAN_MUTATED)
 			icon = species.deform

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -87,7 +87,7 @@ mob/living/carbon/human/proc/handle_pain()
 	var/maxdam = 0
 	var/obj/item/organ/external/damaged_organ = null
 	for(var/obj/item/organ/external/E in organs)
-		if(E.status&ORGAN_DEAD || E.robotic >= ORGAN_ROBOT)
+		if(E.status&ORGAN_DEAD || BP_IS_ROBOTIC(E) || BP_IS_LIFELIKE(E))
 			continue
 		var/dam = E.get_damage()
 		// make the choice of the organ depend on damage,
@@ -100,7 +100,7 @@ mob/living/carbon/human/proc/handle_pain()
 
 	// Damage to internal organs hurts a lot.
 	for(var/obj/item/organ/I in internal_organs)
-		if(I.status&ORGAN_DEAD || I.robotic >= ORGAN_ROBOT)
+		if(I.status&ORGAN_DEAD || BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I))
 			continue
 		if(I.damage > 2) if(prob(2))
 			var/obj/item/organ/external/parent = get_organ(I.parent_organ)

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -87,7 +87,7 @@ mob/living/carbon/human/proc/handle_pain()
 	var/maxdam = 0
 	var/obj/item/organ/external/damaged_organ = null
 	for(var/obj/item/organ/external/E in organs)
-		if(E.status&ORGAN_DEAD || BP_IS_ROBOTIC(E) || BP_IS_LIFELIKE(E))
+		if(E.status&ORGAN_DEAD || BP_IS_ROBOTIC(E))
 			continue
 		var/dam = E.get_damage()
 		// make the choice of the organ depend on damage,
@@ -100,7 +100,7 @@ mob/living/carbon/human/proc/handle_pain()
 
 	// Damage to internal organs hurts a lot.
 	for(var/obj/item/organ/I in internal_organs)
-		if(I.status&ORGAN_DEAD || BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I))
+		if(I.status&ORGAN_DEAD || BP_IS_ROBOTIC(I))
 			continue
 		if(I.damage > 2) if(prob(2))
 			var/obj/item/organ/external/parent = get_organ(I.parent_organ)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -550,7 +550,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 		var/obj/item/organ/external/S = H.organs_by_name[user.targeted_organ]
 
 		if (!S) return
-		if(!(BP_IS_ROBOTIC(S) || BP_IS_LIFELIKE(S)) || user.a_intent != I_HELP)
+		if(!BP_IS_ROBOTIC(S) || user.a_intent != I_HELP)
 			return ..()
 
 		if(S.burn_dam)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -550,7 +550,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 		var/obj/item/organ/external/S = H.organs_by_name[user.targeted_organ]
 
 		if (!S) return
-		if(S.robotic < ORGAN_ROBOT || user.a_intent != I_HELP)
+		if(!(BP_IS_ROBOTIC(S) || BP_IS_LIFELIKE(S)) || user.a_intent != I_HELP)
 			return ..()
 
 		if(S.burn_dam)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -33,7 +33,7 @@
 		if(!affected)
 			user << SPAN_DANGER("\The [H] is missing that limb!")
 			return
-		else if(affected.robotic >= ORGAN_ROBOT)
+		else if(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected))
 			user << SPAN_DANGER("You cannot inject a robotic limb.")
 			return
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -26,28 +26,54 @@
 		return
 	if (!istype(M))
 		return
-
+	var/injtime //Injecting through a hardsuit takes long time due to needing to find a port.
+	// Handling errors and injection duration
 	var/mob/living/carbon/human/H = M
 	if(istype(H))
-		var/obj/item/organ/external/affected = H.get_organ(user.targeted_organ)
-		if(!affected)
-			user << SPAN_DANGER("\The [H] is missing that limb!")
-			return
-		else if(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected))
-			user << SPAN_DANGER("You cannot inject a robotic limb.")
-			return
-
-	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
-	user.do_attack_animation(M)
-	user << SPAN_NOTICE("You inject [M] with [src].")
-	M << SPAN_NOTICE("You feel a tiny prick!")
-
-	if(M.reagents)
-		var/contained = reagents.log_list()
-		var/trans = reagents.trans_to_mob(M, amount_per_transfer_from_this, CHEM_BLOOD)
-		admin_inject_log(user, M, src, contained, trans)
-		user << SPAN_NOTICE("[trans] units injected. [reagents.total_volume] units remaining in \the [src].")
-
+		var/obj/item/clothing/suit/space/SS = H.get_equipped_item(slot_wear_suit)
+		var/obj/item/weapon/rig/RIG = H.get_equipped_item(slot_back)
+		if((istype(RIG) && RIG.suit_is_deployed()) || istype(SS))
+			injtime = 30
+			var/obj/item/organ/external/affected = H.get_organ(BP_CHEST)
+			if(BP_IS_ROBOTIC(affected))
+				to_chat(user, SPAN_WARNING("Injection port on [M]'s suit is refusing your [src]."))
+				// I think rig is advanced enough for this, and people will learn what causes this error
+				if(RIG)
+					playsound(src.loc, 'sound/machines/buzz-two.ogg', 50, 1 -3)
+					RIG.visible_message("\icon[RIG]\The [RIG] states \"Attention: User of this suit appears to be synthetic origin\".")
+				return
+		// check without message
+		else if(!H.can_inject(user, FALSE))
+			// lets check if user is easily fooled
+			var/obj/item/organ/external/affected = H.get_organ(user.targeted_organ)
+			if(BP_IS_LIFELIKE(affected) && user && user.stats.getStat(STAT_BIO) < STAT_LEVEL_BASIC)
+				if(M.reagents)
+					var/trans = reagents.remove_any(amount_per_transfer_from_this)
+					user.visible_message(SPAN_WARNING("[user] injects [M] with [src]!"), SPAN_WARNING("You inject [M] with [src]."))
+					to_chat(user, SPAN_NOTICE("[trans] units injected. [reagents.total_volume] units remaining in \the [src]."))
+				return
+			else
+				// if he is not lets show him what actually happened
+				H.can_inject(user, TRUE)
+				return
+	else if(!M.can_inject(user, TRUE))
+		return
+	// handling injection duration on others
+	if(M != user)
+		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+		user.do_attack_animation(M)
+		if(injtime)
+			user.visible_message(SPAN_WARNING("[user] begins hunting for an injection port on [M]'s suit!"), SPAN_WARNING("You begins hunting for an injection port on [M]'s suit!"))
+			if(do_mob(user, M, injtime))
+				user.visible_message(SPAN_WARNING("[user] injects [M] with [src]!"), SPAN_WARNING("You inject [M] with [src]."))
+			else
+				return
+	// handling actual injection
+	// on this stage we are sure that everything is alright
+	var/contained = reagents.log_list()
+	var/trans = reagents.trans_to_mob(M, amount_per_transfer_from_this, CHEM_BLOOD)
+	admin_inject_log(user, M, src, contained, trans)
+	user << SPAN_NOTICE("[trans] units injected. [reagents.total_volume] units remaining in \the [src].")
 	return
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -142,53 +142,78 @@
 			if(!target.reagents.get_free_space())
 				to_chat(user, SPAN_NOTICE("[target] is full."))
 				return
-
-			var/mob/living/carbon/human/H = target
-			if(istype(H))
-				var/obj/item/organ/external/affected = H.get_organ(user.targeted_organ)
-				if(!affected)
-					to_chat(user, SPAN_DANGER("\The [H] is missing that limb!"))
-					return
-				else if(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected))
-					to_chat(user, SPAN_DANGER("You cannot inject a robotic limb."))
-					return
-
-			if(ismob(target) && target != user)
+			if(isliving(target))
+				var/mob/living/L = target
 				var/injtime = time //Injecting through a hardsuit takes longer due to needing to find a port.
-
+				// Handling errors and injection duration
+				var/mob/living/carbon/human/H = target
 				if(istype(H))
-					if(H.wear_suit)
-						if(istype(H.wear_suit, /obj/item/clothing/suit/space))
-							injtime = injtime * 2
-						else if(!H.can_inject(user, 1))
+					var/obj/item/clothing/suit/space/SS = H.get_equipped_item(slot_wear_suit)
+					var/obj/item/weapon/rig/RIG = H.get_equipped_item(slot_back)
+					if((istype(RIG) && RIG.suit_is_deployed()) || istype(SS))
+						injtime = injtime * 2
+						var/obj/item/organ/external/affected = H.get_organ(BP_CHEST)
+						if(BP_IS_ROBOTIC(affected))
+							to_chat(user, SPAN_WARNING("Injection port on [target]'s suit is refusing your [src]."))
+							// I think rig is advanced enough for this, and people will learn what causes this error
+							if(RIG)
+								playsound(src.loc, 'sound/machines/buzz-two.ogg', 30, 1 -3)
+								RIG.visible_message("\icon[RIG]\The [RIG] states \"Attention: User of this suit appears to be synthetic origin\".")
 							return
-
-				else if(isliving(target))
-
-					var/mob/living/M = target
-					if(!M.can_inject(user, 1))
-						return
-
-				if(injtime == time)
-					user.visible_message(SPAN_WARNING("[user] is trying to inject [target] with [visible_name]!"))
-				else
-					user.visible_message(SPAN_WARNING("[user] begins hunting for an injection port on [target]'s suit!"))
-
-				user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
-				user.do_attack_animation(target)
-
-				if(!do_mob(user, target, injtime))
+					// check without message
+					else if(!H.can_inject(user, FALSE))
+						// lets check if user is easily fooled
+						var/obj/item/organ/external/affected = H.get_organ(user.targeted_organ)
+						if(BP_IS_LIFELIKE(affected) && user && user.stats.getStat(STAT_BIO) < STAT_LEVEL_BASIC)
+							break_syringe(user = user)
+							to_chat(user, SPAN_WARNING("\The [src] have broken while trying to inject [target]."))
+							return
+						else
+							// if he is not lets show him what actually happened
+							H.can_inject(user, TRUE)
+							return
+				
+				else if(!L.can_inject(user, TRUE))
 					return
 
-				user.visible_message(SPAN_WARNING("[user] injects [target] with the syringe!"))
+				if(target != user)
+					user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+					user.do_attack_animation(target)
+					if(injtime == time)
+						user.visible_message(SPAN_WARNING("[user] is trying to inject [target] with [visible_name]!"), SPAN_WARNING("You are trying to inject [target] with [visible_name]!"))
+						to_chat(target, SPAN_NOTICE("You feel a tiny prick!"))
+					else
+						user.visible_message(SPAN_WARNING("[user] begins hunting for an injection port on [target]'s suit!"),SPAN_WARNING("You begin hunting for an injection port on [target]'s suit!"))
 
+					if(do_mob(user, target, injtime))
+						user.visible_message(SPAN_WARNING("[user] injects [target] with [src]!"),SPAN_WARNING("You inject [target] with [src]!"))
+					else
+						return
+				else
+					user.visible_message(SPAN_WARNING("[user] injects \himself with [src]!"), SPAN_WARNING("You inject yourself with [src]."), range = 3)
 			var/trans
 			if(ismob(target))
 				trans = reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_BLOOD)
 				admin_inject_log(user, target, src, reagents.log_list(), trans)
+				// user's stat check that causing pain if they are amateur
+				var/mob/living/carbon/human/H = target
+				if(istype(H))
+					var/obj/item/organ/external/affecting = H.get_organ(user.targeted_organ)
+					if(user && user.stats.getStat(STAT_BIO) < STAT_LEVEL_BASIC)
+						if(prob(affecting.get_damage() - user.stats.getStat(STAT_BIO)))
+							var/pain = rand(min(30,affecting.get_damage()), max(affecting.get_damage() + 30,60) - user.stats.getStat(STAT_BIO))
+							H.pain(affecting, pain)
+							if(user != H)
+								to_chat(H, "<span class='[pain > 50 ? "danger" : "warning"]'>\The [user]'s amateur actions caused you [pain > 50 ? "alot of " : ""]pain.</span>")
+								to_chat(user, SPAN_WARNING("Your amateur actions caused [H] [pain > 50 ? "alot of " : ""]pain."))
+							else
+								to_chat(user, "<span class='[pain > 50 ? "danger" : "warning"]'>Your amateur actions caused you [pain > 50 ? "alot of " : ""]pain.</span>")
+				else
+					to_chat(target, SPAN_NOTICE("You feel a tiny prick!"))
 			else
 				trans = reagents.trans_to(target, amount_per_transfer_from_this)
-			to_chat(user, SPAN_NOTICE("You inject [trans] units of the solution. The syringe now contains [src.reagents.total_volume] units."))
+			to_chat(user, SPAN_NOTICE("You inject [trans] units of the solution. [src] now contains [src.reagents.total_volume] units."))
+				
 
 
 /obj/item/weapon/reagent_containers/syringe/update_icon()

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -149,7 +149,7 @@
 				if(!affected)
 					to_chat(user, SPAN_DANGER("\The [H] is missing that limb!"))
 					return
-				else if(affected.robotic >= ORGAN_ROBOT)
+				else if(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected))
 					to_chat(user, SPAN_DANGER("You cannot inject a robotic limb."))
 					return
 

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -278,7 +278,7 @@
 		var/mob/living/carbon/human/H = M
 
 		for(var/obj/item/organ/I in H.internal_organs)
-			if((I.damage > 0) && (I.robotic != 2)) //Peridaxon heals only non-robotic organs
+			if((I.damage > 0) && !(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I))) //Peridaxon heals only non-robotic organs
 				I.damage = max(I.damage - removed, 0)
 
 /datum/reagent/ryetalyn

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -278,7 +278,7 @@
 		var/mob/living/carbon/human/H = M
 
 		for(var/obj/item/organ/I in H.internal_organs)
-			if((I.damage > 0) && !(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I))) //Peridaxon heals only non-robotic organs
+			if((I.damage > 0) && !BP_IS_ROBOTIC(I)) //Peridaxon heals only non-robotic organs
 				I.damage = max(I.damage - removed, 0)
 
 /datum/reagent/ryetalyn

--- a/code/modules/scrap/scrap.dm
+++ b/code/modules/scrap/scrap.dm
@@ -151,7 +151,7 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 				var/picked = pick(check)
 				var/obj/item/organ/external/affecting = H.get_organ(picked)
 				if(affecting)
-					if(BP_IS_ROBOTIC(affecting) || BP_IS_LIFELIKE(affecting))
+					if(BP_IS_ROBOTIC(affecting))
 						return
 					if(affecting.take_damage(5, 0))
 						H.UpdateDamageIcon()
@@ -229,7 +229,7 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 		var/obj/item/organ/external/BP = victim.get_organ(victim.hand ? BP_L_ARM : BP_R_ARM)
 		if(!BP)
 			return FALSE
-		if(BP_IS_ROBOTIC(BP) || BP_IS_LIFELIKE(BP))
+		if(BP_IS_ROBOTIC(BP))
 			return FALSE
 		to_chat(user, "<span class='danger'>Ouch! You cut yourself while picking through \the [src].</span>")
 		BP.take_damage(5, null, TRUE, TRUE, "Sharp debris")

--- a/code/modules/scrap/scrap.dm
+++ b/code/modules/scrap/scrap.dm
@@ -151,7 +151,7 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 				var/picked = pick(check)
 				var/obj/item/organ/external/affecting = H.get_organ(picked)
 				if(affecting)
-					if(affecting.robotic >= ORGAN_ROBOT)
+					if(BP_IS_ROBOTIC(affecting) || BP_IS_LIFELIKE(affecting))
 						return
 					if(affecting.take_damage(5, 0))
 						H.UpdateDamageIcon()
@@ -229,7 +229,7 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 		var/obj/item/organ/external/BP = victim.get_organ(victim.hand ? BP_L_ARM : BP_R_ARM)
 		if(!BP)
 			return FALSE
-		if(BP.status & ORGAN_ROBOT)
+		if(BP_IS_ROBOTIC(BP) || BP_IS_LIFELIKE(BP))
 			return FALSE
 		to_chat(user, "<span class='danger'>Ouch! You cut yourself while picking through \the [src].</span>")
 		BP.take_damage(5, null, TRUE, TRUE, "Sharp debris")

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -16,7 +16,7 @@
 	if (!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && !(affected.robotic >= ORGAN_ROBOT) && affected.open >= 2 && affected.stage == 0
+	return affected && !(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)) && affected.open >= 2 && affected.stage == 0
 
 /datum/surgery_step/remove_bone_shards/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -48,7 +48,7 @@
 	if (!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && affected.organ_tag != BP_HEAD && !(affected.robotic >= ORGAN_ROBOT) && affected.open >= 2 && affected.stage == 1
+	return affected && affected.organ_tag != BP_HEAD && !(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)) && affected.open >= 2 && affected.stage == 1
 
 /datum/surgery_step/set_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -84,7 +84,7 @@
 	if (!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && affected.organ_tag == BP_HEAD && !(affected.robotic >= ORGAN_ROBOT) && affected.open >= 2 && affected.stage == 1
+	return affected && affected.organ_tag == BP_HEAD && !(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)) && affected.open >= 2 && affected.stage == 1
 
 /datum/surgery_step/mend_skull/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("[user] is beginning to piece together [target]'s skull with \the [tool]."  , \
@@ -118,7 +118,7 @@
 	if (!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && affected.open >= 2 && !(affected.robotic >= ORGAN_ROBOT) && affected.stage == 2
+	return affected && affected.open >= 2 && !(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)) && affected.stage == 2
 
 /datum/surgery_step/finish_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -16,7 +16,7 @@
 	if (!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && !(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)) && affected.open >= 2 && affected.stage == 0
+	return affected && !BP_IS_ROBOTIC(affected) && affected.open >= 2 && affected.stage == 0
 
 /datum/surgery_step/remove_bone_shards/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -48,7 +48,7 @@
 	if (!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && affected.organ_tag != BP_HEAD && !(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)) && affected.open >= 2 && affected.stage == 1
+	return affected && affected.organ_tag != BP_HEAD && !BP_IS_ROBOTIC(affected) && affected.open >= 2 && affected.stage == 1
 
 /datum/surgery_step/set_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -84,7 +84,7 @@
 	if (!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && affected.organ_tag == BP_HEAD && !(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)) && affected.open >= 2 && affected.stage == 1
+	return affected && affected.organ_tag == BP_HEAD && !BP_IS_ROBOTIC(affected) && affected.open >= 2 && affected.stage == 1
 
 /datum/surgery_step/mend_skull/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("[user] is beginning to piece together [target]'s skull with \the [tool]."  , \
@@ -118,7 +118,7 @@
 	if (!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && affected.open >= 2 && !(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)) && affected.stage == 2
+	return affected && affected.open >= 2 && !BP_IS_ROBOTIC(affected) && affected.stage == 2
 
 /datum/surgery_step/finish_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -12,7 +12,7 @@
 		return 0
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && !(affected.robotic >= ORGAN_ROBOT) && affected.encased && affected.open >= 2
+	return affected && !(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)) && affected.encased && affected.open >= 2
 
 
 /datum/surgery_step/open_encased/saw

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -12,7 +12,7 @@
 		return 0
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && !(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)) && affected.encased && affected.open >= 2
+	return affected && !BP_IS_ROBOTIC(affected) && affected.encased && affected.open >= 2
 
 
 /datum/surgery_step/open_encased/saw

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -10,7 +10,7 @@
 	if (!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if (!affected || (BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)))
+	if (!affected || BP_IS_ROBOTIC(affected))
 		return 0
 	return target_zone == BP_MOUTH
 

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -10,7 +10,7 @@
 	if (!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if (!affected || (affected.robotic >= ORGAN_ROBOT))
+	if (!affected || (BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)))
 		return 0
 	return target_zone == BP_MOUTH
 

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -17,7 +17,7 @@
 		return 0
 	if (affected.is_stump())
 		return 0
-	if (affected.robotic >= ORGAN_ROBOT)
+	if (BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected))
 		return 0
 	return 1
 

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -17,7 +17,7 @@
 		return 0
 	if (affected.is_stump())
 		return 0
-	if (BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected))
+	if (BP_IS_ROBOTIC(affected))
 		return 0
 	return 1
 

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -120,7 +120,7 @@
 
 		user.visible_message("\blue [user] puts \the [tool] inside [target]'s [get_cavity(affected)] cavity.", \
 		"\blue You put \the [tool] inside [target]'s [get_cavity(affected)] cavity." )
-		if (tool.w_class > get_max_wclass(affected)/2 && prob(50) && !(affected.robotic >= ORGAN_ROBOT))
+		if (tool.w_class > get_max_wclass(affected)/2 && prob(50) && !(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)))
 			user << "\red You tear some blood vessels trying to fit such a big object in this cavity."
 			var/datum/wound/internal_bleeding/I = new (10)
 			affected.wounds += I

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -120,7 +120,7 @@
 
 		user.visible_message("\blue [user] puts \the [tool] inside [target]'s [get_cavity(affected)] cavity.", \
 		"\blue You put \the [tool] inside [target]'s [get_cavity(affected)] cavity." )
-		if (tool.w_class > get_max_wclass(affected)/2 && prob(50) && !(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)))
+		if (tool.w_class > get_max_wclass(affected)/2 && prob(50) && !BP_IS_ROBOTIC(affected))
 			user << "\red You tear some blood vessels trying to fit such a big object in this cavity."
 			var/datum/wound/internal_bleeding/I = new (10)
 			affected.wounds += I

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -54,15 +54,15 @@
 
 	for(var/obj/item/organ/I in affected.internal_organs)
 		if (istype(tool, /obj/item/stack/medical/advanced/bruise_pack))
-			if (I.damage > 0 && I.robotic <= 1)
+			if (I.damage > 0 && !(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I)))
 				user.visible_message("[user] starts treating damage to [target]'s [I.name] with [tool_name].", \
 				"You start treating damage to [target]'s [I.name] with [tool_name]." )
 		else if (istype(tool, /obj/item/stack/medical/bruise_pack))
-			if (I.damage > 0 && I.robotic <= 1)
+			if (I.damage > 0 && !(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I)))
 				user.visible_message("[user] starts treating damage to [target]'s [I.name] with [tool_name].", \
 				"You start treating damage to [target]'s [I.name] with [tool_name]." )
 		else if (istype(tool, /obj/item/stack/nanopaste))
-			if (I.damage > 0 && I.robotic >= 1)
+			if (I.damage > 0 && (BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I) || BP_IS_ASSISTED(I)))
 				user.visible_message(SPAN_NOTICE("[user] treats damage to [target]'s [I.name] with [tool_name]."), \
 				SPAN_NOTICE("You treat damage to [target]'s [I.name] with [tool_name].") )
 
@@ -84,17 +84,17 @@
 
 	for(var/obj/item/organ/I in affected.internal_organs)
 		if (istype(tool, /obj/item/stack/medical/advanced/bruise_pack))
-			if (I.damage > 0 && I.robotic <= 1)
+			if (I.damage > 0 && !(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I)))
 				user.visible_message(SPAN_NOTICE("[user] treats damage to [target]'s [I.name] with [tool_name]."), \
 				SPAN_NOTICE("You treat damage to [target]'s [I.name] with [tool_name].") )
 				I.damage = 0
 		else if (istype(tool, /obj/item/stack/medical/advanced/bruise_pack))
-			if (I.damage > 0 && I.robotic <= 1)
+			if (I.damage > 0 && !(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I)))
 				user.visible_message(SPAN_NOTICE("[user] treats damage to [target]'s [I.name] with [tool_name]."), \
 				SPAN_NOTICE("You treat damage to [target]'s [I.name] with [tool_name].") )
 				I.damage = 0
 		else if (istype(tool, /obj/item/stack/nanopaste))
-			if (I.damage > 0 && I.robotic >= 1)
+			if (I.damage > 0 && (BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I) || BP_IS_ASSISTED(I)))
 				user.visible_message(SPAN_NOTICE("[user] treats damage to [target]'s [I.name] with [tool_name]."), \
 				SPAN_NOTICE("You treat damage to [target]'s [I.name] with [tool_name].") )
 				I.damage= 0
@@ -135,7 +135,7 @@
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
-	if(!(affected && !(affected.robotic >= ORGAN_ROBOT)))
+	if(!(affected && !(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected))))
 		return 0
 
 	target.op_stage.current_organ = null
@@ -272,7 +272,7 @@
 	if(!istype(O))
 		return 0
 
-	if((affected.robotic >= ORGAN_ROBOT) && !(O.robotic >= ORGAN_ROBOT))
+	if((BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)) && !(BP_IS_ROBOTIC(O) || BP_IS_LIFELIKE(O)))
 		user << SPAN_DANGER("You cannot install a naked organ into a robotic body.")
 		return SURGERY_FAILURE
 
@@ -346,7 +346,7 @@
 	var/list/removable_organs = list()
 	for(var/organ in target.internal_organs_by_name)
 		var/obj/item/organ/I = target.internal_organs_by_name[organ]
-		if(I && (I.status & ORGAN_CUT_AWAY) && !(I.robotic >= ORGAN_ROBOT) && I.parent_organ == target_zone)
+		if(I && (I.status & ORGAN_CUT_AWAY) && !(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I)) && I.parent_organ == target_zone)
 			removable_organs |= organ
 
 	if(!removable_organs.len)
@@ -358,7 +358,7 @@
 	var/list/removable_organs = list()
 	for(var/organ in target.internal_organs_by_name)
 		var/obj/item/organ/I = target.internal_organs_by_name[organ]
-		if(I && (I.status & ORGAN_CUT_AWAY) && !(I.robotic >= ORGAN_ROBOT) && I.parent_organ == target_zone)
+		if(I && (I.status & ORGAN_CUT_AWAY) && !(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I)) && I.parent_organ == target_zone)
 			removable_organs |= organ
 
 	var/organ_to_replace = input(user, "Which organ do you want to reattach?") as null|anything in removable_organs

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -54,15 +54,15 @@
 
 	for(var/obj/item/organ/I in affected.internal_organs)
 		if (istype(tool, /obj/item/stack/medical/advanced/bruise_pack))
-			if (I.damage > 0 && !(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I)))
+			if (I.damage > 0 && !BP_IS_ROBOTIC(I))
 				user.visible_message("[user] starts treating damage to [target]'s [I.name] with [tool_name].", \
 				"You start treating damage to [target]'s [I.name] with [tool_name]." )
 		else if (istype(tool, /obj/item/stack/medical/bruise_pack))
-			if (I.damage > 0 && !(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I)))
+			if (I.damage > 0 && !BP_IS_ROBOTIC(I))
 				user.visible_message("[user] starts treating damage to [target]'s [I.name] with [tool_name].", \
 				"You start treating damage to [target]'s [I.name] with [tool_name]." )
 		else if (istype(tool, /obj/item/stack/nanopaste))
-			if (I.damage > 0 && (BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I) || BP_IS_ASSISTED(I)))
+			if (I.damage > 0 && (BP_IS_ROBOTIC(I) || BP_IS_ASSISTED(I)))
 				user.visible_message(SPAN_NOTICE("[user] treats damage to [target]'s [I.name] with [tool_name]."), \
 				SPAN_NOTICE("You treat damage to [target]'s [I.name] with [tool_name].") )
 
@@ -84,17 +84,17 @@
 
 	for(var/obj/item/organ/I in affected.internal_organs)
 		if (istype(tool, /obj/item/stack/medical/advanced/bruise_pack))
-			if (I.damage > 0 && !(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I)))
+			if (I.damage > 0 && !BP_IS_ROBOTIC(I))
 				user.visible_message(SPAN_NOTICE("[user] treats damage to [target]'s [I.name] with [tool_name]."), \
 				SPAN_NOTICE("You treat damage to [target]'s [I.name] with [tool_name].") )
 				I.damage = 0
 		else if (istype(tool, /obj/item/stack/medical/advanced/bruise_pack))
-			if (I.damage > 0 && !(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I)))
+			if (I.damage > 0 && !BP_IS_ROBOTIC(I))
 				user.visible_message(SPAN_NOTICE("[user] treats damage to [target]'s [I.name] with [tool_name]."), \
 				SPAN_NOTICE("You treat damage to [target]'s [I.name] with [tool_name].") )
 				I.damage = 0
 		else if (istype(tool, /obj/item/stack/nanopaste))
-			if (I.damage > 0 && (BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I) || BP_IS_ASSISTED(I)))
+			if (I.damage > 0 && (BP_IS_ROBOTIC(I) || BP_IS_ASSISTED(I)))
 				user.visible_message(SPAN_NOTICE("[user] treats damage to [target]'s [I.name] with [tool_name]."), \
 				SPAN_NOTICE("You treat damage to [target]'s [I.name] with [tool_name].") )
 				I.damage= 0
@@ -135,7 +135,7 @@
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
-	if(!(affected && !(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected))))
+	if(!(affected && !BP_IS_ROBOTIC(affected)))
 		return 0
 
 	target.op_stage.current_organ = null
@@ -272,7 +272,7 @@
 	if(!istype(O))
 		return 0
 
-	if((BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)) && !(BP_IS_ROBOTIC(O) || BP_IS_LIFELIKE(O)))
+	if(BP_IS_ROBOTIC(affected) && !BP_IS_ROBOTIC(O))
 		user << SPAN_DANGER("You cannot install a naked organ into a robotic body.")
 		return SURGERY_FAILURE
 
@@ -346,7 +346,7 @@
 	var/list/removable_organs = list()
 	for(var/organ in target.internal_organs_by_name)
 		var/obj/item/organ/I = target.internal_organs_by_name[organ]
-		if(I && (I.status & ORGAN_CUT_AWAY) && !(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I)) && I.parent_organ == target_zone)
+		if(I && (I.status & ORGAN_CUT_AWAY) && !BP_IS_ROBOTIC(I) && I.parent_organ == target_zone)
 			removable_organs |= organ
 
 	if(!removable_organs.len)
@@ -358,7 +358,7 @@
 	var/list/removable_organs = list()
 	for(var/organ in target.internal_organs_by_name)
 		var/obj/item/organ/I = target.internal_organs_by_name[organ]
-		if(I && (I.status & ORGAN_CUT_AWAY) && !(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I)) && I.parent_organ == target_zone)
+		if(I && (I.status & ORGAN_CUT_AWAY) && !BP_IS_ROBOTIC(I) && I.parent_organ == target_zone)
 			removable_organs |= organ
 
 	var/organ_to_replace = input(user, "Which organ do you want to reattach?") as null|anything in removable_organs

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -17,7 +17,7 @@
 		return 0
 	if (affected.status & ORGAN_DESTROYED)
 		return 0
-	if (!(affected.robotic >= ORGAN_ROBOT))
+	if (!(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)))
 		return 0
 	return 1
 
@@ -191,7 +191,7 @@
 	if(!affected) return
 	var/is_organ_damaged = 0
 	for(var/obj/item/organ/I in affected.internal_organs)
-		if(I.damage > 0 && I.robotic >= 2)
+		if(I.damage > 0 && (BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I)))
 			is_organ_damaged = 1
 			break
 	return affected.open == 2 && is_organ_damaged
@@ -204,7 +204,7 @@
 
 	for(var/obj/item/organ/I in affected.internal_organs)
 		if(I && I.damage > 0)
-			if(I.robotic >= 2)
+			if(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I))
 				user.visible_message("[user] starts mending the damage to [target]'s [I.name]'s mechanisms.", \
 				"You start mending the damage to [target]'s [I.name]'s mechanisms." )
 
@@ -220,7 +220,7 @@
 	for(var/obj/item/organ/I in affected.internal_organs)
 
 		if(I && I.damage > 0)
-			if(I.robotic >= 2)
+			if(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I))
 				user.visible_message(SPAN_NOTICE("[user] repairs [target]'s [I.name] with [tool]."), \
 				SPAN_NOTICE("You repair [target]'s [I.name] with [tool].") )
 				I.damage = 0
@@ -250,7 +250,7 @@
 /datum/surgery_step/robotics/detatch_organ_robotic/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(!(affected && (affected.robotic >= ORGAN_ROBOT)))
+	if(!(affected && (BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected))))
 		return 0
 	if(affected.open != 2)
 		return 0
@@ -301,7 +301,7 @@
 /datum/surgery_step/robotics/attach_organ_robotic/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(!(affected && (affected.robotic >= ORGAN_ROBOT)))
+	if(!(affected && (BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected))))
 		return 0
 	if(affected.open != 2)
 		return 0
@@ -311,7 +311,7 @@
 	var/list/removable_organs = list()
 	for(var/organ in target.internal_organs_by_name)
 		var/obj/item/organ/I = target.internal_organs_by_name[organ]
-		if(I && (I.status & ORGAN_CUT_AWAY) && (I.robotic >= ORGAN_ROBOT) && I.parent_organ == target_zone)
+		if(I && (I.status & ORGAN_CUT_AWAY) && (BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I)) && I.parent_organ == target_zone)
 			removable_organs |= organ
 
 	var/organ_to_replace = input(user, "Which organ do you want to reattach?") as null|anything in removable_organs
@@ -363,7 +363,7 @@
 		user << SPAN_DANGER("That brain is not usable.")
 		return SURGERY_FAILURE
 
-	if(!(affected.robotic >= ORGAN_ROBOT))
+	if(BP_IS_ORGANIC(affected) || BP_IS_ASSISTED(affected))
 		user << SPAN_DANGER("You cannot install a computer brain into a meat skull.")
 		return SURGERY_FAILURE
 

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -17,7 +17,7 @@
 		return 0
 	if (affected.status & ORGAN_DESTROYED)
 		return 0
-	if (!(BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected)))
+	if (!BP_IS_ROBOTIC(affected))
 		return 0
 	return 1
 
@@ -191,7 +191,7 @@
 	if(!affected) return
 	var/is_organ_damaged = 0
 	for(var/obj/item/organ/I in affected.internal_organs)
-		if(I.damage > 0 && (BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I)))
+		if(I.damage > 0 && BP_IS_ROBOTIC(I))
 			is_organ_damaged = 1
 			break
 	return affected.open == 2 && is_organ_damaged
@@ -204,7 +204,7 @@
 
 	for(var/obj/item/organ/I in affected.internal_organs)
 		if(I && I.damage > 0)
-			if(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I))
+			if(BP_IS_ROBOTIC(I))
 				user.visible_message("[user] starts mending the damage to [target]'s [I.name]'s mechanisms.", \
 				"You start mending the damage to [target]'s [I.name]'s mechanisms." )
 
@@ -220,7 +220,7 @@
 	for(var/obj/item/organ/I in affected.internal_organs)
 
 		if(I && I.damage > 0)
-			if(BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I))
+			if(BP_IS_ROBOTIC(I))
 				user.visible_message(SPAN_NOTICE("[user] repairs [target]'s [I.name] with [tool]."), \
 				SPAN_NOTICE("You repair [target]'s [I.name] with [tool].") )
 				I.damage = 0
@@ -250,7 +250,7 @@
 /datum/surgery_step/robotics/detatch_organ_robotic/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(!(affected && (BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected))))
+	if(!(affected && BP_IS_ROBOTIC(affected)))
 		return 0
 	if(affected.open != 2)
 		return 0
@@ -301,7 +301,7 @@
 /datum/surgery_step/robotics/attach_organ_robotic/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(!(affected && (BP_IS_ROBOTIC(affected) || BP_IS_LIFELIKE(affected))))
+	if(!(affected && BP_IS_ROBOTIC(affected)))
 		return 0
 	if(affected.open != 2)
 		return 0
@@ -311,7 +311,7 @@
 	var/list/removable_organs = list()
 	for(var/organ in target.internal_organs_by_name)
 		var/obj/item/organ/I = target.internal_organs_by_name[organ]
-		if(I && (I.status & ORGAN_CUT_AWAY) && (BP_IS_ROBOTIC(I) || BP_IS_LIFELIKE(I)) && I.parent_organ == target_zone)
+		if(I && (I.status & ORGAN_CUT_AWAY) && BP_IS_ROBOTIC(I) && I.parent_organ == target_zone)
 			removable_organs |= organ
 
 	var/organ_to_replace = input(user, "Which organ do you want to reattach?") as null|anything in removable_organs

--- a/nano/templates/crew_monitor.tmpl
+++ b/nano/templates/crew_monitor.tmpl
@@ -15,6 +15,7 @@ Used In File(s): code\modules\modular_computers\file_system\programs\medical\sui
 </style>
 
 {{:helper.link('Show Tracker Map', 'pin-s', {'showMap' : 1})}}
+{{:helper.link(data.search, 'search', {'search' : 1})}}
 <table class='wideTable'><tbody>
 	{{for data.crewmembers}}
 		<tr class="candystripe">

--- a/nano/templates/crew_monitor.tmpl
+++ b/nano/templates/crew_monitor.tmpl
@@ -22,7 +22,7 @@ Used In File(s): code\modules\modular_computers\file_system\programs\medical\sui
 
 			{{if value.sensor_type >= 2}}
 				{{if value.true_pulse == -1}}
-					<td><span class="white">Pulse</span> <span class='{{:value.pulse_span}}'>{{:value.pulse}}</span></td>
+					<td><span class="white">Heart: </span> <span class='{{:value.pulse_span}}'>{{:value.pulse}}</span></td>
 				{{else}}
 					<td><span class="white">Pulse</span> <span class='{{:value.pulse_span}}'>{{:value.pulse}}</span> bpm</td>
 				{{/if}}

--- a/nano/templates/crew_monitor.tmpl
+++ b/nano/templates/crew_monitor.tmpl
@@ -18,8 +18,11 @@ Used In File(s): code\modules\modular_computers\file_system\programs\medical\sui
 <table class='wideTable'><tbody>
 	{{for data.crewmembers}}
 		<tr class="candystripe">
-			<td>{{:value.name}} ({{:value.assignment}}): </td>
-
+			<td>{{:value.name}} ({{:value.assignment}}): 
+			{{if value.isCriminal}}
+			<span class='average'> [Criminal]</span>
+			{{/if}}
+			</td>
 			{{if value.sensor_type >= 2}}
 				{{if value.true_pulse == -1}}
 					<td><span class="white">Heart: </span> <span class='{{:value.pulse_span}}'>{{:value.pulse}}</span></td>


### PR DESCRIPTION
Fixes:
- some bugs related to wrong organ status comparison
- baymed organ checks

Refactor:
- organ modifications
- syringe/hypospray code

Addition:
- Pain while injection or treating with gauze when user has very low bio stats

Improvements:
- Crew sensor's entries are sorted by name
- People marked as criminals in crew reports has [Criminal] tag in crew sensors
- Criminals or people with health problems are listed first
- People marked as dead i crew reports wont be shown in crew sensors
- People with synthetic heart will be marked in crew sensors
- Search function for crew sensors
- Validation checks to syringe/hypo
- Rig can be injected using syringe/hypo like spacesuit