### PR TITLE
Group litany rework

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -181,7 +181,6 @@
 
 //Core implants
 #define CORE_ACTIVATED /datum/core_module/activatable
-#define GROUP_RITUAL_COOLDOWN 45*60*10
 
 //Cruciform
 #define CRUCIFORM_COMMON /datum/core_module/rituals/cruciform/base

--- a/code/datums/mob_stats.dm
+++ b/code/datums/mob_stats.dm
@@ -16,6 +16,12 @@
 	var/datum/stat/S = stat_list[statName]
 	S.remove_modifier(id)
 
+/datum/stat_holder/proc/getTempStat(statName, id)
+	if(!id)
+		crash_with("no id passed to getTempStat(")
+	var/datum/stat/S = stat_list[statName]
+	return S.get_modifier(id)
+
 /datum/stat_holder/proc/changeStat(statName, Value)
 	var/datum/stat/S = stat_list[statName]
 	S.changeValue(Value)
@@ -134,6 +140,12 @@
 		if(SM.id == id)
 			mods.Remove(SM)
 			return
+
+/datum/stat/proc/get_modifier(id)
+	for(var/elem in mods)
+		var/datum/stat_mod/SM = elem
+		if(SM.id == id)
+			return SM
 
 /datum/stat/proc/changeValue(affect)
 	value = value + affect

--- a/code/modules/core_implant/core_implant.dm
+++ b/code/modules/core_implant/core_implant.dm
@@ -108,23 +108,35 @@
 	return L
 
 /obj/item/weapon/implant/core_implant/hear_talk(mob/living/carbon/human/H, message, verb, datum/language/speaking, speech_volume)
+	var/group_ritual_leader = FALSE
 	for(var/datum/core_module/group_ritual/GR in src.modules)
 		GR.hear(H, message)
+		group_ritual_leader = TRUE
 
 	if(wearer != H)
-		return
+		if(H.get_core_implant() && !group_ritual_leader)
+			addtimer(CALLBACK(src, .proc/hear_other, H, message), 0) // let H's own implant hear first
+	else
+		for(var/RT in known_rituals)
+			var/datum/ritual/R = GLOB.all_rituals[RT]
+			if(R.compare(message))
+				if(R.power > src.power)
+					to_chat(H, SPAN_DANGER("Not enough energy for the [R.name]."))
+					return
+				if(!R.is_allowed(src))
+					to_chat(H, SPAN_DANGER("You are not allowed to perform [R.name]."))
+					return
+				R.activate(H, src, R.get_targets(message))
+				return
 
-	for(var/RT in known_rituals)
-		var/datum/ritual/R = GLOB.all_rituals[RT]
-		if(R.compare(message))
-			if(R.power > src.power)
-				to_chat(H, SPAN_DANGER("Not enough energy for the [R.name]."))
-				return
-			if(!R.is_allowed(src))
-				to_chat(H, SPAN_DANGER("You are not allowed to perform [R.name]."))
-				return
-			R.activate(H, src, R.get_targets(message))
-			return
+/obj/item/weapon/implant/core_implant/proc/hear_other(mob/living/carbon/human/H, message)
+	var/datum/core_module/group_ritual/GR = H.get_core_implant().get_module(/datum/core_module/group_ritual)
+	if(GR?.ritual.name in known_rituals)
+		if(message == GR.phrases[1])
+			if(do_after(wearer, length(message)*0.25))
+				if(GR)
+					GR.ritual.set_personal_cooldown(wearer)
+				wearer.say(message)
 
 
 /obj/item/weapon/implant/core_implant/proc/use_power(var/value)

--- a/code/modules/core_implant/cruciform/machinery/obelisk.dm
+++ b/code/modules/core_implant/cruciform/machinery/obelisk.dm
@@ -67,7 +67,7 @@
 	var/got_neoteo = FALSE
 	for(var/mob/living/carbon/human/mob in range(area_radius, src))
 		if(mob)
-			var/obj/item/weapon/implant/core_implant/I = mob.get_core_implant()
+			var/obj/item/weapon/implant/core_implant/I = mob.get_core_implant(/obj/item/weapon/implant/core_implant/cruciform)
 			if(I && I.active && I.wearer)
 				if(I.power < I.max_power)	I.power += nt_buff_power
 				for(var/r_tag in mob.personal_ritual_cooldowns)

--- a/code/modules/core_implant/cruciform/machinery/obelisk.dm
+++ b/code/modules/core_implant/cruciform/machinery/obelisk.dm
@@ -22,6 +22,8 @@
 	var/nt_buff_power = 5
 	var/nt_buff_cd = 3
 
+	var/static/stat_buff
+
 /obj/machinery/power/nt_obelisk/New()
 	..()
 
@@ -72,6 +74,30 @@
 				if(I.power < I.max_power)	I.power += nt_buff_power
 				for(var/r_tag in mob.personal_ritual_cooldowns)
 					mob.personal_ritual_cooldowns[r_tag] -= nt_buff_cd
+
+				if(stat_buff)
+					var/buff_power = disciples.len
+					var/message
+					var/prev_stat
+					for(var/stat in ALL_STATS)
+						var/datum/stat_mod/SM = mob.stats.getTempStat(stat, "nt_obelisk")
+						if(stat == stat_buff)
+							if(!SM)
+								message = "A wave of dizziness washes over you, and your mind is filled with a sudden insight into [stat]."
+							else if(SM.value != buff_power) // buff power was changed
+								message = "Your knowledge of [stat] feels slightly [SM.value > buff_power ? "lessened" : "broadened"]."
+							else if(SM.time < world.time + 10 MINUTES) // less than 10 minutes of buff duration left
+								message = "Your knowledge of [stat] feels renewed."
+							mob.stats.addTempStat(stat, buff_power, 20 MINUTES, "nt_obelisk")
+						else if(SM)
+							prev_stat = stat
+							mob.stats.removeTempStat(stat, "nt_obelisk")
+
+					if(prev_stat) // buff stat was replaced
+						message = "A wave of dizziness washes over you, and your mind is filled with a sudden insight into [stat_buff] as your knowledge of [prev_stat] feels lessened."
+					if(message)
+						to_chat(mob, SPAN_NOTICE(message))
+
 				got_neoteo = TRUE
 	return got_neoteo
 

--- a/code/modules/core_implant/cruciform/rituals/group.dm
+++ b/code/modules/core_implant/cruciform/rituals/group.dm
@@ -10,6 +10,13 @@
 		return FALSE
 	return TRUE
 
+/datum/ritual/group/cruciform/step_check(mob/living/carbon/human/H)
+	for(var/obj/machinery/power/nt_obelisk/O in range(7,H))
+		if(O.stat || !O.active || get_dist(H, O) > O.area_radius)
+			continue
+		return TRUE
+	return FALSE
+
 /datum/ritual/group/cruciform/mechanical
 	name = "Mechanical"
 	desc = "Boosts Mechanical stat to 3 + 1 for each participant."

--- a/code/modules/core_implant/cruciform/rituals/group.dm
+++ b/code/modules/core_implant/cruciform/rituals/group.dm
@@ -17,6 +17,16 @@
 		return TRUE
 	return FALSE
 
+/datum/group_ritual_effect/cruciform/stat
+	var/stat_buff
+
+/datum/group_ritual_effect/cruciform/stat/success(var/mob/living/M, var/cnt)
+	if(cnt < 3 || !stat_buff)
+		return
+	var/obj/machinery/power/nt_obelisk/O
+	O = O // "unused variable" yourself
+	O.stat_buff = stat_buff
+
 /datum/ritual/group/cruciform/mechanical
 	name = "Mechanical"
 	desc = "Boosts Mechanical stat to 3 + 1 for each participant."
@@ -33,11 +43,10 @@
 		"Perfruere vita cum uxore quam diligis cunctis diebus vitae instabilitatis tuae qui dati sunt tibi sub sole omni tempore vanitatis tuae haec est enim pars in vita et in labore tuo quod laboras sub sole.",
 		"Amen."
 	)
-	effect_type = /datum/group_ritual_effect/cruciform/mechanical
+	effect_type = /datum/group_ritual_effect/cruciform/stat/mechanical
 
-/datum/group_ritual_effect/cruciform/mechanical/success(var/mob/living/M, var/cnt)
-	var/stat = 3 + cnt
-	M.stats.changeStat(STAT_MEC, stat)
+/datum/group_ritual_effect/cruciform/stat/mechanical
+	stat_buff = STAT_MEC
 
 
 /datum/ritual/group/cruciform/cognition
@@ -53,11 +62,10 @@
 		"Et veniebant de cunctis populis ad audiendam sapientiam Salomonis et ab universis regibus terrae qui audiebant sapientiam eius.",
 		"Amen."
 	)
-	effect_type = /datum/group_ritual_effect/cruciform/cognition
+	effect_type = /datum/group_ritual_effect/cruciform/stat/cognition
 
-/datum/group_ritual_effect/cruciform/cognition/success(var/mob/living/M, var/cnt)
-	var/stat = 3 + cnt
-	M.stats.changeStat(STAT_COG, stat)
+/datum/group_ritual_effect/cruciform/stat/cognition
+	stat_buff = STAT_COG
 
 
 
@@ -74,11 +82,10 @@
 		"Egressi autem circumibant per castella evangelizantes et curantes ubique.",
 		"Amen."
 	)
-	effect_type = /datum/group_ritual_effect/cruciform/biology
+	effect_type = /datum/group_ritual_effect/cruciform/stat/biology
 
-/datum/group_ritual_effect/cruciform/biology/success(var/mob/living/M, var/cnt)
-	var/stat = 3 + cnt
-	M.stats.changeStat(STAT_BIO, stat)
+/datum/group_ritual_effect/cruciform/stat/biology
+	stat_buff = STAT_BIO
 
 
 /datum/ritual/group/cruciform/robustness
@@ -94,11 +101,10 @@
 		"Scito igitur quod non propter iustitias tuas Dominus Deus tuus dederit tibi terram hanc optimam in possessionem cum durissimae cervicis sis populus.",
 		"Amen."
 	)
-	effect_type = /datum/group_ritual_effect/cruciform/robustness
+	effect_type = /datum/group_ritual_effect/cruciform/stat/robustness
 
-/datum/group_ritual_effect/cruciform/robustness/success(var/mob/living/M, var/cnt)
-	var/stat = 3 + cnt
-	M.stats.changeStat(STAT_ROB, stat)
+/datum/group_ritual_effect/cruciform/stat/robustness
+	stat_buff = STAT_ROB
 
 
 /datum/ritual/group/cruciform/toughness
@@ -115,11 +121,10 @@
 		"A summo caeli egressio eius et occursus eius usque ad summum eius nec est qui se abscondat a calore eius.",
 		"Amen."
 	)
-	effect_type = /datum/group_ritual_effect/cruciform/toughness
+	effect_type = /datum/group_ritual_effect/cruciform/stat/toughness
 
-/datum/group_ritual_effect/cruciform/toughness/success(var/mob/living/M, var/cnt)
-	var/stat = 3 + cnt
-	M.stats.changeStat(STAT_TGH, stat)
+/datum/group_ritual_effect/cruciform/stat/toughness
+	stat_buff = STAT_TGH
 
 
 /datum/ritual/group/cruciform/crusade
@@ -140,17 +145,13 @@
 	effect_type = /datum/group_ritual_effect/cruciform/crusade
 
 /datum/group_ritual_effect/cruciform/crusade/success(var/mob/living/M, var/cnt)
+	if(cnt < 6)
+		return
 	var/obj/item/weapon/implant/core_implant/CI = M.get_core_implant(/obj/item/weapon/implant/core_implant/cruciform)
 	if(CI)
-		if(cnt >= 2)
-			var/datum/ritual/cruciform/crusader/C = /datum/ritual/cruciform/crusader/brotherhood
-			CI.known_rituals |= initial(C.name)
-
-		if(cnt >= 3)
-			var/datum/ritual/cruciform/crusader/C = /datum/ritual/cruciform/crusader/battle_call
-			CI.known_rituals |= initial(C.name)
-
-		if(cnt >= 4)
-			var/datum/ritual/cruciform/crusader/C = /datum/ritual/cruciform/crusader/flash
-			CI.known_rituals |= initial(C.name)
-
+		var/datum/ritual/cruciform/crusader/C = /datum/ritual/cruciform/crusader/brotherhood
+		CI.known_rituals |= initial(C.name)
+		C = /datum/ritual/cruciform/crusader/battle_call
+		CI.known_rituals |= initial(C.name)
+		C = /datum/ritual/cruciform/crusader/flash
+		CI.known_rituals |= initial(C.name)

--- a/code/modules/core_implant/cruciform/rituals/group.dm
+++ b/code/modules/core_implant/cruciform/rituals/group.dm
@@ -4,6 +4,8 @@
 	fail_message = "The Cruciform feels cold against your chest."
 
 /datum/ritual/group/cruciform/pre_check(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C, targets)
+	if(!..())
+		return FALSE
 	if(!C.get_module(CRUCIFORM_PRIEST) && !C.get_module(CRUCIFORM_INQUISITOR))
 		return FALSE
 	return TRUE

--- a/code/modules/core_implant/group_ritual.dm
+++ b/code/modules/core_implant/group_ritual.dm
@@ -16,6 +16,9 @@
 		return FALSE
 	return ..()
 
+/datum/ritual/group/proc/step_check(mob/living/carbon/human/H)
+	return TRUE
+
 /datum/ritual/group/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C, targets)
 	if(!effect_type)
 		return FALSE
@@ -81,13 +84,13 @@
 
 	if(user == implant.wearer)
 		if(phrases.len > 2)
-			if(phrase == phrases[2])
+			if(phrase == phrases[2] && ritual.step_check(user))
 				next_phrase()
 			else
 				effect.trigger_fail(implant.wearer,participants)
 				implant.remove_module(src)
 		else
-			if(phrase == phrases[2] && participants.len)	//It's a group ritual, isn't it?
+			if(phrase == phrases[2] && ritual.step_check(user) && participants.len)	//It's a group ritual, isn't it?
 				effect.trigger_success(implant.wearer,participants)
 				implant.remove_module(src)
 			else
@@ -96,7 +99,7 @@
 
 	else
 		if(first || (user in participants))
-			if(phrase == phrases[1] && !(user in correct_participants))
+			if(phrase == phrases[1] && !(user in correct_participants) && ritual.step_check(user))
 				correct_participants.Add(user)
 			else
 				participants.Remove(user)

--- a/code/modules/core_implant/group_ritual.dm
+++ b/code/modules/core_implant/group_ritual.dm
@@ -1,23 +1,29 @@
-var/group_global_cooldown = 0
-
 /datum/ritual/group
 	name = "group ritual"
 	desc = ""
 	phrase = null
 	power = 0
 	category = "Group"
-	cooldown = TRUE
 	var/list/phrases = list()
 	var/effect_type = null
+
+	cooldown = TRUE
+	cooldown_time = 1 SECONDS
+	cooldown_category = "group"
+
+/datum/ritual/group/pre_check(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C, targets)
+	if(is_on_cooldown(H))
+		return FALSE
+	return ..()
 
 /datum/ritual/group/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C, targets)
 	if(!effect_type)
 		return FALSE
 
 	var/datum/core_module/group_ritual/GR = new
+	GR.ritual = src
 	GR.implant_type = C.implant_type
 	GR.phrases = phrases
-	GR.cooldown = cooldown
 	GR.effect = new effect_type
 	GR.effect.succ_message = success_message
 	GR.effect.fail_message = fail_message
@@ -51,8 +57,8 @@ var/group_global_cooldown = 0
 	var/list/correct_participants = list()
 	var/list/phrases = list()
 	var/first = TRUE
-	var/cooldown = TRUE
 
+	var/datum/ritual/group/ritual
 	var/datum/group_ritual_effect/effect = null
 
 /datum/core_module/group_ritual/set_up()
@@ -62,14 +68,11 @@ var/group_global_cooldown = 0
 	if(!effect)
 		return FALSE
 
-	return !cooldown || world.time >= group_global_cooldown
+	return TRUE
 
 /datum/core_module/group_ritual/uninstall()
 	if(!effect)
 		return
-
-	if(cooldown)
-		group_global_cooldown = world.time + GROUP_RITUAL_COOLDOWN
 
 
 /datum/core_module/group_ritual/proc/hear(var/mob/user, var/phrase)
@@ -106,9 +109,6 @@ var/group_global_cooldown = 0
 	correct_participants = list()
 	to_chat(implant.wearer, SPAN_NOTICE("There is [participants.len] followers continuing the ritual."))
 
-
-/datum/core_module/group_ritual/proc/d_reset_cooldown()
-	group_global_cooldown = 0
 
 ////////////////////////
 


### PR DESCRIPTION
## About The Pull Request

#### Group litanies
Phrases will now be repeated automatically by everyone around who knows the ritual.
Cooldown removed.

#### NT group litanies
Every phrase must be read near an active obelisk to work.
Buff litanies now require at least 3 followers (for a total of 4 people) and provide global stat buff through obelisks.
Crusader litany now requires at least 6 followers (for a total of 7 people) and opens all crusader litanies when finished.

#### Obelisk buffs
A buff is activated by completing a buff litany. Completing another will replace the buff.
When a buff is active, all active NT obelisks give the buff to NT followers in their active area. Outside of the active area the buff lasts 20 minutes. The buff power depends on the amount of NT followers on the ship.

## Changelog
:cl:
tweak: reworked group litanies
/:cl:

