### PR TITLE
Allowing to construct and deconstruct breaker box

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/power.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/power.dm
@@ -41,3 +41,14 @@
 		/obj/item/weapon/stock_parts/micro_laser = 3,
 		/obj/item/weapon/stock_parts/capacitor = 3
 	)
+
+/obj/item/weapon/circuitboard/breakerbox
+	name = T_BOARD("breakerbox")
+	build_path = /obj/machinery/power/breakerbox
+	board_type = "machine"
+	origin_tech = list(TECH_POWER = 4, TECH_ENGINEERING = 4)
+	req_components = list(
+			/obj/item/weapon/smes_coil = 1,
+			/obj/item/stack/cable_coil = 10,
+			/obj/item/weapon/stock_parts/capacitor = 1
+		)

--- a/code/modules/power/breaker_box.dm
+++ b/code/modules/power/breaker_box.dm
@@ -18,6 +18,7 @@
 	var/directions = list(1,2,4,8,5,6,9,10)
 	var/RCon_tag = "NO_TAG"
 	var/update_locked = 0
+	circuit = /obj/item/weapon/circuitboard/breakerbox
 
 /obj/machinery/power/breakerbox/Destroy()
 	. = ..()
@@ -82,16 +83,16 @@
 			update_locked = 0
 	busy = 0
 
-/obj/machinery/power/breakerbox/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
+/obj/machinery/power/breakerbox/attackby(var/obj/item/W as obj, var/mob/user as mob)
+	if(default_deconstruction(W, user))
+		return
+	if(default_part_replacement(W, user))
+		return
 	if(istype(W, /obj/item/weapon/tool/multitool))
 		var/newtag = input(user, "Enter new RCON tag. Use \"NO_TAG\" to disable RCON or leave empty to cancel.", "SMES RCON system") as text
 		if(newtag)
 			RCon_tag = newtag
 			to_chat(user, SPAN_NOTICE("You changed the RCON tag to: [newtag]"))
-
-
-
-
 
 /obj/machinery/power/breakerbox/proc/set_state(var/state)
 	on = state


### PR DESCRIPTION
## Allowing to construct and deconstruct breaker box
## Changelog
:cl:
add: Allowing to construct and deconstruct breaker box
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
