### PR TITLE
EZ Nutrient Recipe Fix

### DIFF
--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -1978,7 +1978,7 @@
 
 /datum/chemical_reaction/eznutrient
 	result = "eznutrient"
-	required_reagents = list("nutriment" = 1, "carbon" = 3)
+	required_reagents = list("ammonia" = 1, "carbon" = 3)
 	result_amount = 4
 
 /datum/chemical_reaction/left4zed


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Recipe now uses ammonia, a fertilizer, instead of nutriment. This allows chemistry to make it in the absence of anyone willing to do botany, and should stop it from mixing in certain foods.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--fix: EZ Nutrient longer appears in food made in the kitchen
tweak: EZ Nutrient uses Ammonia instead of Nutriment in its chemistry recipe-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
