### PR TITLE
Airlock & console smoke on damage

### DIFF
--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -52,6 +52,10 @@
 
 /obj/machinery/computer/bullet_act(var/obj/item/projectile/Proj)
 	if(prob(Proj.get_structure_damage()))
+		if(!(stat & BROKEN))
+			var/datum/effect/effect/system/smoke_spread/S = new/datum/effect/effect/system/smoke_spread()
+			S.set_up(6, 0, src)
+			S.start()
 		set_broken()
 	..()
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -44,6 +44,8 @@ GLOBAL_LIST_EMPTY(wedge_icon_cache)
 	var/datum/wifi/receiver/button/door/wifi_receiver
 	var/obj/item/wedged_item
 
+	damage_smoke = TRUE
+
 /obj/machinery/door/airlock/attack_generic(var/mob/user, var/damage)
 	if(stat & (BROKEN|NOPOWER))
 		if(damage >= 10)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -35,6 +35,8 @@
 	dir = EAST
 	var/width = 1
 
+	var/damage_smoke = FALSE
+
 	// turf animation
 	var/atom/movable/overlay/c_animation = null
 
@@ -326,17 +328,27 @@
 	if (!isnum(damage))
 		return
 
+	var/smoke_amount
+
 	var/initialhealth = src.health
 	src.health = max(0, src.health - damage)
 	if(src.health <= 0 && initialhealth > 0)
 		src.set_broken()
+		smoke_amount = 6
 	else if(src.health < src.maxhealth / 4 && initialhealth >= src.maxhealth / 4)
 		visible_message("\The [src] looks like it's about to break!" )
+		smoke_amount = 5
 	else if(src.health < src.maxhealth / 2 && initialhealth >= src.maxhealth / 2)
 		visible_message("\The [src] looks seriously damaged!" )
+		smoke_amount = 4
 	else if(src.health < src.maxhealth * 3/4 && initialhealth >= src.maxhealth * 3/4)
 		visible_message("\The [src] shows signs of damage!" )
+		smoke_amount = 3
 	update_icon()
+	if(damage_smoke && smoke_amount)
+		var/datum/effect/effect/system/smoke_spread/S = new
+		S.set_up(smoke_amount, 0, src)
+		S.start()
 	return
 
 

--- a/code/modules/modular_computers/computers/subtypes/dev_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_console.dm
@@ -31,3 +31,10 @@
 	qdel(hard_drive)
 	qdel(network_card)
 	qdel(scanner)
+
+
+/obj/item/modular_computer/console/break_apart()
+	..()
+	var/datum/effect/effect/system/smoke_spread/S = new/datum/effect/effect/system/smoke_spread()
+	S.set_up(6, 0, src)
+	S.start()


### PR DESCRIPTION
## About The Pull Request
Damaging airlocks and destroying consoles now produces smoke.

## Changelog
:cl:
add: Added smoke effect on damaging airlocks and consoles
/:cl:
