### PR TITLE
gives engineers voidsuits rad protection in line with mining and medical void suits

### DIFF
--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -9,7 +9,7 @@
 		slot_l_hand_str = "eng_helm",
 		slot_r_hand_str = "eng_helm",
 		)
-	armor = list(melee = 40, bullet = 35, energy = 5, bomb = 35, bio = 100, rad = 90)
+	armor = list(melee = 40, bullet = 35, energy = 5, bomb = 35, bio = 100, rad = 100)
 
 /obj/item/clothing/suit/space/void/engineering
 	name = "engineering voidsuit"
@@ -17,7 +17,7 @@
 	icon_state = "rig-engineering"
 	item_state = "eng_voidsuit"
 	slowdown = 1
-	armor = list(melee = 40, bullet = 35, energy = 5, bomb = 35, bio = 100, rad = 90)
+	armor = list(melee = 40, bullet = 35, energy = 5, bomb = 35, bio = 100, rad = 100)
 	extra_allowed = list(
 		/obj/item/weapon/storage/toolbox,
 		/obj/item/weapon/storage/briefcase/inflatable,


### PR DESCRIPTION


## About The Pull Request
<details>
changes rad protection from 90 to 100 on voidsuit helmet and regular suit
	About The Pull Request
</summary>
<hr>

cant you read
	
<hr>
</details>

## Changelog
:cl:

tweak: tweaked engineering voidsuit armor values of rad to 100 from 90



/:cl: