### PR TITLE
Reducing sanity lag

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -39,6 +39,8 @@
 		power_environ = 0
 	power_change()		// all machines set to current power level, also updates lighting icon
 
+	sanity = new(src)
+
 
 /area/proc/get_cameras()
 	var/list/cameras = list()

--- a/code/modules/sanity/sanity_area.dm
+++ b/code/modules/sanity/sanity_area.dm
@@ -1,14 +1,25 @@
 /area
-	var/datum/area_sanity/sanity = new
+	var/datum/area_sanity/sanity
 
 /datum/area_sanity
+	var/area/owner
+	var/affect_raw = 0
 	var/affect = 0
 	var/list/positive_flavors = new
 	var/list/negative_flavors = new
 
+/datum/area_sanity/New(area/A)
+	owner = A
+	..()
+
+/datum/area_sanity/proc/update()
+	var/leng = 0
+	for(var/turf/T in owner.contents)
+		++leng
+	affect = affect_raw / leng
 
 /datum/area_sanity/proc/register(datum/component/atom_sanity/AS)
-	affect += AS.affect
+	affect_raw += AS.affect
 	var/list/flavors
 	if(AS.affect < 0)
 		flavors = negative_flavors
@@ -18,9 +29,10 @@
 		flavors[AS.desc] += 1
 	else
 		flavors[AS.desc] = 1
+	update()
 
 /datum/area_sanity/proc/unregister(datum/component/atom_sanity/AS)
-	affect -= AS.affect
+	affect_raw -= AS.affect
 	var/list/flavors
 	if(AS.affect < 0)
 		flavors = negative_flavors
@@ -30,5 +42,6 @@
 		flavors -= AS.desc
 	else
 		flavors[AS.desc] -= 1
+	update()
 
 

--- a/code/modules/sanity/sanity_atom.dm
+++ b/code/modules/sanity/sanity_atom.dm
@@ -16,6 +16,8 @@
 /datum/component/atom_sanity/proc/onMoved(_, oldloc, newloc)
 	if(isturf(oldloc))
 		var/area/current_area = get_area(oldloc) //Actually new area is curret
+		if(isturf(newloc) && current_area == get_area(newloc))
+			return
 		var/datum/area_sanity/AS = current_area.sanity
 		AS.unregister(src)
 	if(isturf(newloc))

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -67,10 +67,7 @@
 	var/area/my_area = get_area(owner)
 	if(!my_area)
 		return 0
-	var/leng = 0
-	for(var/turf/T in my_area.contents)
-		++leng
-	. = my_area.sanity.affect / leng
+	. = my_area.sanity.affect
 	if(. < 0)
 		. *= owner.stats.getStat(STAT_VIG) / STAT_LEVEL_MAX
 


### PR DESCRIPTION
## About The Pull Request
Area sanity is now calculated once when an object with sanity bonus moves to or from an area instead of being calculated every Life tick for each mob.