### PR TITLE
[Balance] Possible fix for damage reduction when wearing anything

### DIFF
--- a/code/modules/biomatter_manipulation/bioreactor/biotank.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/biotank.dm
@@ -47,7 +47,7 @@
 		return
 	switch(get_dirtiness_level())
 		if(DIRT_LVL_LOW)
-			to_chat(user, SPAN_NOTICE("Pipes are weared a bit, it's slightly dirty. You see a signs of biomattir inside these pipes."))
+			to_chat(user, SPAN_NOTICE("Pipes are weared a bit, it's slightly dirty. You see a signs of biomass inside these pipes."))
 		if(DIRT_LVL_MEDIUM)
 			to_chat(user, SPAN_WARNING("It's very dirty. Solid biomass block atleast half of space inside the pipes. Better to clean it up."))
 		if(DIRT_LVL_HIGH)

--- a/code/modules/biomatter_manipulation/toxic_biomass.dm
+++ b/code/modules/biomatter_manipulation/toxic_biomass.dm
@@ -6,7 +6,7 @@
 	if(istype(victim))
 		var/hazard_protection = victim.getarmor(null, "bio")
 		if(!hazard_protection)
-			victim.apply_damage(damage, TOX)
+			victim.apply_damage(damage * victim.reagent_permeability(), TOX)
 
 
 //this proc spill some biomass on the floor


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Quick fix to toxins spills from bioreactors when cleaning it with a mop.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Reduction of tox damage when wearing anything good.
Unsure about the goal of this in this code.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Bioreactor spills should be less deadly.
fix: Typo in a line from Bioreactor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
