### PR TITLE
Allows clothing printing again.

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -16,11 +16,6 @@
 	//Used for hardsuits. If false, this piece cannot be retracted while the core module is engaged
 	var/retract_while_active = TRUE
 
-/obj/item/clothing/Initialize(mapload, ...)
-	. = ..()
-	if(!matter)
-		matter = list()
-	matter.Add(list(MATERIAL_BIOMATTER = 5 * w_class))	// based of item size
 
 /obj/item/clothing/Destroy()
 	for(var/obj/item/clothing/accessory/A in accessories)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Autolathe banned material shouldn't be required for all autolathe clothe printing.
</summary>
<hr>
This allows various clothing objects to be printable through the autolathe again, which causes a lot of problems. To give example, on each object I don't want to require biomatter, I'll have to reiterate the Initialize.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>
