### PR TITLE
Adds Asters omnitool to supply order list

### DIFF
--- a/code/game/objects/items/weapons/tools/misc.dm
+++ b/code/game/objects/items/weapons/tools/misc.dm
@@ -5,6 +5,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	worksound = WORKSOUND_DRIVER_TOOL
 	switched_on_qualities = list(QUALITY_SCREW_DRIVING = 50, QUALITY_BOLT_TURNING = 50, QUALITY_DRILLING = 20, QUALITY_WELDING = 30, QUALITY_CAUTERIZING = 10)
+	price_tag = 1000
 
 	use_fuel_cost = 0.1
 	max_fuel = 50

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -526,7 +526,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 
 /datum/supply_pack/electrical
 	name = "Electrical maintenance crate"
-	contains = list (/obj/item/weapon/storage/toolbox/electrical,
+	contains = list(/obj/item/weapon/storage/toolbox/electrical,
 					/obj/item/weapon/storage/toolbox/electrical,
 					/obj/item/clothing/gloves/insulated,
 					/obj/item/clothing/gloves/insulated,
@@ -568,6 +568,15 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	cost = 1500
 	containertype = /obj/structure/closet/crate
 	crate_name = "Tool upgrade Crate"
+	group = "Engineering"
+
+/datum/supply_pack/omnitool
+	contains = list(/obj/item/weapon/tool/omnitool,
+					/obj/item/weapon/tool/omnitool)
+	name = "\"Munchkin 5000\" omnitool"
+	cost = 2500
+	containertype = /obj/structure/closet/crate
+	crate_name = "omnitool crate"
 	group = "Engineering"
 
 /datum/supply_pack/fueltank


### PR DESCRIPTION
Before, it only existed as rare maint loot, and even the Asters Guild couldn't buy it. That wouldn't do.

## Changelog
:cl: ACCount
add: You can now order Asters \"Munchkin 5000\" omnitool in cargo
/:cl: