### PR TITLE
Basic v513 support

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -65,6 +65,7 @@
 #include "code\__DEFINES\unit_testing.dm"
 #include "code\__DEFINES\weapons.dm"
 #include "code\__DEFINES\ZAS.dm"
+#include "code\__HELPERS\__v512.dm"
 #include "code\__HELPERS\_global_objects.dm"
 #include "code\__HELPERS\_lists.dm"
 #include "code\__HELPERS\areas.dm"

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -202,7 +202,7 @@
 #define MOUSE_OPACITY_OPAQUE 2
 
 //Filters
-#define AMBIENT_OCCLUSION filter(type="drop_shadow", x=0, y=-2, size=4, border=4, color="#04080FAA")
+#define AMBIENT_OCCLUSION filter(type="drop_shadow", x=0, y=-2, size=4, color="#04080FAA")
 
 //Built-in email accounts
 #define EMAIL_DOCUMENTS "document.server@internal-services.net"

--- a/code/__HELPERS/__v512.dm
+++ b/code/__HELPERS/__v512.dm
@@ -1,0 +1,22 @@
+
+
+// v513 ships with "arctan()" builtin
+#if DM_VERSION < 513
+proc/arctan(x)
+	var/y = arcsin(x/sqrt(1+x*x))
+	return y
+#endif
+
+
+#if DM_VERSION > 512
+#warning Remie said that lummox was adding a way to get a lists
+#warning contents via list.values, if that is true remove this
+#warning otherwise, update the version and bug lummox
+#endif
+//Flattens a keyed list into a list of it's contents
+/proc/flatten_list(list/key_list)
+	if(!islist(key_list))
+		return null
+	. = list()
+	for(var/key in key_list)
+		. |= key_list[key]

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -868,18 +868,6 @@ Checks if a list has the same entries and values as an element of big.
 		used_key_list[input_key] = 1
 	return input_key
 
-#if DM_VERSION > 512
-#error Remie said that lummox was adding a way to get a lists
-#error contents via list.values, if that is true remove this
-#error otherwise, update the version and bug lummox
-#endif
-//Flattens a keyed list into a list of it's contents
-/proc/flatten_list(list/key_list)
-	if(!islist(key_list))
-		return null
-	. = list()
-	for(var/key in key_list)
-		. |= key_list[key]
 
 /proc/make_associative(list/flat_list)
 	. = list()

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -553,10 +553,6 @@ Turf and target are seperate in case you want to teleport some distance from a t
 /proc/between(var/low, var/middle, var/high)
 	return max(min(middle, high), low)
 
-proc/arctan(x)
-	var/y=arcsin(x/sqrt(1+x*x))
-	return y
-
 //returns random gauss number
 proc/GaussRand(var/sigma)
   var/x, y, rsq

--- a/code/game/jobs/department.dm
+++ b/code/game/jobs/department.dm
@@ -31,7 +31,7 @@
 	//This is a key value list of datacore records and their total owed wage
 	//When payday comes, accounts in the department are added here, and removed once the balance is paid off
 	//They are not removed until they are paid, so multiple paydays could rollover and stack up if unpaid
-	var/list/pending_wages()
+	var/list/pending_wages
 
 	// The total of the values in the above wage list. Just cached for convenience
 	var/pending_wage_total = 0
@@ -124,5 +124,4 @@
 	*/
 	account_initial_balance = 7500
 	funding_type = FUNDING_NONE
-
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -834,14 +834,15 @@ Note that amputating the affected organ does in fact remove the infection from t
 		W.germ_level = 0
 	return rval
 
-/obj/item/organ/external/proc/clamp()
-	var/rval = 0
+/obj/item/organ/external/proc/clamp_wounds()
+	var/rval = FALSE
+
 	src.stopBleeding()
 	for(var/datum/wound/W in wounds)
 		if(W.internal)
 			continue
 		rval |= !W.clamped
-		W.clamped = 1
+		W.clamped = TRUE
 	return rval
 
 /obj/item/organ/external/proc/fracture()

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -50,7 +50,7 @@
 		affected.setBleeding()
 
 	affected.createwound(CUT, 1)
-	affected.clamp()
+	affected.clamp_wounds()
 	spread_germs_to_organ(affected, user)
 
 /datum/surgery_step/generic/cut_with_laser/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -118,7 +118,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("\blue [user] clamps bleeders in [target]'s [affected.name] with \the [tool].",	\
 	"\blue You clamp bleeders in [target]'s [affected.name] with \the [tool].")
-	affected.clamp()
+	affected.clamp_wounds()
 	spread_germs_to_organ(affected, user)
 
 /datum/surgery_step/generic/clamp_bleeders/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)


### PR DESCRIPTION
CEV-Eris will now build and run on BYOND v513.

It still doesn't use any v513-specific features, as we don't want to break v512 compatibility yet.