### PR TITLE
Fix and tweak martin overlays

### DIFF
--- a/code/modules/projectiles/guns/energy/egun.dm
+++ b/code/modules/projectiles/guns/energy/egun.dm
@@ -42,8 +42,9 @@
 	var/datum/firemode/current_mode = firemodes[sel_mode]
 	switch(current_mode.name)
 		if("stun") overlays += "taser_pdw"
-		if("lethal") overlays += "lazer_pdw"
+		if("kill") overlays += "lazer_pdw"
 
 /obj/item/weapon/gun/energy/gun/martin/update_icon()
 	overlays.Cut()
-	update_mode()
+	if(cell && cell.charge >= charge_cost) //no overlay if we dont have any power
+		update_mode()


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	Fixes #4051 Fixes #3383 
I also made it so that the martin doesn't light up if it doesn't have the power to shoot to make it more clear when you are out of ammo or don't have a cell inside the gun.
</summary>
<hr>

**no power**
![image](https://user-images.githubusercontent.com/22408776/68106160-57a57c00-fea6-11e9-96ef-d10daffd7883.png)
**stun**
![image](https://user-images.githubusercontent.com/22408776/68106182-6ab84c00-fea6-11e9-8eb0-26a9b675f174.png)
**kill**
![image](https://user-images.githubusercontent.com/22408776/68106244-93d8dc80-fea6-11e9-8b22-9354045a28b7.png)
<hr>
</details>

## Changelog
:cl: Garen7
tweak: The martin will now have no lights when it does not have enough power to fire
fix: The martin will now properly show the red kill setting lights when set to kill mode
/:cl: