### PR TITLE
Automatically restarts server after sometime if no players

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -70,6 +70,7 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 	var/ToRban = 0
 	var/automute_on = 0					//enables automuting/spam prevention
 	var/use_cortical_stacks = 0			//enables neural lace
+	var/empty_server_restart_time = 0	// Time in minutes before empty server will restart		
 
 	var/character_slots = 10				// The number of available character slots
 	var/loadout_slots = 3					// The number of loadout slots per character
@@ -654,6 +655,9 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 
 				if ("lobby_screens")
 					config.lobby_screens = splittext(value, ";")
+				
+				if("empty_server_restart_time")
+					config.empty_server_restart_time = text2num(value)
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -30,6 +30,7 @@ SUBSYSTEM_DEF(ticker)
 	var/list/availablefactions = list()	  // list of factions with openings
 
 	var/pregame_timeleft = 180
+	var/last_player_left_timestamp = 0
 
 	var/delay_end = 0	//if set to nonzero, the round will not restart on it's own
 
@@ -104,6 +105,9 @@ SUBSYSTEM_DEF(ticker)
 			if(start_immediately)
 				pregame_timeleft = 0
 
+			if(!process_empty_server())
+				return
+
 			if(round_progressing)
 				pregame_timeleft--
 
@@ -130,6 +134,9 @@ SUBSYSTEM_DEF(ticker)
 		if(GAME_STATE_PLAYING)
 			GLOB.storyteller.Process()
 			GLOB.storyteller.process_events()
+
+			if(!process_empty_server())
+				return
 
 			var/game_finished = (evacuation_controller.round_over() || ship_was_nuked  || universe_has_ended)
 
@@ -159,6 +166,45 @@ SUBSYSTEM_DEF(ticker)
 							world << SPAN_NOTICE("<b>An admin has delayed the round end</b>")
 					else
 						world << SPAN_NOTICE("<b>An admin has delayed the round end</b>")
+
+// This proc will scan for player and if the game is in progress and... 
+// there is no player for certain minutes (see config.empty_server_restart_time) it will restart the server and return FALSE
+// If the game in pregame state if will reset roundstart timer and return FALSE
+// otherwise it will return TRUE
+// will also return TRUE if its currently counting down to server's restart after last player left
+
+/datum/controller/subsystem/ticker/proc/process_empty_server()
+	if(!config.empty_server_restart_time)
+		return TRUE
+	switch(current_state)
+		if(GAME_STATE_PLAYING)
+			if(clients.len)
+				// Resets countdown if any player connects on empty server
+				if(last_player_left_timestamp)
+					last_player_left_timestamp = 0
+				return TRUE
+			else
+				// Last player left so we store the time when he left
+				if(!last_player_left_timestamp)
+					last_player_left_timestamp = world.time
+					return TRUE
+				// Counting down the world's end
+				else if (world.time >= last_player_left_timestamp + (config.empty_server_restart_time MINUTES))
+					last_player_left_timestamp = 0
+					log_game("\[Server\] No players were on a server last [config.empty_server_restart_time] minutes, restarting server...")
+					world.Reboot()
+					return FALSE
+		if(GAME_STATE_PREGAME)
+			if(!clients.len)
+				// if pregame and no player we break fire() execution so no countdown will be done
+				if(pregame_timeleft == initial(pregame_timeleft))
+					return FALSE
+				// Resetting countdown time
+				else
+					pregame_timeleft = initial(pregame_timeleft)
+					quoted = FALSE
+					return FALSE
+	return TRUE
 
 /datum/controller/subsystem/ticker/proc/setup()
 	//Create and announce mode

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -302,3 +302,6 @@ JOIN_UNASSIGNED
 
 ## Clients will be unable to connect unless their build is equal to or higher than this (a number, e.g. 1000)
 #MINIMUM_BYOND_BUILD
+
+## Time in minutes before empty server will restart	
+EMPTY_SERVER_RESTART_TIME 30


### PR DESCRIPTION
This PR adds automatic server restart when there is no players on a server for some time (can be changed in config)
Will not restart if there is no value in config or it is 0

### **This can potentially solve no player issues on russian server cause many players don't know how to restart server when the ship us fucked up**


### **AND DONT FORGET TO UPDATE CONFIG FILE**