### PR TITLE
Reduces storage size on two material_trash items

### DIFF
--- a/code/game/objects/items/weapons/material_trash.dm
+++ b/code/game/objects/items/weapons/material_trash.dm
@@ -38,6 +38,7 @@
 /obj/item/weapon/material_trash/circuit
 	name = "burnt circuit"
 	desc = "A burnt circuit that can be recycled in an autolathe."
+	w_class = ITEM_SIZE_SMALL
 	icon_state = "circuit0"
 	matter_chances = list(
 		list(MATERIAL_GLASS, 100, 4),
@@ -56,6 +57,7 @@
 /obj/item/weapon/material_trash/device
 	name = "broken device"
 	desc = "A broken device that can be recycled in an autolathe."
+	w_class = ITEM_SIZE_SMALL
 	icon_state = "device0"
 	matter_chances = list(
 		list(MATERIAL_STEEL, 100, 10),


### PR DESCRIPTION
Broken devices and burnt circuits should look like this now:
![test](https://user-images.githubusercontent.com/38330373/68255941-6bb7bd80-000d-11ea-8164-cd12931b1d0b.png)

Scrap metal will be left the same since they have a (small) chance of having plenty plasteel in them.