### PR TITLE
Cyberplants give positive sanity value to area.

### DIFF
--- a/code/game/objects/structures/cyberplants.dm
+++ b/code/game/objects/structures/cyberplants.dm
@@ -28,6 +28,8 @@
 		COLOR_LIGHTING_CYAN_BRIGHT
 	)
 
+	var/sanity_value = 0.2
+
 /obj/structure/cyberplant/Initialize()
 	..()
 	change_plant(plant)
@@ -36,6 +38,8 @@
 	update_icon()
 
 	set_light(brightness_on, brightness_on/2)
+
+	AddComponent(/datum/component/atom_sanity, sanity_value, "")
 
 /obj/structure/cyberplant/update_icon()
 	..()


### PR DESCRIPTION
## About The Pull Request
<!-- Why is it needed, what it fixes. Write up links to closing issues there as well, but make it short. -->
Cyberplants give positive sanity value to the area that they are located in, much needed for the ship's public areas, and gives a mechanical depth to decor. For reference, it takes 5 cyberplants to reach the same sanity value as a single oddity, so this will mostly benefit large public areas.

