### PR TITLE
NanoUI: Remove padding for icons without text

### DIFF
--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -58,6 +58,10 @@ hr {
     padding: 0px 4px 4px 0px;
 }
 
+.onlyIcon {
+    padding: 0px 0px 4px 0px;
+}
+
 a:hover, .zoomLink:hover, .linkActive:hover {
     background: #507aac;
 }

--- a/nano/js/nano_base_helpers.js
+++ b/nano/js/nano_base_helpers.js
@@ -23,7 +23,7 @@ NanoBaseHelpers = function ()
 				if (typeof icon != 'undefined' && icon)
 				{
 					iconHtml = '<div class="uiLinkPendingIcon"></div><div class="uiIcon16 icon-' + icon + '"></div>';
-					iconClass = 'hasIcon';
+					iconClass = text ? 'hasIcon' : 'onlyIcon';
 				}
 
 				if (typeof elementClass == 'undefined' || !elementClass)


### PR DESCRIPTION
## About The Pull Request

![img](https://user-images.githubusercontent.com/8840325/64332282-f0219c00-cfdc-11e9-93f9-92aca5a2cd09.png)

## Why It's Good For The Game

Buttons are less ugly now.

## Changelog
:cl:
fix: Removed superfluous padding in NanoUI buttons without text
/:cl:
