### PR TITLE
Ammo loading QoL

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -211,16 +211,16 @@
 	if(istype(W, /obj/item/ammo_casing))
 		var/obj/item/ammo_casing/C = W
 		if(stored_ammo.len >= max_ammo)
-			to_chat(user, SPAN_WARNING("[src] is full!"))
+			to_chat(user, SPAN_WARNING("\The [src] is full!"))
 			return
 		if(C.caliber != caliber)
-			to_chat(user, SPAN_WARNING("[C] does not fit into [src]."))
+			to_chat(user, SPAN_WARNING("\The [C] does not fit into \the [src]."))
 			return
 		insertCasing(C)
 	else if(istype(W, /obj/item/ammo_magazine))
 		var/obj/item/ammo_magazine/other = W
 		if(!src.stored_ammo.len)
-			to_chat(user, SPAN_WARNING("There is no ammo in [src]!"))
+			to_chat(user, SPAN_WARNING("There is no ammo in \the [src]!"))
 			return
 		if(other.stored_ammo.len >= other.max_ammo)
 			to_chat(user, SPAN_NOTICE("\The [other] is already full."))

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -222,18 +222,19 @@
 		if(!src.stored_ammo.len)
 			to_chat(user, SPAN_WARNING("There is no ammo in [src]!"))
 			return
-		if(!do_after(user, src.reload_delay, src))
-			to_chat(user, SPAN_WARNING("You stop loading ammo into [other]"))
+		if(other.stored_ammo.len >= other.max_ammo)
+			to_chat(user, SPAN_NOTICE("\The [other] is already full."))
 			return
+		var/diff = FALSE
 		for(var/obj/item/ammo in src.stored_ammo)
-			if(other.stored_ammo.len >= other.max_ammo)
-				break
-			var/obj/item/ammo_casing/T = removeCasing()
-			if(T)
-				other.insertCasing(T)
-			else
-				break
-		to_chat(user, SPAN_NOTICE("You're done here"))
+			if(other.stored_ammo.len < other.max_ammo && do_after(user, reload_delay/other.max_ammo, src) && other.insertCasing(removeCasing()))
+				diff = TRUE
+				continue
+			break
+		if(diff)
+			to_chat(user, SPAN_NOTICE("You finish loading \the [other]. It now contains [other.stored_ammo.len] rounds, and \the [src] now contains [stored_ammo.len] rounds."))
+		else
+			to_chat(user, SPAN_WARNING("You fail to load anything into \the [other]"))
 
 /obj/item/ammo_magazine/attack_hand(mob/user)
 	if(user.get_inactive_hand() == src && stored_ammo.len)


### PR DESCRIPTION


## About The Pull Request
<!-- Why is it needed, what it fixes. Write up links to closing issues there as well, but make it short. -->

Adds some sanity to magazine loading, where it would try to load a magazine that was full.

An aesthetic change, the do_after for loading a magazine is now done for each round, the time taken is donor reload_delay/receiver max ammo

Player feedback has been added for the following: should they have loaded the magazine, which tells you how much ammo is now in the magazine, and how much is left in the donor ammo container, and for if you failed to load anything into the receiving ammo container.

closes #4164 


