### PR TITLE
fixed lathe paths

### DIFF
--- a/code/datums/autolathe/ammo.dm
+++ b/code/datums/autolathe/ammo.dm
@@ -72,11 +72,11 @@
 
 /datum/design/autolathe/ammo/sl_magnum_rubber
 	name = "speed loader (.40 Magnum rubber)"
-	build_path = /obj/item/ammo_magazine/magnum/rubber
+	build_path = /obj/item/ammo_magazine/slmagnum/rubber
 
 /datum/design/autolathe/ammo/sl_magnum_brute
 	name = "speed loader (.40 Magnum hollow point)"
-	build_path = /obj/item/ammo_magazine/magnum
+	build_path = /obj/item/ammo_magazine/slmagnum
 
 /datum/design/autolathe/ammo/mg_magnum_rubber
 	name = "magazine (.40 Magnum rubber)"


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	fixed lathe paths
</summary>
<hr>

small fix, just changed the paths for the speedloaders in the autolathe so they actually produce speedloaders instead of popping out magazines
	
<hr>
</details>

## Changelog
:cl:
<!--fix: speedloaders now print from the lathe properly->
/:cl: