### PR TITLE
Adds Bone Setters to Moebius Medical Designs

### DIFF
--- a/code/datums/autolathe/tools.dm
+++ b/code/datums/autolathe/tools.dm
@@ -138,6 +138,10 @@
 	name = "cautery"
 	build_path = /obj/item/weapon/tool/cautery
 
+/datum/design/autolathe/tool/bonesetter
+	name = "bonesetter"
+	build_path = /obj/item/weapon/tool/bonesetter
+
 /datum/design/autolathe/tool/hemostat
 	name = "hemostat"
 	build_path = /obj/item/weapon/tool/hemostat

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -209,6 +209,7 @@
 		/datum/design/autolathe/tool/retractor,
 		/datum/design/autolathe/tool/cautery,
 		/datum/design/autolathe/tool/hemostat,
+		/datum/design/autolathe/tool/bonesetter,
 		/datum/design/autolathe/container/syringe,
 		/datum/design/autolathe/container/vial,
 		/datum/design/autolathe/container/beaker,

--- a/code/game/objects/items/weapons/tools/bonesetters.dm
+++ b/code/game/objects/items/weapons/tools/bonesetters.dm
@@ -4,5 +4,6 @@
 	throw_speed = 3
 	throw_range = 5
 	w_class = ITEM_SIZE_SMALL
+	matter = list(MATERIAL_STEEL = 4)
 	attack_verb = list("attacked", "hit", "bludgeoned")
 	tool_qualities = list(QUALITY_BONE_SETTING = 30)


### PR DESCRIPTION
Simply adds a a bone setter tool to Moebius Medical Designs disk so that medical can get replacements if needed.
To make a new bone setter you just need 4 metal, same as a retractor.