### PR TITLE
Container processing in sorter

### DIFF
--- a/code/game/machinery/smelter.dm
+++ b/code/game/machinery/smelter.dm
@@ -24,7 +24,7 @@
 
 	var/progress = 0
 
-	var/obj/item/current_item
+	var/obj/current_item
 
 	var/forbidden_materials = list(MATERIAL_CARDBOARD,MATERIAL_WOOD,MATERIAL_BIOMATTER)
 
@@ -70,15 +70,15 @@
 
 
 /obj/machinery/smelter/proc/grab()
-	for(var/obj/item/I in get_step(src, input_side))
-		if(I.anchored)
+	for(var/obj/O in get_step(src, input_side))
+		if(O.anchored)
 			continue
-		I.forceMove(src)
-		var/list/materials = result_materials(I)
+		O.forceMove(src)
+		var/list/materials = result_materials(O)
 		if(!materials?.len || !are_valid_materials(materials))
-			eject(I, refuse_output_side)
+			eject(O, refuse_output_side)
 			return
-		current_item = I
+		current_item = O
 		return
 
 

--- a/code/game/machinery/sorter.dm
+++ b/code/game/machinery/sorter.dm
@@ -42,7 +42,7 @@
 	var/progress = 0
 
 	var/list/sort_settings = list()
-	var/obj/item/current_item
+	var/obj/current_item
 
 	//UI vars
 	var/list/custom_rule = list("accept", "sort_type", "value", "amount")
@@ -118,11 +118,19 @@
 	if(current_item)
 		return
 	var/turf/T = get_step(src, input_side)
-	var/obj/item/O = locate(/obj/item) in T
-	if(istype(O) && !O.anchored)
+	for(var/obj/O in T)
+		if(O.anchored)
+			continue
+		var/obj/structure/closet/C = O
+		if(istype(C))
+			C.open()
 		current_item = O
 		O.forceMove(src)
+		if(istype(C) && !C.opened)
+			eject()
+			return
 		state("scanning now: [O]...")
+		return
 
 
 /obj/machinery/sorter/proc/eject(var/sorted = FALSE)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -211,7 +211,6 @@
 	if(!(opened ? close(user) : open(user)))
 		to_chat(user, SPAN_NOTICE("It won't budge!"))
 		return
-	update_icon()
 
 /obj/structure/closet/proc/togglelock(mob/user as mob)
 	var/ctype = istype(src,/obj/structure/closet/crate) ? "crate" : "closet"

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -29,8 +29,8 @@
 	playsound(src.loc, 'sound/machines/click.ogg', 15, 1, -3)
 	for(var/obj/O in src)
 		O.forceMove(get_turf(src))
-//	icon_state = icon_opened
 	src.opened = TRUE
+	update_icon()
 
 	if(climbable)
 		structure_shaken()
@@ -56,8 +56,8 @@
 		O.forceMove(src)
 		itemcount++
 
-//	icon_state = icon_closed
 	src.opened = FALSE
+	update_icon()
 	return TRUE
 
 /obj/structure/closet/crate/attackby(obj/item/weapon/W as obj, mob/user as mob)


### PR DESCRIPTION
## About The Pull Request

Sorter now automatically opens containers (closets, crates, etc.) and processes their contents one by one. If the container is locked, it is refused.
Smelter and sorter input is no longer limited to items.

## Changelog
:cl:
add: added ability to open containers to sorter
/:cl:
