### PR TITLE
Fixes random direction footprints

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/tracks.dm
+++ b/code/game/objects/effects/decals/Cleanable/tracks.dm
@@ -43,6 +43,7 @@ var/global/list/image/fluidtrack_cache=list()
 	var/dirs=0
 	icon = 'icons/effects/fluidtracks.dmi'
 	icon_state = ""
+	random_rotation = FALSE
 	var/coming_state="blood1"
 	var/going_state="blood2"
 	var/updatedtracks=0


### PR DESCRIPTION
## About The Pull Request
Fixes #4050. The bug is pretty self explanatory, someone made it so decals would rotate randomly by default but forgot to set it so footprints didn't.


