### PR TITLE
Map fixes

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -16463,10 +16463,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
 "aMJ" = (
@@ -16496,12 +16496,11 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/eris/hallway/side/atmosphericshallway)
 "aMO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
 /obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
 "aMP" = (
@@ -16636,13 +16635,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/blue,
 /obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
 "aNh" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/blue,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
 "aNi" = (
@@ -16770,12 +16769,12 @@
 	},
 /area/eris/rnd/server)
 "aNu" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
 	tag = "icon-intact (NORTHEAST)";
 	icon_state = "intact";
 	dir = 5
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
 "aNv" = (
@@ -16822,12 +16821,12 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/red{
 	tag = "icon-intact (NORTHEAST)";
 	icon_state = "intact";
 	dir = 5
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
 "aNB" = (
@@ -16860,12 +16859,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/red{
 	tag = "icon-intact (EAST)";
 	icon_state = "intact";
 	dir = 4
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
 "aNG" = (
@@ -30527,6 +30526,11 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/quartermaster/storage)
 "bqa" = (
@@ -34762,6 +34766,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/storage)
@@ -47946,7 +47955,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cce" = (
@@ -48971,7 +48980,7 @@
 /area/eris/storage/tech)
 "cek" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cel" = (
@@ -50243,6 +50252,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/quartermaster/storage)
 "chf" = (
@@ -50263,6 +50277,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/quartermaster/storage)
 "chi" = (
@@ -50278,6 +50297,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/storage)
 "chk" = (
@@ -50309,6 +50333,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/storage)
 "chp" = (
@@ -50318,12 +50347,22 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/storage)
 "chq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/storage)
@@ -50369,6 +50408,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/quartermaster/storage)
 "chv" = (
@@ -50388,6 +50432,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/quartermaster/storage)
@@ -54794,6 +54843,11 @@
 	dir = 10
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
 "crM" = (
@@ -54908,6 +54962,11 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
 "csa" = (
@@ -54915,6 +54974,11 @@
 	dir = 10
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
 "csb" = (
@@ -56113,6 +56177,11 @@
 /area/eris/neotheology/chapel)
 "cvo" = (
 /obj/random/cluster/roaches/low_chance,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck4starboard)
 "cvp" = (
@@ -58395,7 +58464,7 @@
 /turf/simulated/floor/bluegrid,
 /area/eris/crew_quarters/bar)
 "cAq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/blue{
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
 	tag = "icon-intact (EAST)";
 	icon_state = "intact";
 	dir = 4
@@ -59246,7 +59315,7 @@
 /turf/simulated/open,
 /area/eris/maintenance/section3deck4central)
 "cCb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/obj/machinery/atmospherics/pipe/simple/hidden/red,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
 "cCc" = (
@@ -60754,13 +60823,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/section3starboard)
 "cFm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section3deck4starboard)
 "cFn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section3deck4starboard)
 "cFo" = (
@@ -61258,11 +61327,11 @@
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/main/section3)
 "cGs" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
 "cGt" = (
@@ -61514,13 +61583,13 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cGX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
 "cGY" = (
@@ -78504,6 +78573,11 @@
 	dir = 9
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
 "dtn" = (
@@ -102475,6 +102549,11 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/storage)
 "euT" = (
@@ -108387,6 +108466,77 @@
 	},
 /turf/simulated/open,
 /area/eris/engineering/gravity_generator)
+"fYb" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck4starboard)
+"gGF" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_cargo{
+	name = "Cargo Maintenance";
+	req_access = list(50)
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "CargoTotalLockdown";
+	layer = 2.6;
+	name = "Cargo Total Lockdown";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel/cargo,
+/area/eris/quartermaster/storage)
+"gXN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "South APC";
+	pixel_y = -28
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck4starboard)
+"hGo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck4starboard)
+"hUg" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck4starboard)
 "ijn" = (
 /obj/structure/table/bar_special,
 /obj/item/weapon/reagent_containers/food/condiment/peppermill{
@@ -108397,6 +108547,41 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
+"iIi" = (
+/obj/machinery/door/airlock/maintenance_common{
+	name = "Service Maintenance";
+	req_access = list(12)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint_cargo,
+/area/eris/maintenance/section3deck4starboard)
+"jDg" = (
+/obj/random/traps/low_chance,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck4starboard)
+"jSU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/eris/quartermaster/storage)
 "kcK" = (
 /obj/structure/table/bar_special,
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker{
@@ -108407,6 +108592,42 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
+"lLG" = (
+/obj/machinery/door/airlock/maintenance_common{
+	name = "Service Maintenance";
+	req_access = list(12)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint_cargo,
+/area/eris/maintenance/section3deck4starboard)
+"mcA" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck4starboard)
+"qyI" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck4starboard)
+"tth" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck4starboard)
 
 (1,1,1) = {"
 aaa
@@ -172953,7 +173174,7 @@ bVX
 cap
 cgO
 cgX
-chk
+jSU
 bgH
 chO
 cie
@@ -173155,7 +173376,7 @@ bVX
 cap
 cgO
 cgY
-chk
+jSU
 bgH
 cEJ
 cgY
@@ -173963,7 +174184,7 @@ bVX
 caG
 cgO
 cuu
-chk
+jSU
 bgH
 cFj
 cie
@@ -174165,7 +174386,7 @@ bVX
 bVX
 cgO
 cgY
-chk
+jSU
 bgH
 chN
 cHY
@@ -174367,7 +174588,7 @@ aaa
 aaa
 cgO
 cus
-chk
+jSU
 cgO
 cgO
 cgO
@@ -174569,7 +174790,7 @@ aad
 aaa
 cgO
 cgX
-chk
+jSU
 cCJ
 chR
 cig
@@ -174973,7 +175194,7 @@ aad
 aad
 cgO
 cgO
-bxU
+gGF
 cgO
 cgO
 cgO
@@ -175601,7 +175822,7 @@ csb
 cfm
 bVX
 esi
-dtf
+gXN
 bVX
 dtG
 csb
@@ -175803,7 +176024,7 @@ don
 cCK
 dsy
 esj
-dtf
+hGo
 bVX
 dtE
 dtF
@@ -175983,7 +176204,7 @@ acR
 acR
 bVX
 bVX
-csb
+iIi
 bVX
 cAn
 cti
@@ -176185,7 +176406,7 @@ aaa
 aaa
 bVX
 cqR
-cap
+tth
 bVX
 bVX
 bVX
@@ -176200,14 +176421,14 @@ dem
 cNf
 avn
 dHA
-cap
-cap
-cap
-cap
-cap
-cap
-cap
-cap
+hUg
+mcA
+mcA
+mcA
+mcA
+mcA
+mcA
+qyI
 bVX
 dtG
 csb
@@ -176387,9 +176608,9 @@ aaa
 aaa
 cfm
 cqR
-cap
+tth
 bVX
-cAo
+cCc
 cCb
 cDO
 cFm
@@ -176402,7 +176623,7 @@ avn
 avn
 avn
 dHA
-cap
+tth
 bVX
 bVX
 bVX
@@ -176589,10 +176810,10 @@ aaa
 aaa
 cfm
 cqR
-cap
+tth
 bVX
 cAq
-cCc
+cAo
 cDO
 cFn
 cGX
@@ -176604,7 +176825,7 @@ dFm
 dFm
 dhl
 dHj
-cap
+tth
 bVX
 caG
 cap
@@ -176791,7 +177012,7 @@ aaa
 aaa
 cfm
 cqR
-cap
+tth
 bVX
 cAr
 cAr
@@ -176799,14 +177020,14 @@ bVX
 bVX
 bVX
 bVX
-cap
-cap
-cap
-cxp
-cap
-csb
-cap
-cap
+hUg
+mcA
+mcA
+jDg
+mcA
+lLG
+mcA
+qyI
 bVX
 bVX
 bVX
@@ -176993,7 +177214,7 @@ aaa
 aaa
 cfm
 cqR
-cap
+tth
 bVX
 bVX
 bVX
@@ -177001,7 +177222,7 @@ bVX
 cFt
 cFt
 bVX
-csb
+iIi
 bVX
 bVX
 bVX
@@ -177195,15 +177416,15 @@ aaa
 aaa
 cfm
 cqR
-cap
+fYb
 cvo
-cap
-cap
-cap
-cap
-cap
-cap
-cap
+mcA
+mcA
+mcA
+mcA
+mcA
+mcA
+qyI
 cap
 cap
 csb


### PR DESCRIPTION
138,93,3 - fixes a piping error that caused scrubber pipe and vent pipe to merge. Adds an APC to an area that lacked one.

60,51,1 - fixes a piping error - another mix-up between scrubber and vent pipes.

93,97,2 - fixes a piping error - z-level scrubber/air pipes not being connected through the universal adapter, resulting in a broken connection.

Your mapping? **Wack.** Your quality control? **Lacking.**