### PR TITLE
changeling unstun now removes agony as it should

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -502,6 +502,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	C.SetStunned(0)
 	C.SetWeakened(0)
 	C.lying = 0
+	C.setHalLoss(0)
 	C.update_lying_buckled_and_verb_status()
 
 	src.verbs -= /mob/proc/changeling_unstun


### PR DESCRIPTION

## About The Pull Request
<details>
<summary>
	changeling unstun power sets agony to 0
</summary>
<hr>
45 changeling gamer points is a lot for a chemical that doesn't remove agony, and as such it is kind of useless when everyone has stun gloves and agony dealing weapons.
<hr>
</details>
## Changelog
:cl:
balance: changeling unstun power sets agony to 0
/:cl:
