### PR TITLE
Fix personal closet related runtime

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/personal/_personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal/_personal.dm
@@ -9,7 +9,7 @@
 /obj/structure/closet/secure_closet/personal/CanToggleLock(var/mob/user)
 	var/obj/item/weapon/card/id/id_card = user.GetIdCard()
 
-	if(id_card.registered_name == registered_name)
+	if(id_card && id_card.registered_name == registered_name)
 		return TRUE
 
 	if(!registered_name && ..())


### PR DESCRIPTION
fix #3875 

<hr>
</details>

## Changelog
:cl:
fix: runtime occures when smone trying to open personal closet without ID card
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
