### PR TITLE
Rnd ammo additions

### DIFF
--- a/code/modules/research/designs/weapon.dm
+++ b/code/modules/research/designs/weapon.dm
@@ -86,4 +86,8 @@
 	name = "Moebius BT \"Q-del\" gas tube"
 	build_path = /obj/item/weapon/hatton_magazine/moebius
 	sort_string = "TAACC"
-
+/datum/design/research/item/ammo/c20r_ammo
+	name = "C20R 10mm Magazine"
+	desc = "10mm SMG magazine for the C-20r"
+	build_path = /obj/item/ammo_magazine/smg10mm
+	sort_string = "TAACD"

--- a/code/modules/research/nodes/combat.dm
+++ b/code/modules/research/nodes/combat.dm
@@ -143,6 +143,7 @@
 
 	unlocks_designs = list(
 							/datum/design/research/item/weapon/c20r
+							/datum/design/research/item/ammo/c20r_ammo
 						)
 
 /datum/technology/laser_weaponry

--- a/code/modules/research/nodes/combat.dm
+++ b/code/modules/research/nodes/combat.dm
@@ -142,7 +142,7 @@
 	cost = 2000
 
 	unlocks_designs = list(
-							/datum/design/research/item/weapon/c20r
+							/datum/design/research/item/weapon/c20r,
 							/datum/design/research/item/ammo/c20r_ammo
 						)
 


### PR DESCRIPTION

## About The Pull Request
<details>
<summary>
	Adds C-20r ammo to Advanced-Lethal Weapons Node of Combat research
</summary>
<hr>
I have made it so when someone researches Advanced Lethal weapons, they get not only the C-20r, but the ammo for it, which can also be made in the proto lathe and auto lathe. All of sciences other weapons come with ammo either built in in the form of rechargables, either by rechargers or on their own, or with the ability to install power cells which Moebius can get very good ones easily.
<hr>
</details>

## Changelog
:cl:
add: Added a research datum for 10 mm SMG ammo
add: Added 10 mm SMG ammo to be researched alongside the C-20r so it doesnt go without ammo
/:cl:
