### PR TITLE
Technomancer component disk now allows the printing of voice analyzers.

### DIFF
--- a/code/datums/autolathe/parts.dm
+++ b/code/datums/autolathe/parts.dm
@@ -14,6 +14,10 @@
 	name = "infrared sensor"
 	build_path = /obj/item/device/assembly/infra
 
+/datum/design/autolathe/part/voice_analyzer
+	name = "voice analyzer"
+	build_path = /obj/item/device/assembly/voice
+
 /datum/design/autolathe/part/timer
 	name = "timer"
 	build_path = /obj/item/device/assembly/timer

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -144,6 +144,7 @@
 		/datum/design/autolathe/part/signaler,
 		/datum/design/autolathe/part/sensor_infra,
 		/datum/design/autolathe/part/timer,
+		/datum/design/autolathe/part/voice_analyzer,
 		/datum/design/autolathe/part/sensor_prox,
 		/datum/design/autolathe/part/camera_assembly,
 		/datum/design/autolathe/part/laserguide,


### PR DESCRIPTION
It couldn't print them because there was no design datum for it. Already tested:
![voice](https://user-images.githubusercontent.com/38330373/68258533-c2c19080-0015-11ea-9b69-3e82e3fb3e94.png)

