### PR TITLE
TM toolbelts no longer spawn half empty

### DIFF
--- a/code/datums/outfits/jobs/engineering.dm
+++ b/code/datums/outfits/jobs/engineering.dm
@@ -1,6 +1,6 @@
 /decl/hierarchy/outfit/job/engineering
 	hierarchy_type = /decl/hierarchy/outfit/job/engineering
-	belt = /obj/item/weapon/storage/belt/utility/mostlyfull
+	belt = /obj/item/weapon/storage/belt/utility/full
 	l_ear = /obj/item/device/radio/headset/headset_eng
 	shoes = /obj/item/clothing/shoes/jackboots
 	gloves = /obj/item/clothing/gloves/thick

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -30,7 +30,7 @@
 
 
 /obj/item/weapon/storage/belt/utility
-	name = "tool-belt" //Carn: utility belt is nicer, but it bamboozles the text parsing.
+	name = "tool belt"
 	desc = "Can hold various tools."
 	icon_state = "utilitybelt"
 	item_state = "utility"
@@ -64,23 +64,6 @@
 	new /obj/item/weapon/tool/crowbar(src)
 	new /obj/item/weapon/tool/wirecutters(src)
 	new /obj/item/stack/cable_coil/random(src)
-
-//Mostly full toolbelt has a high chance - but not guaranteed - to contain each common tool
-/obj/item/weapon/storage/belt/utility/mostlyfull/New()
-	..()
-	if (prob(65))
-		new /obj/item/weapon/tool/screwdriver(src)
-	if (prob(65))
-		new /obj/item/weapon/tool/wrench(src)
-	if (prob(65))
-		new /obj/item/weapon/tool/weldingtool(src)
-	if (prob(65))
-		new /obj/item/weapon/tool/crowbar(src)
-	if (prob(65))
-		new /obj/item/weapon/tool/wirecutters(src)
-	if (prob(65))
-		new /obj/item/stack/cable_coil/random(src)
-
 
 /obj/item/weapon/storage/belt/utility/atmostech/New()
 	..()

--- a/code/modules/stashes/stash_types/weapons.dm
+++ b/code/modules/stashes/stash_types/weapons.dm
@@ -53,8 +53,8 @@
 	/obj/item/weapon/storage/toolbox/emergency = 50,
 	/obj/item/clothing/suit/armor/laserproof = 30,
 	/obj/item/clothing/suit/armor/laserproof = 30,
-	/obj/item/weapon/storage/belt/utility/mostlyfull = 70,
-	/obj/item/weapon/storage/belt/utility/mostlyfull = 70)
+	/obj/item/weapon/storage/belt/utility/full = 70,
+	/obj/item/weapon/storage/belt/utility/full = 70)
 
 //Variant of the above with slightly deeper story
 /datum/stash/weapon/mutiny_AI/robots


### PR DESCRIPTION
That was a dumb idea that contributed nothing but annoyance to the game.