### PR TITLE
Bugfix Bonanza

### DIFF
--- a/code/datums/objective/steal.dm
+++ b/code/datums/objective/steal.dm
@@ -9,7 +9,7 @@
 		"a jetpack" = /obj/item/weapon/tank/jetpack,
 		"a captain's jumpsuit" = /obj/item/clothing/under/rank/captain,
 		"a functional AI" = /obj/item/device/aicard,
-		"the Technomancer Exultant's advanced voidsuit" = /obj/item/weapon/rig/ce,
+		"the Technomancer Exultant's advanced voidsuit control module" = /obj/item/weapon/rig/ce,
 		"the station blueprints" = /obj/item/blueprints,
 		"a nasa voidsuit" = /obj/item/clothing/suit/space/void,
 		"28 moles of plasma (full tank)" = /obj/item/weapon/tank,
@@ -23,7 +23,7 @@
 		"the hypospray" = /obj/item/weapon/reagent_containers/hypospray,
 		"the captain's pinpointer" = /obj/item/weapon/pinpointer,
 		"an ablative armor vest" = /obj/item/clothing/suit/armor/laserproof,
-		"an ironhammer hardsuit" = /obj/item/weapon/rig/ihs_combat
+		"an Ironhammer hardsuit control module" = /obj/item/weapon/rig/ihs_combat
 	)
 
 	var/global/possible_items_special[] = list(

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -486,8 +486,8 @@
 	icon = 'icons/obj/toy.dmi'
 
 /obj/item/toy/figure/cmo
-	name = "Chief Medical Officer action figure"
-	desc = "A \"Space Life\" brand Chief Medical Officer action figure."
+	name = "Biolab Officer action figure"
+	desc = "A \"Space Life\" brand Biolab Officer action figure."
 	icon_state = "cmo"
 
 /obj/item/toy/figure/assistant
@@ -496,8 +496,8 @@
 	icon_state = "assistant"
 
 /obj/item/toy/figure/atmos
-	name = "Atmospheric Technician action figure"
-	desc = "A \"Space Life\" brand Atmospheric Technician action figure."
+	name = "Technomancer Atmosphericist action figure"
+	desc = "A \"Space Life\" brand Technomancer Atmosphericist action figure."
 	icon_state = "atmos"
 
 /obj/item/toy/figure/bartender
@@ -521,13 +521,13 @@
 	icon_state = "captain"
 
 /obj/item/toy/figure/cargotech
-	name = "Cargo Technician action figure"
-	desc = "A \"Space Life\" brand Cargo Technician action figure."
+	name = "Guild Technician action figure"
+	desc = "A \"Space Life\" brand Guild Technician action figure."
 	icon_state = "cargotech"
 
 /obj/item/toy/figure/ce
-	name = "Chief Engineer action figure"
-	desc = "A \"Space Life\" brand Chief Engineer action figure."
+	name = "Technomancer Exultant action figure"
+	desc = "A \"Space Life\" brand Technomancer Exultant action figure."
 	icon_state = "ce"
 
 /obj/item/toy/figure/chaplain
@@ -556,8 +556,8 @@
 	icon_state = "ian"
 
 /obj/item/toy/figure/detective
-	name = "Detective action figure"
-	desc = "A \"Space Life\" brand Detective action figure."
+	name = "Inspector action figure"
+	desc = "A \"Space Life\" brand Inspector action figure."
 	icon_state = "detective"
 
 /obj/item/toy/figure/dsquad
@@ -566,8 +566,8 @@
 	icon_state = "dsquad"
 
 /obj/item/toy/figure/engineer
-	name = "Engineer action figure"
-	desc = "A \"Space Life\" brand Engineer action figure."
+	name = "Technomancer action figure"
+	desc = "A \"Space Life\" brand Technomancer action figure."
 	icon_state = "engineer"
 
 /obj/item/toy/figure/geneticist
@@ -576,18 +576,18 @@
 	icon_state = "geneticist"
 
 /obj/item/toy/figure/hop
-	name = "Head of Personel action figure"
-	desc = "A \"Space Life\" brand Head of Personel action figure."
+	name = "First Officer action figure"
+	desc = "A \"Space Life\" brand First Officer action figure."
 	icon_state = "hop"
 
 /obj/item/toy/figure/hos
-	name = "Head of Security action figure"
-	desc = "A \"Space Life\" brand Head of Security action figure."
+	name = "Ironhammer Commander action figure"
+	desc = "A \"Space Life\" brand Ironhammer Commander action figure."
 	icon_state = "hos"
 
 /obj/item/toy/figure/qm
-	name = "Quartermaster action figure"
-	desc = "A \"Space Life\" brand Quartermaster action figure."
+	name = "Guild Merchant action figure"
+	desc = "A \"Space Life\" brand Guild Merchant action figure."
 	icon_state = "qm"
 
 /obj/item/toy/figure/janitor
@@ -616,8 +616,8 @@
 	icon_state = "mime"
 
 /obj/item/toy/figure/miner
-	name = "Shaft Miner action figure"
-	desc = "A \"Space Life\" brand Shaft Miner action figure."
+	name = "Guild Miner action figure"
+	desc = "A \"Space Life\" brand Guild Miner action figure."
 	icon_state = "miner"
 
 /obj/item/toy/figure/ninja
@@ -631,8 +631,8 @@
 	icon_state = "wizard"
 
 /obj/item/toy/figure/rd
-	name = "Research Director action figure"
-	desc = "A \"Space Life\" brand Research Director action figure."
+	name = "Expedition Overseer action figure"
+	desc = "A \"Space Life\" brand Expedition Overseer action figure."
 	icon_state = "rd"
 
 /obj/item/toy/figure/roboticist
@@ -651,18 +651,18 @@
 	icon_state = "syndie"
 
 /obj/item/toy/figure/secofficer
-	name = "Security Officer action figure"
-	desc = "A \"Space Life\" brand Security Officer action figure."
+	name = "Ironhammer Operative action figure"
+	desc = "A \"Space Life\" brand Ironhammer Operative action figure."
 	icon_state = "secofficer"
 
 /obj/item/toy/figure/warden
-	name = "Warden action figure"
-	desc = "A \"Space Life\" brand Warden action figure."
+	name = "Gunnery Sergeant action figure"
+	desc = "A \"Space Life\" brand Gunnery Sergeant action figure."
 	icon_state = "warden"
 
 /obj/item/toy/figure/psychologist
-	name = "Psychologist action figure"
-	desc = "A \"Space Life\" brand Psychologist action figure."
+	name = "Psychiatrist action figure"
+	desc = "A \"Space Life\" brand Psychiatrist action figure."
 	icon_state = "psychologist"
 
 /obj/item/toy/figure/paramedic

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -256,8 +256,8 @@
 //I think we'll put this shit right here
 var/list/rank_prefix = list(\
 	"Ironhammer Operative" = "Operative",\
-	"Inspector" = "Inspector",\
-	"Gunnery Sergeant" = "Sergeant",\
+	"Ironhammer Inspector" = "Inspector",\
+	"Ironhammer Gunnery Sergeant" = "Sergeant",\
 	"Ironhammer Commander" = "Lieutenant",\
 	"Captain" = "Captain",\
 	)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -163,6 +163,8 @@
 	reagents.trans_to_mob(target, issmall(user) ? ceil(amount_per_transfer_from_this/2) : amount_per_transfer_from_this, CHEM_INGEST)
 
 	feed_sound(user)
+	if(istype(src, /obj/item/weapon/reagent_containers/pill))
+		qdel(src) //pills are swallowed whole, so delete it here
 	return TRUE
 
 /obj/item/weapon/reagent_containers/proc/standard_pour_into(mob/user, atom/target) // This goes into afterattack and yes, it's atom-level

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -98,3 +98,16 @@
 		icon_state = initial(icon_state)
 	else
 		icon_state = "[initial(icon_state)]0"
+
+
+/obj/item/weapon/reagent_containers/hypospray/verb/empty()
+
+	set name = "Empty Hypospray"
+	set category = "Object"
+	set src in usr
+
+	if (alert(usr, "Are you sure you want to empty that?", "Empty Bottle:", "Yes", "No") != "Yes")
+		return
+	if(isturf(usr.loc))
+		usr << SPAN_NOTICE("You empty \the [src] onto the floor.")
+		reagents.splash(usr.loc, reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -19,10 +19,7 @@
 
 
 /obj/item/weapon/reagent_containers/pill/attack(mob/M as mob, mob/user as mob, def_zone)
-	if(standard_feed_mob(user, M))
-		qdel(src)
-		return 1
-	return 0
+	standard_feed_mob(user, M)
 
 /obj/item/weapon/reagent_containers/pill/self_feed_message(var/mob/user)
 	to_chat(user, SPAN_NOTICE("You swallow \the [src]."))


### PR DESCRIPTION
Closes #358 by changing the names to be a little more lore-friendly.
Closes #1701 - unable to reproduce.
Closes #3249 - unable to reproduce.
Closes #3375 by clarifying you only need the control module.
Closes #3398 by adding an 'empty' verb to hyposprays.
Closes #3409 by fixing the job title.
Closes #3419 - unable to reproduce.
Closes #3424 - unable to reproduce.
Closes #3448 - unable to reproduce.
Closes #3581 by making pills actually work like they're supposed to.