### PR TITLE
Cleaning from shit code of autolathe.update_icon()

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -74,16 +74,6 @@
 	unsuitable_materials = list()
 	circuit = /obj/item/weapon/circuitboard/neotheology/bioprinter
 
-/obj/machinery/autolathe/bioprinter/update_icon()
-	overlays.Cut()
-
-	icon_state = "bio_autolathe"
-	if(panel_open)
-		overlays.Add(image(icon, "bio_autolathe_p"))
-
-	if(working && !error) // if error, work animation looks awkward.
-		icon_state = "bio_autolathe_n"
-
 /obj/machinery/autolathe/Initialize()
 	. = ..()
 	wires = new(src)
@@ -498,7 +488,7 @@
 
 
 /obj/machinery/autolathe/proc/res_load()
-	flick("autolathe_o", src)
+	flick("[icon_state]_o", src)
 
 
 /obj/machinery/autolathe/proc/can_print(datum/computer_file/binary/design/design_file)
@@ -573,12 +563,13 @@
 /obj/machinery/autolathe/update_icon()
 	overlays.Cut()
 
-	icon_state = "autolathe"
+	icon_state = initial(icon_state)
+
 	if(panel_open)
-		overlays.Add(image(icon, "autolathe_p"))
+		overlays.Add(image(icon, "[icon_state]_p"))
 
 	if(working && !error) // if error, work animation looks awkward.
-		icon_state = "autolathe_n"
+		icon_state = "[icon_state]_n"
 
 /obj/machinery/autolathe/proc/consume_materials(datum/design/design)
 	for(var/material in design.materials)


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>
Update_icon() of autolathe now can be inherit
<hr>
</details>

## Changelog
:cl:
refactor: Update_icon() of autolathe now can be inherit by subtypes of it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
