### PR TITLE
Scrap fixes

### DIFF
--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -140,7 +140,7 @@
 
 /obj/item/weapon/oddity/common/paper_omega
 	name = "collection of obscure reports"
-	desc = "Even the authors seem to be rather skeptical about their findings. Yet they are not connected to each other, but results are simular."
+	desc = "Even the authors seem to be rather skeptical about their findings. Yet they are not connected to each other, but results are similar."
 	icon_state = "paper_omega"
 	oddity_stats = list(
 		STAT_MEC = 8,
@@ -179,7 +179,7 @@
 
 /obj/item/weapon/oddity/common/old_money
 	name = "old money"
-	desc = "It's not like organization that issues this exist now."
+	desc = "It's not like organization that issued this exist now."
 	icon_state = "old_money"
 	oddity_stats = list(
 		STAT_ROB = 4,
@@ -187,7 +187,7 @@
 	)
 
 /obj/item/weapon/oddity/common/healthscanner
-	name = "odd healthscanner"
+	name = "odd health scanner"
 	desc = "It's broken and stuck on some really strange readings. Was this even human?"
 	icon_state = "healthscanner"
 	item_state = "electronic"
@@ -217,7 +217,7 @@
 
 /obj/item/weapon/oddity/common/teddy
 	name = "teddy bear"
-	desc = "He will there for you, im tough times."
+	desc = "He will there for you, in tough times."
 	icon_state = "teddy"
 	oddity_stats = list(
 		STAT_ROB = 7,

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -132,6 +132,9 @@
 /obj/item/stack/rods/make_old()
 	return
 
+/obj/item/weapon/ore/make_old()
+	return
+
 /obj/item/weapon/grenade/make_old()
 	..()
 	det_time = RAND_DECIMAL(0, det_time)

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -113,11 +113,15 @@
 /obj/item/weapon/cell/make_old()
 	.=..()
 	if (.)
-		charge = min(charge, RAND_DECIMAL(0, maxcharge))
+		// It's silly to have old self-charging cells spawn partially discharged
+		if(!autorecharging)
+			charge = min(charge, RAND_DECIMAL(0, maxcharge))
+
 		if(prob(10))
 			rigged = TRUE
 			if(prob(80))
 				charge = maxcharge  //make it BOOM hard
+		update_icon()
 
 /obj/item/weapon/stock_parts/make_old()
 	.=..()

--- a/code/modules/scrap/scrap.dm
+++ b/code/modules/scrap/scrap.dm
@@ -181,6 +181,7 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 			if(O == loot || O == big_item)
 				continue
 			total_storage_space += O.get_storage_cost()
+			O.forceMove(loot)
 			num--
 	loot.max_storage_space = max(10, total_storage_space)
 	update_icon()

--- a/code/modules/scrap/scrap.dm
+++ b/code/modules/scrap/scrap.dm
@@ -170,16 +170,19 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 	for(var/A in loot)
 		loot.remove_from_storage(A,src)
 
+	var/total_storage_space = 0
+
 	if(contents.len)
 		contents = shuffle(contents)
-		var/num = rand(2,loot_min)
+		var/num = rand(2, loot_min)
 		for(var/obj/item/O in contents)
 			if(!num)
 				break
 			if(O == loot || O == big_item)
 				continue
-			O.forceMove(loot)
+			total_storage_space += O.get_storage_cost()
 			num--
+	loot.max_storage_space = max(10, total_storage_space)
 	update_icon()
 
 /obj/structure/scrap/proc/randomize_image(image/I)


### PR DESCRIPTION
*  Fixes a runtime when touching a scrap pile for the first time.
*  Stops ore from being oldified.
*  Fixes some minor typos in oddity descriptions.