### PR TITLE
Wallet front_id exploit fix

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -30,11 +30,10 @@
 
 /obj/item/weapon/storage/wallet/remove_from_storage(obj/item/W as obj, atom/new_location)
 	. = ..(W, new_location)
-	if(.)
-		if(W == front_id)
-			front_id = null
-			name = initial(name)
-			update_icon()
+	if(W == front_id)
+		front_id = null
+		name = initial(name)
+		update_icon()
 
 /obj/item/weapon/storage/wallet/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
 	. = ..(W, prevent_warning)


### PR DESCRIPTION
The front_id variable on wallets wasn't clearing itself properly. By deleting a single line and unindenting a few others, it clears itself properly now.