### PR TITLE
Full windows no longer have priority when determining entering or leaving a turf.

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -527,6 +527,7 @@
 	alpha = 120
 	maxhealth = 40
 	resistance = RESISTANCE_NONE
+	flags = null
 
 /obj/structure/window/plasmabasic
 	name = "plasma window"
@@ -547,6 +548,7 @@
 	alpha = 150
 	maxhealth = 200
 	resistance = RESISTANCE_AVERAGE
+	flags = null
 
 /obj/structure/window/reinforced
 	name = "reinforced window"
@@ -575,6 +577,7 @@
 	alpha = 150
 	maxhealth = 80
 	resistance = RESISTANCE_FRAGILE
+	flags = null
 
 /obj/structure/window/reinforced/plasma
 	name = "reinforced plasma window"
@@ -595,6 +598,7 @@
 	alpha = 150
 	maxhealth = 250
 	resistance = RESISTANCE_IMPROVED
+	flags = null
 
 /obj/structure/window/reinforced/tinted
 	name = "tinted window"
@@ -631,6 +635,7 @@
 	dir = SOUTH|EAST
 	icon = 'icons/obj/structures/windows.dmi'
 	icon_state = "fwindow"
+	flags = null
 
 /obj/structure/window/reinforced/polarized/proc/toggle()
 	if(opacity)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Full windows no longer override other checks first.
</summary>
<hr>
This change of behavior prevents characters from placing other characters on a low wall, despite the presence of a full window on that same turf.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
