### PR TITLE
Reverts toxin damage changes

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -211,56 +211,12 @@
 		toxloss = 0
 	return ..()
 
-/mob/living/carbon/human/adjustToxLoss(var/amount)
-	if((species.flags & NO_POISON) || isSynthetic())
-		return
-
-	var/heal = amount < 0
-	amount = abs(amount)
-
-	if (!heal)
-		amount = amount * species.toxins_mod
-		if (CE_ANTITOX in chem_effects)
-			amount *= 1 - (chem_effects[CE_ANTITOX] * 0.25)
-
-	var/list/pick_organs = shuffle(internal_organs.Copy())
-
-	// Prioritize damaging our filtration organs first.
-	var/obj/item/organ/internal/kidneys/kidneys = internal_organs_by_name[BP_KIDNEYS]
-	if(kidneys)
-		pick_organs -= kidneys
-		pick_organs.Insert(1, kidneys)
-	var/obj/item/organ/internal/liver/liver = internal_organs_by_name[BP_LIVER]
-	if(liver)
-		pick_organs -= liver
-		pick_organs.Insert(1, liver)
-
-	// Move the brain to the very end since damage to it is vastly more dangerous
-	// (and isn't technically counted as toxloss) than general organ damage.
-	var/obj/item/organ/internal/brain/brain = internal_organs_by_name[BP_BRAIN]
-	if(brain)
-		pick_organs -= brain
-		pick_organs += brain
-
-	for(var/internal in pick_organs)
-		var/obj/item/organ/internal/I = internal
-		if(amount <= 0)
-			break
-		if(heal)
-			if(I.damage < amount)
-				amount -= I.damage
-				I.damage = 0
-			else
-				I.damage -= amount
-				amount = 0
-		else
-			var/cap_dam = I.max_damage - I.damage
-			if(amount >= cap_dam)
-				I.take_internal_damage(cap_dam, silent=TRUE)
-				amount -= cap_dam
-			else
-				I.take_internal_damage(amount, silent=TRUE)
-				amount = 0
+/mob/living/carbon/human/adjustToxLoss(amount)
+	if(species.flags & NO_POISON)
+		toxloss = 0
+	else
+		amount = amount*species.toxins_mod
+		..(amount)
 
 /mob/living/carbon/human/setToxLoss(var/amount)
 	if(!(species.flags & NO_POISON) && !isSynthetic())


### PR DESCRIPTION
Reverts the `adjustToxLoss` change made in #3697, because it caused toxins to become incredibly lethal, and the new medicine rework would do it differently anyway. 

Fixes #3809.
