### PR TITLE
Crafting improvements, stat checks reworks

### DIFF
--- a/code/__defines/mob_stats.dm
+++ b/code/__defines/mob_stats.dm
@@ -17,10 +17,3 @@
 
 #define STAT_LEVEL_MIN      0 // Min stat value selectable
 #define STAT_LEVEL_MAX      60 // Max stat value selectable
-
-
-//Compound stat checks. These tell the getStat function how to combine multiple stats
-#define STAT_MAX	"max"	//Get the highest value among the stats passed in
-#define STAT_MIN	"min"	//Lowest value among the stats passed in
-#define STAT_AVG	"avg"	//Get the average (mean) value of the stats
-#define STAT_SUM	"sum" 	//Sum total of the stats

--- a/code/datums/craft/recipe.dm
+++ b/code/datums/craft/recipe.dm
@@ -7,6 +7,7 @@
 	var/list/steps
 	var/flags
 	var/time = 30 //Used when no specific time is set
+	var/related_stats = list(STAT_COG)	// used to decrease crafting time for non tool steps
 
 /datum/craft_recipe/New()
 	var/step_definations = steps
@@ -17,7 +18,6 @@
 
 /datum/craft_recipe/proc/is_compelete(step)
 	return steps.len < step
-
 
 /datum/craft_recipe/proc/spawn_result(obj/item/craft/C, mob/living/user)
 	var/atom/movable/M = new result(get_turf(C))

--- a/code/datums/craft/recipes/airlocks.dm
+++ b/code/datums/craft/recipes/airlocks.dm
@@ -5,6 +5,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL),
 	)
+	related_stats = list(STAT_MEC)
 
 /datum/craft_recipe/airlock/standard
 	name = "standard airlock assembly"

--- a/code/datums/craft/recipes/clothing.dm
+++ b/code/datums/craft/recipes/clothing.dm
@@ -1,6 +1,7 @@
 /datum/craft_recipe/clothing
 	category = "Clothing"
 	time = 50
+	related_stats = list(STAT_COG)
 
 /datum/craft_recipe/clothing/cardborg_suit
 	name = "cardborg suit"

--- a/code/datums/craft/recipes/floor.dm
+++ b/code/datums/craft/recipes/floor.dm
@@ -4,6 +4,7 @@
 		list(CRAFT_MATERIAL, 1, MATERIAL_STEEL),
 	)
 	time = 1 //Crafting individual tiles is fast
+	related_stats = list(STAT_MEC)
 
 /datum/craft_recipe/floor/wood
 	name = "wood floor tile"

--- a/code/datums/craft/recipes/furniture.dm
+++ b/code/datums/craft/recipes/furniture.dm
@@ -1,12 +1,20 @@
 /datum/craft_recipe/furniture
 	category = "Furniture"
 	flags = CRAFT_ON_FLOOR|CRAFT_ONE_PER_TURF
+	related_stats = list(STAT_MEC)
 	time = 80
 
 
 /datum/craft_recipe/furniture/railing
 	name = "railing"
 	result = /obj/structure/railing
+	steps = list(
+		list(CRAFT_MATERIAL, 4, MATERIAL_STEEL),
+	)
+
+/datum/craft_recipe/furniture/railing_grey
+	name = "grey railing"
+	result = /obj/structure/railing/grey
 	steps = list(
 		list(CRAFT_MATERIAL, 4, MATERIAL_STEEL),
 	)

--- a/code/datums/craft/recipes/machinery.dm
+++ b/code/datums/craft/recipes/machinery.dm
@@ -2,6 +2,7 @@
 	category = "Machinery"
 	flags = CRAFT_ON_FLOOR|CRAFT_ONE_PER_TURF
 	time = 120
+	related_stats = list(STAT_MEC)
 
 /datum/craft_recipe/machinery/machine_frame
 	name = "machine frame"
@@ -17,14 +18,17 @@
 		list(CRAFT_MATERIAL, 8, MATERIAL_STEEL),
 	)
 
-/datum/craft_recipe/machinery/computer_frame
+/datum/craft_recipe/machinery/computer
+	related_stats = list(STAT_MEC, STAT_COG)
+
+/datum/craft_recipe/machinery/computer/computer_frame
 	name = "computer frame"
 	result = /obj/structure/computerframe
 	steps = list(
 		list(CRAFT_MATERIAL, 5, MATERIAL_STEEL),
 	)
 
-/datum/craft_recipe/machinery/modularconsole
+/datum/craft_recipe/machinery/computer/modularconsole
 	name = "modular console frame"
 	result = /obj/item/modular_computer/console
 	time = 200
@@ -34,7 +38,7 @@
 		list(CRAFT_MATERIAL, 4, MATERIAL_GLASS),
 	)
 
-/datum/craft_recipe/machinery/modularlaptop
+/datum/craft_recipe/machinery/computer/modularlaptop
 	name = "modular laptop frame"
 	result = /obj/item/modular_computer/laptop
 	time = 200
@@ -43,7 +47,7 @@
 		list(CRAFT_MATERIAL, 4, MATERIAL_GLASS),
 	)
 
-/datum/craft_recipe/machinery/modulartablet
+/datum/craft_recipe/machinery/computer/modulartablet
 	name = "modular tablet frame"
 	result = /obj/item/modular_computer/tablet
 	time = 200
@@ -52,7 +56,7 @@
 		list(CRAFT_MATERIAL, 2, MATERIAL_GLASS),
 	)
 
-/datum/craft_recipe/machinery/modularpda
+/datum/craft_recipe/machinery/computer/modularpda
 	name = "modular pda frame"
 	result = /obj/item/modular_computer/pda
 	time = 200
@@ -61,7 +65,7 @@
 		list(CRAFT_MATERIAL, 1, MATERIAL_GLASS),
 	)
 
-/datum/craft_recipe/machinery/modulartelescreen
+/datum/craft_recipe/machinery/computer/modulartelescreen
 	name = "modular telescreen frame"
 	result = /obj/item/modular_computer/telescreen
 	time = 200
@@ -112,3 +116,4 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 10, MATERIAL_PLASTEEL),
 	)
+	related_stats = list(STAT_MEC, STAT_COG)

--- a/code/datums/craft/recipes/misc.dm
+++ b/code/datums/craft/recipes/misc.dm
@@ -6,6 +6,7 @@
 		list(CRAFT_MATERIAL, 5, MATERIAL_STEEL)
 	)
 	flags = CRAFT_ON_FLOOR|CRAFT_ONE_PER_TURF
+	related_stats = list(STAT_MEC)
 
 /datum/craft_recipe/wall_girders/low
 	name = "low girders"
@@ -14,6 +15,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 3, MATERIAL_STEEL)
 	)
+	related_stats = list(STAT_MEC)
 
 /datum/craft_recipe/kitchen_spike
 	name = "Meat spike"
@@ -24,6 +26,7 @@
 		list(QUALITY_WELDING, 20, 50)
 	)
 	flags = CRAFT_ON_FLOOR|CRAFT_ONE_PER_TURF
+	related_stats = list(STAT_MEC)
 
 /datum/craft_recipe/metal_rod
 	name = "metal rod"
@@ -32,6 +35,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_STEEL)
 	)
+	related_stats = list(STAT_COG)
 
 /datum/craft_recipe/box
 	name = "box"
@@ -39,7 +43,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
 	)
-
+	related_stats = list(STAT_COG)
 
 /datum/craft_recipe/plastic_bag
 	name = "plastic bag"
@@ -47,6 +51,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTIC)
 	)
+	related_stats = list(STAT_COG)
 
 /datum/craft_recipe/blood_pack
 	name = "blood pack"
@@ -54,6 +59,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTIC)
 	)
+	related_stats = list(STAT_COG)
 
 /datum/craft_recipe/ashtray
 	name = "ashtray"
@@ -61,6 +67,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_STEEL)
 	)
+	related_stats = list(STAT_COG)
 
 /datum/craft_recipe/beehive_assembly
 	name = "beehive assembly"
@@ -68,6 +75,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 10, MATERIAL_WOOD)
 	)
+	related_stats = list(STAT_MEC)
 
 /datum/craft_recipe/beehive_frame
 	name = "beehive frame"
@@ -75,6 +83,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_WOOD)
 	)
+	related_stats = list(STAT_MEC)
 
 /datum/craft_recipe/canister
 	name = "canister"
@@ -83,6 +92,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL)
 	)
+	related_stats = list(STAT_MEC)
 
 /datum/craft_recipe/cannon_frame
 	name = "cannon frame"
@@ -91,8 +101,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL)
 	)
-
-
+	related_stats = list(STAT_MEC)
 
 /datum/craft_recipe/folder
 	name = "grey folder"
@@ -100,6 +109,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
 	)
+	related_stats = list(STAT_COG)
 
 /datum/craft_recipe/folder/blue
 	name = "blue folder"
@@ -117,14 +127,13 @@
 	name = "yellow folder"
 	result = /obj/item/weapon/folder/yellow
 
-
-
 /datum/craft_recipe/bandage
 	name = "bandages"
 	result = /obj/item/stack/medical/bruise_pack/handmade
 	steps = list(
 		list(/obj/item/clothing, 1, time = 30)
 	)
+	related_stats = list(STAT_COG)
 
 /datum/craft_recipe/handmade_handtele
 	name = "cheap hand-tele"
@@ -138,6 +147,7 @@
 		list(/obj/item/weapon/cell/small, 1),
 		list(/obj/item/stack/cable_coil, 5, "time" = 20)
 	)
+	related_stats = list(STAT_COG)
 
 /datum/craft_recipe/tray
 	name = "dinner tray"
@@ -146,6 +156,7 @@
 		list(CRAFT_MATERIAL, 1, MATERIAL_STEEL, "time" = 40),
 		list(QUALITY_WIRE_CUTTING, 10, 120)
 	)
+	related_stats = list(STAT_COG)
 
 
 //You build a frame from rods, add metal shelves, plastic wheels and handles
@@ -161,6 +172,7 @@
 		list(CRAFT_MATERIAL, 10, MATERIAL_PLASTIC, "time" = 40),
 		list(QUALITY_BOLT_TURNING, 10, 60)
 	)
+	related_stats = list(STAT_COG)
 
 
 //Cut variously sized bits of plastic down to size, tape them together, and then use a welder to melt gaps
@@ -174,6 +186,7 @@
 		list(QUALITY_SEALING, 10, 60),
 		list(QUALITY_WELDING, 10, 60)
 	)
+	related_stats = list(STAT_COG)
 
 
 //You get some article of clothing and shred it with a blade to make a mophead. Add in some metal rods for a handle
@@ -186,3 +199,4 @@
 		list(/obj/item/stack/rods, 2),
 		list(QUALITY_BOLT_TURNING, 10, 60)
 	)
+	related_stats = list(STAT_COG)

--- a/code/datums/craft/recipes/tools.dm
+++ b/code/datums/craft/recipes/tools.dm
@@ -1,6 +1,7 @@
 /datum/craft_recipe/tool
 	category = "Tools"
 	time = 100
+	related_stats = list(STAT_COG)
 
 
 /datum/craft_recipe/tool/webtape

--- a/code/datums/craft/recipes/weapon.dm
+++ b/code/datums/craft/recipes/weapon.dm
@@ -1,6 +1,7 @@
 /datum/craft_recipe/weapon
 	category = "Weapon"
 	time = 60
+	related_stats = list(STAT_COG)
 
 /datum/craft_recipe/weapon/baseballbat
 	name = "baseball bat"

--- a/code/datums/craft/step.dm
+++ b/code/datums/craft/step.dm
@@ -95,6 +95,14 @@
 			user << "Not enough items in [I]"
 			return
 
+	var/new_time = time // for reqed_type or raw materials
+	if(reqed_type || !reqed_quality)
+		if(recipe.related_stats)
+			var/mastery_factor = min(user.stats.getAvgStat(recipe.related_stats)/STAT_LEVEL_PROF, 1) //we will assume that STAT_LEVEL_PROF is highest value of mastery
+			mastery_factor *= 0.66 //	we want cut no more than 2/3 of time
+			var/time_reduction_factor = max(0, 1 - mastery_factor)
+			new_time *= time_reduction_factor
+
 	if(reqed_type)
 		if(!istype(I, reqed_type))
 			user << "Wrong item!"
@@ -109,10 +117,10 @@
 				user << "Not enough items in [I]"
 				return
 
-
 		if(target)
 			announce_action(start_msg, user, I, target)
-		if(!do_after(user, time, target || user))
+
+		if(!do_after(user, new_time, target || user))
 			return
 
 	else if(reqed_quality)
@@ -122,7 +130,7 @@
 			return
 		if(target)
 			announce_action(start_msg, user, I, target)
-		if(!I.use_tool(user, target || user, time, reqed_quality, FAILCHANCE_NORMAL, list(STAT_SUM, STAT_MEC, STAT_COG)))
+		if(!I.use_tool(user, target || user, time, reqed_quality, FAILCHANCE_NORMAL, list(STAT_MEC, STAT_COG)))
 			user << SPAN_WARNING("Work aborted")
 			return
 
@@ -130,7 +138,7 @@
 			user << SPAN_WARNING("That tool is too crude for the task. You need a tool with [reqed_quality_level] [reqed_quality] quality. This tool only has [q] [reqed_quality]")
 			return
 	else
-		if(!do_after(user, time, target || user))
+		if(!do_after(user, new_time, target || user))
 			return
 
 	if (target)
@@ -193,8 +201,6 @@
 			//Okay, so we found something that matches
 			if (is_valid_to_consume(I, user))
 				return I
-
-
 
 	else if(reqed_quality)
 		var/best_value = 0

--- a/code/datums/mob_stats.dm
+++ b/code/datums/mob_stats.dm
@@ -14,56 +14,52 @@
 	var/datum/stat/S = stat_list[statName]
 	S.changeValue(Value)
 
-
-/datum/stat_holder/proc/getStat(statName, Pure = null)
+/datum/stat_holder/proc/getStat(statName, pure = FALSE)
 	if (!islist(statName))
 		var/datum/stat/S = stat_list[statName]
-		return S ? S.getValue(Pure) : 0
-	else
-		/*
-			Passing a list to getStat allows you to do some fancy compound behaviour
-			Check the other mob_stats define file for the defines used here
-		*/
-		var/list/request = statName
-		var/combine_type = request[1]
+		return S ? S.getValue(pure) : 0
 
-		var/list/values = list()
+//	Those are accept list of stats
+//	Compound stat checks.
+//	Lowest value among the stats passed in
+/datum/stat_holder/proc/getMinStat(var/list/namesList, pure = FALSE)
+	if(!islist(namesList))
+		log_debug("passed non-list to getMinStat()")
+		return 0
+	var/lowest = INFINITY
+	for (var/name in namesList)
+		if(getStat(name, pure) < lowest)
+			lowest = getStat(name, pure)
+	return lowest
 
-		//Lets get the values of the stats involved
-		//We loop through the list starting from 2, since element 1 is a define telling us how to combine values
-		for (var/i = 2; i <= request.len;i++)
-			var/datum/stat/S = stat_list[request[i]]
-			values.Add(S ? S.getValue(Pure) : 0)
+//	Get the highest value among the stats passed in
+/datum/stat_holder/proc/getMaxStat(var/list/namesList, pure = FALSE)
+	if(!islist(namesList))
+		log_debug("passed non-list to getMaxStat()")
+		return 0
+	var/highest = -INFINITY
+	for (var/name in namesList)
+		if(getStat(name, pure) > highest)
+			highest = getStat(name, pure)
+	return highest
 
-		//Now we've got the values, what do we do with them?
-		switch (combine_type)
-			if (STAT_MAX)
-				var/highest = -INFINITY
-				for (var/a in values)
-					if (a > highest)
-						highest = a
-				return highest
-			if (STAT_MIN)
-				var/lowest = INFINITY
-				for (var/a in values)
-					if (a < lowest)
-						lowest = a
-				return lowest
+//	Sum total of the stats
+/datum/stat_holder/proc/getSumOfStat(var/list/namesList, pure = FALSE)
+	if(!islist(namesList))
+		log_debug("passed non-list to getSumStat()")
+		return 0
+	var/sum = 0
+	for (var/name in namesList)
+		sum += getStat(name, pure)
+	return sum
 
-			if (STAT_SUM)
-				var/total = 0
-				for (var/a in values)
-					total += a
-				return total
-
-			if (STAT_AVG)
-				var/total = 0
-				for (var/a in values)
-					total += a
-				return total / values.len
-
-			else
-				return 0
+//	Get the average (mean) value of the stats
+/datum/stat_holder/proc/getAvgStat(var/list/namesList, pure = FALSE)
+	if(!islist(namesList))
+		log_debug("passed non-list to getAvgStat()")
+		return 0
+	var/avg = getSumOfStat(namesList, pure)
+	return avg / namesList.len
 
 /datum/stat_holder/proc/Clone()
 	var/datum/stat_holder/new_stat = new()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -613,7 +613,7 @@ There are 9 wires.
 		user = usr
 
 	if(wedged_item)
-		if(user && !wedged_item.use_tool(user, src, WORKTIME_NEAR_INSTANT, QUALITY_PRYING, FAILCHANCE_ZERO, STAT_ROB))
+		if(user && !wedged_item.use_tool(user, src, WORKTIME_NEAR_INSTANT, QUALITY_PRYING, FAILCHANCE_ZERO, list(STAT_MEC, STAT_ROB)))
 			return
 		wedged_item.forceMove(loc)
 		if(user)
@@ -977,7 +977,7 @@ There are 9 wires.
 	switch(tool_type)
 		if(QUALITY_PRYING)
 			if(!repairing)
-				if(I.use_tool(user, src, WORKTIME_FAST, tool_type, FAILCHANCE_VERY_EASY,  required_stat = STAT_ROB))
+				if(I.use_tool(user, src, WORKTIME_FAST, tool_type, FAILCHANCE_VERY_EASY,  required_stat = list(STAT_MEC, STAT_ROB)))
 					if(src.p_open && (operating < 0 || (!operating && welded && !src.arePowerSystemsOn() && density && (!src.locked || (stat & BROKEN)))) )
 						user << SPAN_NOTICE("You removed the airlock electronics!")
 

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -251,7 +251,10 @@
 	//Precalculate worktime here
 	var/time_to_finish = 0
 	if (base_time)
-		time_to_finish = base_time - get_tool_quality(required_quality) - user.stats.getStat(required_stat)
+		if(islist(required_stat))
+			time_to_finish = base_time - get_tool_quality(required_quality) - user.stats.getMaxStat(required_stat)
+		else
+			time_to_finish = base_time - get_tool_quality(required_quality) - user.stats.getStat(required_stat)
 
 		//Workspeed var, can be improved by upgrades
 		if (T && T.workspeed > 0)

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -83,7 +83,7 @@ Freeing yourself is much harder than freeing someone else. Calling for help is a
 
 		//How about your stats? Being strong or crafty helps.
 		//We'll subtract the highest of either robustness or mechanical, from the difficulty
-		var/reduction = user.stats.getStat(list(STAT_MAX, STAT_ROB, STAT_MEC))
+		var/reduction = user.stats.getMaxStat(list(STAT_ROB, STAT_MEC))
 		if (user == buckled_mob)
 			reduction *= 0.66 //But it helps less if you don't have good leverage
 		difficulty -= reduction

--- a/code/game/objects/structures/burrows.dm
+++ b/code/game/objects/structures/burrows.dm
@@ -479,7 +479,7 @@ percentage is a value in the range 0..1 that determines what portion of this mob
 		var/start = world.time
 		var/target_time = WORKTIME_FAST+ 2*integrity
 
-		if (I.use_tool(user, src, target_time, QUALITY_DIGGING, 1.3*integrity, list(STAT_SUM, STAT_MEC, STAT_ROB), forced_sound = WORKSOUND_PICKAXE))
+		if (I.use_tool(user, src, target_time, QUALITY_DIGGING, 1.3*integrity, list(STAT_MEC, STAT_ROB), forced_sound = WORKSOUND_PICKAXE))
 			//On success, the hole is destroyed!
 			user.visible_message("[user] collapses [src] with the [I]", "You collapse [src] with the [I]")
 


### PR DESCRIPTION
### Merge grey railing first
Crafting speed now depends on stats.
Making recipes availability based on stats will be mistake, instead it should be based on knowledge, like baystation's education background or learned by books etc.
Reworked stat checks, previous way was unintuitive mess.
Added new grey railing crafting recipe.