### PR TITLE
Lowers amount of smoke that coming from the shoot up consoles and doors

### DIFF
--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -54,7 +54,7 @@
 	if(prob(Proj.get_structure_damage()))
 		if(!(stat & BROKEN))
 			var/datum/effect/effect/system/smoke_spread/S = new/datum/effect/effect/system/smoke_spread()
-			S.set_up(6, 0, src)
+			S.set_up(3, 0, src)
 			S.start()
 		set_broken()
 	..()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -334,10 +334,10 @@
 	src.health = max(0, src.health - damage)
 	if(src.health <= 0 && initialhealth > 0)
 		src.set_broken()
-		smoke_amount = 3
+		smoke_amount = 4
 	else if(src.health < src.maxhealth / 4 && initialhealth >= src.maxhealth / 4)
 		visible_message("\The [src] looks like it's about to break!" )
-		smoke_amount = 2
+		smoke_amount = 3
 	else if(src.health < src.maxhealth / 2 && initialhealth >= src.maxhealth / 2)
 		visible_message("\The [src] looks seriously damaged!" )
 		smoke_amount = 2

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -334,16 +334,16 @@
 	src.health = max(0, src.health - damage)
 	if(src.health <= 0 && initialhealth > 0)
 		src.set_broken()
-		smoke_amount = 6
+		smoke_amount = 3
 	else if(src.health < src.maxhealth / 4 && initialhealth >= src.maxhealth / 4)
 		visible_message("\The [src] looks like it's about to break!" )
-		smoke_amount = 5
+		smoke_amount = 2
 	else if(src.health < src.maxhealth / 2 && initialhealth >= src.maxhealth / 2)
 		visible_message("\The [src] looks seriously damaged!" )
-		smoke_amount = 4
+		smoke_amount = 2
 	else if(src.health < src.maxhealth * 3/4 && initialhealth >= src.maxhealth * 3/4)
 		visible_message("\The [src] shows signs of damage!" )
-		smoke_amount = 3
+		smoke_amount = 1
 	update_icon()
 	if(damage_smoke && smoke_amount)
 		var/datum/effect/effect/system/smoke_spread/S = new

--- a/code/modules/modular_computers/computers/subtypes/dev_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_console.dm
@@ -36,5 +36,5 @@
 /obj/item/modular_computer/console/break_apart()
 	..()
 	var/datum/effect/effect/system/smoke_spread/S = new/datum/effect/effect/system/smoke_spread()
-	S.set_up(6, 0, src)
+	S.set_up(3, 0, src)
 	S.start()


### PR DESCRIPTION
## About The Pull Request
It was too much, honestly, more like smoke grenade coming from the tiny circuit in door. I pretty much straight up halved amount of smoke coming from it. In my opinion, it should always give away one tile smoke, but i figured out this way PR won't be accepted. Can be changed easily tho.

