### PR TITLE
Fixes agony from reduced damage

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -50,7 +50,7 @@
 		//Pain part of the damage, that simulates impact from armor absorbtion
 		//For balance purposes, it's lowered by ARMOR_AGONY_COEFFICIENT
 		var/agony_gamage = round( ( effective_damage * armor_effectiveness * ARMOR_AGONY_COEFFICIENT ) / 100 )
-		stun_effect_act(0, agony_gamage, def_zone)
+		apply_effect(agony_gamage, AGONY)
 
 		//Actual part of the damage that passed through armor
 		var/actual_damage = round ( ( effective_damage * ( 100 - armor_effectiveness ) ) / 100 )


### PR DESCRIPTION
##  About The Pull Request
<details>
<summary>
	Fixes the agony from damage reduced by armor being reduced by energy armor
</summary>
<hr>

Stun_effect_act is reduced by energy armor so agony from damage reduced was being reduced from energy armor for no reason. This means attacking someone in say an ironhammer rigsuit will now make the target feel a good bit more agony. I tested this and the damage values did change and are now properly calculated.
	
<hr>
</details>

## Changelog
:cl:
fix: Fixes agony from reduced damage being reduced by energy armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
