### PR TITLE
Area sanity runtime fix

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -29,6 +29,8 @@
 		power_equip = 0
 		power_environ = 0
 
+	sanity = new(src)
+
 	..()
 
 /area/Initialize()
@@ -38,8 +40,6 @@
 		power_equip = 0
 		power_environ = 0
 	power_change()		// all machines set to current power level, also updates lighting icon
-
-	sanity = new(src)
 
 
 /area/proc/get_cameras()


### PR DESCRIPTION
## About The Pull Request
Some objects providing area sanity bonus were initialized before area sanity was, resulting in a runtime. Area sanity is now initialized earlier.
