### PR TITLE
Fixes soap description and adds it to the biomatter printer

### DIFF
--- a/code/datums/autolathe/biomatter.dm
+++ b/code/datums/autolathe/biomatter.dm
@@ -11,6 +11,10 @@
 	name = "Milk"
 	build_path = /obj/item/weapon/reagent_containers/food/drinks/milk
 
+/datum/design/bioprinter/soap
+	name = "Soap"
+	build_path = /obj/item/weapon/soap/nanotrasen
+
 //[NUTRIMENTS]
 /datum/design/bioprinter/ez
 	name = "EZ-Nutrient"

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -490,6 +490,7 @@
 	designs = list(
 		/datum/design/bioprinter/meat,
 		/datum/design/bioprinter/milk,
+		/datum/design/bioprinter/soap,
 
 		/datum/design/bioprinter/ez,
 		/datum/design/bioprinter/l4z,

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -93,7 +93,7 @@
 	..()
 
 /obj/item/weapon/soap/nanotrasen
-	desc = "A NanoTrasen-brand bar of soap. Smells of plasma."
+	desc = "A NeoTheology-brand bar of soap. Smells of biomatter."
 	icon_state = "soapnt"
 
 /obj/item/weapon/soap/deluxe


### PR DESCRIPTION
## About The Pull Request
The nt soap description no longer references NanoTrasen and now references NeoTheology. I also added the nt soap to the biomatter autolathe for a total of 18 biomatter.
