### PR TITLE
Update movement code a bit

### DIFF
--- a/code/__defines/components.dm
+++ b/code/__defines/components.dm
@@ -41,6 +41,7 @@
 // /turf signals
 
 // /atom/movable signals
+#define COMSIG_MOVABLE_MOVED "movable_moved"					//from base of atom/movable/Moved(): (/atom, origin_loc, new_loc)
 
 // /mob signals
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -90,19 +90,16 @@
 			if(is_new_area && is_destination_turf)
 				destination.loc.Entered(src, origin)
 
-	if((!isturf(origin) || !isturf(destination)) || origin.z != destination.z)
-		update_plane()
+	SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED, origin, loc)
+
+	// Only update plane if we're located on map
+	if(isturf(loc))
+		// if we wasn't on map OR our Z coord was changed
+		if( !isturf(origin) || (get_z(loc) != get_z(origin)) )
+			update_plane()
 
 	return 1
 
-/atom/movable/proc/forceMoveOld(atom/destination)
-	if(destination)
-		if(loc)
-			loc.Exited(src)
-		loc = destination
-		loc.Entered(src)
-		return 1
-	return 0
 
 //called when src is thrown into hit_atom
 /atom/movable/proc/throw_impact(atom/hit_atom, var/speed)
@@ -322,8 +319,6 @@
 //This proc should never be overridden elsewhere at /atom/movable to keep directions sane.
 // Spoiler alert: it is, in moved.dm
 /atom/movable/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, var/glide_size_override = 0)
-	var/atom/oldloc = loc
-
 	if (glide_size_override > 0)
 		set_glide_size(glide_size_override)
 
@@ -363,10 +358,11 @@
 							if (step(src, WEST))
 								step(src, SOUTH)
 	else
-		var/atom/A = src.loc
-
+		var/atom/oldloc = src.loc
 		var/olddir = dir //we can't override this without sacrificing the rest of movable/New()
+
 		. = ..()
+
 		if(Dir != olddir)
 			dir = olddir
 			set_dir(Dir)
@@ -375,11 +371,16 @@
 		src.l_move_time = world.time
 		src.m_flag = 1
 
-		if ((A != src.loc && A && A.z == src.z))
-			src.last_move = get_dir(A, src.loc)
+		if (oldloc != src.loc && oldloc && oldloc.z == src.z)
+			src.last_move = get_dir(oldloc, src.loc)
 
-	if((!isturf(loc) || !isturf(oldloc)) || loc.z != oldloc.z)
-		update_plane()
+		// Only update plane if we're located on map
+		if(isturf(loc))
+			// if we wasn't on map OR our Z coord was changed
+			if( !isturf(oldloc) || (get_z(loc) != get_z(oldloc)) )
+				update_plane()
+
+		SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED, oldloc, loc)
 
 // Wrapper of step() that also sets glide size to a specific value.
 /proc/step_glide(var/atom/movable/am, var/dir, var/glide_size_override)


### PR DESCRIPTION
## About The Pull Request
Reduse plane recalculation calls.
Implement `COMSIG_MOVABLE_MOVED` signal call. Items not located on map will not try to update plane.

## Changelog
:cl:
add: `COMSIG_MOVABLE_MOVED` signal call
tweak: reduse `update_plane` calls
/:cl: