### PR TITLE
Changes biomatter code

### DIFF
--- a/code/modules/biomatter_manipulation/bioreactor/platform.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/platform.dm
@@ -56,24 +56,20 @@
 				var/obj/item/target = M
 				//if we found biomatter, let's start processing
 				//it will slowly disappear. Time based at size of object and we manipulate with its alpha (we also check for it)
-				to_world("PRE CHECK")
 				if((MATERIAL_BIOMATTER in target.matter) || istype(target,/obj/item/clothing))
 					target.alpha -= round(100 / target.w_class)
 					var/icon/I = new(target.icon, icon_state = target.icon_state)
 					//we turn this things to degenerate sprite a bit
 					I.Turn(rand(-10, 10))
-					to_world("degrading thing")
 					target.icon = I
 					if(target.alpha <= 50)
 						if(istype(target,/obj/item/clothing))
 							var/clothingbiomatter
 							clothingbiomatter = 5 * target.w_class
 							MS_bioreactor.biotank_platform.take_amount(clothingbiomatter)
-							to_world("gave CLOTH: [target.name] matter to thing")
 						else
 							MS_bioreactor.biotank_platform.take_amount(target.matter[MATERIAL_BIOMATTER])
 							target.matter -= MATERIAL_BIOMATTER
-							to_world("gave ITEM [target.name] thing matter to thing")
 						MS_bioreactor.biotank_platform.pipes_wearout(target.w_class)
 							//if we have other matter, let's spit it out
 						for(var/material in target.matter)
@@ -83,10 +79,8 @@
 								waste.amount = target.matter[material]
 								waste.update_strings()
 							target.matter -= material
-						to_world("CONSUMING [target.name]")
 						consume(target)
 				else
-					to_world("REFUSED")
 					target.forceMove(MS_bioreactor.misc_output)
 	else
 		//if our machine is non operational, let's go idle powermode and pump out solution

--- a/code/modules/biomatter_manipulation/bioreactor/platform.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/platform.dm
@@ -52,20 +52,30 @@
 			if(istype(M, /obj/item))
 				if(M.anchored)
 					continue
+
 				var/obj/item/target = M
 				//if we found biomatter, let's start processing
 				//it will slowly disappear. Time based at size of object and we manipulate with its alpha (we also check for it)
-				if(MATERIAL_BIOMATTER in target.matter)
+				to_world("PRE CHECK")
+				if((MATERIAL_BIOMATTER in target.matter) || istype(target,/obj/item/clothing))
 					target.alpha -= round(100 / target.w_class)
 					var/icon/I = new(target.icon, icon_state = target.icon_state)
 					//we turn this things to degenerate sprite a bit
 					I.Turn(rand(-10, 10))
+					to_world("degrading thing")
 					target.icon = I
 					if(target.alpha <= 50)
-						MS_bioreactor.biotank_platform.take_amount(target.matter[MATERIAL_BIOMATTER])
+						if(istype(target,/obj/item/clothing))
+							var/clothingbiomatter
+							clothingbiomatter = 5 * target.w_class
+							MS_bioreactor.biotank_platform.take_amount(clothingbiomatter)
+							to_world("gave CLOTH: [target.name] matter to thing")
+						else
+							MS_bioreactor.biotank_platform.take_amount(target.matter[MATERIAL_BIOMATTER])
+							target.matter -= MATERIAL_BIOMATTER
+							to_world("gave ITEM [target.name] thing matter to thing")
 						MS_bioreactor.biotank_platform.pipes_wearout(target.w_class)
-						target.matter -= MATERIAL_BIOMATTER
-						//if we have other matter, let's spit it out
+							//if we have other matter, let's spit it out
 						for(var/material in target.matter)
 							var/stack_type = material_stack_type(material_display_name(material))
 							if(stack_type)
@@ -73,8 +83,10 @@
 								waste.amount = target.matter[material]
 								waste.update_strings()
 							target.matter -= material
+						to_world("CONSUMING [target.name]")
 						consume(target)
 				else
+					to_world("REFUSED")
 					target.forceMove(MS_bioreactor.misc_output)
 	else
 		//if our machine is non operational, let's go idle powermode and pump out solution

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -16,9 +16,6 @@
 	//Used for hardsuits. If false, this piece cannot be retracted while the core module is engaged
 	var/retract_while_active = TRUE
 
-/obj/item/clothing/Initialize(mapload, ...)
-	. = ..()
-
 /obj/item/clothing/Destroy()
 	for(var/obj/item/clothing/accessory/A in accessories)
 		qdel(A)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -18,9 +18,6 @@
 
 /obj/item/clothing/Initialize(mapload, ...)
 	. = ..()
-	if(!matter)
-		matter = list()
-	matter.Add(list(MATERIAL_BIOMATTER = 5 * w_class))	// based of item size
 
 /obj/item/clothing/Destroy()
 	for(var/obj/item/clothing/accessory/A in accessories)


### PR DESCRIPTION
Biomatter is now something the reactor itself makes from clothing depending on size of the garment and whatnot. Sends out extra material from the garment as waste like everything else.
Biomatter is removed automatically from clothing to be added as people choose to put it and give it recipes require it from the autolathe.

:cl: Wild Jalleo
fix: You can now craft clothing in normal autolathes using the old recipes again.
/:cl:
