### PR TITLE
Adds Bluespace Interference Devices to the Brig

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -649,6 +649,7 @@
 #include "code\game\machinery\suit_storage_unit.dm"
 #include "code\game\machinery\supply_display.dm"
 #include "code\game\machinery\supplybeacon.dm"
+#include "code\game\machinery\teleblocker.dm"
 #include "code\game\machinery\teleporter.dm"
 #include "code\game\machinery\turret_control.dm"
 #include "code\game\machinery\vending.dm"

--- a/code/game/machinery/teleblocker.dm
+++ b/code/game/machinery/teleblocker.dm
@@ -1,0 +1,83 @@
+GLOBAL_LIST_EMPTY(teleblockers)
+
+/obj/machinery/teleblocker
+	name = "bluespace interference device"
+	desc = "A device which interferes with bluespace teleportation in a specifiable area."
+	icon = 'icons/obj/stationobjs.dmi'
+	icon_state = "bus"
+	density = 1
+	anchored = 1
+	use_power = 1
+	idle_power_usage = 60
+	active_power_usage = 1000	//1 kW
+	var/target_area = null
+	var/possible_areas = list("Command" = /area/eris/command,
+							"Security" = /area/eris/security,
+							"Medical" = /area/eris/medical,
+							"Science" = /area/eris/rnd,
+							"Engineering" = /area/eris/engineering,
+							"\improper Guild" = /area/eris/quartermaster,
+							"\improper Chapel" = /area/eris/neotheology)
+
+/obj/machinery/teleblocker/proc/can_teleport(turf/start, turf/dest)
+	if(!target_area || stat)
+		return TRUE
+	return !istype(get_area(start), possible_areas[target_area]) && !istype(get_area(dest), possible_areas[target_area])
+
+/obj/machinery/teleblocker/Initialize()
+	. = ..()
+	//Add ourselves to the global list
+	GLOB.teleblockers += src
+	update_visuals()
+
+/obj/machinery/teleblocker/attack_hand(user as mob)
+	if(..())
+		return
+	src.add_fingerprint(usr)
+	if(stat)
+		return
+	if(input("Would you like to change the affected area?") in list("Yes", "No") == "No")
+		return
+	target_area = input("Select area to prevent teleportation in:", "Item Mode Select","") as null|anything in possible_areas
+	if(!target_area)
+		to_chat(user, "You disable \the [name].")
+		update_use_power(1)
+	else
+		to_chat(user, "You set \the [name] to prevent teleportation at \the [target_area]")
+		update_use_power(2)
+
+/obj/machinery/teleblocker/emp_act()
+	. = ..()
+	update_visuals()
+
+/obj/machinery/teleblocker/proc/update_visuals()
+	update_icon()
+	if(use_power == 2 && !stat)
+		set_light(1, 2, "#00B0B0")
+	else
+		set_light(0)
+
+/obj/machinery/teleblocker/update_icon()
+	if(stat || !target_area)
+		icon_state = "[initial(icon_state)]_off"
+	else
+		icon_state = initial(icon_state)
+
+/obj/machinery/teleblocker/update_use_power(var/new_use_power)
+	. = ..()
+	update_visuals()
+
+/obj/machinery/teleblocker/examine(mob/user)
+	. = ..()
+	if(target_area)
+		to_chat(user, "It is currently interfering with teleportation at \the [target_area]")
+	else
+		to_chat(user, "It is currently turned off.")
+
+/obj/machinery/teleblocker/security
+	use_power = 2
+	target_area = "Security"
+
+/obj/machinery/teleblocker/command
+	use_power = 2
+	target_area = "Command"

--- a/code/game/objects/items/weapons/space_harpoon.dm
+++ b/code/game/objects/items/weapons/space_harpoon.dm
@@ -37,14 +37,27 @@
 		return
 	else if(istype(A, /obj/structure/table/) && (get_dist(A, user) <= 1))
 		return
-
-	if(!cell || !cell.checked_use(100))
-		to_chat(user, SPAN_WARNING("[src] battery is dead or missing."))
-		return
 	if(!user || !A || user.machine)
 		return
 	if(transforming)
 		to_chat(user, "<span class = 'warning'>You can't fire while [src] transforming!</span>")
+		return
+
+	var/turf/AtomTurf = get_turf(A)
+	var/turf/UserTurf = get_turf(user)
+
+	for(var/obj/machinery/teleblocker/T in GLOB.teleblockers)
+		if(mode)
+			if(!T.can_teleport(UserTurf, AtomTurf))
+				to_chat(user, "<span class = 'warning'>Something is interfering with [src]!</span>")
+				return
+		else
+			if(!T.can_teleport(AtomTurf, UserTurf))
+				to_chat(user, "<span class = 'warning'>Something is interfering with [src]!</span>")
+				return
+
+	if(!cell || !cell.checked_use(100))
+		to_chat(user, SPAN_WARNING("[src] battery is dead or missing."))
 		return
 
 	playsound(user, 'sound/weapons/wave.ogg', 60, 1)
@@ -57,9 +70,6 @@
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	s.set_up(4, 1, A)
 	s.start()
-
-	var/turf/AtomTurf = get_turf(A)
-	var/turf/UserTurf = get_turf(user)
 
 	if(mode)
 		teleport(UserTurf, AtomTurf)

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -100,8 +100,9 @@
 	if(!..()) return 0
 
 	var/mob/living/carbon/human/H = holder.wearer
+	var/turf/user_turf = H.loc
 
-	if(!istype(H.loc, /turf))
+	if(!istype(user_turf))
 		to_chat(H, SPAN_WARNING("You cannot teleport out of your current location."))
 		return 0
 
@@ -110,6 +111,11 @@
 		T = get_turf(target)
 	else
 		T = get_teleport_loc(get_turf(H), H, rand(5, 9))
+
+	for(var/obj/machinery/teleblocker/TB in GLOB.teleblockers)
+		if(!TB.can_teleport(user_turf, T))
+			to_chat(H, "<span class = 'warning'>Something is interfering with \the [src]!</span>")
+			return 0
 
 	if(!T || T.density)
 		to_chat(H, SPAN_WARNING("You cannot teleport into solid walls."))

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -406,9 +406,9 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck5central)
 "abl" = (
-/obj/random/pack/machine,
-/turf/simulated/floor/tiled/techmaint_panels,
-/area/eris/maintenance/section1deck5central)
+/obj/machinery/teleblocker/command,
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/security/bs_interference)
 "abm" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor/tiled/techmaint,
@@ -528,9 +528,8 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/security/range)
 "abA" = (
-/obj/random/closet_tech/low_chance,
-/turf/simulated/floor/tiled/techmaint_panels,
-/area/eris/maintenance/section1deck5central)
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/security/bs_interference)
 "abB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -601,8 +600,13 @@
 	name = "Security Maintenance";
 	req_access = list(1)
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techmaint_cargo,
-/area/eris/maintenance/section1deck5central)
+/area/eris/security/bs_interference)
 "abJ" = (
 /obj/structure/table/rack,
 /obj/random/lowkeyrandom,
@@ -2498,6 +2502,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck5central)
 "agd" = (
@@ -2807,6 +2816,11 @@
 	icon_state = "4-8"
 	},
 /obj/random/traps/low_chance,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck5central)
 "agG" = (
@@ -108387,6 +108401,15 @@
 	},
 /turf/simulated/open,
 /area/eris/engineering/gravity_generator)
+"fPY" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/security/bs_interference)
 "ijn" = (
 /obj/structure/table/bar_special,
 /obj/item/weapon/reagent_containers/food/condiment/peppermill{
@@ -108407,6 +108430,51 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
+"lsW" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel/bluecorner,
+/area/eris/security/prisoncells)
+"lUD" = (
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating,
+/area/eris/security/bs_interference)
+"nqq" = (
+/turf/simulated/wall/r_wall,
+/area/eris/security/bs_interference)
+"opC" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_security{
+	name = "Security Maintenance";
+	req_access = list(1)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint_cargo,
+/area/eris/maintenance/section1deck5central)
+"rbb" = (
+/obj/machinery/teleblocker/security,
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/security/bs_interference)
+"rLl" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "North APC";
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/security/bs_interference)
 
 (1,1,1) = {"
 aaa
@@ -131487,8 +131555,8 @@ aaR
 aaR
 aaR
 aaR
-dzi
-dzi
+nqq
+nqq
 afs
 afs
 afs
@@ -131688,9 +131756,9 @@ acL
 aaR
 abF
 abF
-dzi
+nqq
 abl
-dzn
+rbb
 afs
 aga
 aga
@@ -131890,9 +131958,9 @@ acM
 aaR
 aaR
 abF
-dzq
+lUD
 abA
-dzn
+abA
 afs
 agb
 agb
@@ -132092,13 +132160,13 @@ acN
 adl
 aaR
 abG
-dzi
-abl
-aex
+nqq
+rLl
+fPY
 abI
-agd
-agd
-abI
+lsW
+lsW
+opC
 agc
 agF
 agO
@@ -132294,8 +132362,8 @@ acO
 adz
 aaR
 abF
-dzi
-dzi
+nqq
+nqq
 afs
 afD
 agd

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -108445,6 +108445,10 @@
 "nqq" = (
 /turf/simulated/wall/r_wall,
 /area/eris/security/bs_interference)
+"ooU" = (
+/obj/random/pack/machine,
+/turf/simulated/floor/tiled/techmaint_panels,
+/area/eris/maintenance/section1deck5central)
 "opC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_security{
@@ -108475,6 +108479,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/security/bs_interference)
+"wYP" = (
+/obj/random/closet_tech/low_chance,
+/turf/simulated/floor/tiled/techmaint_panels,
+/area/eris/maintenance/section1deck5central)
 
 (1,1,1) = {"
 aaa
@@ -130760,7 +130768,7 @@ ahf
 ahw
 ahS
 dAp
-dzn
+ooU
 dzn
 dzn
 dzn
@@ -130962,8 +130970,8 @@ dAp
 dAp
 dAp
 dAp
+wYP
 dzn
-dAp
 dAp
 dAp
 alP
@@ -131164,7 +131172,7 @@ dzp
 aex
 dzn
 dAp
-dzn
+ooU
 dzn
 dzn
 dzn

--- a/maps/CEVEris/_Eris_areas.dm
+++ b/maps/CEVEris/_Eris_areas.dm
@@ -946,6 +946,12 @@
 	icon_state = "hammerblue"
 	is_maintenance = TRUE
 
+/area/eris/security/bs_interference
+	name = "Security Bluespace Interference Room"
+	flags = AREA_FLAG_RAD_SHIELDED
+	icon_state = "hammerblue"
+	is_maintenance = TRUE
+
 /area/eris/security/barracks
 	name = "Ironhammer Barracks"
 	icon_state = "hammerblue"


### PR DESCRIPTION
## About The Pull Request
<!-- Why is it needed, what it fixes. Write up links to closing issues there as well, but make it short. -->



## Details
<!-- If you need, describe details inside. Remove whole block if not used. -->
<details>
  <summary>Expand</summary>
Adds 2 of a new machine called Bluespace Interference Devices which block teleportation(currently bs harpoons and rig teleportation modules) in a selectable department to the brig. At the start of the round one of the machines target command and the other targets the brig. I made this PR because it is currently very easy to loot the armory and captains spare if you have a way to teleport and security usually cant move fast enough to stop you (especially since it really only takes literally 5 seconds to loot the armory with a bs harpoon). I asked Reere what to do about it and this machine was the solution he said. I put both of the machines in the 'maintenance closet' in front of the Lieutenant's office and gave it its own area and apc. Also let it be noted that command includes the FO's Id changing office but does not include the command hallway or the ai core, and none of this affects maintenance.
</details>


## Screenshots
<!-- Map an UI changes MUST have screenshots in them. Graphical changes should have it as well, when icon diff is not enough. Remove whole block if not used. -->
<details>
  <summary>Expand</summary>

![image](https://user-images.githubusercontent.com/22408776/69503586-c2b00480-0ee0-11ea-90da-841625c591d4.png)
</details>


