### PR TITLE
Unifies Moebius Communications

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -56,6 +56,11 @@
 	icon_state = "sci_cypherkey"
 	channels = list("Science" = 1)
 
+/obj/item/device/encryptionkey/headset_moebius
+	name = "Moebius laboratories encryption key"
+	icon_state = "sci_cypherkey"
+	channels = list("Science" = 1, "Medical" = 1)
+
 /obj/item/device/encryptionkey/headset_com
 	name = "Eris command radio encryption key"
 	icon_state = "com_cypherkey"
@@ -76,6 +81,11 @@
 	name = "expedition overseer's encryption key"
 	icon_state = "rd_cypherkey"
 	channels = list("Science" = 1, "Command" = 1)
+
+/obj/item/device/encryptionkey/heads/moebius
+	name = "Moebius command encryption key"
+	icon_state = "rd_cypherkey"
+	channels = list("Science" = 1, "Medical" = 1, "Command" = 1)
 
 /obj/item/device/encryptionkey/heads/hos
 	name = "Ironhammer commander's encryption key"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -95,21 +95,21 @@
 	desc = "Made specifically for the roboticists who cannot decide between departments."
 	icon_state = "rob_headset"
 	item_state = "headset"
-	ks2type = /obj/item/device/encryptionkey/headset_rob
+	ks2type = /obj/item/device/encryptionkey/headset_moebius
 
 /obj/item/device/radio/headset/headset_med
 	name = "medical radio headset"
 	desc = "A headset for the trained staff of the medbay."
 	icon_state = "med_headset"
 	item_state = "headset"
-	ks2type = /obj/item/device/encryptionkey/headset_med
+	ks2type = /obj/item/device/encryptionkey/headset_moebius
 
 /obj/item/device/radio/headset/headset_sci
 	name = "science radio headset"
 	desc = "A sciency headset. Like usual."
 	icon_state = "com_headset"
 	item_state = "headset"
-	ks2type = /obj/item/device/encryptionkey/headset_sci
+	ks2type = /obj/item/device/encryptionkey/headset_moebius
 
 /obj/item/device/radio/headset/headset_com
 	name = "command radio headset"
@@ -145,7 +145,7 @@
 	desc = "Headset of the researching God."
 	icon_state = "com_headset"
 	item_state = "headset"
-	ks2type = /obj/item/device/encryptionkey/heads/rd
+	ks2type = /obj/item/device/encryptionkey/heads/moebius
 
 /obj/item/device/radio/headset/heads/hos
 	name = "ironhammer commander headset"
@@ -166,7 +166,7 @@
 	desc = "The headset of the highly trained medical chief."
 	icon_state = "com_headset"
 	item_state = "headset"
-	ks2type = /obj/item/device/encryptionkey/heads/cmo
+	ks2type = /obj/item/device/encryptionkey/heads/moebius
 
 /obj/item/device/radio/headset/heads/hop
 	name = "first officer's headset"


### PR DESCRIPTION
<details>
<summary>
	Gives medical personnel access to research channels and vice versa. Both work for Moebius and so the communication between two shouldn't be treated as though they're completely separate departments (especially with medical personnel having access to science and vice versa).

Keeps medical and research channels separate, partly for my own sanity, but also to help prevent discussion within the departments from getting jumbled up with the others' business, though still keeping them in the know of each other.
</summary>
</details>

## Changelog
:cl:
tweak: Moebius medical and research now have access to each other's channels in a single encryption key.
/:cl: