### PR TITLE
[FIX] Closets will check ID then cruciform now

### DIFF
--- a/code/game/machinery/walllockers.dm
+++ b/code/game/machinery/walllockers.dm
@@ -1,4 +1,4 @@
-n/obj/structure/walllocker
+/obj/structure/walllocker
 	name = "Wall Locker"
 	icon = 'icons/obj/lockwall.dmi'
 	icon_state = "emerg"

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -234,15 +234,6 @@
 		src.togglelock(user)
 
 /obj/structure/closet/proc/CanToggleLock(var/mob/user, var/obj/item/weapon/card/id/id_card)
-	if (istype(user))
-		id_card = id_card || user.GetIdCard()
-
-	if (istype(id_card))
-		if(check_access_list(id_card.GetAccess()))
-			return TRUE
-		else
-			return check_access_list(user.GetAccess())
-
 	return allowed(user)
 
 /obj/structure/closet/proc/set_locked(var/newlocked, mob/user = null)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -213,7 +213,7 @@
 		return
 	update_icon()
 
-/obj/structure/closet/proc/togglelock(mob/user as mob, var/obj/item/weapon/card/id/id_card)
+/obj/structure/closet/proc/togglelock(mob/user as mob)
 	var/ctype = istype(src,/obj/structure/closet/crate) ? "crate" : "closet"
 	if(!secure)
 		return
@@ -224,7 +224,7 @@
 	if(src.broken)
 		to_chat(user, SPAN_WARNING("The [ctype] appears to be broken."))
 		return
-	if(CanToggleLock(user, id_card))
+	if(CanToggleLock(user))
 		set_locked(!locked, user)
 	else
 		to_chat(user, SPAN_NOTICE("Access Denied"))
@@ -233,7 +233,7 @@
 	if(Adjacent(user))
 		src.togglelock(user)
 
-/obj/structure/closet/proc/CanToggleLock(var/mob/user, var/obj/item/weapon/card/id/id_card)
+/obj/structure/closet/proc/CanToggleLock(var/mob/user)
 	return allowed(user)
 
 /obj/structure/closet/proc/set_locked(var/newlocked, mob/user = null)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -238,7 +238,10 @@
 		id_card = id_card || user.GetIdCard()
 
 	if (istype(id_card))
-		return check_access_list(id_card.GetAccess())
+		if(check_access_list(id_card.GetAccess()))
+			return TRUE
+		else
+			return check_access_list(user.GetAccess())
 
 	return allowed(user)
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal/_personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal/_personal.dm
@@ -6,18 +6,14 @@
 	var/list/access_occupy = list()
 	icon_state = "secure"
 
-/obj/structure/closet/secure_closet/personal/CanToggleLock(var/mob/user, var/obj/item/weapon/card/id/id_card)
-	if(istype(user))
-		id_card = id_card || user.GetIdCard()
+/obj/structure/closet/secure_closet/personal/CanToggleLock(var/mob/user)
+	var/obj/item/weapon/card/id/id_card = user.GetIdCard()
 
-	if(istype(id_card))
-		if(id_card.registered_name == registered_name)
-			return TRUE
+	if(id_card.registered_name == registered_name)
+		return TRUE
 
-		if(!registered_name && has_access(access_occupy, list(), id_card.GetAccess()))
-			return TRUE
-
-	return ..()
+	if(!registered_name && ..())
+		return TRUE
 
 /obj/structure/closet/secure_closet/personal/attackby(obj/item/W, mob/living/user)
 	if (src.opened)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It stops the annoyance and fixes the access for closets. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Closets will check first the ID then Cruciform. No more annoyances.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
