### PR TITLE
Stumbling & bullet knockback

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -24,6 +24,7 @@
 		weapon_sharp = 0
 		weapon_edge = 0
 
+	hit_impact(effective_force)
 	damage_through_armor(effective_force, I.damtype, hit_zone, ARMOR_MELEE, armour_pen = I.armor_penetration, used_weapon = I, sharp = weapon_sharp, edge = weapon_edge)
 
 /*Its entirely possible that we were gibbed or dusted by the above. Check if we still exist before

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -38,6 +38,51 @@ meteor_act
 			organ.embed(SP)
 
 
+/mob/living/carbon/human/hit_impact(damage)
+	if(stat)
+		return
+	if(damage < 20)
+		..()
+		return
+
+	visible_message(SPAN_WARNING("[src] stumbles around."))
+	step(src, pick(cardinal))
+
+	for(var/atom/movable/A in oview(1))
+		if(!A.Adjacent(src) || prob(50))
+			continue
+
+		//Set usr to src for calling verbs
+		var/_usr = usr
+		usr = src
+
+		if(istype(A, /obj/structure/table))
+			var/obj/structure/table/T = A
+			if (!T.can_touch(src) || T.flipped != 0 || !T.flip(get_cardinal_dir(src, T)))
+				continue
+			if(T.climbable)
+				T.structure_shaken()
+			playsound(T,'sound/machines/Table_Fall.ogg',100,1)
+
+		else if(istype(A, /obj/machinery/door))
+			var/obj/machinery/door/D = A
+			D.Bumped(src)
+
+		else if(istype(A, /obj/machinery/button))
+			A.attack_hand(src)
+
+		else if(istype(A, /obj/structure/bed/chair))
+			var/obj/structure/bed/chair/C = A
+			C.rotate()
+
+		else if(istype(A, /obj/item) || prob(33))
+			if(A.anchored)
+				continue
+			step(A, pick(cardinal))
+
+		usr = _usr
+
+
 /mob/living/carbon/human/stun_effect_act(var/stun_amount, var/agony_amount, var/def_zone)
 
 	var/obj/item/organ/external/affected = get_organ(check_zone(def_zone))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -64,13 +64,15 @@
 	return 0
 
 
-/mob/living/proc/hit_impact(damage)
-	if(damage < 10 || stat)
+/mob/living/proc/hit_impact(damage, dir)
+	if(incapacitated(INCAPACITATION_DEFAULT|INCAPACITATION_BUCKLED_PARTIALLY))
 		return
 	shake_animation(damage)
 
 
 /mob/living/bullet_act(var/obj/item/projectile/P, var/def_zone)
+	var/hit_dir = get_dir(P, src)
+
 	if (P.is_hot() >= HEAT_MOBIGNITE_THRESHOLD)
 		IgniteMob()
 
@@ -89,14 +91,13 @@
 		qdel(P)
 		return TRUE
 
+	if(P.knockback)
+		throw_at(get_edge_target_turf(src, hit_dir), P.knockback, P.knockback)
+
 	//Armor and damage
 	if(!P.nodamage)
-		if(!P.knockback)
-			hit_impact(P.damage)
+		hit_impact(P.damage, hit_dir)
 		damage_through_armor(P.damage, P.damage_type, def_zone, P.check_armour, armour_pen = P.armor_penetration, used_weapon = P, sharp=is_sharp(P), edge=has_edge(P))
-
-	if(P.knockback)
-		throw_at(get_edge_target_turf(src, get_dir(P, src)), P.knockback, P.knockback)
 
 	P.on_hit(src, def_zone)
 	return TRUE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -87,6 +87,9 @@
 	if(!P.nodamage)
 		damage_through_armor(P.damage, P.damage_type, def_zone, P.check_armour, armour_pen = P.armor_penetration, used_weapon = P, sharp=is_sharp(P), edge=has_edge(P))
 
+	if(P.knockback)
+		throw_at(get_edge_target_turf(src, get_dir(P, src)), P.knockback, P.knockback)
+
 	P.on_hit(src, def_zone)
 	return TRUE
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -64,6 +64,12 @@
 	return 0
 
 
+/mob/living/proc/hit_impact(damage)
+	if(damage < 10 || stat)
+		return
+	shake_animation(damage)
+
+
 /mob/living/bullet_act(var/obj/item/projectile/P, var/def_zone)
 	if (P.is_hot() >= HEAT_MOBIGNITE_THRESHOLD)
 		IgniteMob()
@@ -85,6 +91,8 @@
 
 	//Armor and damage
 	if(!P.nodamage)
+		if(!P.knockback)
+			hit_impact(P.damage)
 		damage_through_armor(P.damage, P.damage_type, def_zone, P.check_armour, armour_pen = P.armor_penetration, used_weapon = P, sharp=is_sharp(P), edge=has_edge(P))
 
 	if(P.knockback)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -57,6 +57,7 @@
 	var/drowsy = 0
 	var/agony = 0
 	var/embed = 0 // whether or not the projectile can embed itself in the mob
+	var/knockback = 0
 
 	var/hitscan = FALSE		// whether the projectile should be hitscan
 	var/step_delay = 1	// the delay between iterations if not a hitscan projectile

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -248,6 +248,7 @@
 	icon_state = "slug"
 	damage = DAMAGE_SLUG
 	armor_penetration = ARMOR_PENETRATION_SLUG
+	knockback = 1
 
 /obj/item/projectile/bullet/shotgun/beanbag		//because beanbags are not bullets
 	name = "beanbag"
@@ -265,6 +266,7 @@
 	agony = DAMAGE_SLUG * PRACTICE_AGONY_MULTIPLIER
 	armor_penetration = ARMOR_PENETRATION_SLUG * PRACTICE_PENETRATION_MULTIPLIER
 	embed = FALSE
+	knockback = 0
 
 //Should do about 80 damage at 1 tile distance (adjacent), and 50 damage at 3 tiles distance.
 //Overall less damage than slugs in exchange for more damage at very close range and more embedding
@@ -275,6 +277,7 @@
 	pellets = 6
 	range_step = 1
 	spread_step = 10
+	knockback = 1
 
 /obj/item/projectile/bullet/pellet/shotgun/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
- Hitting a mob with a bullet or a weapon now plays shaking animation. If hit for ~~20~~ *TGH* or more damage, the character will stumble instead, moving himself and stuff around him, dropping tables and interacting with doors and buttons.
- Added knockback effect to certain bullet types. A mob hit by such bullet will be pushed, receiving damage if there is an obstacle. ~~Stumbling will not be triggered.~~

## Changelog
:cl:
add: Added shaking animation on hit and stumbling
add: Added knockback to shotgun ammo
/:cl:
