### PR TITLE
Flamethrowers actually fit suit storage now 

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -404,7 +404,7 @@ BLIND     // can't see anything
 		/obj/item/device/suit_cooling_unit,
 		/obj/item/weapon/cell,
 		/obj/item/weapon/storage/fancy,
-		/obj/item/weapon/flame,
+		/obj/item/weapon/flamethrower,
 		/obj/item/device/lighting,
 		/obj/item/device/scanner,
 		/obj/item/weapon/reagent_containers/spray,


### PR DESCRIPTION
Fixes age old syntax error that prevented flamethrowers from fitting in suit storage (also thanks to my last pull they also fit belts now which is nice i guess?) 