### PR TITLE
Sanity damage tweaks & Fabric for ghosts

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -276,6 +276,7 @@
 #include "code\datums\autolathe\security.dm"
 #include "code\datums\autolathe\tools.dm"
 #include "code\datums\components\_component.dm"
+#include "code\datums\components\fabric.dm"
 #include "code\datums\craft\item.dm"
 #include "code\datums\craft\menu.dm"
 #include "code\datums\craft\recipe.dm"

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -45,6 +45,7 @@
 #define COMSIG_MOVABLE_MOVED "movable_moved"					//from base of atom/movable/Moved(): (/atom, origin_loc, new_loc)
 
 // /mob signals
+#define COMSIG_MOB_LIFE  "mob_life"                             //from mob/Life()
 #define COMSIG_MOB_LOGIN "mob_login"                            //from mob/Login()
 
 // /mob/living signals

--- a/code/datums/components/fabric.dm
+++ b/code/datums/components/fabric.dm
@@ -1,0 +1,29 @@
+GLOBAL_LIST_EMPTY(fabric_list)
+
+/datum/component/fabric
+	var/image/fabric_image
+
+/datum/component/fabric/Initialize(value, new_desc)
+	if(!istype(parent, /mob))
+		return COMPONENT_INCOMPATIBLE
+
+	RegisterSignal(parent, COMSIG_MOB_LIFE, .proc/onLife)
+
+	GLOB.fabric_list |= src
+
+	fabric_image = image('icons/effects/fabric_symbols.dmi', parent)
+	fabric_image.override = TRUE
+
+	onLife()
+
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_FABRIC_NEW, fabric_image)
+
+/datum/component/fabric/Destroy()
+	GLOB.fabric_list -= src
+	return ..()
+
+/datum/component/fabric/proc/onLife()
+	fabric_image.icon_state = pick(icon_states('icons/effects/fabric_symbols.dmi', 2))
+	fabric_image.pixel_x = rand(-1,1)
+	fabric_image.pixel_y = rand(-1,1)
+	fabric_image.color = RANDOM_RGB

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -50,12 +50,7 @@
 
 	sanity = new(src)
 
-	fabric_image = image('icons/effects/fabric_symbols.dmi', src, pick(icon_states('icons/effects/fabric_symbols.dmi', 2)))
-	fabric_image.pixel_x = rand(-1,1)
-	fabric_image.pixel_y = rand(-1,1)
-	fabric_image.color = RANDOM_RGB
-	fabric_image.override = TRUE
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_FABRIC_NEW, fabric_image)
+	AddComponent(/datum/component/fabric)
 
 /mob/living/carbon/human/Destroy()
 	GLOB.human_mob_list -= src

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -89,8 +89,6 @@
 
 	var/shock_resist = 0 // Resistance to paincrit
 
-	var/image/fabric_image
-
 	var/language_blackout = 0
 	var/suppress_communication = 0
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -77,8 +77,6 @@
 
 		sanity.onLife()
 
-	handle_fabric()
-
 	if(!handle_some_updates())
 		return											//We go ahead and process them 5 times for HUD images and other stuff though.
 
@@ -1031,9 +1029,3 @@
 		return
 	if(XRAY in mutations)
 		sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
-
-/mob/living/carbon/human/proc/handle_fabric()
-	fabric_image.icon_state = pick(icon_states('icons/effects/fabric_symbols.dmi', 2))
-	fabric_image.pixel_x = rand(-1,1)
-	fabric_image.pixel_y = rand(-1,1)
-	fabric_image.color = RANDOM_RGB

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -75,8 +75,6 @@
 		if(!client)
 			species.handle_npc(src)
 
-		sanity.onLife()
-
 	if(!handle_some_updates())
 		return											//We go ahead and process them 5 times for HUD images and other stuff though.
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -148,6 +148,7 @@
 
 
 /mob/proc/Life()
+	SEND_SIGNAL(src, COMSIG_MOB_LIFE)
 //	if(organStructure)
 //		organStructure.ProcessOrgans()
 	//handle_typing_indicator() //You said the typing indicator would be fine. The test determined that was a lie.

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -78,6 +78,8 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 	ghost_multitool = new(src)
 	..()
 
+	AddComponent(/datum/component/fabric)
+
 /mob/observer/ghost/Destroy()
 	stop_following()
 	qdel(ghost_multitool)

--- a/code/modules/sanity/breakdowns.dm
+++ b/code/modules/sanity/breakdowns.dm
@@ -290,10 +290,10 @@
 /datum/breakdown/negative/fabric/occur()
 	RegisterSignal(SSdcs, COMSIG_GLOB_FABRIC_NEW, .proc/add_image)
 	RegisterSignal(holder.owner, COMSIG_MOB_LOGIN, .proc/update_client_images)
-	for(var/mob/living/carbon/human/H in GLOB.human_mob_list)
-		if(H == holder.owner)
+	for(var/datum/component/fabric/F in GLOB.fabric_list)
+		if(F.parent == holder.owner)
 			continue
-		add_image(null, H.fabric_image)
+		add_image(null, F.fabric_image)
 	++holder.owner.language_blackout
 	return ..()
 

--- a/code/modules/sanity/breakdowns.dm
+++ b/code/modules/sanity/breakdowns.dm
@@ -220,8 +220,8 @@
 	. = ..()
 	if(!.)
 		return
-	holder.owner.Weaken(2)
-	holder.owner.Stun(2)
+	holder.owner.Weaken(3)
+	holder.owner.Stun(3)
 	if(prob(50))
 		holder.owner.emote("scream")
 	else

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -1,18 +1,20 @@
 #define SANITY_PASSIVE_GAIN 0.2
 
+#define SANITY_DAMAGE_MOD 0.7
+
 // Damage received from unpleasant stuff in view
-#define SANITY_DAMAGE_VIEW(damage, vig, dist) ((damage) * (1.2 - (vig) / STAT_LEVEL_MAX) * (1 - (dist)/15))
+#define SANITY_DAMAGE_VIEW(damage, vig, dist) ((damage) * SANITY_DAMAGE_MOD * (1.2 - (vig) / STAT_LEVEL_MAX) * (1 - (dist)/15))
 
 #define SANITY_DAMAGE_THRESHOLD_VIEW 20
 
 // Damage received from body damage
-#define SANITY_DAMAGE_HURT(damage, vig) ((damage) / 5 * (1.2 - (vig) / STAT_LEVEL_MAX))
+#define SANITY_DAMAGE_HURT(damage, vig) ((damage) / 5 * SANITY_DAMAGE_MOD * (1.2 - (vig) / STAT_LEVEL_MAX))
 
 // Damage received from shock
-#define SANITY_DAMAGE_SHOCK(shock, vig) ((shock) / 50 * (1.2 - (vig) / STAT_LEVEL_MAX))
+#define SANITY_DAMAGE_SHOCK(shock, vig) ((shock) / 50 * SANITY_DAMAGE_MOD * (1.2 - (vig) / STAT_LEVEL_MAX))
 
 // Damage received from seeing someone die
-#define SANITY_DAMAGE_DEATH(vig) (10 * (1 - (vig) / STAT_LEVEL_MAX))
+#define SANITY_DAMAGE_DEATH(vig) (10 * SANITY_DAMAGE_MOD * (1 - (vig) / STAT_LEVEL_MAX))
 
 #define SANITY_GAIN_SMOKE 0.05 // A full cig restores 300 times that
 #define SANITY_GAIN_SAY 1

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -5,8 +5,6 @@
 // Damage received from unpleasant stuff in view
 #define SANITY_DAMAGE_VIEW(damage, vig, dist) ((damage) * SANITY_DAMAGE_MOD * (1.2 - (vig) / STAT_LEVEL_MAX) * (1 - (dist)/15))
 
-#define SANITY_DAMAGE_THRESHOLD_VIEW 20
-
 // Damage received from body damage
 #define SANITY_DAMAGE_HURT(damage, vig) ((damage) / 5 * SANITY_DAMAGE_MOD * (1.2 - (vig) / STAT_LEVEL_MAX))
 
@@ -34,6 +32,8 @@
 	var/positive_prob = 20
 	var/negative_prob = 30
 
+	var/view_damage_threshold = 20
+
 	var/say_time = 0
 	var/breakdown_time = 0
 
@@ -52,7 +52,7 @@
 	if(!(owner.sdisabilities & BLIND) && !owner.blinded)
 		affect += handle_area()
 		affect -= handle_view()
-	changeLevel(max(affect, min(SANITY_DAMAGE_THRESHOLD_VIEW - level, 0)))
+	changeLevel(max(affect, min(view_damage_threshold - level, 0)))
 	handle_breakdowns()
 	handle_level()
 

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -42,9 +42,12 @@
 /datum/sanity/New(mob/living/carbon/human/H)
 	owner = H
 	level = max_level
+	RegisterSignal(owner, COMSIG_MOB_LIFE, .proc/onLife)
 	RegisterSignal(owner, COMSIG_HUMAN_SAY, .proc/onSay)
 
 /datum/sanity/proc/onLife()
+	if(owner.stat == DEAD || owner.in_stasis)
+		return
 	var/affect = SANITY_PASSIVE_GAIN
 	if(owner.stat)
 		changeLevel(affect)


### PR DESCRIPTION
<!-- i herd you like preprocessor macros so i put a macro in your macro so you can substitute while substituting -->

## About The Pull Request
Added global sanity damage modifier for easier balancing, currently set to 70%.
Changed sanity view damage threshold from a define to a varibable, allowing to modify it per-character.
Ghosts how have fabric images too.