### PR TITLE
Allows any type of /storage/bag to be emptied in a disposal bin.

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -119,8 +119,8 @@
 			return
 
 
-	if(istype(I, /obj/item/weapon/storage/bag/trash))
-		var/obj/item/weapon/storage/bag/trash/T = I
+	if(istype(I, /obj/item/weapon/storage/bag))
+		var/obj/item/weapon/storage/bag/T = I
 		to_chat(user, "\blue You empty the bag.")
 		for(var/obj/item/O in T.contents)
 			T.remove_from_storage(O,src)


### PR DESCRIPTION
## About The Pull Request
Allows plant/ore/plastic bags to be emptied in disposals bin like the trash bag. The only issue (or non-issue) is that you can not longer put the those bags in a bin by clicking it with the bag in hand. Nonetheless you can still dump the bag by dragclicking the sprite into the disposal bin. (But why would you want to do that, most bag types are pretty fucking rare)

I tested interactions and nothing seems to be broken, you can still load ore crates with ore bags, the trash bag icon still updates properly when emptied and you can still empty any bag by just clicking on a tile.

In short, this is a QoL for agrolytes and custodians.



## Changelog
:cl:
tweak: You can now empty plant, ore and plastic bags in disposals bins without having to dump the whole thing in. You can still dump those bags by dragclicking their sprite into the bins. 
/:cl: