### PR TITLE
Adds FS Revolver Pack to cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -150,12 +150,12 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	containertype = /obj/structure/closet/crate/secure/weapon
 	crate_name = "FS Handgun Pack"
 	group = "Security"
-	
+
 /datum/supply_pack/fsrevolver
 	name = "FS Revolver Pack"
 	contains = list(/obj/item/weapon/gun/projectile/revolver/detective,
 					/obj/item/weapon/gun/projectile/revolver/detective,
-					/obj/item/weapon/gun/projectile/revolver/)
+					/obj/item/weapon/gun/projectile/revolver/consul)
 	cost = 3300
 	containertype = /obj/structure/closet/crate/secure/weapon
 	crate_name = "FS Revolver Pack"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -150,6 +150,16 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	containertype = /obj/structure/closet/crate/secure/weapon
 	crate_name = "FS Handgun Pack"
 	group = "Security"
+	
+/datum/supply_pack/fsrevolver
+	name = "FS Revolver Pack"
+	contains = list(/obj/item/weapon/gun/projectile/revolver/detective,
+					/obj/item/weapon/gun/projectile/revolver/detective,
+					/obj/item/weapon/gun/projectile/revolver/)
+	cost = 3300
+	containertype = /obj/structure/closet/crate/secure/weapon
+	crate_name = "FS Revolver Pack"
+	group = "Security"
 
 /datum/supply_pack/fsassault
 	name = "FS Assault Pack"


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	Adds FS revolver crate to cargo 
</summary>
<hr>

One problem with revolvers is that it is hard to get them in any quantity without paying huge prices at the IH vendor. It makes sense guild bought revolvers would be cheaper. This refrains from making this crate too cheap, as it is revolvers compared to handguns but does not exceed the maximum return by too much. 
	
<hr>
</details>

## Changelog
:cl:
add: FS revolver pack to cargo, contains 2 Havelocks, and 1 Consul  costs 3300
/:cl:
