### PR TITLE
Air tank refactor

### DIFF
--- a/code/game/objects/items/weapons/tanks/onestar_regenerator.dm
+++ b/code/game/objects/items/weapons/tanks/onestar_regenerator.dm
@@ -13,10 +13,9 @@
 	volume = 2
 
 
-/obj/item/weapon/tank/onestar_regenerator/New()
-		..()
-		ensure_breath()
-		return
+/obj/item/weapon/tank/onestar_regenerator/Initialize(mapload, ...)
+	. = ..()
+	ensure_breath()
 
 /obj/item/weapon/tank/onestar_regenerator/examine(mob/user)
 	. = ..(user, 0)
@@ -24,7 +23,7 @@
 
 /obj/item/weapon/tank/onestar_regenerator/remove_air(amount)
 	var/datum/gas_mixture/M = air_contents.remove(amount)
-	if(istype(loc,/mob/living/carbon))
+	if(istype(loc, /mob/living/carbon))
 		var/mob/living/carbon/C = loc
 		if(C.internal == src)
 			ensure_breath()

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -16,18 +16,12 @@
 	icon_state = "oxygen"
 	force = WEAPON_FORCE_PAINFUL
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
+	default_pressure = 6*ONE_ATMOSPHERE
+	default_gas = "oxygen"
 
-
-	New()
-		..()
-		air_contents.adjust_gas("oxygen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-		return
-
-
-	examine(mob/user)
-		if(..(user, 0) && air_contents.gas["oxygen"] < 10)
-			to_chat(user, text(SPAN_WARNING("The meter on \the [src] indicates you are almost out of oxygen!")))
-			//playsound(usr, 'sound/effects/alert.ogg', 50, 1)
+/obj/item/weapon/tank/oxygen/examine(mob/user)
+	if(..(user, 0) && air_contents.gas["oxygen"] < 10)
+		to_chat(user, text(SPAN_WARNING("The meter on \the [src] indicates you are almost out of oxygen!")))
 
 
 /obj/item/weapon/tank/oxygen/yellow
@@ -47,15 +41,14 @@
 	desc = "A tank with an N2O/O2 gas mix."
 	icon_state = "anesthetic"
 	item_state = "an_tank"
+	default_pressure = 3*ONE_ATMOSPHERE
 
-/obj/item/weapon/tank/anesthetic/New()
-	..()
+/obj/item/weapon/tank/anesthetic/spawn_gas()
+	air_contents.adjust_multi(
+		"oxygen", default_pressure*volume/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD,
+		"sleeping_agent", default_pressure*volume/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD
+	)
 
-	air_contents.gas["oxygen"] = (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD
-	air_contents.gas["sleeping_agent"] = (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD
-	air_contents.update_values()
-
-	return
 
 /*
  * Air
@@ -65,19 +58,19 @@
 	desc = "Mixed anyone?"
 	icon_state = "oxygen"
 	force = WEAPON_FORCE_PAINFUL
+	default_pressure = 6*ONE_ATMOSPHERE
 
+/obj/item/weapon/tank/air/examine(mob/user)
+	if(..(user, 0) && air_contents.gas["oxygen"] < 1 && loc==user)
+		to_chat(user, SPAN_DANGER("The meter on the [src.name] indicates you are almost out of air!"))
+		user << sound('sound/effects/alert.ogg')
 
-	examine(mob/user)
-		if(..(user, 0) && air_contents.gas["oxygen"] < 1 && loc==user)
-			to_chat(user, SPAN_DANGER("The meter on the [src.name] indicates you are almost out of air!"))
-			user << sound('sound/effects/alert.ogg')
+/obj/item/weapon/tank/air/spawn_gas()
+	air_contents.adjust_multi(
+		"oxygen", default_pressure*volume/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD,
+		"nitrogen", default_pressure*volume/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD
+	)
 
-/obj/item/weapon/tank/air/New()
-	..()
-
-	src.air_contents.adjust_multi("oxygen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD, "nitrogen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD)
-
-	return
 
 
 /*
@@ -91,13 +84,9 @@
 	gauge_icon = null
 	flags = CONDUCT
 	slot_flags = null	//they have no straps!
+	default_pressure = 3*ONE_ATMOSPHERE
+	default_gas = "plasma"
 
-
-/obj/item/weapon/tank/plasma/New()
-	..()
-
-	src.air_contents.adjust_gas("plasma", (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /*
  * Emergency Oxygen
@@ -113,20 +102,14 @@
 	w_class = ITEM_SIZE_SMALL
 	force = WEAPON_FORCE_NORMAL
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
+	default_pressure = 3*ONE_ATMOSPHERE
+	default_gas = "oxygen"
 	volume = 2 //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)
 
-
-	New()
-		..()
-		src.air_contents.adjust_gas("oxygen", (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-
-		return
-
-
-	examine(mob/user)
-		if(..(user, 0) && air_contents.gas["oxygen"] < 0.2 && loc==user)
-			to_chat(user, text(SPAN_DANGER("The meter on the [src.name] indicates you are almost out of air!")))
-			user << sound('sound/effects/alert.ogg')
+/obj/item/weapon/tank/emergency_oxygen/examine(mob/user)
+	if(..(user, 0) && air_contents.gas["oxygen"] < 0.2 && loc==user)
+		to_chat(user, text(SPAN_DANGER("The meter on the [src.name] indicates you are almost out of air!")))
+		user << sound('sound/effects/alert.ogg')
 
 /obj/item/weapon/tank/emergency_oxygen/engi
 	name = "extended-capacity emergency oxygen tank"
@@ -148,13 +131,8 @@
 	force = WEAPON_FORCE_PAINFUL
 	icon_state = "oxygen_fr"
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
-
-
-/obj/item/weapon/tank/nitrogen/New()
-	..()
-
-	src.air_contents.adjust_gas("nitrogen", (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C))
-	return
+	default_pressure = 3*ONE_ATMOSPHERE
+	default_gas = "nitrogen"
 
 /obj/item/weapon/tank/nitrogen/examine(mob/user)
 	if(..(user, 0) && air_contents.gas["nitrogen"] < 10)


### PR DESCRIPTION
I tried fixing that bug when all emergency air tanks spawned with a blinking red light. I ended up changing the way gas spawns in air tanks - shouldn't affect gameplay, just makes the code neater.

## Changelog
:cl: ACCount
fix: Emergency air tanks no longer blink red lights all the time.
/:cl:
