### PR TITLE
IH job slots reduced from 12 to 8

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -115,7 +115,7 @@
 	department_flag = IRONHAMMER
 	faction = "CEV Eris"
 	total_positions = 1
-	spawn_positions = 1
+	spawn_positions = 2
 	supervisors = "the Ironhammer Commander"
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
@@ -169,7 +169,7 @@
 	department_flag = IRONHAMMER
 	faction = "CEV Eris"
 	total_positions = 1
-	spawn_positions = 1
+	spawn_positions = 2
 	supervisors = "the Ironhammer Commander"
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
@@ -219,7 +219,7 @@
 	department_flag = IRONHAMMER
 	faction = "CEV Eris"
 	total_positions = 4
-	spawn_positions = 4
+	spawn_positions = 6
 	supervisors = "the Ironhammer Commander"
 	//alt_titles = list("Ironhammer Junior Operative")
 	selection_color = "#a7bbc6"

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -114,8 +114,8 @@
 	department = DEPARTMENT_SECURITY
 	department_flag = IRONHAMMER
 	faction = "CEV Eris"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 1
+	spawn_positions = 1
 	supervisors = "the Ironhammer Commander"
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
@@ -168,8 +168,8 @@
 	department = DEPARTMENT_SECURITY
 	department_flag = IRONHAMMER
 	faction = "CEV Eris"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 1
+	spawn_positions = 1
 	supervisors = "the Ironhammer Commander"
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
@@ -218,8 +218,8 @@
 	department = DEPARTMENT_SECURITY
 	department_flag = IRONHAMMER
 	faction = "CEV Eris"
-	total_positions = 6
-	spawn_positions = 6
+	total_positions = 4
+	spawn_positions = 4
 	supervisors = "the Ironhammer Commander"
 	//alt_titles = list("Ironhammer Junior Operative")
 	selection_color = "#a7bbc6"


### PR DESCRIPTION


## About The Pull Request
<details>
<summary>
            Reduces IH total job slots from 12 to 8, helps reduce overflow of IH for the time
</summary>
<hr>
          I am making this PR because I have seen IH take up 2/3's of the total server population, which should not be happening. We do not need that many IH, and the mere presence of so many suffocates antags and denies them their ability to do their job, while also contributing to the abuse of  the power of IH due to perceived invulnerability in numbers.
<hr>
</details>

## Changelog
:cl:
balance: Inspector Job slots changed to 1 from 2
balance: Medical Specialist Job slots changed to 1 from 2
balance: Operative Job slots changed from 6 to 4
/:cl: