### PR TITLE
fixes BSDM inventory size

### DIFF
--- a/code/game/objects/items/weapons/storage/bsdm.dm
+++ b/code/game/objects/items/weapons/storage/bsdm.dm
@@ -3,7 +3,8 @@
 	desc = "A Blue Space Direct Mail unit."
 	icon_state = "bsdm"
 	item_state = "bsdm"
-	max_storage_space = DEFAULT_NORMAL_STORAGE
+	max_storage_space = DEFAULT_BULKY_STORAGE
+	max_w_class = ITEM_SIZE_BULKY
 	var/datum/mind/owner
 
 /obj/item/weapon/storage/bsdm/attack_self(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	fixes BSDM inventory size
</summary>
<hr>

Another small fix, increases the max weight class of items that can be placed in the BSDM box and increased the BSDM box's inventory capacity.

Reasoning: some steal contract targets were too large to be placed in the BSDM for traitors to claim the reward
	
<hr>
</details>

## Changelog
:cl:
<!--fix: changed BSDM inventory size to accomodate bulky items-->
/:cl: