### PR TITLE
fix lathes inifinity math

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -461,7 +461,7 @@
 
 	if(istype(eating, /obj/item/stack))
 		var/obj/item/stack/stack = eating
-		stack.use(max(1, round(total_used/mass_per_sheet))) // Always use at least 1 to prevent infinite materials.
+		stack.use(total_used/mass_per_sheet)
 	else
 		user.remove_from_mob(eating)
 		qdel(eating)
@@ -641,7 +641,7 @@
 /obj/machinery/autolathe/on_deconstruction()
 	for(var/mat in stored_material)
 		eject(mat, stored_material[mat])
-		
+
 	eject_disk()
 	..()
 


### PR DESCRIPTION
Fix #3952
Now, when stuffing not an integer number of sheets of material in autolathe, it entirely takes them into itself, without leaving a fractional part to you, giving you the opportunity to feed it endlessly