### PR TITLE
Update drugs.dm

### DIFF
--- a/code/modules/reagents/reagents/drugs.dm
+++ b/code/modules/reagents/reagents/drugs.dm
@@ -176,7 +176,7 @@
 	metabolism = REM * 0.15
 	overdose = REAGENTS_OVERDOSE * 0.66
 	withdrawal_threshold = 10
-	nerve_system_accumulations = 70
+	nerve_system_accumulations = 55
 	reagent_type = "Drug/Stimulator"
 
 /datum/reagent/drug/hyperzine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)


### PR DESCRIPTION

## About The Pull Request
<details>
<summary>
	Hyperzines NSA nerfed to 55 from 70
</summary>
<hr>
            Hyperzine making you OD with anything at or over 30 is not exactly fair and balanced in line with other NSA amounts
<hr>
</details>

## Changelog
:cl:
balance: Hyperzine now has an NSA of 55, so people dont NSA OD so easily on it
/:cl: