### PR TITLE
Asteroid starts on Ship's starting location.

### DIFF
--- a/maps/encounters/asteroid/asteroid.dm
+++ b/maps/encounters/asteroid/asteroid.dm
@@ -9,8 +9,8 @@
 		"nav_asteroid_1",
 		"nav_asteroid_2"
 	)
-	start_x = 4
-	start_y = 5
+	start_x = 9
+	start_y = 10
 	known = 1
 	in_space = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Asteroid no longer needs to be flown to.
</summary>
<hr>
There's no reason for the asteroid to be off of the ship's starting location, it just annoys and delays the miners until the ship can be moved to it. This wastes time that can be done doing something much more interesting, like exploring the Abandoned Fortress or the new encounter system since they still need to collect minerals.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>
