### PR TITLE
Excelsior implant fix

### DIFF
--- a/code/game/antagonist/_antagonist_setup.dm
+++ b/code/game/antagonist/_antagonist_setup.dm
@@ -77,11 +77,11 @@ GLOBAL_LIST_EMPTY(faction_types)
 		if(istype(M) && A.create_antagonist(M))
 			return A
 
-/proc/make_antagonist_faction(var/datum/mind/M, var/a_id, var/datum/faction/F)
+/proc/make_antagonist_faction(datum/mind/M, a_id, datum/faction/F, check = TRUE)
 	if(GLOB.all_antag_types[a_id])
 		var/a_type = GLOB.all_antag_types[a_id].type
 		var/datum/antagonist/A = new a_type
-		A.create_antagonist(M, F)
+		A.create_antagonist(M, F, check = check)
 
 		return A
 

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -1,9 +1,9 @@
-/datum/antagonist/proc/create_antagonist(var/datum/mind/target, var/datum/faction/new_faction, var/doequip = TRUE, var/announce = TRUE, var/update = TRUE)
+/datum/antagonist/proc/create_antagonist(datum/mind/target, datum/faction/new_faction, doequip = TRUE, announce = TRUE, update = TRUE, check = TRUE)
 	if(!istype(target) || !target.current)
 		log_debug("ANTAGONIST Wrong target passed to create_antagonist of [id]! Target: [target == null?"NULL":target] \ref[target]")
 		return FALSE
 
-	if(!can_become_antag(target))
+	if(check && !can_become_antag(target))
 		log_debug("ANTAGONIST [target.name] cannot become this antag, but passed roleset candidate.")
 		return FALSE
 

--- a/code/game/objects/items/weapons/implant/implants/excelsior.dm
+++ b/code/game/objects/items/weapons/implant/implants/excelsior.dm
@@ -88,7 +88,7 @@
 		if(A.id == antag_id && A.faction && A.faction.id == faction_id)
 			return
 
-	make_antagonist_faction(wearer.mind, antag_id, F)
+	make_antagonist_faction(wearer.mind, antag_id, F, check = FALSE)
 
 
 /obj/item/weapon/implant/excelsior/on_uninstall()


### PR DESCRIPTION
## About The Pull Request
Removed `can_become_antag` check for excelsior implant. All necessary checks are already performed in implant's `can_install`. This likely fixes #4301. Note that implants still do not work on mindless (debug-spawned) humans.
