### PR TITLE
fixes dual wielding rifles and whatnot

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -209,7 +209,7 @@
 			off_hand.Fire(A,user,params)
 		else
 			dual_wielding = FALSE
-	:
+
 		Fire(A,user,params) //Otherwise, fire normally.
 
 /obj/item/weapon/gun/attack(atom/A, mob/living/user, def_zone)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -38,6 +38,7 @@
 	var/muzzle_flash = 3
 	var/requires_two_hands
 	var/dual_wielding
+	var/can_dual = 0 // Controls whether guns can be dual-wielded (firing two at once).
 	var/wielded_icon = "gun_wielded"
 	var/zoom_factor = 0 //How much to scope in when using weapon
 
@@ -190,6 +191,11 @@
 	var/obj/item/weapon/gun/off_hand   //DUAL WIELDING
 	if(ishuman(user) && user.a_intent == "harm")
 		var/mob/living/carbon/human/H = user
+
+		if(!can_dual)
+			dual_wielding = FALSE
+			goto skip
+
 		if(H.r_hand == src && istype(H.l_hand, /obj/item/weapon/gun))
 			off_hand = H.l_hand
 			dual_wielding = TRUE
@@ -203,10 +209,10 @@
 		if(off_hand && off_hand.can_hit(user))
 			spawn(1)
 			off_hand.Fire(A,user,params)
-	else
-		dual_wielding = FALSE
-
-	Fire(A,user,params) //Otherwise, fire normally.
+		else
+			dual_wielding = FALSE
+	skip:
+		Fire(A,user,params) //Otherwise, fire normally.
 
 /obj/item/weapon/gun/attack(atom/A, mob/living/user, def_zone)
 	if (A == user && user.targeted_organ == BP_MOUTH && !mouthshoot)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -192,10 +192,6 @@
 	if(ishuman(user) && user.a_intent == "harm")
 		var/mob/living/carbon/human/H = user
 
-		if(!can_dual)
-			dual_wielding = FALSE
-			goto skip
-
 		if(H.r_hand == src && istype(H.l_hand, /obj/item/weapon/gun))
 			off_hand = H.l_hand
 			dual_wielding = TRUE
@@ -206,12 +202,14 @@
 		else
 			dual_wielding = FALSE
 
-		if(off_hand && off_hand.can_hit(user))
+		if(!can_dual)
+			dual_wielding = FALSE
+		else if(off_hand && off_hand.can_hit(user))
 			spawn(1)
 			off_hand.Fire(A,user,params)
 		else
 			dual_wielding = FALSE
-	skip:
+	:
 		Fire(A,user,params) //Otherwise, fire normally.
 
 /obj/item/weapon/gun/attack(atom/A, mob/living/user, def_zone)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -207,10 +207,10 @@
 		else if(off_hand && off_hand.can_hit(user))
 			spawn(1)
 			off_hand.Fire(A,user,params)
-		else
-			dual_wielding = FALSE
+	else
+		dual_wielding = FALSE
 
-		Fire(A,user,params) //Otherwise, fire normally.
+	Fire(A,user,params) //Otherwise, fire normally.
 
 /obj/item/weapon/gun/attack(atom/A, mob/living/user, def_zone)
 	if (A == user && user.targeted_organ == BP_MOUTH && !mouthshoot)

--- a/code/modules/projectiles/guns/energy/crossbow.dm
+++ b/code/modules/projectiles/guns/energy/crossbow.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/guns/energy/crossbow.dmi'
 	icon_state = "crossbow"
 	w_class = ITEM_SIZE_SMALL
+	can_dual = 1
 	item_state = "crossbow"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 2, TECH_ILLEGAL = 5)
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 10, MATERIAL_SILVER = 6, MATERIAL_URANIUM = 6)

--- a/code/modules/projectiles/guns/energy/decloner.dm
+++ b/code/modules/projectiles/guns/energy/decloner.dm
@@ -6,6 +6,7 @@
 	item_state = "decloner"
 	fire_sound = 'sound/weapons/pulse3.ogg'
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 4, TECH_POWER = 3)
+	can_dual = 1
 	projectile_type = /obj/item/projectile/energy/declone
 	charge_cost = 100
 	matter = list(MATERIAL_STEEL = 20)

--- a/code/modules/projectiles/guns/energy/egun.dm
+++ b/code/modules/projectiles/guns/energy/egun.dm
@@ -5,6 +5,7 @@
 	icon_state = "energystun100"
 	item_state = null	//so the human update icon uses the icon_state instead.
 	item_charge_meter = TRUE
+	can_dual = 1
 	fire_sound = 'sound/weapons/Taser.ogg'
 	charge_cost = 100
 	matter = list(MATERIAL_PLASTEEL = 13, MATERIAL_PLASTIC = 6, MATERIAL_SILVER = 6)
@@ -35,6 +36,7 @@
 	item_state = "gun"
 	charge_meter = FALSE
 	w_class = ITEM_SIZE_SMALL
+	can_dual = 1
 	charge_cost = 50
 	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 1)
 	matter = list(MATERIAL_PLASTEEL = 8, MATERIAL_PLASTIC = 4, MATERIAL_SILVER = 2)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -35,6 +35,7 @@ obj/item/weapon/gun/energy/retro
 	fire_sound = 'sound/weapons/Laser.ogg'
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_NORMAL
+	can_dual = 1
 	matter = list(MATERIAL_STEEL = 12)
 	projectile_type = /obj/item/projectile/beam
 	fire_delay = 10 //old technology
@@ -51,6 +52,7 @@ obj/item/weapon/gun/energy/retro
 	fire_sound = 'sound/weapons/Laser.ogg'
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_NORMAL
+	can_dual = 1
 	projectile_type = /obj/item/projectile/beam
 	origin_tech = null
 	self_recharge = TRUE

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -7,6 +7,7 @@
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASTIC = 6, MATERIAL_SILVER = 3)
 	price_tag = 2000
 	fire_sound = 'sound/weapons/Taser.ogg'
+	can_dual = 1
 	projectile_type = /obj/item/projectile/beam/stun
 
 /obj/item/weapon/gun/energy/taser/mounted
@@ -27,6 +28,7 @@
 	icon_state = "stunrevolver"
 	item_state = "stunrevolver"
 	fire_sound = 'sound/weapons/Gunshot.ogg'
+	can_dual = 1
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
 	charge_cost = 50
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6, MATERIAL_SILVER = 2)

--- a/code/modules/projectiles/guns/energy/toxgun.dm
+++ b/code/modules/projectiles/guns/energy/toxgun.dm
@@ -5,6 +5,7 @@
 	icon_state = "toxgun"
 	fire_sound = 'sound/effects/stealthoff.ogg'
 	w_class = ITEM_SIZE_NORMAL
+	can_dual = 1
 	origin_tech = list(TECH_COMBAT = 5, TECH_PLASMA = 4)
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_PLASMA = 5)
 	price_tag = 2500

--- a/code/modules/projectiles/guns/projectile/automatic/IH_machinepistol.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/IH_machinepistol.dm
@@ -5,6 +5,7 @@
 	icon_state = "IH_mp"
 	item_state = "IH_mp"
 	w_class = ITEM_SIZE_NORMAL
+	can_dual = 1
 	caliber = "pistol"
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 2)
 	slot_flags = SLOT_BELT|SLOT_HOLSTER

--- a/code/modules/projectiles/guns/projectile/automatic/atreides.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/atreides.dm
@@ -5,6 +5,7 @@
 	icon_state = "mac"
 	item_state = "mac"
 	w_class = ITEM_SIZE_NORMAL
+	can_dual = 1
 	caliber = "pistol"
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	slot_flags = SLOT_BELT

--- a/code/modules/projectiles/guns/projectile/automatic/drozd.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/drozd.dm
@@ -5,6 +5,7 @@
 	icon_state = "drozd"
 	item_state = "drozd"
 	w_class = ITEM_SIZE_NORMAL
+	can_dual = 1
 	force = WEAPON_FORCE_PAINFUL
 	caliber = "pistol"
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 2)

--- a/code/modules/projectiles/guns/projectile/automatic/idaho.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/idaho.dm
@@ -5,6 +5,7 @@
 	icon_state = "idaho"
 	item_state = "idaho"
 	w_class = ITEM_SIZE_NORMAL
+	can_dual = 1
 	caliber = "pistol"
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	slot_flags = SLOT_BELT

--- a/code/modules/projectiles/guns/projectile/pistol/IH_sidearm.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/IH_sidearm.dm
@@ -5,6 +5,7 @@
 	icon_state = "IH_sidearm"
 	item_state = "IH_sidearm"
 	w_class = ITEM_SIZE_NORMAL
+	can_dual = 1
 	caliber = "pistol"
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	slot_flags = SLOT_BELT|SLOT_HOLSTER

--- a/code/modules/projectiles/guns/projectile/pistol/clarissa.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/clarissa.dm
@@ -5,6 +5,7 @@
 	icon_state = "clarissa"
 	item_state = "clarissa"
 	w_class = ITEM_SIZE_SMALL
+	can_dual = 1
 	caliber = "pistol"
 	silenced = 0
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)

--- a/code/modules/projectiles/guns/projectile/pistol/colt.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/colt.dm
@@ -8,6 +8,7 @@
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASTIC = 6)
 	price_tag = 1200
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
+	can_dual = 1
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_PISTOL
 	damage_multiplier = 1.5

--- a/code/modules/projectiles/guns/projectile/pistol/deagle.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/deagle.dm
@@ -10,6 +10,7 @@
 	mag_well = MAG_WELL_PISTOL
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 8)
 	price_tag = 1600
+	can_dual = 1
 	damage_multiplier = 0.83
 	penetration_multiplier = 1.2
 	recoil_buildup = 27

--- a/code/modules/projectiles/guns/projectile/pistol/giskard.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/giskard.dm
@@ -9,6 +9,7 @@
 	caliber = "pistol"
 	ammo_mag = "mag_lpistol"
 	w_class = ITEM_SIZE_SMALL
+	can_dual = 1
 	fire_delay = 0.6
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 3)
 	load_method = MAGAZINE

--- a/code/modules/projectiles/guns/projectile/pistol/gyropistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/gyropistol.dm
@@ -6,6 +6,7 @@
 	item_state = "pistol"
 	caliber = "70"
 	fire_sound = 'sound/weapons/guns/fire/hpistol_fire.ogg'
+	can_dual = 1
 	origin_tech = list(TECH_COMBAT = 3)
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASTIC = 6)
 	price_tag = 2500

--- a/code/modules/projectiles/guns/projectile/pistol/handmade.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/handmade.dm
@@ -7,6 +7,7 @@
 	caliber = "pistol"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
+	can_dual = 1
 	load_method = SINGLE_CASING
 	max_shells = 1
 	ammo_type = /obj/item/ammo_casing/pistol

--- a/code/modules/projectiles/guns/projectile/pistol/lamia.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/lamia.dm
@@ -8,6 +8,7 @@
 	caliber = "magnum"
 	ammo_mag = "mag_magnum"
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 4)
+	can_dual = 1
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_PISTOL
 	auto_eject = 1

--- a/code/modules/projectiles/guns/projectile/pistol/mk58.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mk58.dm
@@ -9,6 +9,7 @@
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASTIC = 6)
 	price_tag = 1400
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
+	can_dual = 1
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_PISTOL
 	damage_multiplier = 0.9

--- a/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
@@ -8,6 +8,7 @@
 	caliber = "pistol"
 	ammo_mag = "mag_lpistol"
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
+	can_dual = 1
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_L_PISTOL
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)

--- a/code/modules/projectiles/guns/projectile/pistol/silenced.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/silenced.dm
@@ -5,6 +5,7 @@
 	icon_state = "mandella"
 	item_state = "pistol_s"
 	w_class = ITEM_SIZE_NORMAL
+	can_dual = 1
 	caliber = "pistol"
 	silencer_type = /obj/item/weapon/silencer/integrated
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)

--- a/code/modules/projectiles/guns/projectile/revolver/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/revolver.dm
@@ -5,6 +5,7 @@
 	icon_state = "revolver"
 	item_state = "revolver"
 	caliber = "magnum"
+	can_dual = 1
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	handle_casings = CYCLE_CASINGS
 	max_shells = 7

--- a/code/modules/projectiles/guns/projectile/shotgun/sawnoff.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/sawnoff.dm
@@ -5,6 +5,7 @@
 	icon_state = "sawnshotgun"
 	item_state = "sawnshotgun"
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
+	can_dual = 1
 	ammo_type = /obj/item/ammo_casing/shotgun/pellet
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 10)
 	w_class = ITEM_SIZE_NORMAL


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	Fixes Dual Wielding 
</summary>
<hr>

Makes it impossible to dual wield (fire simultaneously using harm intent) weapons that should logically be fired while carried with two hands, including most rifles, shotguns, and two-handed SMGs (you can tell the difference between an SMG and a machinepistol by their sprite, the molly can be dual-wielded, but not the straylight).
	
<hr>
</details>

## Changelog
:cl:
<!--fix: Can't dual wield rifles, machineguns, full-size shotguns, grenade launchers and RPGs anymore. Sorry, Jeff.-->
/:cl:
