### PR TITLE
You can no longer resist grabs while handcuffed

### DIFF
--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -58,9 +58,6 @@
 
 
 /mob/living/proc/resist_grab()
-	var/mob/living/carbon/C = src
-	if(istype(C) && C.handcuffed)
-		return
 	var/resisting = 0
 	for(var/obj/O in requests)
 		requests.Remove(O)
@@ -82,6 +79,9 @@
 					qdel(G)
 	if(resisting)
 		visible_message("<span class='danger'>[src] resists!</span>")
+
+/mob/living/carbon/resist_grab()
+	return !handcuffed && ..()
 
 /mob/living/carbon/process_resist()
 

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -58,6 +58,9 @@
 
 
 /mob/living/proc/resist_grab()
+	var/mob/living/carbon/C = src
+	if(istype(C) && C.handcuffed)
+		return
 	var/resisting = 0
 	for(var/obj/O in requests)
 		requests.Remove(O)


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	Now you have to break out of the cuffs before you can resist out of the grab just like in every other ss13 server.
</summary>
<hr>
	I feel like this is a bug but if I'm wrong someone correct me, either way its pretty annoying when the person you arrested keeps resisting out while you try to bring them to brig, strip them, or whatever you were doing with them. 
<hr>
</details>

## Changelog
:cl:
fix: You can no longer resist grabs while handcuffed
/:cl: