### PR TITLE
Optimizing and some recast of loadout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,20 @@
 #ignore misc BYOND files
 Thumbs.db
+*.sav
 *.log
 *.int
 *.rsc
 *.dmb
 *.lk
 *.backup
+*.before
 tools/
 data/
 cfg/
+tmp/
 build_log.txt
+__pycache__
+
+#vscode
 .vscode
+.history

--- a/code/modules/client/preference_setup/loadout/lists/accessories.dm
+++ b/code/modules/client/preference_setup/loadout/lists/accessories.dm
@@ -1,4 +1,3 @@
-
 /datum/gear/accessory
 	sort_category = "Accessories"
 	category = /datum/gear/accessory
@@ -43,14 +42,17 @@
 /datum/gear/accessory/cargo
 	display_name = "armband, cargo"
 	path = /obj/item/clothing/accessory/armband/cargo
+	allowed_roles = list(JOBS_CARGO)
 
 /datum/gear/accessory/emt
 	display_name = "armband, EMT"
 	path = /obj/item/clothing/accessory/armband/medgreen
+	allowed_roles = list(JOBS_MEDICAL)
 
 /datum/gear/accessory/engineering
 	display_name = "armband, engineering"
 	path = /obj/item/clothing/accessory/armband/engine
+	allowed_roles = list(JOBS_ENGINEERING)
 
 /datum/gear/accessory/hydroponics
 	display_name = "armband, hydroponics"
@@ -59,23 +61,26 @@
 /datum/gear/accessory/medical
 	display_name = "armband, medical"
 	path = /obj/item/clothing/accessory/armband/med
+	allowed_roles = list(JOBS_MEDICAL)
 
 /datum/gear/accessory/science
 	display_name = "armband, science"
 	path = /obj/item/clothing/accessory/armband/science
+	allowed_roles = list(JOBS_SCIENCE)
 
 /datum/gear/accessory/holster
 	display_name = "holster, armpit"
 	path = /obj/item/clothing/accessory/holster/armpit
-	allowed_roles = list("Captain", "First Officer", "Ironhammer Operative", "Ironhammer Gunnery Sergeant", "Ironhammer Commander","Ironhammer Inspector")
+	allowed_roles = list("Captain", "First Officer", JOBS_SECURITY)
 
-/datum/gear/accessory/holster/hip
-	display_name = "holster, hip"
-	path = /obj/item/clothing/accessory/holster/hip
-
-/datum/gear/accessory/holster/waist
-	display_name = "holster, waist"
-	path = /obj/item/clothing/accessory/holster/waist
+/datum/gear/accessory/holster/New()
+	..()
+	var/ties = list(
+		"Armpit"	=	/obj/item/clothing/accessory/holster/armpit,
+		"Hip"		=	/obj/item/clothing/accessory/holster/hip,
+		"Waist"		=	/obj/item/clothing/accessory/holster/waist,
+	)
+	gear_tweaks += new/datum/gear_tweak/path(ties)
 
 /datum/gear/accessory/tie/blue
 	display_name = "tie, blue"

--- a/code/modules/client/preference_setup/loadout/lists/clothing.dm
+++ b/code/modules/client/preference_setup/loadout/lists/clothing.dm
@@ -1,4 +1,3 @@
-
 /datum/gear/clothing/
 	sort_category = "Clothing Pieces"
 	category = /datum/gear/clothing/

--- a/code/modules/client/preference_setup/loadout/lists/eyegear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/eyegear.dm
@@ -28,16 +28,17 @@
 /datum/gear/eyes/sciencegoggles
 	display_name = "Science Goggles"
 	path = /obj/item/clothing/glasses/powered/science
+	allowed_roles = list(JOBS_SCIENCE)
 
 /datum/gear/eyes/security
 	display_name = "Security HUD"
 	path = /obj/item/clothing/glasses/hud/security
-	allowed_roles = list("Ironhammer Operative","Ironhammer Commander","Ironhammer Gunnery Sergeant")
+	allowed_roles = list(JOBS_SECURITY)
 
 /datum/gear/eyes/medical
 	display_name = "Medical HUD"
 	path = /obj/item/clothing/glasses/hud/health
-	allowed_roles = list("Moebius Doctor","Moebius Biolab Officer","Moebius Chemist","Moebius Paramedic")
+	allowed_roles = list(JOBS_MEDICAL)
 
 /datum/gear/eyes/shades
 	display_name = "Sunglasses, fat"

--- a/code/modules/client/preference_setup/loadout/lists/footwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/footwear.dm
@@ -13,54 +13,45 @@
 	display_name = "sandals"
 	path = /obj/item/clothing/shoes/sandal
 
-/datum/gear/shoes/black
-	display_name = "shoes, black"
-	path = /obj/item/clothing/shoes/black
-
-/datum/gear/shoes/blue
-	display_name = "shoes, blue"
-	path = /obj/item/clothing/shoes/color/blue
-
-/datum/gear/shoes/brown
-	display_name = "shoes, brown"
-	path = /obj/item/clothing/shoes/color/brown
 
 /datum/gear/shoes/lacey
 	display_name = "shoes, classy"
 	path = /obj/item/clothing/shoes/reinforced
 
+/*//Same with /datum/gear/shoes/lacey
+
 /datum/gear/shoes/dress
 	display_name = "shoes, dress"
-	path = /obj/item/clothing/shoes/reinforced
-
-/datum/gear/shoes/green
-	display_name = "shoes, green"
-	path = /obj/item/clothing/shoes/color/green
+	path = /obj/item/clothing/shoes/reinforced*/
 
 /datum/gear/shoes/leather
 	display_name = "shoes, leather"
 	path = /obj/item/clothing/shoes/leather
 
-/datum/gear/shoes/orange
-	display_name = "shoes, orange"
-	path = /obj/item/clothing/shoes/color/orange
-
-/datum/gear/shoes/purple
-	display_name = "shoes, purple"
-	path = /obj/item/clothing/shoes/color/purple
-
 /datum/gear/shoes/rainbow
 	display_name = "shoes, rainbow"
 	path = /obj/item/clothing/shoes/color/rainbow
 
-/datum/gear/shoes/red
-	display_name = "shoes, red"
-	path = /obj/item/clothing/shoes/color/red
+/datum/gear/shoes/colorable
+	display_name = "shoes, colorable"
+	flags = GEAR_HAS_COLOR_SELECTION
+	path = /obj/item/clothing/shoes/color
 
-/datum/gear/shoes/white
-	display_name = "shoes, white"
-	path = /obj/item/clothing/shoes/color/white
+/datum/gear/shoes/color_presets
+	display_name = "shoes, color presets"
+	path = /obj/item/clothing/shoes/black
 
-/datum/gear/shoes/yellow
-	display_name = "shoes, yellow"
-	path = /obj/item/clothing/shoes/color/yellow
+/datum/gear/shoes/color_presets/New()
+	..()
+	var/shoes = list(
+		"White"			=	/obj/item/clothing/shoes/color/white,
+		"Black"			=	/obj/item/clothing/shoes/black,
+		"Brown"			=	/obj/item/clothing/shoes/color/brown,
+		"Red"			=	/obj/item/clothing/shoes/color/red,
+		"Orange"		=	/obj/item/clothing/shoes/color/orange,
+		"Yellow"		=	/obj/item/clothing/shoes/color/yellow,
+		"Green"			=	/obj/item/clothing/shoes/color/green,
+		"Blue"			=	/obj/item/clothing/shoes/color/blue,
+		"Purple"		=	/obj/item/clothing/shoes/color/purple,
+	)
+	gear_tweaks += new /datum/gear_tweak/path(shoes)

--- a/code/modules/client/preference_setup/loadout/lists/gloves.dm
+++ b/code/modules/client/preference_setup/loadout/lists/gloves.dm
@@ -1,55 +1,44 @@
 // Gloves
-/datum/gear/gloves
-	display_name = "gloves, black"
-	path = /obj/item/clothing/gloves/thick
-	cost = 2
+/datum/gear/gloves/
 	slot = slot_gloves
 	sort_category = "Gloves and Handwear"
+	category = /datum/gear/gloves/
 
-/datum/gear/gloves/blue
-	display_name = "gloves, blue"
-	path = /obj/item/clothing/gloves/color/blue
-
-/datum/gear/gloves/yellow
-	display_name = "gloves, yellow"
-	path = /obj/item/clothing/gloves/color/yellow
-
-/datum/gear/gloves/brown
-	display_name = "gloves, brown"
-	path = /obj/item/clothing/gloves/color/brown
-
-/datum/gear/gloves/light_brown
-	display_name = "gloves, light-brown"
-	path = /obj/item/clothing/gloves/color/light_brown
-
-/datum/gear/gloves/green
-	display_name = "gloves, green"
-	path = /obj/item/clothing/gloves/color/green
-
-/datum/gear/gloves/grey
-	display_name = "gloves, grey"
-	path = /obj/item/clothing/gloves/color/grey
+/datum/gear/gloves/work
+	display_name = "gloves, work"
+	path = /obj/item/clothing/gloves/thick
+	cost = 3
 
 /datum/gear/gloves/latex
 	display_name = "gloves, latex"
 	path = /obj/item/clothing/gloves/latex
 
-/datum/gear/gloves/orange
-	display_name = "gloves, orange"
-	path = /obj/item/clothing/gloves/color/orange
-
-/datum/gear/gloves/purple
-	display_name = "gloves, purple"
-	path = /obj/item/clothing/gloves/color/purple
-
 /datum/gear/gloves/rainbow
 	display_name = "gloves, rainbow"
 	path = /obj/item/clothing/gloves/color/rainbow
+	cost = 2
 
-/datum/gear/gloves/red
-	display_name = "gloves, red"
-	path = /obj/item/clothing/gloves/color/red
+/datum/gear/gloves/colored
+	display_name = "gloves, colored"
+	flags = GEAR_HAS_COLOR_SELECTION
+	path = /obj/item/clothing/gloves/color
 
-/datum/gear/gloves/white
-	display_name = "gloves, white"
-	path = /obj/item/clothing/gloves/color/white
+/datum/gear/gloves/color_presets
+	display_name = "gloves, color presets"
+	path = /obj/item/clothing/gloves/color/blue
+
+/datum/gear/gloves/color_presets/New()
+	..()
+	var/gloves = list(
+		"Blue"			= 	/obj/item/clothing/gloves/color/blue,
+		"Yellow"		= 	/obj/item/clothing/gloves/color/yellow,
+		"White"			= 	/obj/item/clothing/gloves/color/white,
+		"Red"			= 	/obj/item/clothing/gloves/color/red,
+		"Purple"		= 	/obj/item/clothing/gloves/color/purple,
+		"Orange"		= 	/obj/item/clothing/gloves/color/orange,
+		"Grey"			= 	/obj/item/clothing/gloves/color/grey,
+		"Green"			=	/obj/item/clothing/gloves/color/green,
+		"Light-Brown"	=	/obj/item/clothing/gloves/color/light_brown,
+		"Brown"			=	/obj/item/clothing/gloves/color/brown
+	)
+	gear_tweaks += new /datum/gear_tweak/path(gloves)

--- a/code/modules/client/preference_setup/loadout/lists/headwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/headwear.dm
@@ -16,6 +16,10 @@
 	display_name = "beret, red"
 	path = /obj/item/clothing/head/beret
 
+/datum/gear/head/beret/purp
+	display_name = "beret, purple"
+	path = /obj/item/clothing/head/beret/purple
+
 /datum/gear/head/beret/bsec
 	display_name = "beret, navy (officer)"
 	path = /obj/item/clothing/head/beret/sec/navy/officer
@@ -34,23 +38,12 @@
 /datum/gear/head/beret/eng
 	display_name = "beret, engie-orange"
 	path = /obj/item/clothing/head/beret/engineering
-
-/datum/gear/head/beret/purp
-	display_name = "beret, purple"
-	path = /obj/item/clothing/head/beret/purple
+	allowed_roles = list(JOBS_ENGINEERING)
 
 /datum/gear/head/beret/sec
 	display_name = "beret, red (security)"
 	path = /obj/item/clothing/head/beret/sec
-	allowed_roles = list("Ironhammer Operative","Ironhammer Commander","Gunnery Sergeant")
-
-/datum/gear/head/cap/blue
-	display_name = "cap, blue"
-	path = /obj/item/clothing/head/soft/blue
-
-/datum/gear/head/cap/mailman
-	display_name = "cap, blue station"
-	path = /obj/item/clothing/head/mailman
+	allowed_roles = list(JOBS_SECURITY)
 
 /datum/gear/head/cap/flat
 	display_name = "cap, brown-flat"
@@ -61,63 +54,53 @@
 	path = /obj/item/clothing/head/soft/sec/corp
 	allowed_roles = list("Ironhammer Operative","Ironhammer Commander","Gunnery Sergeant", "Inspector")
 
-/datum/gear/head/cap/green
-	display_name = "cap, green"
-	path = /obj/item/clothing/head/soft/green
-
-/datum/gear/head/cap/grey
-	display_name = "cap, grey"
-	path = /obj/item/clothing/head/soft/grey
-
-/datum/gear/head/cap/orange
-	display_name = "cap, orange"
-	path = /obj/item/clothing/head/soft/orange
-
-/datum/gear/head/cap/purple
-	display_name = "cap, purple"
-	path = /obj/item/clothing/head/soft/purple
-
 /datum/gear/head/cap/rainbow
 	display_name = "cap, rainbow"
 	path = /obj/item/clothing/head/soft/rainbow
 
-/datum/gear/head/cap/red
-	display_name = "cap, red"
-	path = /obj/item/clothing/head/soft/red
-
 /datum/gear/head/cap/sec
 	display_name = "cap, security (Security)"
 	path = /obj/item/clothing/head/soft/sec
-	allowed_roles = list("Ironhammer Operative","Ironhammer Commander","Gunnery Sergeant", "Inspector")
+	allowed_roles = list(JOBS_SECURITY)
 
-/datum/gear/head/cap/yellow
-	display_name = "cap, yellow"
-	path = /obj/item/clothing/head/soft/yellow
+/datum/gear/head/cap/color_presets
+	display_name = "cap, color presets"
+	path = /obj/item/clothing/head/soft/blue
 
-/datum/gear/head/cap/white
-	display_name = "cap, white"
-	path = /obj/item/clothing/head/soft/mime
+/datum/gear/head/cap/color_presets/New()
+	..()
+	var/cap = list(
+		"White"			=	/obj/item/clothing/head/soft/mime,
+		"Grey"			=	/obj/item/clothing/head/soft/grey,
+		"Brown-Flat"	=	/obj/item/clothing/head/flatcap,
+		"Red"			=	/obj/item/clothing/head/soft/red,
+		"Orange"		=	/obj/item/clothing/head/soft/orange,
+		"Yellow"		=	/obj/item/clothing/head/soft/yellow,
+		"Green"			=	/obj/item/clothing/head/soft/green,
+		"Blue"			=	/obj/item/clothing/head/soft/blue,
+		"Blue Station"	=	/obj/item/clothing/head/mailman,
+		"Purple"		=	/obj/item/clothing/head/soft/purple,
+	)
+	gear_tweaks += new /datum/gear_tweak/path(cap)
 
 /datum/gear/head/hairflower
 	display_name = "hair flower pin, red"
 	path = /obj/item/clothing/head/hairflower
 
-/datum/gear/head/hardhat
-	display_name = "hardhat, yellow"
-	path = /obj/item/clothing/head/hardhat
+/datum/gear/head/hardhat/color_presets
+	display_name = "hardhat, color presets"
+	path = /obj/item/clothing/head/hardhat/dblue
 	cost = 2
 
-/datum/gear/head/hardhat/blue
-	display_name = "hardhat, blue"
-	path = /obj/item/clothing/head/hardhat/dblue
-
-/datum/gear/head/hardhat/orange
-	display_name = "hardhat, orange"
-	path = /obj/item/clothing/head/hardhat/orange
-
-/datum/gear/head/hardhat/red
-	display_name = "hardhat, red"
-	path = /obj/item/clothing/head/hardhat/red
+/datum/gear/head/hardhat/color_presets/New()
+	..()
+	var/hardhat = list(
+		"Red"		=	/obj/item/clothing/head/hardhat/red,
+		"Orange"	=	/obj/item/clothing/head/hardhat/orange,
+		"Yellow"	=	/obj/item/clothing/head/hardhat,
+		"Blue"		=	/obj/item/clothing/head/hardhat/dblue,
+	)
+	gear_tweaks += new /datum/gear_tweak/path(hardhat)
 
 /datum/gear/head/boater
 	display_name = "hat, boatsman"

--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -93,12 +93,13 @@
 
 /datum/gear/plush_toy/New()
 	..()
-	var/plushes = list()
-	plushes["mouse plush"] = /obj/item/toy/plushie/mouse
-	plushes["kitten plush"] = /obj/item/toy/plushie/kitten
-	plushes["lizard plush"] = /obj/item/toy/plushie/lizard
-	plushes["spider plush"] = /obj/item/toy/plushie/spider
-	plushes["farwa plush"] = /obj/item/toy/plushie/farwa
+	var/plushes = list(
+		"mouse plush"	=	/obj/item/toy/plushie/mouse,
+		"kitten plush"	=	/obj/item/toy/plushie/kitten,
+		"lizard plush"	=	/obj/item/toy/plushie/lizard,
+		"spider plush"	=	/obj/item/toy/plushie/spider,
+		"farwa plush"	=	/obj/item/toy/plushie/farwa,
+	)
 	gear_tweaks += new /datum/gear_tweak/path(plushes)
 
 /datum/gear/mirror/

--- a/code/modules/client/preference_setup/loadout/lists/suits.dm
+++ b/code/modules/client/preference_setup/loadout/lists/suits.dm
@@ -6,26 +6,34 @@
 	sort_category = "Suits and Overwear"
 	cost = 1
 
-/datum/gear/suit/bomber
-	display_name = "bomber jacket"
+/datum/gear/suit/jacket
+	display_name = "jacket"
 	path = /obj/item/clothing/suit/storage/toggle/bomber
-
-/datum/gear/suit/leather_jacket
-	display_name = "leather jacket"
-	path = /obj/item/clothing/suit/storage/leather_jacket
 	cost = 2 //higher price because it has some armor value
+
+/datum/gear/suit/jacket/New()
+	..()
+	var/jacket = list(
+		"Bomber"		=	/obj/item/clothing/suit/storage/toggle/bomber,
+		"Leather"		=	/obj/item/clothing/suit/storage/leather_jacket,
+	)
+	gear_tweaks += new /datum/gear_tweak/path(jacket)
 
 /datum/gear/suit/hazard_vest
 	display_name = "hazard vest"
 	path = /obj/item/clothing/suit/storage/hazardvest
 
 /datum/gear/suit/hoodie
-	display_name = "hoodie, grey"
-	path = /obj/item/clothing/suit/storage/toggle/hoodie
-
-/datum/gear/suit/hoodie/black
-	display_name = "hoodie, black"
+	display_name = "hoodie"
 	path = /obj/item/clothing/suit/storage/toggle/hoodie/black
+
+/datum/gear/suit/hoodie/New()
+	..()
+	var/jacket = list(
+		"Black"		=	/obj/item/clothing/suit/storage/toggle/hoodie/black,
+		"Grey"		=	/obj/item/clothing/suit/storage/toggle/hoodie,
+	)
+	gear_tweaks += new /datum/gear_tweak/path(jacket)
 
 /datum/gear/suit/labcoat
 	display_name = "labcoat"

--- a/code/modules/client/preference_setup/loadout/lists/uniforms.dm
+++ b/code/modules/client/preference_setup/loadout/lists/uniforms.dm
@@ -9,85 +9,44 @@
 	display_name = "kilt"
 	path = /obj/item/clothing/under/kilt
 
-/datum/gear/uniform/jumpsuit
+/datum/gear/uniform/jumpsuit/rainbow
 	display_name = "jumpsuit, rainbow"
 	path = /obj/item/clothing/under/rainbow
 
-/datum/gear/uniform/jumpsuit/black
-	display_name = "jumpsuit, black"
-	path = /obj/item/clothing/under/color/black
-
-/datum/gear/uniform/jumpsuit/blue
-	display_name = "jumpsuit, blue"
-	path = /obj/item/clothing/under/color/blue
-
-/datum/gear/uniform/jumpsuit/green
-	display_name = "jumpsuit, green"
-	path = /obj/item/clothing/under/color/green
-
-/datum/gear/uniform/jumpsuit/grey
-	display_name = "jumpsuit, grey"
-	path = /obj/item/clothing/under/color/grey
-
-/datum/gear/uniform/jumpsuit/pink
-	display_name = "jumpsuit, pink"
-	path = /obj/item/clothing/under/color/pink
-
-/datum/gear/uniform/jumpsuit/white
-	display_name = "jumpsuit, white"
-	path = /obj/item/clothing/under/color/white
-
-/datum/gear/uniform/jumpsuit/yellow
-	display_name = "jumpsuit, yellow"
-	path = /obj/item/clothing/under/color/yellow
-
-/datum/gear/uniform/jumpsuit/lightblue
-	display_name = "jumpsuit, lightblue"
-	path = /obj/item/clothing/under/lightblue
-
-/datum/gear/uniform/jumpsuit/red
-	display_name = "jumpsuit, red"
-	path = /obj/item/clothing/under/color/red
-
-/datum/gear/uniform/jumpsuit/aqua
-	display_name = "jumpsuit, aqua"
+/datum/gear/uniform/jumpsuit/color_presets
+	display_name = "jumpsuit, color presets"
 	path = /obj/item/clothing/under/aqua
+	cost = 2
 
-/datum/gear/uniform/jumpsuit/purple
-	display_name = "jumpsuit, purple"
-	path = /obj/item/clothing/under/purple
+/datum/gear/uniform/jumpsuit/color_presets/New()
+	..()
+	var/jumpsuit = list(
+		"Black"			=	/obj/item/clothing/under/color/black,
+		"White"			=	/obj/item/clothing/under/color/white,
+		"Blue"			=	/obj/item/clothing/under/color/blue,
+		"Green"			=	/obj/item/clothing/under/color/green,
+		"Grey"			=	/obj/item/clothing/under/color/grey,
+		"Pink"			=	/obj/item/clothing/under/color/pink,
+		"Yellow"		=	/obj/item/clothing/under/color/yellow,
+		"Light-Blue"	=	/obj/item/clothing/under/lightblue,
+		"Red"			=	/obj/item/clothing/under/color/red,
+		"Aqua"			=	/obj/item/clothing/under/aqua,
+		"Purple"		=	/obj/item/clothing/under/purple,
+		"Light-Purple"	=	/obj/item/clothing/under/lightpurple,
+		"Light-Green"	=	/obj/item/clothing/under/lightgreen,
+		"Light-Brown"	=	/obj/item/clothing/under/lightbrown,
+		"Brown"			=	/obj/item/clothing/under/brown,
+		"Yellow-Green"	=	/obj/item/clothing/under/yellowgreen,
+		"Dark-Blue"		=	/obj/item/clothing/under/darkblue,
+		"Light-Red"		=	/obj/item/clothing/under/lightred,
+		"Dark-Red"		=	/obj/item/clothing/under/darkred,
+	)
+	gear_tweaks += new /datum/gear_tweak/path(jumpsuit)
 
-/datum/gear/uniform/jumpsuit/lightpurple
-	display_name = "jumpsuit, lightpurple"
-	path = /obj/item/clothing/under/lightpurple
-
-/datum/gear/uniform/jumpsuit/lightgreen
-	display_name = "jumpsuit, lightgreen"
-	path = /obj/item/clothing/under/lightgreen
-
-/datum/gear/uniform/jumpsuit/lightbrown
-	display_name = "jumpsuit, lightbrown"
-	path = /obj/item/clothing/under/lightbrown
-
-/datum/gear/uniform/jumpsuit/brown
-	display_name = "jumpsuit, brown"
-	path = /obj/item/clothing/under/brown
-
-/datum/gear/uniform/jumpsuit/yellowgreen
-	display_name = "jumpsuit, yellowgreen"
-	path = /obj/item/clothing/under/yellowgreen
-
-/datum/gear/uniform/jumpsuit/darkblue
-	display_name = "jumpsuit, darkblue"
-	path = /obj/item/clothing/under/darkblue
-
-/datum/gear/uniform/jumpsuit/lightred
-	display_name = "jumpsuit, lightred"
-	path = /obj/item/clothing/under/lightred
-
-/datum/gear/uniform/jumpsuit/darkred
-	display_name = "jumpsuit, darkred"
-	path = /obj/item/clothing/under/darkred
+/datum/gear/uniform/jumpsuit/colorable
+	display_name = "jumpsuit, colorable"
+	flags = GEAR_HAS_COLOR_SELECTION
+	path = /obj/item/clothing/under/color/white
 
 /*/datum/gear/uniform/skirt
 	display_name = "plaid skirt, blue"
@@ -101,22 +60,22 @@
 	display_name = "plaid skirt, red"
 	path = /obj/item/clothing/under/dress/plaid_red*/
 
-///datum/gear/uniform/suit  //amish
-	//display_name = "suit, amish"
-	//path = /obj/item/clothing/under/sl_suit
+/*/datum/gear/uniform/suit  //amish
+	display_name = "suit, amish"
+	path = /obj/item/clothing/under/sl_suit*/
 
-
-/datum/gear/uniform/scrubs/blue
-	display_name = "scrubs, blue"
+/datum/gear/uniform/scrubs/color_presets
+	display_name = "scrubs, color presets"
 	path = /obj/item/clothing/under/rank/medical/blue
 
-/datum/gear/uniform/scrubs/purple
-	display_name = "scrubs, purple"
-	path = /obj/item/clothing/under/rank/medical/purple
-
-/datum/gear/uniform/scrubs/green
-	display_name = "scrubs, green"
-	path = /obj/item/clothing/under/rank/medical/green
+/datum/gear/uniform/scrubs/color_presets/New()
+	..()
+	var/jumpsuit = list(
+		"Blue"			=	/obj/item/clothing/under/rank/medical/blue,
+		"Purple"		=	/obj/item/clothing/under/rank/medical/purple,
+		"Green"			=	/obj/item/clothing/under/rank/medical/green,
+	)
+	gear_tweaks += new /datum/gear_tweak/path(jumpsuit)
 
 /*/datum/gear/uniform/uniform_hop
 	display_name = "uniform, HoP's dress"

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -8,25 +8,25 @@
 	display_name = "clipboard"
 	path = /obj/item/weapon/clipboard
 
-/datum/gear/utility/folder_blue
-	display_name = "folder, blue"
-	path = /obj/item/weapon/folder/blue
-
-/datum/gear/utility/folder_grey
-	display_name = "folder, grey"
+/datum/gear/utility/folder_colorable
+	display_name = "folder, colorable"
+	flags = GEAR_HAS_COLOR_SELECTION
 	path = /obj/item/weapon/folder
 
-/datum/gear/utility/folder_red
-	display_name = "folder, red"
-	path = /obj/item/weapon/folder/red
+/datum/gear/utility/folder_presets
+	display_name = "folder"
+	path = /obj/item/weapon/folder
 
-/datum/gear/utility/folder_white
-	display_name = "folder, white"
-	path = /obj/item/weapon/folder/white
-
-/datum/gear/utility/folder_yellow
-	display_name = "folder, yellow"
-	path = /obj/item/weapon/folder/yellow
+/datum/gear/utility/folder_presets/New()
+	..()
+	var/folder = list(
+		"Grey"			=	/obj/item/weapon/folder,
+		"White"			=	/obj/item/weapon/folder/white,
+		"Red"			=	/obj/item/weapon/folder/red,
+		"Yellow"		=	/obj/item/weapon/folder/yellow,
+		"Blue"			=	/obj/item/weapon/folder/blue,
+	)
+	gear_tweaks += new /datum/gear_tweak/path(folder)
 
 /datum/gear/utility/paicard
 	display_name = "personal AI device"
@@ -38,6 +38,6 @@
 	cost = 2
 
 /datum/gear/utility/normaltablet
-	display_name = "tablet computer"
+	display_name = "advanced tablet computer"
 	path = /obj/item/modular_computer/tablet/preset/custom_loadout/advanced
 	cost = 3


### PR DESCRIPTION
## Delete extra datums of colored clothes, and give to job things an `allowed_jobs`, and using defines for `allowed_jobs`.

## Why It's Good For The Game:
This will facilitate the speed of finding things in loadout among colored clothes.
### Additional
`.gitignore` now ignore __pycache__ of python, ignore .sav and folder tmp/, and ignore things.history of visual code. .before of mapmerge ignoring too.
## Changelog
:cl:AlexMorgan3817/_Elar_
tweak: Many of colored clothes now compressed in one datum, that will improve comfortability of searching in loadout.
/:cl:
