### PR TITLE
Adds files that can be uploaded to R&D console for research points

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -1948,7 +1948,7 @@
 #include "code\modules\modular_computers\file_system\program_events.dm"
 #include "code\modules\modular_computers\file_system\binary\binary.dm"
 #include "code\modules\modular_computers\file_system\binary\design.dm"
-#include "code\modules\modular_computers\file_system\binary\tech.dm"
+#include "code\modules\modular_computers\file_system\binary\research.dm"
 #include "code\modules\modular_computers\file_system\programs\antagonist\access_decrypter.dm"
 #include "code\modules\modular_computers\file_system\programs\antagonist\dos.dm"
 #include "code\modules\modular_computers\file_system\programs\antagonist\hacked_camera.dm"

--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -1080,6 +1080,7 @@
 #include "code\game\objects\random\purerandom.dm"
 #include "code\game\objects\random\random.dm"
 #include "code\game\objects\random\rig.dm"
+#include "code\game\objects\random\science.dm"
 #include "code\game\objects\random\scrap.dm"
 #include "code\game\objects\random\structures.dm"
 #include "code\game\objects\random\surgerytools.dm"

--- a/code/game/objects/random/pouches.dm
+++ b/code/game/objects/random/pouches.dm
@@ -16,7 +16,7 @@
 	/obj/item/weapon/storage/pouch/baton_holster = 3
 	))
 
-/obj/random/gun_normal/low_chance
+/obj/random/pouch/low_chance
 	name = "low chance random pouch"
 	icon_state = "box-green-low"
 	spawn_nothing_percentage = 80

--- a/code/game/objects/random/science.dm
+++ b/code/game/objects/random/science.dm
@@ -1,0 +1,29 @@
+/obj/random/science
+	name = "random scientific item"
+	icon_state = "box-green"
+
+/obj/random/science/item_to_spawn()
+	return pickweight(list(
+	/obj/item/device/science_tool = 8,
+	/obj/item/device/scanner/reagent = 6,
+	/obj/item/weapon/computer_hardware/scanner/reagent = 3,
+	/obj/item/weapon/reagent_containers/dropper = 2,
+	/obj/item/weapon/reagent_containers/glass/beaker/vial = 3,
+	/obj/item/weapon/reagent_containers/glass/beaker/vial/random = 2,
+	/obj/item/weapon/reagent_containers/glass/beaker/vial/random/toxin = 2,
+	/obj/item/weapon/reagent_containers/glass/beaker/vial/nanites = 2,
+	/obj/item/weapon/stock_parts/scanning_module/adv = 3,
+	/obj/item/weapon/stock_parts/manipulator/nano = 3,
+	/obj/item/weapon/stock_parts/matter_bin/adv = 2,
+	/obj/item/weapon/stock_parts/micro_laser/high = 2,
+	/obj/item/weapon/computer_hardware/hard_drive/portable/research_points = 5,
+	/obj/item/weapon/computer_hardware/hard_drive/portable/research_points/rare = 1,
+	/obj/item/weapon/rig/hazmat = 2,
+	/obj/item/weapon/rig/hazmat/equipped = 1
+	))
+
+/obj/random/science/low_chance
+	name = "low chance random scientific item"
+	icon_state = "box-green-low"
+	spawn_nothing_percentage = 80
+

--- a/code/modules/modular_computers/file_system/binary/research.dm
+++ b/code/modules/modular_computers/file_system/binary/research.dm
@@ -1,0 +1,32 @@
+// R&D tech file
+/datum/computer_file/binary/tech
+	filetype = "RDF"
+	size = 8
+	var/datum/technology/node = null
+
+/datum/computer_file/binary/tech/clone()
+	var/datum/computer_file/binary/tech/F = ..()
+	F.node = node
+	return F
+
+/datum/computer_file/binary/tech/proc/set_tech(datum/technology/new_tech)
+	node = new_tech
+	filename = sanitizeFileName(lowertext(node.name))
+
+
+// R&D research points file
+/datum/computer_file/binary/research_points
+	filetype = "RDAT"
+	size = 1 		// Scales with the amount of research points
+	var/research_id	// ID of a generated file, so you can't feed a single file into an R&D console indefinitely
+
+/datum/computer_file/binary/research_points/New(size = 1)
+	..()
+	research_id = rand(1000, 9999)
+	src.size = size
+	filename = "RESEARCH_[research_id]"
+
+/datum/computer_file/binary/research_points/clone()
+	var/datum/computer_file/binary/research_points/F = ..()
+	F.research_id = research_id
+	return F

--- a/code/modules/modular_computers/file_system/binary/tech.dm
+++ b/code/modules/modular_computers/file_system/binary/tech.dm
@@ -1,9 +1,0 @@
-// R&D tech file
-/datum/computer_file/binary/tech
-	filetype = "RDF"
-	size = 8
-	var/datum/technology/node = null
-
-/datum/computer_file/binary/tech/proc/set_tech(datum/technology/new_tech)
-	node = new_tech
-	filename = sanitizeFileName(lowertext(node.name))

--- a/code/modules/research/experiment.dm
+++ b/code/modules/research/experiment.dm
@@ -249,11 +249,6 @@ GLOBAL_LIST_EMPTY(explosion_watcher_list)
 /obj/item/device/science_tool/afterattack(obj/O, mob/living/user)
 	var/scanneddata = 0
 
-	if(istype(O, /obj/item/weapon/disk/research_points))
-		var/obj/item/weapon/disk/research_points/disk = O
-		to_chat(user, SPAN_NOTICE("[disk] stores approximately [disk.stored_points] research points"))
-		return
-
 	if(istype(O,/obj/item/weapon/paper/autopsy_report))
 		var/obj/item/weapon/paper/autopsy_report/report = O
 		for(var/datum/autopsy_data/W in report.autopsy_data)
@@ -304,24 +299,17 @@ GLOBAL_LIST_EMPTY(explosion_watcher_list)
 	scanned_slimecores = list()
 	datablocks = 0
 
-/obj/item/weapon/disk/research_points
-	name = "Important Disk"
-	desc = "Looks a disk with some important information stored. Scientists might know what to do with it"
-	icon = 'icons/obj/cloning.dmi'
-	icon_state = "datadisk2"
-	item_state = "card-id"
-	w_class = ITEM_SIZE_SMALL
-	matter = list(MATERIAL_STEEL = 3, MATERIAL_GLASS = 1)
-	var/stored_points
 
-/obj/item/weapon/disk/research_points/Initialize()
-	. = ..()
-	pixel_x = rand(-5.0, 5)
-	pixel_y = rand(-5.0, 5)
+/obj/item/weapon/computer_hardware/hard_drive/portable/research_points
+	disk_name = "research data"
+	var/min_points = 2000
+	var/max_points = 10000
 
-	stored_points = rand(1,10)*1000
+/obj/item/weapon/computer_hardware/hard_drive/portable/research_points/install_default_files()
+	..()
+	var/datum/computer_file/binary/research_points/F = new(size = rand(min_points / 1000, max_points / 1000))
+	store_file(F)
 
-/obj/item/weapon/disk/research_points/rare/Initialize()
-	. = ..()
-
-	stored_points = rand(10, 20)*1000
+/obj/item/weapon/computer_hardware/hard_drive/portable/research_points/rare
+	min_points = 10000
+	max_points = 20000

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -16,11 +16,11 @@ Procs:
 - IsResearched(datum/technology/T): Is T in researched_nodes?
 - CanResearch(datum/technology/T): Can T be researched (checks T cost, if T's associated tree is shown and if we have the required tech levels/nodes).
 - UnlockTechology(datum/technology/T, force = FALSE): Unlocks a technology node T for src. Safe (uses the procs above). Adds T to the needed lists, and adds its designs too.
-														Setting force to true ignores T's cost. 
-- download_from(datum/research/O): Downloads data from O. The result is the union of src and O. 
-- forget_techology(datum/technology/T): Removes T from src. 
-- forget_all(tech_type): Forget all the technology nodes associated to a tree with type tech_type. 
-- AddDesign2Known(datum/design/D): Add design to known_designs. 
+														Setting force to true ignores T's cost.
+- download_from(datum/research/O): Downloads data from O. The result is the union of src and O.
+- forget_techology(datum/technology/T): Removes T from src.
+- forget_all(tech_type): Forget all the technology nodes associated to a tree with type tech_type.
+- AddDesign2Known(datum/design/D): Add design to known_designs.
 - check_item_for_tech(obj/item/I): Unlocks a hidden tech tree if the item has the tree's item_tech_req in its origin_tech.
 
 */
@@ -38,6 +38,8 @@ Procs:
 	var/list/researched_nodes = list() // All research nodes
 
 	var/datum/experiment_data/experiments
+
+	var/known_research_file_ids = list()
 
 	var/research_points = 0
 
@@ -101,6 +103,7 @@ Procs:
 			var/datum/technology/T = tech
 			if(UnlockTechology(T, force = TRUE))
 				. = TRUE // we actually updated something
+	known_research_file_ids |= O.known_research_file_ids
 	experiments.merge_with(O.experiments)
 
 /datum/research/proc/forget_techology(datum/technology/T)
@@ -159,6 +162,32 @@ Procs:
 			if(item_tech == T.item_tech_req)
 				T.shown = TRUE
 				return
+
+/datum/research/proc/is_research_file_type(datum/computer_file/file)
+	if(istype(file, /datum/computer_file/binary/research_points))
+		return TRUE
+
+	return FALSE
+
+/datum/research/proc/can_load_file(datum/computer_file/file)
+	if(istype(file, /datum/computer_file/binary/research_points))
+		var/datum/computer_file/binary/research_points/research_points_file = file
+		return !(research_points_file.research_id in known_research_file_ids)
+
+	return FALSE
+
+/datum/research/proc/load_file(datum/computer_file/file)
+	if(!can_load_file(file))
+		return FALSE
+
+	if(istype(file, /datum/computer_file/binary/research_points))
+		var/datum/computer_file/binary/research_points/research_points_file = file
+		known_research_file_ids += research_points_file.research_id
+		research_points += research_points_file.size * 1000
+		return TRUE
+
+	return FALSE
+
 
 /***************************************************************
 **						Technology Trees					  **

--- a/code/modules/scrap/scrap.dm
+++ b/code/modules/scrap/scrap.dm
@@ -384,6 +384,7 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 		/obj/random/pack/tech_loot = 4,
 		/obj/random/powercell,
 		/obj/random/circuitboard,
+		/obj/random/science,
 		/obj/random/material_ore,
 		/obj/random/common_oddities = 0.5,
 		/obj/random/pack/rare,//No weight on this, rare loot is pretty likely to appear in scientific scrap

--- a/nano/templates/rdconsole.tmpl
+++ b/nano/templates/rdconsole.tmpl
@@ -85,6 +85,7 @@
 					Disk capacity: <div style="width: 90%">{{:helper.displayBar(data.disk_used, 0, data.disk_size, 'good', data.disk_used + "GQ / " + data.disk_size + "GQ")}}</div>
 					{{:helper.link("Disk Designs Management", 'save', {'go_screen' : 'disk_management_designs'}, null, 'sciMenuButton')}}
 					{{:helper.link("Disk Technology Management", 'save', {'go_screen' : 'disk_management_tech'}, null, 'sciMenuButton')}}
+					{{:helper.link("Disk Research Data Management", 'save', {'go_screen' : 'disk_management_data'}, null, 'sciMenuButton')}}
 					{{:helper.link("Eject", 'eject', {'eject_disk' : 1}, null, 'sciMenuButton')}}
 				</div>
 			{{else}}
@@ -458,7 +459,7 @@
 		{{for data.disk_designs}}
 			<div class="item">
 				{{:value.name}}
-				{{:helper.link("", 'trash', {'delete_disk_design' : value.id}, data.disk_read_only==1 ? 'disabled' : null)}}
+				{{:helper.link("", 'trash', {'delete_disk_file' : value.id}, data.disk_read_only==1 ? 'disabled' : null)}}
 				{{:helper.link("", 'arrowthick-1-e', {'download_disk_design' : value.id}, value.can_download==1 ? null : 'disabled')}}
 			</div>
 		{{empty}}
@@ -501,7 +502,7 @@
 		{{for data.disk_tech_nodes}}
 			<div class="item">
 				{{:value.name}}
-				{{:helper.link("", 'trash', {'delete_disk_node' : value.id},data.disk_read_only==1 ? 'disabled' : null)}}
+				{{:helper.link("", 'trash', {'delete_disk_file' : value.id},data.disk_read_only==1 ? 'disabled' : null)}}
 				{{:helper.link("", 'arrowthick-1-e', {'download_disk_node' : value.id})}}
 				</div>
 		{{empty}}
@@ -522,5 +523,27 @@
 		</td>
 		</tr>
 		</table>
+	{{/if}}
+{{/if}}
+{{if data.screen == "disk_management_data"}}
+	<table style="width: 30%">
+	<div class='item'>
+	<tr><td>{{:helper.link("Back", 'arrowreturn-1-w', {'go_screen' : 'main'},null,'fixedLeft')}}</td></tr>
+	<tr><td>Disk capacity:</td><td style="width: 100%"><div style="width: 50%">{{:helper.displayBar(data.disk_used, 0, data.disk_size, 'good', data.disk_used + "GQ / " + data.disk_size + "GQ")}}</div></td>
+	</div>
+	</table>
+	{{if data.has_disk}}
+		<div class="statusDisplayRecords">
+		Detected research data files:
+		{{for data.disk_research_data}}
+			<div class="item">
+				{{:value.name}}
+				{{:helper.link("", 'trash', {'delete_disk_file' : value.id},data.disk_read_only==1 ? 'disabled' : null)}}
+				{{:helper.link("", 'arrowthick-1-e', {'download_disk_data' : value.id}, value.can_download==1 ? null : 'disabled')}}
+				</div>
+		{{empty}}
+			<div class="item">The disk has no accessible research data files stored on it.</div>
+		{{/for}}
+		</div>
 	{{/if}}
 {{/if}}


### PR DESCRIPTION
This only supports one file type for now, but it can be easily extended in the future. I also added a category of science loot to scrap spawn tables, with some random science-related junk in it - including disks with those science files.

## Changelog
:cl: ACCount
add: Disks with research data can now be found in maintenance.
/:cl: