### PR TITLE
Misc fixes

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -45,11 +45,6 @@
 	item_cost = 2
 	path = /obj/item/ammo_magazine/m12/pellet
 
-/datum/uplink_item/item/ammo/m12
-	name = "M12 shotgun mag with slugs"
-	item_cost = 2
-	path = /obj/item/ammo_magazine/m12
-
 /datum/uplink_item/item/ammo/m12/stun
 	name = "M12 shotgun mag with taser shells"
 	item_cost = 4

--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -8,7 +8,7 @@
 /datum/uplink_item/item/ammo/pistol
 	name = ".35 Auto"
 	item_cost = 1
-	path = /obj/item/ammo_magazine/pistol/highvelocity
+	path = /obj/item/ammo_magazine/hpistol/highvelocity
 
 /datum/uplink_item/item/ammo/smg
 	name = "smg .35 Auto"

--- a/code/game/objects/items/weapons/storage/deferred.dm
+++ b/code/game/objects/items/weapons/storage/deferred.dm
@@ -199,7 +199,7 @@
 	desc = "A crate containing six Makarov .35 pistols, 200 rounds of .35 ammunition, and six fixed-blade combat knives."
 	icon_state = "old_weaponcrate"
 	initial_contents = list(/obj/item/weapon/gun/projectile/clarissa/makarov = 6,
-	/obj/item/ammo_magazine/pistol  = 20,
+	/obj/item/ammo_magazine/hpistol = 20,
 	/obj/item/weapon/material/knife/boot = 6)
 
 /obj/item/weapon/storage/deferred/crate/cells

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -192,7 +192,7 @@
 	..()
 	new /obj/item/weapon/gun/projectile/clarissa(src)
 	new /obj/item/weapon/silencer(src)
-	new /obj/item/ammo_magazine/pistol(src)
+	new /obj/item/ammo_magazine/hpistol(src)
 
 /obj/item/weapon/storage/box/syndie_kit/c20r
 	name = "C-20r box"

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -377,7 +377,7 @@
 /obj/item/ammo_magazine/magnum/hv
 	name = "magazine (40 Magnum high-velocity)"
 	icon_state = "mg_ih_pst_44hv"
-	ammo_type = /obj/item/ammo_casing/pistol/hv
+	ammo_type = /obj/item/ammo_casing/magnum/hv
 
 /obj/item/ammo_magazine/caps
 	name = "speed loader (caps)"

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -8,7 +8,7 @@
 	force = WEAPON_FORCE_PAINFUL
 	slot_flags = SLOT_BACK
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2, TECH_ILLEGAL = 2)
-	caliber = "50am"
+	caliber = "antim"
 	recoil_buildup = 75
 	handle_casings = HOLD_CASINGS
 	load_method = SINGLE_CASING

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -703,7 +703,7 @@
 	name = "\improper Sin-pocket"
 	desc = "The food of choice for the veteran. Do <B>NOT</B> overconsume."
 	filling_color = "#6D6D00"
-	heated_reagents = list("doctorsdelight" = 5, "hyperzine" = 0.75, "synaptizine" = 0.25)
+	heated_reagents = list("doctorsdelight" = 5, "hyperzine" = 1)
 	var/has_been_heated = 0
 
 /obj/item/weapon/reagent_containers/food/snacks/donkpocket/sinpocket/attack_self(mob/user)

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -37,7 +37,7 @@
 
 	storage_capacity = 120
 
-	have_reagents = FALSE
+	have_reagents = TRUE
 
 
 /obj/machinery/autolathe/rnd/imprinter


### PR DESCRIPTION
## About The Pull Request
- Ammo fixes:
  - Replaced regular magazines with high-cap ones that fit clarissa/makarov:
    - In clarissa uplink kit.
    - Ordered from uplink separately.
    - In sidearms crate.
  - AMR accepts ammo once again.
  - Magnum HV magazine now contains magnum ammo instead of pistol one.
- Removed synaptizine from sin-pockets so they do not cause NSA breach.
- Fixed protolathe not accepting beakers.