### PR TITLE
nanopaste material cost reduction

### DIFF
--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -4,7 +4,7 @@
 	desc = "A tube of paste containing swarms of repair nanites. Very effective in repairing robotic machinery."
 	icon = 'icons/obj/nanopaste.dmi'
 	icon_state = "tube"
-	matter = list(MATERIAL_PLASTIC = 10)
+	matter = list(MATERIAL_PLASTIC = 2)
 	origin_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
 	amount = 10
 	w_class = ITEM_SIZE_SMALL //just so you can place same places that a brute pack would be


### PR DESCRIPTION
it costs 100 plastic to print this stuff because 1 use of it has 10 plastic and it prints 10 of it. big yikes.

this brings the matter in it from 10 per use to 2 per use, which should lower it to a more reasonable cost of 20 per stack. open for other numbers at this point.