### PR TITLE
Minor storage containers refactor

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -18,15 +18,15 @@
 	name = "body bags"
 	desc = "This box contains a number of body bags."
 	icon_state = "bodybags"
-	New()
-		..()
-		new /obj/item/bodybag(src)
-		new /obj/item/bodybag(src)
-		new /obj/item/bodybag(src)
-		new /obj/item/bodybag(src)
-		new /obj/item/bodybag(src)
-		new /obj/item/bodybag(src)
-		new /obj/item/bodybag(src)
+
+/obj/item/weapon/storage/box/bodybags/populate_contents()
+	new /obj/item/bodybag(src)
+	new /obj/item/bodybag(src)
+	new /obj/item/bodybag(src)
+	new /obj/item/bodybag(src)
+	new /obj/item/bodybag(src)
+	new /obj/item/bodybag(src)
+	new /obj/item/bodybag(src)
 
 
 /obj/structure/closet/body_bag

--- a/code/game/objects/items/contraband.dm
+++ b/code/game/objects/items/contraband.dm
@@ -5,29 +5,27 @@
 	name = "bottle of Happy pills"
 	desc = "Highly illegal drug. When you want to see the rainbow."
 
-/obj/item/weapon/storage/pill_bottle/happy/New()
-	..()
-	new /obj/item/weapon/reagent_containers/pill/happy( src )
-	new /obj/item/weapon/reagent_containers/pill/happy( src )
-	new /obj/item/weapon/reagent_containers/pill/happy( src )
-	new /obj/item/weapon/reagent_containers/pill/happy( src )
-	new /obj/item/weapon/reagent_containers/pill/happy( src )
-	new /obj/item/weapon/reagent_containers/pill/happy( src )
-	new /obj/item/weapon/reagent_containers/pill/happy( src )
+/obj/item/weapon/storage/pill_bottle/happy/populate_contents()
+	new /obj/item/weapon/reagent_containers/pill/happy(src)
+	new /obj/item/weapon/reagent_containers/pill/happy(src)
+	new /obj/item/weapon/reagent_containers/pill/happy(src)
+	new /obj/item/weapon/reagent_containers/pill/happy(src)
+	new /obj/item/weapon/reagent_containers/pill/happy(src)
+	new /obj/item/weapon/reagent_containers/pill/happy(src)
+	new /obj/item/weapon/reagent_containers/pill/happy(src)
 
 /obj/item/weapon/storage/pill_bottle/zoom
 	name = "bottle of Zoom pills"
 	desc = "Highly illegal drug. Trade brain for speed."
 
-/obj/item/weapon/storage/pill_bottle/zoom/New()
-	..()
-	new /obj/item/weapon/reagent_containers/pill/zoom( src )
-	new /obj/item/weapon/reagent_containers/pill/zoom( src )
-	new /obj/item/weapon/reagent_containers/pill/zoom( src )
-	new /obj/item/weapon/reagent_containers/pill/zoom( src )
-	new /obj/item/weapon/reagent_containers/pill/zoom( src )
-	new /obj/item/weapon/reagent_containers/pill/zoom( src )
-	new /obj/item/weapon/reagent_containers/pill/zoom( src )
+/obj/item/weapon/storage/pill_bottle/zoom/populate_contents()
+	new /obj/item/weapon/reagent_containers/pill/zoom(src)
+	new /obj/item/weapon/reagent_containers/pill/zoom(src)
+	new /obj/item/weapon/reagent_containers/pill/zoom(src)
+	new /obj/item/weapon/reagent_containers/pill/zoom(src)
+	new /obj/item/weapon/reagent_containers/pill/zoom(src)
+	new /obj/item/weapon/reagent_containers/pill/zoom(src)
+	new /obj/item/weapon/reagent_containers/pill/zoom(src)
 
 /obj/item/weapon/reagent_containers/glass/beaker/vial/random
 	flags = 0

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -19,10 +19,10 @@
 	matter = list(MATERIAL_BIOMATTER = 10, MATERIAL_PLASTIC = 2)
 	var/worn_access = FALSE
 
-/obj/item/weapon/storage/backpack/New()
+/obj/item/weapon/storage/backpack/Initialize()
+	. = ..()
 	if (!item_state)
 		item_state = icon_state
-	..()
 
 /obj/item/weapon/storage/backpack/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (!worn_check())
@@ -285,8 +285,7 @@
 	desc = "It's a very fancy satchel made with fine leather."
 	icon_state = "satchel_leather"
 
-/obj/item/weapon/storage/backpack/satchel/leather/withwallet/New()
-	..()
+/obj/item/weapon/storage/backpack/satchel/leather/withwallet/populate_contents()
 	new /obj/item/weapon/storage/wallet/random(src)
 
 //Faction-specific satchels

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -131,9 +131,6 @@
 	storage_slots = 7
 	allow_quick_empty = TRUE // this function is superceded
 
-/obj/item/weapon/storage/bag/sheetsnatcher/New()
-	..()
-
 /obj/item/weapon/storage/bag/sheetsnatcher/can_be_inserted(obj/item/W as obj, stop_messages = 0)
 	if(!istype(W,/obj/item/stack/material))
 		if(!stop_messages)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -58,8 +58,7 @@
 		)
 
 
-/obj/item/weapon/storage/belt/utility/full/New()
-	..()
+/obj/item/weapon/storage/belt/utility/full/populate_contents()
 	new /obj/item/weapon/tool/screwdriver(src)
 	new /obj/item/weapon/tool/wrench(src)
 	new /obj/item/weapon/tool/weldingtool(src)
@@ -67,8 +66,7 @@
 	new /obj/item/weapon/tool/wirecutters(src)
 	new /obj/item/stack/cable_coil/random(src)
 
-/obj/item/weapon/storage/belt/utility/atmostech/New()
-	..()
+/obj/item/weapon/storage/belt/utility/atmostech/populate_contents()
 	new /obj/item/weapon/tool/screwdriver(src)
 	new /obj/item/weapon/tool/wrench(src)
 	new /obj/item/weapon/tool/weldingtool(src)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -59,14 +59,14 @@
 		..()
 
 // BubbleWrap - A box can be folded up to make card
-/obj/item/weapon/storage/box/attack_self(mob/user as mob)
+/obj/item/weapon/storage/box/attack_self(mob/user)
 	if(..()) return
 
 	//try to fold it.
-	if ( contents.len )
+	if(contents.len)
 		return
 
-	if ( !ispath(src.foldable) )
+	if(!ispath(src.foldable))
 		return
 
 	// Close any open UI windows first
@@ -77,47 +77,41 @@
 	new src.foldable(get_turf(src))
 	qdel(src)
 
-/obj/item/weapon/storage/box/survival/
-	New()
-		..()
-		new /obj/item/clothing/mask/breath( src )
-		new /obj/item/weapon/tank/emergency_oxygen( src )
+/obj/item/weapon/storage/box/survival/populate_contents()
+	new /obj/item/clothing/mask/breath(src)
+	new /obj/item/weapon/tank/emergency_oxygen(src)
 
-/obj/item/weapon/storage/box/engineer/
-	New()
-		..()
-		new /obj/item/clothing/mask/breath( src )
-		new /obj/item/weapon/tank/emergency_oxygen/engi( src )
+/obj/item/weapon/storage/box/engineer/populate_contents()
+	new /obj/item/clothing/mask/breath(src)
+	new /obj/item/weapon/tank/emergency_oxygen/engi(src)
 
 /obj/item/weapon/storage/box/gloves
 	name = "box of latex gloves"
 	desc = "Contains white gloves."
 	icon_state = "latex"
 
-	New()
-		..()
-		new /obj/item/clothing/gloves/latex(src)
-		new /obj/item/clothing/gloves/latex(src)
-		new /obj/item/clothing/gloves/latex(src)
-		new /obj/item/clothing/gloves/latex(src)
-		new /obj/item/clothing/gloves/latex(src)
-		new /obj/item/clothing/gloves/latex(src)
-		new /obj/item/clothing/gloves/latex(src)
+/obj/item/weapon/storage/box/gloves/populate_contents()
+	new /obj/item/clothing/gloves/latex(src)
+	new /obj/item/clothing/gloves/latex(src)
+	new /obj/item/clothing/gloves/latex(src)
+	new /obj/item/clothing/gloves/latex(src)
+	new /obj/item/clothing/gloves/latex(src)
+	new /obj/item/clothing/gloves/latex(src)
+	new /obj/item/clothing/gloves/latex(src)
 
 /obj/item/weapon/storage/box/masks
 	name = "box of sterile masks"
 	desc = "This box contains masks of sterility."
 	icon_state = "sterile"
 
-	New()
-		..()
-		new /obj/item/clothing/mask/surgical(src)
-		new /obj/item/clothing/mask/surgical(src)
-		new /obj/item/clothing/mask/surgical(src)
-		new /obj/item/clothing/mask/surgical(src)
-		new /obj/item/clothing/mask/surgical(src)
-		new /obj/item/clothing/mask/surgical(src)
-		new /obj/item/clothing/mask/surgical(src)
+/obj/item/weapon/storage/box/masks/populate_contents()
+	new /obj/item/clothing/mask/surgical(src)
+	new /obj/item/clothing/mask/surgical(src)
+	new /obj/item/clothing/mask/surgical(src)
+	new /obj/item/clothing/mask/surgical(src)
+	new /obj/item/clothing/mask/surgical(src)
+	new /obj/item/clothing/mask/surgical(src)
+	new /obj/item/clothing/mask/surgical(src)
 
 
 /obj/item/weapon/storage/box/syringes
@@ -125,58 +119,54 @@
 	desc = "A box full of syringes."
 	icon_state = "syringe"
 
-	New()
-		..()
-		new /obj/item/weapon/reagent_containers/syringe( src )
-		new /obj/item/weapon/reagent_containers/syringe( src )
-		new /obj/item/weapon/reagent_containers/syringe( src )
-		new /obj/item/weapon/reagent_containers/syringe( src )
-		new /obj/item/weapon/reagent_containers/syringe( src )
-		new /obj/item/weapon/reagent_containers/syringe( src )
-		new /obj/item/weapon/reagent_containers/syringe( src )
+/obj/item/weapon/storage/box/syringes/populate_contents()
+	new /obj/item/weapon/reagent_containers/syringe(src)
+	new /obj/item/weapon/reagent_containers/syringe(src)
+	new /obj/item/weapon/reagent_containers/syringe(src)
+	new /obj/item/weapon/reagent_containers/syringe(src)
+	new /obj/item/weapon/reagent_containers/syringe(src)
+	new /obj/item/weapon/reagent_containers/syringe(src)
+	new /obj/item/weapon/reagent_containers/syringe(src)
 
 /obj/item/weapon/storage/box/syringegun
 	name = "box of syringe gun cartridges"
 	desc = "A box full of compressed gas cartridges."
 	icon_state = "syringe"
 
-	New()
-		..()
-		new /obj/item/weapon/syringe_cartridge( src )
-		new /obj/item/weapon/syringe_cartridge( src )
-		new /obj/item/weapon/syringe_cartridge( src )
-		new /obj/item/weapon/syringe_cartridge( src )
-		new /obj/item/weapon/syringe_cartridge( src )
-		new /obj/item/weapon/syringe_cartridge( src )
-		new /obj/item/weapon/syringe_cartridge( src )
+/obj/item/weapon/storage/box/syringegun/populate_contents()
+	new /obj/item/weapon/syringe_cartridge(src)
+	new /obj/item/weapon/syringe_cartridge(src)
+	new /obj/item/weapon/syringe_cartridge(src)
+	new /obj/item/weapon/syringe_cartridge(src)
+	new /obj/item/weapon/syringe_cartridge(src)
+	new /obj/item/weapon/syringe_cartridge(src)
+	new /obj/item/weapon/syringe_cartridge(src)
 
 
 /obj/item/weapon/storage/box/beakers
 	name = "box of beakers"
 	icon_state = "beaker"
 
-	New()
-		..()
-		new /obj/item/weapon/reagent_containers/glass/beaker( src )
-		new /obj/item/weapon/reagent_containers/glass/beaker( src )
-		new /obj/item/weapon/reagent_containers/glass/beaker( src )
-		new /obj/item/weapon/reagent_containers/glass/beaker( src )
-		new /obj/item/weapon/reagent_containers/glass/beaker( src )
-		new /obj/item/weapon/reagent_containers/glass/beaker( src )
-		new /obj/item/weapon/reagent_containers/glass/beaker( src )
+/obj/item/weapon/storage/box/beakers/populate_contents()
+	new /obj/item/weapon/reagent_containers/glass/beaker(src)
+	new /obj/item/weapon/reagent_containers/glass/beaker(src)
+	new /obj/item/weapon/reagent_containers/glass/beaker(src)
+	new /obj/item/weapon/reagent_containers/glass/beaker(src)
+	new /obj/item/weapon/reagent_containers/glass/beaker(src)
+	new /obj/item/weapon/reagent_containers/glass/beaker(src)
+	new /obj/item/weapon/reagent_containers/glass/beaker(src)
 
 /obj/item/weapon/storage/box/injectors
 	name = "box of DNA injectors"
 	desc = "This box contains injectors it seems."
 
-	New()
-		..()
-		new /obj/item/weapon/dnainjector/h2m(src)
-		new /obj/item/weapon/dnainjector/h2m(src)
-		new /obj/item/weapon/dnainjector/h2m(src)
-		new /obj/item/weapon/dnainjector/m2h(src)
-		new /obj/item/weapon/dnainjector/m2h(src)
-		new /obj/item/weapon/dnainjector/m2h(src)
+/obj/item/weapon/storage/box/injectors/populate_contents()
+	new /obj/item/weapon/dnainjector/h2m(src)
+	new /obj/item/weapon/dnainjector/h2m(src)
+	new /obj/item/weapon/dnainjector/h2m(src)
+	new /obj/item/weapon/dnainjector/m2h(src)
+	new /obj/item/weapon/dnainjector/m2h(src)
+	new /obj/item/weapon/dnainjector/m2h(src)
 
 /obj/item/weapon/storage/box/shotgunammo
 	name = "box of shotgun slugs"
@@ -186,148 +176,123 @@
 /obj/item/weapon/storage/box/shotgunammo/slug
 	name = "box of shotgun slugs"
 
-	New()
-		..()
-		new /obj/item/ammo_casing/shotgun/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/prespawned(src)
-		for(var/obj/item/ammo_casing/temp_casing in src)
-			temp_casing.update_icon()
-
+/obj/item/weapon/storage/box/shotgunammo/slug/populate_contents()
+	new /obj/item/ammo_casing/shotgun/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/prespawned(src)
 
 /obj/item/weapon/storage/box/shotgunammo/blanks
 	name = "box of blank shells"
 
-	New()
-		..()
-		new /obj/item/ammo_casing/shotgun/blank/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/blank/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/blank/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/blank/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/blank/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/blank/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/blank/prespawned(src)
-		for(var/obj/item/ammo_casing/temp_casing in src)
-			temp_casing.update_icon()
+/obj/item/weapon/storage/box/shotgunammo/blanks/populate_contents()
+	new /obj/item/ammo_casing/shotgun/blank/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/blank/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/blank/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/blank/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/blank/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/blank/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/blank/prespawned(src)
 
 /obj/item/weapon/storage/box/shotgunammo/beanbags
 	name = "box of beanbag shells"
 
-	New()
-		..()
-		new /obj/item/ammo_casing/shotgun/beanbag/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/beanbag/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/beanbag/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/beanbag/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/beanbag/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/beanbag/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/beanbag/prespawned(src)
-		for(var/obj/item/ammo_casing/temp_casing in src)
-			temp_casing.update_icon()
+/obj/item/weapon/storage/box/shotgunammo/beanbags/populate_contents()
+	new /obj/item/ammo_casing/shotgun/beanbag/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/beanbag/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/beanbag/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/beanbag/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/beanbag/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/beanbag/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/beanbag/prespawned(src)
 
 /obj/item/weapon/storage/box/shotgunammo/buckshot
 	name = "box of shotgun shells"
 
-	New()
-		..()
-		new /obj/item/ammo_casing/shotgun/pellet/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/pellet/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/pellet/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/pellet/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/pellet/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/pellet/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/pellet/prespawned(src)
-		for(var/obj/item/ammo_casing/temp_casing in src)
-			temp_casing.update_icon()
+/obj/item/weapon/storage/box/shotgunammo/buckshot/populate_contents()
+	new /obj/item/ammo_casing/shotgun/pellet/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/pellet/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/pellet/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/pellet/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/pellet/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/pellet/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/pellet/prespawned(src)
 
 /obj/item/weapon/storage/box/shotgunammo/flashshells
 	name = "box of illumination shells"
 
-	New()
-		..()
-		new /obj/item/ammo_casing/shotgun/flash/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/flash/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/flash/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/flash/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/flash/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/flash/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/flash/prespawned(src)
-		for(var/obj/item/ammo_casing/temp_casing in src)
-			temp_casing.update_icon()
+/obj/item/weapon/storage/box/shotgunammo/flashshells/populate_contents()
+	new /obj/item/ammo_casing/shotgun/flash/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/flash/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/flash/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/flash/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/flash/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/flash/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/flash/prespawned(src)
 
 /obj/item/weapon/storage/box/shotgunammo/stunshells
 	name = "box of stun shells"
 
-	New()
-		..()
-		new /obj/item/ammo_casing/shotgun/stunshell/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/stunshell/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/stunshell/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/stunshell/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/stunshell/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/stunshell/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/stunshell/prespawned(src)
-		for(var/obj/item/ammo_casing/temp_casing in src)
-			temp_casing.update_icon()
+/obj/item/weapon/storage/box/shotgunammo/stunshells/populate_contents()
+	new /obj/item/ammo_casing/shotgun/stunshell/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/stunshell/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/stunshell/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/stunshell/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/stunshell/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/stunshell/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/stunshell/prespawned(src)
 
 /obj/item/weapon/storage/box/shotgunammo/practiceshells
 	name = "box of practice shells"
 
-	New()
-		..()
-		new /obj/item/ammo_casing/shotgun/practice/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/practice/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/practice/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/practice/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/practice/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/practice/prespawned(src)
-		new /obj/item/ammo_casing/shotgun/practice/prespawned(src)
-		for(var/obj/item/ammo_casing/temp_casing in src)
-			temp_casing.update_icon()
+/obj/item/weapon/storage/box/shotgunammo/practiceshells/populate_contents()
+	new /obj/item/ammo_casing/shotgun/practice/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/practice/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/practice/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/practice/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/practice/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/practice/prespawned(src)
+	new /obj/item/ammo_casing/shotgun/practice/prespawned(src)
 
 /obj/item/weapon/storage/box/sniperammo
 	name = "box of 14.5mm shells"
 	desc = "It has a picture of a gun and several warning symbols on the front.<br>WARNING: Live ammunition. Misuse may result in serious injury or death."
 	icon_state = "ammo"
 
-	New()
-		..()
-		new /obj/item/ammo_casing/antim/prespawned(src)
-		for(var/obj/item/ammo_casing/temp_casing in src)
-			temp_casing.update_icon()
+/obj/item/weapon/storage/box/sniperammo/populate_contents()
+	new /obj/item/ammo_casing/antim/prespawned(src)
+	for(var/obj/item/ammo_casing/temp_casing in src)
+		temp_casing.update_icon()
 
 /obj/item/weapon/storage/box/flashbangs
 	name = "box of flashbangs"
 	desc = "A box containing 7 antipersonnel flashbang grenades.<br> WARNING: These devices are extremely dangerous and can cause blindness or deafness in repeated use."
 	icon_state = "flashbang"
 
-	New()
-		..()
-		new /obj/item/weapon/grenade/flashbang(src)
-		new /obj/item/weapon/grenade/flashbang(src)
-		new /obj/item/weapon/grenade/flashbang(src)
-		new /obj/item/weapon/grenade/flashbang(src)
-		new /obj/item/weapon/grenade/flashbang(src)
-		new /obj/item/weapon/grenade/flashbang(src)
-		new /obj/item/weapon/grenade/flashbang(src)
+/obj/item/weapon/storage/box/flashbangs/populate_contents()
+	new /obj/item/weapon/grenade/flashbang(src)
+	new /obj/item/weapon/grenade/flashbang(src)
+	new /obj/item/weapon/grenade/flashbang(src)
+	new /obj/item/weapon/grenade/flashbang(src)
+	new /obj/item/weapon/grenade/flashbang(src)
+	new /obj/item/weapon/grenade/flashbang(src)
+	new /obj/item/weapon/grenade/flashbang(src)
 
 /obj/item/weapon/storage/box/teargas
 	name = "box of pepperspray grenades"
 	desc = "A box containing 6 tear gas grenades. A gas mask is printed on the label.<br> WARNING: Exposure carries risk of serious injury or death. Keep away from persons with lung conditions."
 	icon_state = "flashbang"
 
-	New()
-		..()
-		new /obj/item/weapon/grenade/chem_grenade/teargas(src)
-		new /obj/item/weapon/grenade/chem_grenade/teargas(src)
-		new /obj/item/weapon/grenade/chem_grenade/teargas(src)
-		new /obj/item/weapon/grenade/chem_grenade/teargas(src)
-		new /obj/item/weapon/grenade/chem_grenade/teargas(src)
-		new /obj/item/weapon/grenade/chem_grenade/teargas(src)
+/obj/item/weapon/storage/box/teargas/populate_contents()
+	new /obj/item/weapon/grenade/chem_grenade/teargas(src)
+	new /obj/item/weapon/grenade/chem_grenade/teargas(src)
+	new /obj/item/weapon/grenade/chem_grenade/teargas(src)
+	new /obj/item/weapon/grenade/chem_grenade/teargas(src)
+	new /obj/item/weapon/grenade/chem_grenade/teargas(src)
+	new /obj/item/weapon/grenade/chem_grenade/teargas(src)
 
 
 
@@ -336,37 +301,34 @@
 	desc = "A box containing 5 military grade EMP grenades.<br> WARNING: Do not use near unshielded electronics or biomechanical augmentations, death or permanent paralysis may occur."
 	icon_state = "flashbang"
 
-	New()
-		..()
-		new /obj/item/weapon/grenade/empgrenade(src)
-		new /obj/item/weapon/grenade/empgrenade(src)
-		new /obj/item/weapon/grenade/empgrenade(src)
-		new /obj/item/weapon/grenade/empgrenade(src)
-		new /obj/item/weapon/grenade/empgrenade(src)
+/obj/item/weapon/storage/box/emps/populate_contents()
+	new /obj/item/weapon/grenade/empgrenade(src)
+	new /obj/item/weapon/grenade/empgrenade(src)
+	new /obj/item/weapon/grenade/empgrenade(src)
+	new /obj/item/weapon/grenade/empgrenade(src)
+	new /obj/item/weapon/grenade/empgrenade(src)
 
 /obj/item/weapon/storage/box/frag
 	name = "box of fragmentation grenades"
 	desc = "A box containing 4 fragmentation grenades. Designed for use on enemies in the open."
 	icon_state = "flashbang"
 
-	New()
-		..()
-		new /obj/item/weapon/grenade/frag(src)
-		new /obj/item/weapon/grenade/frag(src)
-		new /obj/item/weapon/grenade/frag(src)
-		new /obj/item/weapon/grenade/frag(src)
+/obj/item/weapon/storage/box/frag/populate_contents()
+	new /obj/item/weapon/grenade/frag(src)
+	new /obj/item/weapon/grenade/frag(src)
+	new /obj/item/weapon/grenade/frag(src)
+	new /obj/item/weapon/grenade/frag(src)
 
 /obj/item/weapon/storage/box/explosive
 	name = "box of blast grenades"
 	desc = "A box containing 4 blast grenades. Designed for assaulting strongpoints."
 	icon_state = "flashbang"
 
-	New()
-		..()
-		new /obj/item/weapon/grenade/frag/explosive(src)
-		new /obj/item/weapon/grenade/frag/explosive(src)
-		new /obj/item/weapon/grenade/frag/explosive(src)
-		new /obj/item/weapon/grenade/frag/explosive(src)
+/obj/item/weapon/storage/box/explosive/populate_contents()
+	new /obj/item/weapon/grenade/frag/explosive(src)
+	new /obj/item/weapon/grenade/frag/explosive(src)
+	new /obj/item/weapon/grenade/frag/explosive(src)
+	new /obj/item/weapon/grenade/frag/explosive(src)
 
 
 /obj/item/weapon/storage/box/smokes
@@ -374,56 +336,52 @@
 	desc = "A box containing 5 smoke bombs."
 	icon_state = "flashbang"
 
-/obj/item/weapon/storage/box/smokes/New()
-		..()
-		new /obj/item/weapon/grenade/smokebomb(src)
-		new /obj/item/weapon/grenade/smokebomb(src)
-		new /obj/item/weapon/grenade/smokebomb(src)
-		new /obj/item/weapon/grenade/smokebomb(src)
-		new /obj/item/weapon/grenade/smokebomb(src)
+/obj/item/weapon/storage/box/smokes/populate_contents()
+	new /obj/item/weapon/grenade/smokebomb(src)
+	new /obj/item/weapon/grenade/smokebomb(src)
+	new /obj/item/weapon/grenade/smokebomb(src)
+	new /obj/item/weapon/grenade/smokebomb(src)
+	new /obj/item/weapon/grenade/smokebomb(src)
 
 /obj/item/weapon/storage/box/anti_photons
 	name = "box of anti-photon grenades"
 	desc = "A box containing 5 experimental photon disruption grenades."
 	icon_state = "flashbang"
 
-/obj/item/weapon/storage/box/anti_photons/New()
-		..()
-		new /obj/item/weapon/grenade/anti_photon(src)
-		new /obj/item/weapon/grenade/anti_photon(src)
-		new /obj/item/weapon/grenade/anti_photon(src)
-		new /obj/item/weapon/grenade/anti_photon(src)
-		new /obj/item/weapon/grenade/anti_photon(src)
+/obj/item/weapon/storage/box/anti_photons/populate_contents()
+	new /obj/item/weapon/grenade/anti_photon(src)
+	new /obj/item/weapon/grenade/anti_photon(src)
+	new /obj/item/weapon/grenade/anti_photon(src)
+	new /obj/item/weapon/grenade/anti_photon(src)
+	new /obj/item/weapon/grenade/anti_photon(src)
 
 /obj/item/weapon/storage/box/trackimp
 	name = "boxed tracking implant kit"
 	desc = "Box full of scum-bag tracking utensils."
 	icon_state = "implant"
 
-	New()
-		..()
-		new /obj/item/weapon/implantcase/tracking(src)
-		new /obj/item/weapon/implantcase/tracking(src)
-		new /obj/item/weapon/implantcase/tracking(src)
-		new /obj/item/weapon/implantcase/tracking(src)
-		new /obj/item/weapon/implanter(src)
-		new /obj/item/weapon/implantpad(src)
-		new /obj/item/weapon/locator(src)
+/obj/item/weapon/storage/box/trackimp/populate_contents()
+	new /obj/item/weapon/implantcase/tracking(src)
+	new /obj/item/weapon/implantcase/tracking(src)
+	new /obj/item/weapon/implantcase/tracking(src)
+	new /obj/item/weapon/implantcase/tracking(src)
+	new /obj/item/weapon/implanter(src)
+	new /obj/item/weapon/implantpad(src)
+	new /obj/item/weapon/locator(src)
 
 /obj/item/weapon/storage/box/chemimp
 	name = "boxed chemical implant kit"
 	desc = "Box of stuff used to implant chemicals."
 	icon_state = "implant"
 
-	New()
-		..()
-		new /obj/item/weapon/implantcase/chem(src)
-		new /obj/item/weapon/implantcase/chem(src)
-		new /obj/item/weapon/implantcase/chem(src)
-		new /obj/item/weapon/implantcase/chem(src)
-		new /obj/item/weapon/implantcase/chem(src)
-		new /obj/item/weapon/implanter(src)
-		new /obj/item/weapon/implantpad(src)
+/obj/item/weapon/storage/box/chemimp/populate_contents()
+	new /obj/item/weapon/implantcase/chem(src)
+	new /obj/item/weapon/implantcase/chem(src)
+	new /obj/item/weapon/implantcase/chem(src)
+	new /obj/item/weapon/implantcase/chem(src)
+	new /obj/item/weapon/implantcase/chem(src)
+	new /obj/item/weapon/implanter(src)
+	new /obj/item/weapon/implantpad(src)
 
 
 
@@ -432,28 +390,26 @@
 	desc = "This box contains nerd glasses."
 	icon_state = "glasses"
 
-	New()
-		..()
-		new /obj/item/clothing/glasses/regular(src)
-		new /obj/item/clothing/glasses/regular(src)
-		new /obj/item/clothing/glasses/regular(src)
-		new /obj/item/clothing/glasses/regular(src)
-		new /obj/item/clothing/glasses/regular(src)
-		new /obj/item/clothing/glasses/regular(src)
-		new /obj/item/clothing/glasses/regular(src)
+/obj/item/weapon/storage/box/rxglasses/populate_contents()
+	new /obj/item/clothing/glasses/regular(src)
+	new /obj/item/clothing/glasses/regular(src)
+	new /obj/item/clothing/glasses/regular(src)
+	new /obj/item/clothing/glasses/regular(src)
+	new /obj/item/clothing/glasses/regular(src)
+	new /obj/item/clothing/glasses/regular(src)
+	new /obj/item/clothing/glasses/regular(src)
 
 /obj/item/weapon/storage/box/drinkingglasses
 	name = "box of drinking glasses"
 	desc = "It has a picture of drinking glasses on it."
 
-	New()
-		..()
-		new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
-		new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
-		new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
-		new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
-		new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
-		new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
+/obj/item/weapon/storage/box/drinkingglasses/populate_contents()
+	new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
+	new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
+	new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
+	new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
+	new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
+	new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
 
 /obj/item/weapon/storage/box/cdeathalarm_kit
 	name = "death alarm kit"
@@ -461,43 +417,41 @@
 	icon_state = "implant"
 	item_state = "syringe_kit"
 
-	New()
-		..()
-		new /obj/item/weapon/implanter(src)
-		new /obj/item/weapon/implantcase/death_alarm(src)
-		new /obj/item/weapon/implantcase/death_alarm(src)
-		new /obj/item/weapon/implantcase/death_alarm(src)
-		new /obj/item/weapon/implantcase/death_alarm(src)
-		new /obj/item/weapon/implantcase/death_alarm(src)
-		new /obj/item/weapon/implantcase/death_alarm(src)
+/obj/item/weapon/storage/box/cdeathalarm_kit/populate_contents()
+	new /obj/item/weapon/implanter(src)
+	new /obj/item/weapon/implantcase/death_alarm(src)
+	new /obj/item/weapon/implantcase/death_alarm(src)
+	new /obj/item/weapon/implantcase/death_alarm(src)
+	new /obj/item/weapon/implantcase/death_alarm(src)
+	new /obj/item/weapon/implantcase/death_alarm(src)
+	new /obj/item/weapon/implantcase/death_alarm(src)
 
 /obj/item/weapon/storage/box/condimentbottles
 	name = "box of condiment bottles"
 	desc = "It has a large ketchup smear on it."
 
-	New()
-		..()
-		new /obj/item/weapon/reagent_containers/food/condiment(src)
-		new /obj/item/weapon/reagent_containers/food/condiment(src)
-		new /obj/item/weapon/reagent_containers/food/condiment(src)
-		new /obj/item/weapon/reagent_containers/food/condiment(src)
-		new /obj/item/weapon/reagent_containers/food/condiment(src)
-		new /obj/item/weapon/reagent_containers/food/condiment(src)
+/obj/item/weapon/storage/box/condimentbottles/populate_contents()
+	new /obj/item/weapon/reagent_containers/food/condiment(src)
+	new /obj/item/weapon/reagent_containers/food/condiment(src)
+	new /obj/item/weapon/reagent_containers/food/condiment(src)
+	new /obj/item/weapon/reagent_containers/food/condiment(src)
+	new /obj/item/weapon/reagent_containers/food/condiment(src)
+	new /obj/item/weapon/reagent_containers/food/condiment(src)
 
 
 
 /obj/item/weapon/storage/box/cups
 	name = "box of paper cups"
 	desc = "It has pictures of paper cups on the front."
-	New()
-		..()
-		new /obj/item/weapon/reagent_containers/food/drinks/sillycup( src )
-		new /obj/item/weapon/reagent_containers/food/drinks/sillycup( src )
-		new /obj/item/weapon/reagent_containers/food/drinks/sillycup( src )
-		new /obj/item/weapon/reagent_containers/food/drinks/sillycup( src )
-		new /obj/item/weapon/reagent_containers/food/drinks/sillycup( src )
-		new /obj/item/weapon/reagent_containers/food/drinks/sillycup( src )
-		new /obj/item/weapon/reagent_containers/food/drinks/sillycup( src )
+
+/obj/item/weapon/storage/box/cups/populate_contents()
+	new /obj/item/weapon/reagent_containers/food/drinks/sillycup(src)
+	new /obj/item/weapon/reagent_containers/food/drinks/sillycup(src)
+	new /obj/item/weapon/reagent_containers/food/drinks/sillycup(src)
+	new /obj/item/weapon/reagent_containers/food/drinks/sillycup(src)
+	new /obj/item/weapon/reagent_containers/food/drinks/sillycup(src)
+	new /obj/item/weapon/reagent_containers/food/drinks/sillycup(src)
+	new /obj/item/weapon/reagent_containers/food/drinks/sillycup(src)
 
 
 /obj/item/weapon/storage/box/donkpockets
@@ -505,28 +459,26 @@
 	desc = "<B>Instructions:</B> <I>Heat in microwave. Product will cool if not eaten within seven minutes.</I>"
 	icon_state = "donk_kit"
 
-	New()
-		..()
-		new /obj/item/weapon/reagent_containers/food/snacks/donkpocket(src)
-		new /obj/item/weapon/reagent_containers/food/snacks/donkpocket(src)
-		new /obj/item/weapon/reagent_containers/food/snacks/donkpocket(src)
-		new /obj/item/weapon/reagent_containers/food/snacks/donkpocket(src)
-		new /obj/item/weapon/reagent_containers/food/snacks/donkpocket(src)
-		new /obj/item/weapon/reagent_containers/food/snacks/donkpocket(src)
+/obj/item/weapon/storage/box/donkpockets/populate_contents()
+	new /obj/item/weapon/reagent_containers/food/snacks/donkpocket(src)
+	new /obj/item/weapon/reagent_containers/food/snacks/donkpocket(src)
+	new /obj/item/weapon/reagent_containers/food/snacks/donkpocket(src)
+	new /obj/item/weapon/reagent_containers/food/snacks/donkpocket(src)
+	new /obj/item/weapon/reagent_containers/food/snacks/donkpocket(src)
+	new /obj/item/weapon/reagent_containers/food/snacks/donkpocket(src)
 
 /obj/item/weapon/storage/box/sinpockets
 	name = "box of sin-pockets"
 	desc = "<B>Instructions:</B> <I>Crush bottom of package to initiate chemical heating. Wait for 20 seconds before consumption. Product will cool if not eaten within seven minutes.</I>"
 	icon_state = "donk_kit"
 
-	New()
-		..()
-		new /obj/item/weapon/reagent_containers/food/snacks/donkpocket/sinpocket(src)
-		new /obj/item/weapon/reagent_containers/food/snacks/donkpocket/sinpocket(src)
-		new /obj/item/weapon/reagent_containers/food/snacks/donkpocket/sinpocket(src)
-		new /obj/item/weapon/reagent_containers/food/snacks/donkpocket/sinpocket(src)
-		new /obj/item/weapon/reagent_containers/food/snacks/donkpocket/sinpocket(src)
-		new /obj/item/weapon/reagent_containers/food/snacks/donkpocket/sinpocket(src)
+/obj/item/weapon/storage/box/sinpockets/populate_contents()
+	new /obj/item/weapon/reagent_containers/food/snacks/donkpocket/sinpocket(src)
+	new /obj/item/weapon/reagent_containers/food/snacks/donkpocket/sinpocket(src)
+	new /obj/item/weapon/reagent_containers/food/snacks/donkpocket/sinpocket(src)
+	new /obj/item/weapon/reagent_containers/food/snacks/donkpocket/sinpocket(src)
+	new /obj/item/weapon/reagent_containers/food/snacks/donkpocket/sinpocket(src)
+	new /obj/item/weapon/reagent_containers/food/snacks/donkpocket/sinpocket(src)
 
 /obj/item/weapon/storage/box/monkeycubes
 	name = "monkey cube box"
@@ -534,58 +486,38 @@
 	icon = 'icons/obj/food.dmi'
 	icon_state = "monkeycubebox"
 	can_hold = list(/obj/item/weapon/reagent_containers/food/snacks/monkeycube)
-	New()
-		..()
-		if(src.type == /obj/item/weapon/storage/box/monkeycubes)
-			for(var/i = 1; i <= 5; i++)
-				new /obj/item/weapon/reagent_containers/food/snacks/monkeycube/wrapped(src)
+
+/obj/item/weapon/storage/box/monkeycubes/populate_contents()
+	for(var/i in 1 to 5)
+		new /obj/item/weapon/reagent_containers/food/snacks/monkeycube/wrapped(src)
 
 /obj/item/weapon/storage/box/ids
 	name = "box of spare IDs"
 	desc = "Has so many empty IDs."
 	icon_state = "id"
 
-	New()
-		..()
-		new /obj/item/weapon/card/id(src)
-		new /obj/item/weapon/card/id(src)
-		new /obj/item/weapon/card/id(src)
-		new /obj/item/weapon/card/id(src)
-		new /obj/item/weapon/card/id(src)
-		new /obj/item/weapon/card/id(src)
-		new /obj/item/weapon/card/id(src)
-
-
-/obj/item/weapon/storage/box/seccarts
-	name = "box of spare R.O.B.U.S.T. Cartridges"
-	desc = "A box full of R.O.B.U.S.T. Cartridges, used by Security."
-	icon_state = "pda"
-
-	New()
-		..()
-		new /obj/item/weapon/cartridge/security(src)
-		new /obj/item/weapon/cartridge/security(src)
-		new /obj/item/weapon/cartridge/security(src)
-		new /obj/item/weapon/cartridge/security(src)
-		new /obj/item/weapon/cartridge/security(src)
-		new /obj/item/weapon/cartridge/security(src)
-		new /obj/item/weapon/cartridge/security(src)
-
+/obj/item/weapon/storage/box/ids/populate_contents()
+	new /obj/item/weapon/card/id(src)
+	new /obj/item/weapon/card/id(src)
+	new /obj/item/weapon/card/id(src)
+	new /obj/item/weapon/card/id(src)
+	new /obj/item/weapon/card/id(src)
+	new /obj/item/weapon/card/id(src)
+	new /obj/item/weapon/card/id(src)
 
 /obj/item/weapon/storage/box/handcuffs
 	name = "box of spare handcuffs"
 	desc = "A box full of handcuffs."
 	icon_state = "handcuff"
 
-	New()
-		..()
-		new /obj/item/weapon/handcuffs(src)
-		new /obj/item/weapon/handcuffs(src)
-		new /obj/item/weapon/handcuffs(src)
-		new /obj/item/weapon/handcuffs(src)
-		new /obj/item/weapon/handcuffs(src)
-		new /obj/item/weapon/handcuffs(src)
-		new /obj/item/weapon/handcuffs(src)
+/obj/item/weapon/storage/box/handcuffs/populate_contents()
+	new /obj/item/weapon/handcuffs(src)
+	new /obj/item/weapon/handcuffs(src)
+	new /obj/item/weapon/handcuffs(src)
+	new /obj/item/weapon/handcuffs(src)
+	new /obj/item/weapon/handcuffs(src)
+	new /obj/item/weapon/handcuffs(src)
+	new /obj/item/weapon/handcuffs(src)
 
 
 /obj/item/weapon/storage/box/mousetraps
@@ -593,28 +525,26 @@
 	desc = "<B><FONT color='red'>WARNING:</FONT></B> <I>Keep out of reach of children</I>."
 	icon_state = "mousetraps"
 
-	New()
-		..()
-		new /obj/item/device/assembly/mousetrap( src )
-		new /obj/item/device/assembly/mousetrap( src )
-		new /obj/item/device/assembly/mousetrap( src )
-		new /obj/item/device/assembly/mousetrap( src )
-		new /obj/item/device/assembly/mousetrap( src )
-		new /obj/item/device/assembly/mousetrap( src )
+/obj/item/weapon/storage/box/mousetraps/populate_contents()
+	new /obj/item/device/assembly/mousetrap(src)
+	new /obj/item/device/assembly/mousetrap(src)
+	new /obj/item/device/assembly/mousetrap(src)
+	new /obj/item/device/assembly/mousetrap(src)
+	new /obj/item/device/assembly/mousetrap(src)
+	new /obj/item/device/assembly/mousetrap(src)
 
 /obj/item/weapon/storage/box/pillbottles
 	name = "box of pill bottles"
 	desc = "It has pictures of pill bottles on its front."
 
-	New()
-		..()
-		new /obj/item/weapon/storage/pill_bottle( src )
-		new /obj/item/weapon/storage/pill_bottle( src )
-		new /obj/item/weapon/storage/pill_bottle( src )
-		new /obj/item/weapon/storage/pill_bottle( src )
-		new /obj/item/weapon/storage/pill_bottle( src )
-		new /obj/item/weapon/storage/pill_bottle( src )
-		new /obj/item/weapon/storage/pill_bottle( src )
+/obj/item/weapon/storage/box/pillbottles/populate_contents()
+	new /obj/item/weapon/storage/pill_bottle(src)
+	new /obj/item/weapon/storage/pill_bottle(src)
+	new /obj/item/weapon/storage/pill_bottle(src)
+	new /obj/item/weapon/storage/pill_bottle(src)
+	new /obj/item/weapon/storage/pill_bottle(src)
+	new /obj/item/weapon/storage/pill_bottle(src)
+	new /obj/item/weapon/storage/pill_bottle(src)
 
 
 /obj/item/weapon/storage/box/snappops
@@ -622,11 +552,10 @@
 	desc = "Eight wrappers of fun! Ages 8 and up. Not suitable for children."
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "spbox"
-	can_hold = list(/obj/item/toy/snappop)
-	New()
-		..()
-		for(var/i=1; i <= 8; i++)
-			new /obj/item/toy/snappop(src)
+
+/obj/item/weapon/storage/box/snappops/populate_contents()
+	for(var/i in 1 to 8)
+		new /obj/item/toy/snappop(src)
 
 /obj/item/weapon/storage/box/matches
 	name = "matchbox"
@@ -636,32 +565,31 @@
 	item_state = "zippo"
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_BELT
-	can_hold = list(/obj/item/weapon/flame/match)
 
-	New()
-		..()
-		for(var/i=1; i <= 10; i++)
-			new /obj/item/weapon/flame/match(src)
+/obj/item/weapon/storage/box/matches/populate_contents()
+	for(var/i in 1 to 14)
+		new /obj/item/weapon/flame/match(src)
+	make_exact_fit()
 
-	attackby(obj/item/weapon/flame/match/W as obj, mob/user as mob)
-		if(istype(W) && !W.lit && !W.burnt)
-			playsound(src, 'sound/items/matchstrike.ogg', 20, 1, 1)
-			W.lit = 1
-			W.damtype = "burn"
-			W.icon_state = "match_lit"
-			W.tool_qualities = list(QUALITY_CAUTERIZING = 10)
-			START_PROCESSING(SSobj, W)
-		W.update_icon()
-		return
+/obj/item/weapon/storage/box/matches/attackby(obj/item/weapon/flame/match/W, mob/user)
+	if(istype(W) && !W.lit && !W.burnt)
+		playsound(src, 'sound/items/matchstrike.ogg', 20, 1, 1)
+		W.lit = 1
+		W.damtype = "burn"
+		W.icon_state = "match_lit"
+		W.tool_qualities = list(QUALITY_CAUTERIZING = 10)
+		START_PROCESSING(SSobj, W)
+	W.update_icon()
+	return
 
 /obj/item/weapon/storage/box/autoinjectors
 	name = "box of injectors"
 	desc = "Contains autoinjectors."
 	icon_state = "syringe"
-	New()
-		..()
-		for (var/i; i < 7; i++)
-			new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
+
+/obj/item/weapon/storage/box/autoinjectors/populate_contents()
+	for(var/i in 1 to 7)
+		new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
 
 /obj/item/weapon/storage/box/lights
 	name = "box of replacement bulbs"
@@ -671,34 +599,31 @@
 	item_state = "syringe_kit"
 	use_to_pickup = 1 // for picking up broken bulbs, not that most people will try
 
-/obj/item/weapon/storage/box/lights/New()
-	..()
-	make_exact_fit()
-
-/obj/item/weapon/storage/box/lights/bulbs/New()
-	for(var/i = 0; i < 21; i++)
+/obj/item/weapon/storage/box/lights/bulbs/populate_contents()
+	for(var/i in 1 to 21)
 		new /obj/item/weapon/light/bulb(src)
-	..()
+	make_exact_fit()
 
 /obj/item/weapon/storage/box/lights/tubes
 	name = "box of replacement tubes"
 	icon_state = "lighttube"
 
-/obj/item/weapon/storage/box/lights/tubes/New()
-	for(var/i = 0; i < 21; i++)
+/obj/item/weapon/storage/box/lights/tubes/populate_contents()
+	for(var/i in 1 to 21)
 		new /obj/item/weapon/light/tube(src)
-	..()
+	make_exact_fit()
+
 
 /obj/item/weapon/storage/box/lights/mixed
 	name = "box of replacement lights"
 	icon_state = "lightmixed"
 
-/obj/item/weapon/storage/box/lights/mixed/New()
-	for(var/i = 0; i < 14; i++)
+/obj/item/weapon/storage/box/lights/mixed/populate_contents()
+	for(var/i in 1 to 14)
 		new /obj/item/weapon/light/tube(src)
-	for(var/i = 0; i < 7; i++)
+	for(var/i in 1 to 7)
 		new /obj/item/weapon/light/bulb(src)
-	..()
+	make_exact_fit()
 
 /obj/item/weapon/storage/box/freezer
 	name = "portable freezer"
@@ -716,7 +641,6 @@
 	name = "data disk box"
 	icon_state = "disk_kit"
 
-/obj/item/weapon/storage/box/autolathe_blank/Initialize()
-	. = ..()
+/obj/item/weapon/storage/box/autolathe_blank/populate_contents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/computer_hardware/hard_drive/portable(src)

--- a/code/game/objects/items/weapons/storage/deferred.dm
+++ b/code/game/objects/items/weapons/storage/deferred.dm
@@ -24,7 +24,11 @@
 	icon_state = "box"
 	item_state = "syringe_kit"
 
-/obj/item/weapon/storage/deferred/proc/spawn_contents()
+/obj/item/weapon/storage/deferred/populate_contents()
+	// Do not create contents if they are already spawned, or if prompted to by Initialize call
+	if(!initialized || contents_spawned)
+		return
+
 	contents_spawned = TRUE
 	for (var/a in initial_contents)
 		var/quantity = 1
@@ -35,21 +39,17 @@
 			new a(src)
 	expand_to_fit()
 
-/obj/item/weapon/storage/deferred/open(var/mob/user)
-	if (!contents_spawned)
-		spawn_contents()
-	.=..()
+/obj/item/weapon/storage/deferred/open(mob/user)
+	populate_contents()
+	. = ..()
 
-/obj/item/weapon/storage/deferred/show_to(var/mob/user)
-	if (!contents_spawned)
-		spawn_contents()
-	.=..()
+/obj/item/weapon/storage/deferred/show_to(mob/user)
+	populate_contents()
+	. = ..()
 
-
-/obj/item/weapon/storage/deferred/can_be_inserted(obj/item/W as obj, stop_messages = 0)
-	if (!contents_spawned)
-		spawn_contents()
-	.=..()
+/obj/item/weapon/storage/deferred/can_be_inserted(obj/item/W, stop_messages = 0)
+	populate_contents()
+	. = ..()
 
 
 /obj/item/weapon/storage/deferred/rations

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -53,11 +53,9 @@
 		/obj/item/weapon/reagent_containers/food/snacks/boiledegg
 		)
 
-/obj/item/weapon/storage/fancy/egg_box/New()
-	..()
-	for(var/i=1; i <= storage_slots; i++)
+/obj/item/weapon/storage/fancy/egg_box/populate_contents()
+	for(var/i in 1 to storage_slots)
 		new /obj/item/weapon/reagent_containers/food/snacks/egg(src)
-	return
 
 /*
  * Candle Box
@@ -74,11 +72,9 @@
 	slot_flags = SLOT_BELT
 
 
-/obj/item/weapon/storage/fancy/candle_box/New()
-	..()
-	for(var/i=1; i <= 5; i++)
+/obj/item/weapon/storage/fancy/candle_box/populate_contents()
+	for(var/i in 1 to 5)
 		new /obj/item/weapon/flame/candle(src)
-	return
 
 /*
  * Crayon Box
@@ -95,8 +91,7 @@
 		/obj/item/weapon/pen/crayon
 	)
 
-/obj/item/weapon/storage/fancy/crayons/New()
-	..()
+/obj/item/weapon/storage/fancy/crayons/populate_contents()
 	new /obj/item/weapon/pen/crayon/red(src)
 	new /obj/item/weapon/pen/crayon/orange(src)
 	new /obj/item/weapon/pen/crayon/yellow(src)
@@ -139,9 +134,8 @@
 	icon_type = "cigarette"
 	reagent_flags = REFILLABLE | NO_REACT
 
-/obj/item/weapon/storage/fancy/cigarettes/New()
-	..()
-	for(var/i = 1 to storage_slots)
+/obj/item/weapon/storage/fancy/cigarettes/populate_contents()
+	for(var/i in 1 to storage_slots)
 		new /obj/item/clothing/mask/smokable/cigarette(src)
 	create_reagents(15 * storage_slots)//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
 
@@ -184,9 +178,9 @@
 	icon_state = "Bpacket"
 	item_state = "Bpacket" //Doesn't have an inhand state, but neither does dromedary, so, ya know..
 
-	New()
-		..()
-		fill_cigarre_package(src,list("fuel" = 15))
+/obj/item/weapon/storage/fancy/cigarettes/killthroat/Initialize()
+	. = ..()
+	fill_cigarre_package(src, list("fuel" = 15))
 
 /obj/item/weapon/storage/fancy/cigar
 	name = "cigar case"
@@ -202,16 +196,14 @@
 	icon_type = "cigar"
 	reagent_flags = REFILLABLE | NO_REACT
 
-/obj/item/weapon/storage/fancy/cigar/New()
-	..()
-	for(var/i = 1 to storage_slots)
+/obj/item/weapon/storage/fancy/cigar/populate_contents()
+	for(var/i in 1 to storage_slots)
 		new /obj/item/clothing/mask/smokable/cigarette/cigar(src)
 	create_reagents(15 * storage_slots)
 	update_icon()
 
 /obj/item/weapon/storage/fancy/cigar/update_icon()
 	icon_state = "[initial(icon_state)][contents.len]"
-	return
 
 /obj/item/weapon/storage/fancy/cigar/remove_from_storage(obj/item/W as obj, atom/new_location)
 		var/obj/item/clothing/mask/smokable/cigarette/cigar/C = W
@@ -232,11 +224,9 @@
 	can_hold = list(/obj/item/weapon/reagent_containers/glass/beaker/vial)
 
 
-/obj/item/weapon/storage/fancy/vials/New()
-	..()
-	for(var/i=1; i <= storage_slots; i++)
+/obj/item/weapon/storage/fancy/vials/populate_contents()
+	for(var/i in 1 to storage_slots)
 		new /obj/item/weapon/reagent_containers/glass/beaker/vial(src)
-	return
 
 /obj/item/weapon/storage/lockbox/vials
 	name = "secure vial storage box"
@@ -250,8 +240,8 @@
 	storage_slots = 6
 	req_access = list(access_virology)
 
-/obj/item/weapon/storage/lockbox/vials/New()
-	..()
+/obj/item/weapon/storage/lockbox/vials/Initialize()
+	. = ..()
 	update_icon()
 
 /obj/item/weapon/storage/lockbox/vials/update_icon(var/itemremoved = 0)

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -22,36 +22,32 @@
 	icon_state = "ointment"
 	item_state = "firstaid-ointment"
 
-	New()
-		..()
-		if (empty) return
+/obj/item/weapon/storage/firstaid/fire/populate_contents()
+	icon_state = pick("ointment","firefirstaid")
 
-		icon_state = pick("ointment","firefirstaid")
-
-		new /obj/item/device/scanner/health( src )
-		new /obj/item/weapon/reagent_containers/hypospray/autoinjector( src )
-		new /obj/item/stack/medical/ointment( src )
-		new /obj/item/stack/medical/ointment( src )
-		new /obj/item/weapon/reagent_containers/pill/kelotane( src )
-		new /obj/item/weapon/reagent_containers/pill/kelotane( src )
-		new /obj/item/weapon/reagent_containers/pill/kelotane( src ) //Replaced ointment with these since they actually work --Errorage
-		return
+	if (empty) return
+	new /obj/item/stack/medical/ointment(src)
+	new /obj/item/stack/medical/ointment(src)
+	new /obj/item/weapon/reagent_containers/pill/kelotane(src)
+	new /obj/item/weapon/reagent_containers/pill/kelotane(src)
+	new /obj/item/weapon/reagent_containers/pill/kelotane(src) //Replaced ointment with these since they actually work --Errorage
+	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
+	new /obj/item/device/scanner/health(src)
 
 
 /obj/item/weapon/storage/firstaid/regular
 	icon_state = "firstaid"
 
-	New()
-		..()
-		if (empty) return
-		new /obj/item/stack/medical/bruise_pack(src)
-		new /obj/item/stack/medical/bruise_pack(src)
-		new /obj/item/stack/medical/bruise_pack(src)
-		new /obj/item/stack/medical/ointment(src)
-		new /obj/item/stack/medical/ointment(src)
-		new /obj/item/device/scanner/health(src)
-		new /obj/item/weapon/reagent_containers/hypospray/autoinjector( src )
-		return
+/obj/item/weapon/storage/firstaid/regular/populate_contents()
+	if (empty) return
+	new /obj/item/stack/medical/bruise_pack(src)
+	new /obj/item/stack/medical/bruise_pack(src)
+	new /obj/item/stack/medical/bruise_pack(src)
+	new /obj/item/stack/medical/ointment(src)
+	new /obj/item/stack/medical/ointment(src)
+	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
+	new /obj/item/device/scanner/health(src)
+
 
 /obj/item/weapon/storage/firstaid/toxin
 	name = "toxin first aid"
@@ -59,20 +55,19 @@
 	icon_state = "antitoxin"
 	item_state = "firstaid-toxin"
 
-	New()
-		..()
-		if (empty) return
+/obj/item/weapon/storage/firstaid/toxin/populate_contents()
+	icon_state = pick("antitoxin","antitoxfirstaid","antitoxfirstaid2","antitoxfirstaid3")
 
-		icon_state = pick("antitoxin","antitoxfirstaid","antitoxfirstaid2","antitoxfirstaid3")
+	if (empty) return
+	new /obj/item/weapon/reagent_containers/syringe/antitoxin(src)
+	new /obj/item/weapon/reagent_containers/syringe/antitoxin(src)
+	new /obj/item/weapon/reagent_containers/syringe/antitoxin(src)
+	new /obj/item/weapon/reagent_containers/pill/antitox(src)
+	new /obj/item/weapon/reagent_containers/pill/antitox(src)
+	new /obj/item/weapon/reagent_containers/pill/antitox(src)
+	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
+	new /obj/item/device/scanner/health(src)
 
-		new /obj/item/weapon/reagent_containers/syringe/antitoxin( src )
-		new /obj/item/weapon/reagent_containers/syringe/antitoxin( src )
-		new /obj/item/weapon/reagent_containers/syringe/antitoxin( src )
-		new /obj/item/weapon/reagent_containers/pill/antitox( src )
-		new /obj/item/weapon/reagent_containers/pill/antitox( src )
-		new /obj/item/weapon/reagent_containers/pill/antitox( src )
-		new /obj/item/device/scanner/health( src )
-		return
 
 /obj/item/weapon/storage/firstaid/o2
 	name = "oxygen deprivation first aid"
@@ -80,17 +75,16 @@
 	icon_state = "o2"
 	item_state = "firstaid-o2"
 
-	New()
-		..()
-		if (empty) return
-		new /obj/item/weapon/reagent_containers/pill/dexalin( src )
-		new /obj/item/weapon/reagent_containers/pill/dexalin( src )
-		new /obj/item/weapon/reagent_containers/pill/dexalin( src )
-		new /obj/item/weapon/reagent_containers/pill/dexalin( src )
-		new /obj/item/weapon/reagent_containers/hypospray/autoinjector( src )
-		new /obj/item/weapon/reagent_containers/syringe/inaprovaline( src )
-		new /obj/item/device/scanner/health( src )
-		return
+/obj/item/weapon/storage/firstaid/o2/populate_contents()
+	if (empty) return
+	new /obj/item/weapon/reagent_containers/pill/dexalin(src)
+	new /obj/item/weapon/reagent_containers/pill/dexalin(src)
+	new /obj/item/weapon/reagent_containers/pill/dexalin(src)
+	new /obj/item/weapon/reagent_containers/pill/dexalin(src)
+	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
+	new /obj/item/weapon/reagent_containers/syringe/inaprovaline(src)
+	new /obj/item/device/scanner/health(src)
+
 
 /obj/item/weapon/storage/firstaid/adv
 	name = "advanced first-aid kit"
@@ -98,17 +92,16 @@
 	icon_state = "advfirstaid"
 	item_state = "firstaid-advanced"
 
-/obj/item/weapon/storage/firstaid/adv/New()
-	..()
+/obj/item/weapon/storage/firstaid/adv/populate_contents()
 	if (empty) return
-	new /obj/item/weapon/reagent_containers/hypospray/autoinjector( src )
 	new /obj/item/stack/medical/advanced/bruise_pack(src)
 	new /obj/item/stack/medical/advanced/bruise_pack(src)
 	new /obj/item/stack/medical/advanced/bruise_pack(src)
 	new /obj/item/stack/medical/advanced/ointment(src)
 	new /obj/item/stack/medical/advanced/ointment(src)
 	new /obj/item/stack/medical/splint(src)
-	return
+	new /obj/item/weapon/reagent_containers/syringe/inaprovaline(src)
+	new /obj/item/device/scanner/health(src)
 
 /obj/item/weapon/storage/firstaid/combat
 	name = "combat medical kit"
@@ -116,8 +109,7 @@
 	icon_state = "bezerk"
 	item_state = "firstaid-advanced"
 
-/obj/item/weapon/storage/firstaid/combat/New()
-	..()
+/obj/item/weapon/storage/firstaid/combat/populate_contents()
 	if (empty) return
 	new /obj/item/weapon/storage/pill_bottle/bicaridine(src)
 	new /obj/item/weapon/storage/pill_bottle/dermaline(src)
@@ -126,7 +118,6 @@
 	new /obj/item/weapon/storage/pill_bottle/tramadol(src)
 	new /obj/item/weapon/storage/pill_bottle/spaceacillin(src)
 	new /obj/item/stack/medical/splint(src)
-	return
 
 /obj/item/weapon/storage/firstaid/surgery
 	name = "surgery kit"
@@ -141,11 +132,12 @@
 		/obj/item/weapon/tool/retractor,
 		/obj/item/weapon/tool/scalpel,
 		/obj/item/weapon/tool/surgicaldrill,
-		/obj/item/stack/medical/advanced/bruise_pack
+		/obj/item/device/scanner,
+		/obj/item/weapon/storage/pill_bottle,
+		/obj/item/stack/medical,
 		)
 
-/obj/item/weapon/storage/firstaid/surgery/New()
-	..()
+/obj/item/weapon/storage/firstaid/surgery/populate_contents()
 	if (empty) return
 	new /obj/item/weapon/tool/bonesetter(src)
 	new /obj/item/weapon/tool/cautery(src)
@@ -155,7 +147,6 @@
 	new /obj/item/weapon/tool/scalpel(src)
 	new /obj/item/weapon/tool/surgicaldrill(src)
 	new /obj/item/stack/medical/advanced/bruise_pack(src)
-
 	make_exact_fit()
 
 /*
@@ -182,22 +173,20 @@
 	name = "bottle of Dylovene pills"
 	desc = "Contains pills used to counter toxins."
 
-	New()
-		..()
-		new /obj/item/weapon/reagent_containers/pill/antitox( src )
-		new /obj/item/weapon/reagent_containers/pill/antitox( src )
-		new /obj/item/weapon/reagent_containers/pill/antitox( src )
-		new /obj/item/weapon/reagent_containers/pill/antitox( src )
-		new /obj/item/weapon/reagent_containers/pill/antitox( src )
-		new /obj/item/weapon/reagent_containers/pill/antitox( src )
-		new /obj/item/weapon/reagent_containers/pill/antitox( src )
+/obj/item/weapon/storage/pill_bottle/antitox/populate_contents()
+	new /obj/item/weapon/reagent_containers/pill/antitox(src)
+	new /obj/item/weapon/reagent_containers/pill/antitox(src)
+	new /obj/item/weapon/reagent_containers/pill/antitox(src)
+	new /obj/item/weapon/reagent_containers/pill/antitox(src)
+	new /obj/item/weapon/reagent_containers/pill/antitox(src)
+	new /obj/item/weapon/reagent_containers/pill/antitox(src)
+	new /obj/item/weapon/reagent_containers/pill/antitox(src)
 
 /obj/item/weapon/storage/pill_bottle/bicaridine
 	name = "bottle of Bicaridine pills"
 	desc = "Contains pills used to stabilize the severely injured."
 
-/obj/item/weapon/storage/pill_bottle/bicaridine/New()
-    ..()
+/obj/item/weapon/storage/pill_bottle/bicaridine/populate_contents()
     new /obj/item/weapon/reagent_containers/pill/bicaridine(src)
     new /obj/item/weapon/reagent_containers/pill/bicaridine(src)
     new /obj/item/weapon/reagent_containers/pill/bicaridine(src)
@@ -210,8 +199,7 @@
 	name = "bottle of Dexalin Plus pills"
 	desc = "Contains pills used to treat extreme cases of oxygen deprivation."
 
-/obj/item/weapon/storage/pill_bottle/dexalin_plus/New()
-    ..()
+/obj/item/weapon/storage/pill_bottle/dexalin_plus/populate_contents()
     new /obj/item/weapon/reagent_containers/pill/dexalin_plus(src)
     new /obj/item/weapon/reagent_containers/pill/dexalin_plus(src)
     new /obj/item/weapon/reagent_containers/pill/dexalin_plus(src)
@@ -224,8 +212,7 @@
 	name = "bottle of Dermaline pills"
 	desc = "Contains pills used to treat burn wounds."
 
-/obj/item/weapon/storage/pill_bottle/dermaline/New()
-    ..()
+/obj/item/weapon/storage/pill_bottle/dermaline/populate_contents()
     new /obj/item/weapon/reagent_containers/pill/dermaline(src)
     new /obj/item/weapon/reagent_containers/pill/dermaline(src)
     new /obj/item/weapon/reagent_containers/pill/dermaline(src)
@@ -238,8 +225,7 @@
 	name = "bottle of Dylovene pills"
 	desc = "Contains pills used to treat toxic substances in the blood."
 
-/obj/item/weapon/storage/pill_bottle/dylovene/New()
-    ..()
+/obj/item/weapon/storage/pill_bottle/dylovene/populate_contents()
     new /obj/item/weapon/reagent_containers/pill/dylovene(src)
     new /obj/item/weapon/reagent_containers/pill/dylovene(src)
     new /obj/item/weapon/reagent_containers/pill/dylovene(src)
@@ -252,36 +238,33 @@
 	name = "bottle of Inaprovaline pills"
 	desc = "Contains pills used to stabilize patients."
 
-	New()
-		..()
-		new /obj/item/weapon/reagent_containers/pill/inaprovaline( src )
-		new /obj/item/weapon/reagent_containers/pill/inaprovaline( src )
-		new /obj/item/weapon/reagent_containers/pill/inaprovaline( src )
-		new /obj/item/weapon/reagent_containers/pill/inaprovaline( src )
-		new /obj/item/weapon/reagent_containers/pill/inaprovaline( src )
-		new /obj/item/weapon/reagent_containers/pill/inaprovaline( src )
-		new /obj/item/weapon/reagent_containers/pill/inaprovaline( src )
+/obj/item/weapon/storage/pill_bottle/inaprovaline/populate_contents()
+	new /obj/item/weapon/reagent_containers/pill/inaprovaline(src)
+	new /obj/item/weapon/reagent_containers/pill/inaprovaline(src)
+	new /obj/item/weapon/reagent_containers/pill/inaprovaline(src)
+	new /obj/item/weapon/reagent_containers/pill/inaprovaline(src)
+	new /obj/item/weapon/reagent_containers/pill/inaprovaline(src)
+	new /obj/item/weapon/reagent_containers/pill/inaprovaline(src)
+	new /obj/item/weapon/reagent_containers/pill/inaprovaline(src)
 
 /obj/item/weapon/storage/pill_bottle/kelotane
-	name = "bottle of kelotane pills"
+	name = "bottle of Kelotane pills"
 	desc = "Contains pills used to treat burns."
 
-	New()
-		..()
-		new /obj/item/weapon/reagent_containers/pill/kelotane( src )
-		new /obj/item/weapon/reagent_containers/pill/kelotane( src )
-		new /obj/item/weapon/reagent_containers/pill/kelotane( src )
-		new /obj/item/weapon/reagent_containers/pill/kelotane( src )
-		new /obj/item/weapon/reagent_containers/pill/kelotane( src )
-		new /obj/item/weapon/reagent_containers/pill/kelotane( src )
-		new /obj/item/weapon/reagent_containers/pill/kelotane( src )
+/obj/item/weapon/storage/pill_bottle/kelotane/populate_contents()
+	new /obj/item/weapon/reagent_containers/pill/kelotane(src)
+	new /obj/item/weapon/reagent_containers/pill/kelotane(src)
+	new /obj/item/weapon/reagent_containers/pill/kelotane(src)
+	new /obj/item/weapon/reagent_containers/pill/kelotane(src)
+	new /obj/item/weapon/reagent_containers/pill/kelotane(src)
+	new /obj/item/weapon/reagent_containers/pill/kelotane(src)
+	new /obj/item/weapon/reagent_containers/pill/kelotane(src)
 
 /obj/item/weapon/storage/pill_bottle/spaceacillin
 	name = "bottle of Spaceacillin pills"
 	desc = "A theta-lactam antibiotic. Effective against many diseases likely to be encountered in space."
 
-/obj/item/weapon/storage/pill_bottle/spaceacillin/New()
-    ..()
+/obj/item/weapon/storage/pill_bottle/spaceacillin/populate_contents()
     new /obj/item/weapon/reagent_containers/pill/spaceacillin(src)
     new /obj/item/weapon/reagent_containers/pill/spaceacillin(src)
     new /obj/item/weapon/reagent_containers/pill/spaceacillin(src)
@@ -294,26 +277,24 @@
 	name = "bottle of Tramadol pills"
 	desc = "Contains pills used to relieve pain."
 
-	New()
-		..()
-		new /obj/item/weapon/reagent_containers/pill/tramadol( src )
-		new /obj/item/weapon/reagent_containers/pill/tramadol( src )
-		new /obj/item/weapon/reagent_containers/pill/tramadol( src )
-		new /obj/item/weapon/reagent_containers/pill/tramadol( src )
-		new /obj/item/weapon/reagent_containers/pill/tramadol( src )
-		new /obj/item/weapon/reagent_containers/pill/tramadol( src )
-		new /obj/item/weapon/reagent_containers/pill/tramadol( src )
+/obj/item/weapon/storage/pill_bottle/tramadol/populate_contents()
+	new /obj/item/weapon/reagent_containers/pill/tramadol(src)
+	new /obj/item/weapon/reagent_containers/pill/tramadol(src)
+	new /obj/item/weapon/reagent_containers/pill/tramadol(src)
+	new /obj/item/weapon/reagent_containers/pill/tramadol(src)
+	new /obj/item/weapon/reagent_containers/pill/tramadol(src)
+	new /obj/item/weapon/reagent_containers/pill/tramadol(src)
+	new /obj/item/weapon/reagent_containers/pill/tramadol(src)
 
 /obj/item/weapon/storage/pill_bottle/citalopram
 	name = "bottle of Citalopram pills"
 	desc = "Contains pills used to stabilize a patient's mood."
 
-	New()
-		..()
-		new /obj/item/weapon/reagent_containers/pill/citalopram( src )
-		new /obj/item/weapon/reagent_containers/pill/citalopram( src )
-		new /obj/item/weapon/reagent_containers/pill/citalopram( src )
-		new /obj/item/weapon/reagent_containers/pill/citalopram( src )
-		new /obj/item/weapon/reagent_containers/pill/citalopram( src )
-		new /obj/item/weapon/reagent_containers/pill/citalopram( src )
-		new /obj/item/weapon/reagent_containers/pill/citalopram( src )
+/obj/item/weapon/storage/pill_bottle/citalopram/populate_contents()
+	new /obj/item/weapon/reagent_containers/pill/citalopram(src)
+	new /obj/item/weapon/reagent_containers/pill/citalopram(src)
+	new /obj/item/weapon/reagent_containers/pill/citalopram(src)
+	new /obj/item/weapon/reagent_containers/pill/citalopram(src)
+	new /obj/item/weapon/reagent_containers/pill/citalopram(src)
+	new /obj/item/weapon/reagent_containers/pill/citalopram(src)
+	new /obj/item/weapon/reagent_containers/pill/citalopram(src)

--- a/code/game/objects/items/weapons/storage/misc.dm
+++ b/code/game/objects/items/weapons/storage/misc.dm
@@ -2,10 +2,9 @@
 	name = "pack of dice"
 	desc = "It's a small container with dice inside."
 
-	New()
-		..()
-		new /obj/item/weapon/dice( src )
-		new /obj/item/weapon/dice/d20( src )
+/obj/item/weapon/storage/pill_bottle/dice/populate_contents()
+	new /obj/item/weapon/dice(src)
+	new /obj/item/weapon/dice/d20(src)
 
 /*
  * Donut Box
@@ -20,12 +19,10 @@
 	can_hold = list(/obj/item/weapon/reagent_containers/food/snacks/donut)
 	foldable = /obj/item/stack/material/cardboard
 
-/obj/item/weapon/storage/box/donut/New()
-	..()
-	for(var/i=1; i <= startswith; i++)
+/obj/item/weapon/storage/box/donut/populate_contents()
+	for(var/i in 1 to 6)
 		new /obj/item/weapon/reagent_containers/food/snacks/donut/normal(src)
 	update_icon()
-	return
 
 /obj/item/weapon/storage/box/donut/update_icon()
 	overlays.Cut()

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -181,14 +181,9 @@
 	density = FALSE
 	cant_hold = list(/obj/item/weapon/storage/secure/briefcase)
 
-/obj/item/weapon/storage/secure/safe/New()
-	..()
+/obj/item/weapon/storage/secure/safe/populate_contents()
 	new /obj/item/weapon/paper(src)
 	new /obj/item/weapon/pen(src)
 
-/obj/item/weapon/storage/secure/safe/attack_hand(mob/user as mob)
+/obj/item/weapon/storage/secure/safe/attack_hand(mob/user)
 	return attack_self(user)
-
-/obj/item/weapon/storage/secure/safe/HoS/New()
-	..()
-	//new /obj/item/weapon/storage/lockbox/clusterbang(src) This item is currently broken... and probably shouldnt exist to begin with (even though it's cool)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -505,8 +505,8 @@
 	for(var/obj/item/I in contents)
 		remove_from_storage(I, target)
 
-/obj/item/weapon/storage/New()
-	..()
+/obj/item/weapon/storage/Initialize(mapload, ...)
+	. = ..()
 	if(allow_quick_empty)
 		verbs += /obj/item/weapon/storage/verb/quick_empty
 	else
@@ -519,12 +519,17 @@
 
 	if(isnull(max_storage_space) && !isnull(storage_slots))
 		max_storage_space = storage_slots*BASE_STORAGE_COST(max_w_class)
-	
-	spawn(5)
-		var/total_storage_space = 0
-		for(var/obj/item/I in contents)
-			total_storage_space += I.get_storage_cost()
-		max_storage_space = max(total_storage_space,max_storage_space) //prevents spawned containers from being too small for their contents
+
+	populate_contents()
+
+	var/total_storage_space = 0
+	for(var/obj/item/I in contents)
+		total_storage_space += I.get_storage_cost()
+	max_storage_space = max(total_storage_space, max_storage_space) //prevents spawned containers from being too small for their contents
+
+// Override in subtypes
+/obj/item/weapon/storage/proc/populate_contents()
+	return
 
 /obj/item/weapon/storage/emp_act(severity)
 	if(!isliving(loc))

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -21,52 +21,54 @@
 	icon_state = "red"
 	item_state = "toolbox_red"
 
-	New()
-		..()
-		new /obj/item/weapon/tool/crowbar(src)
-		new /obj/item/weapon/extinguisher/mini(src)
-		if(prob(50))
-			new /obj/item/device/lighting/toggleable/flashlight(src)
-		else
-			new /obj/item/device/lighting/glowstick/flare(src)
-		if (prob(40))
-			new /obj/item/weapon/tool/tape_roll(src)
-		new /obj/item/device/radio(src)
+/obj/item/weapon/storage/toolbox/emergency/populate_contents()
+	new /obj/item/weapon/tool/crowbar(src)
+	new /obj/item/weapon/extinguisher/mini(src)
+	if(prob(50))
+		new /obj/item/device/lighting/toggleable/flashlight(src)
+	else
+		new /obj/item/device/lighting/glowstick/flare(src)
+	if (prob(40))
+		new /obj/item/weapon/tool/tape_roll(src)
+	new /obj/item/device/radio(src)
 
 /obj/item/weapon/storage/toolbox/mechanical
 	name = "mechanical toolbox"
 	icon_state = "blue"
 	item_state = "toolbox_blue"
 
-	New()
-		..()
-		new /obj/item/weapon/tool/screwdriver(src)
-		new /obj/item/weapon/tool/wrench(src)
-		new /obj/item/weapon/tool/weldingtool(src)
-		new /obj/item/weapon/tool/crowbar(src)
-		new /obj/item/device/scanner/gas(src)
-		new /obj/item/weapon/tool/wirecutters(src)
+/obj/item/weapon/storage/toolbox/mechanical/populate_contents()
+	new /obj/item/weapon/tool/screwdriver(src)
+	new /obj/item/weapon/tool/wrench(src)
+	new /obj/item/weapon/tool/weldingtool(src)
+	new /obj/item/weapon/tool/crowbar(src)
+	new /obj/item/device/scanner/gas(src)
+	new /obj/item/weapon/tool/wirecutters(src)
 
 /obj/item/weapon/storage/toolbox/electrical
 	name = "electrical toolbox"
 	icon_state = "yellow"
 	item_state = "toolbox_yellow"
 
-	New()
-		..()
-		var/color = pick("red","yellow","green","blue","pink","orange","cyan","white")
-		new /obj/item/weapon/tool/screwdriver(src)
-		new /obj/item/weapon/tool/wirecutters(src)
-		new /obj/item/device/t_scanner(src)
-		new /obj/item/weapon/tool/crowbar(src)
+/obj/item/weapon/storage/toolbox/electrical/populate_contents()
+	var/color = pick("red","yellow","green","blue","pink","orange","cyan","white")
+
+	new /obj/item/weapon/tool/screwdriver(src)
+	new /obj/item/weapon/tool/wirecutters(src)
+	new /obj/item/device/t_scanner(src)
+	new /obj/item/weapon/tool/crowbar(src)
+	new /obj/item/stack/cable_coil(src,30,color)
+	new /obj/item/stack/cable_coil(src,30,color)
+
+	if(prob(5))
+		new /obj/item/clothing/gloves/insulated(src)
+	else if(prob(10))
+		new /obj/item/weapon/tool/multitool(src)
+	else
 		new /obj/item/stack/cable_coil(src,30,color)
-		new /obj/item/stack/cable_coil(src,30,color)
-		if (prob(60))
-			new /obj/item/weapon/tool/tape_roll(src)
-		if(prob(5))
-			new /obj/item/clothing/gloves/insulated(src)
-		else
-			new /obj/item/stack/cable_coil(src,30,color)
+
+	if(prob(60))
+		new /obj/item/weapon/tool/tape_roll(src)
 
 /obj/item/weapon/storage/toolbox/syndicate
 	name = "suspicious looking toolbox"
@@ -75,12 +77,22 @@
 	origin_tech = list(TECH_COMBAT = 1, TECH_ILLEGAL = 1)
 	force = WEAPON_FORCE_DANGEROUS
 
-	New()
-		..()
-		new /obj/item/clothing/gloves/insulated(src)
-		new /obj/item/weapon/tool/screwdriver/combi_driver(src)
-		new /obj/item/weapon/tool/wrench/big_wrench(src)
-		new /obj/item/weapon/tool/weldingtool/advanced(src)
-		new /obj/item/weapon/tool/crowbar/pneumatic(src)
-		new /obj/item/weapon/tool/wirecutters/armature(src)
-		new /obj/item/weapon/tool/multitool(src)
+/obj/item/weapon/storage/toolbox/syndicate/populate_contents()
+	var/obj/item/weapon/tool/cell_tool
+
+	new /obj/item/clothing/gloves/insulated(src)
+
+	cell_tool = new /obj/item/weapon/tool/screwdriver/combi_driver(src)
+	qdel(cell_tool.cell)
+	cell_tool.cell = new /obj/item/weapon/cell/small/super(cell_tool)
+
+	cell_tool = new /obj/item/weapon/tool/crowbar/pneumatic(src)
+	qdel(cell_tool.cell)
+	cell_tool.cell = new /obj/item/weapon/cell/medium/super(cell_tool)
+
+	new /obj/item/weapon/tool/weldingtool/advanced(src)
+	new /obj/item/weapon/tool/wirecutters/armature(src)
+	new /obj/item/weapon/tool/multitool(src)
+	new /obj/item/weapon/cell/medium/super(src)
+	new /obj/item/weapon/cell/small/super(src)
+

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -1,75 +1,73 @@
-/obj/item/weapon/storage/box/syndicate/
-	New()
-		..()
-		switch (pickweight(list("bloodyspai" = 1, "stealth" = 1, "screwed" = 1, "guns" = 1, "murder" = 1, "freedom" = 1, "hacker" = 1, "lordsingulo" = 1, "smoothoperator" = 1)))
-			if("bloodyspai")
-				new /obj/item/clothing/under/chameleon(src)
-				new /obj/item/clothing/mask/gas/voice(src)
-				new /obj/item/weapon/card/id/syndicate(src)
-				new /obj/item/clothing/shoes/syndigaloshes(src)
-				return
+/obj/item/weapon/storage/box/syndicate/populate_contents()
+	switch (pickweight(list("bloodyspai" = 1, "stealth" = 1, "screwed" = 1, "guns" = 1, "murder" = 1, "freedom" = 1, "hacker" = 1, "lordsingulo" = 1, "smoothoperator" = 1)))
+		if("bloodyspai")
+			new /obj/item/clothing/under/chameleon(src)
+			new /obj/item/clothing/mask/gas/voice(src)
+			new /obj/item/weapon/card/id/syndicate(src)
+			new /obj/item/clothing/shoes/syndigaloshes(src)
+			return
 
-			if("stealth")
-				new /obj/item/weapon/gun/energy/crossbow(src)
-				new /obj/item/weapon/pen/reagent/paralysis(src)
-				new /obj/item/device/chameleon(src)
-				return
+		if("stealth")
+			new /obj/item/weapon/gun/energy/crossbow(src)
+			new /obj/item/weapon/pen/reagent/paralysis(src)
+			new /obj/item/device/chameleon(src)
+			return
 
-			if("screwed")
-				new /obj/effect/spawner/newbomb/timer/syndicate(src)
-				new /obj/effect/spawner/newbomb/timer/syndicate(src)
-				new /obj/item/device/powersink(src)
-				new /obj/item/clothing/suit/space/syndicate(src)
-				new /obj/item/clothing/head/helmet/space/syndicate(src)
-				new /obj/item/clothing/mask/gas/syndicate(src)
-				new /obj/item/weapon/tank/emergency_oxygen/double(src)
-				return
+		if("screwed")
+			new /obj/effect/spawner/newbomb/timer/syndicate(src)
+			new /obj/effect/spawner/newbomb/timer/syndicate(src)
+			new /obj/item/device/powersink(src)
+			new /obj/item/clothing/suit/space/syndicate(src)
+			new /obj/item/clothing/head/helmet/space/syndicate(src)
+			new /obj/item/clothing/mask/gas/syndicate(src)
+			new /obj/item/weapon/tank/emergency_oxygen/double(src)
+			return
 
-			if("guns")
-				new /obj/item/weapon/gun/projectile/revolver(src)
-				new /obj/item/ammo_magazine/slmagnum(src)
-				new /obj/item/weapon/card/emag(src)
-				new /obj/item/weapon/plastique(src)
-				new /obj/item/weapon/plastique(src)
-				return
+		if("guns")
+			new /obj/item/weapon/gun/projectile/revolver(src)
+			new /obj/item/ammo_magazine/slmagnum(src)
+			new /obj/item/weapon/card/emag(src)
+			new /obj/item/weapon/plastique(src)
+			new /obj/item/weapon/plastique(src)
+			return
 
-			if("murder")
-				new /obj/item/weapon/melee/energy/sword(src)
-				new /obj/item/clothing/glasses/powered/thermal/syndi(src)
-				new /obj/item/weapon/card/emag(src)
-				new /obj/item/clothing/shoes/syndigaloshes(src)
-				return
+		if("murder")
+			new /obj/item/weapon/melee/energy/sword(src)
+			new /obj/item/clothing/glasses/powered/thermal/syndi(src)
+			new /obj/item/weapon/card/emag(src)
+			new /obj/item/clothing/shoes/syndigaloshes(src)
+			return
 
-			if("freedom")
-				var/obj/item/weapon/implanter/O = new /obj/item/weapon/implanter(src)
-				O.implant = new /obj/item/weapon/implant/freedom(O)
-				var/obj/item/weapon/implanter/U = new /obj/item/weapon/implanter(src)
-				U.implant = new /obj/item/weapon/implant/uplink(U)
-				return
+		if("freedom")
+			var/obj/item/weapon/implanter/O = new /obj/item/weapon/implanter(src)
+			O.implant = new /obj/item/weapon/implant/freedom(O)
+			var/obj/item/weapon/implanter/U = new /obj/item/weapon/implanter(src)
+			U.implant = new /obj/item/weapon/implant/uplink(U)
+			return
 
-			if("hacker")
-				new /obj/item/device/encryptionkey/syndicate(src)
-				new /obj/item/weapon/aiModule/syndicate(src)
-				new /obj/item/weapon/card/emag(src)
-				new /obj/item/device/encryptionkey/binary(src)
-				return
+		if("hacker")
+			new /obj/item/device/encryptionkey/syndicate(src)
+			new /obj/item/weapon/aiModule/syndicate(src)
+			new /obj/item/weapon/card/emag(src)
+			new /obj/item/device/encryptionkey/binary(src)
+			return
 
 /*			if("lordsingulo")
-				new /obj/item/device/radio/beacon/syndicate(src)
-				new /obj/item/clothing/suit/space/syndicate(src)
-				new /obj/item/clothing/head/helmet/space/syndicate(src)
-				new /obj/item/clothing/mask/gas/syndicate(src)
-				new /obj/item/weapon/tank/emergency_oxygen/double(src)
-				new /obj/item/weapon/card/emag(src)
-				return
+			new /obj/item/device/radio/beacon/syndicate(src)
+			new /obj/item/clothing/suit/space/syndicate(src)
+			new /obj/item/clothing/head/helmet/space/syndicate(src)
+			new /obj/item/clothing/mask/gas/syndicate(src)
+			new /obj/item/weapon/tank/emergency_oxygen/double(src)
+			new /obj/item/weapon/card/emag(src)
+			return
 */
-			if("smoothoperator")
-				new /obj/item/weapon/storage/box/syndie_kit/pistol(src)
-				new /obj/item/weapon/storage/bag/trash(src)
-				new /obj/item/weapon/soap/syndie(src)
-				new /obj/item/bodybag(src)
-				new /obj/item/clothing/shoes/reinforced(src)
-				return
+		if("smoothoperator")
+			new /obj/item/weapon/storage/box/syndie_kit/pistol(src)
+			new /obj/item/weapon/storage/bag/trash(src)
+			new /obj/item/weapon/soap/syndie(src)
+			new /obj/item/bodybag(src)
+			new /obj/item/clothing/shoes/reinforced(src)
+			return
 
 /obj/item/weapon/storage/box/syndie_kit
 	name = "box"
@@ -80,50 +78,44 @@
 	name = "boxed freedom implant (with injector)"
 	desc = "A box with freedom implant inside. Install it in your hand or leg, chose emote. You can remove instantly handcuffs or legcuffs with your emotion. Have a small amount of uses."
 
-/obj/item/weapon/storage/box/syndie_kit/imp_freedom/New()
+/obj/item/weapon/storage/box/syndie_kit/imp_freedom/populate_contents()
 	new /obj/item/weapon/implanter/freedom(src)
-	..()
 
 /obj/item/weapon/storage/box/syndie_kit/imp_compress
 	name = "box (C)"
 	desc = "A box with compressed implanter inside. Choose an item with this implant, install it inside you and choose emote to activate it. Take your chosen item whenever you want by your chosen emotion. One use."
 
-/obj/item/weapon/storage/box/syndie_kit/imp_compress/New()
+/obj/item/weapon/storage/box/syndie_kit/imp_compress/populate_contents()
 	new /obj/item/weapon/implanter/compressed(src)
-	..()
 
 /obj/item/weapon/storage/box/syndie_kit/imp_explosive
 	name = "box (E)"
 	desc = "A box with explosive implant inside. When you use it on yours enemy, you can choose three ways to use it: destroy limb, destroy your enemy or make a small explosion. Activation by phrase you choose too. One use."
 
-/obj/item/weapon/storage/box/syndie_kit/imp_explosive/New()
+/obj/item/weapon/storage/box/syndie_kit/imp_explosive/populate_contents()
 	new /obj/item/weapon/implanter/explosive(src)
-	..()
 
 /obj/item/weapon/storage/box/syndie_kit/imp_spying
 	name = "box (S)"
 
-/obj/item/weapon/storage/box/syndie_kit/imp_spying/New()
+/obj/item/weapon/storage/box/syndie_kit/imp_spying/populate_contents()
 	new /obj/item/weapon/implanter/spying(src)
-	..()
 
 /obj/item/weapon/storage/box/syndie_kit/imp_uplink
 	name = "boxed uplink implant (with injector)"
 	desc = "Uplink inside your head."
 
-/obj/item/weapon/storage/box/syndie_kit/imp_uplink/New()
+/obj/item/weapon/storage/box/syndie_kit/imp_uplink/populate_contents()
 	//Turn off passive gain for boxed implant uplinks. To prevent exploits of gathering tons of free TC
 	var/obj/item/weapon/implanter/uplink/U1 = new /obj/item/weapon/implanter/uplink(src)
 	var/obj/item/weapon/implant/uplink/U2 = locate(/obj/item/weapon/implant/uplink) in U1
 	var/obj/item/device/uplink/hidden/U3 = locate(/obj/item/device/uplink/hidden) in U2
 	U3.passive_gain = 0
-	..()
 
 /obj/item/weapon/storage/box/syndie_kit/space
 	name = "boxed space suit and helmet"
 
-/obj/item/weapon/storage/box/syndie_kit/space/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/space/populate_contents()
 	new /obj/item/clothing/suit/space/syndicate(src)
 	new /obj/item/clothing/head/helmet/space/syndicate(src)
 	new /obj/item/clothing/mask/gas/syndicate(src)
@@ -133,8 +125,7 @@
 	name = "chameleon kit"
 	desc = "Comes with all the clothes you need to impersonate most people.  Acting lessons sold seperately."
 
-/obj/item/weapon/storage/box/syndie_kit/chameleon/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/chameleon/populate_contents()
 	new /obj/item/clothing/under/chameleon(src)
 	new /obj/item/clothing/head/chameleon(src)
 	new /obj/item/clothing/suit/chameleon(src)
@@ -149,8 +140,7 @@
 	name = "clerical kit"
 	desc = "Comes with all you need to fake paperwork. Assumes you have passed basic writing lessons."
 
-/obj/item/weapon/storage/box/syndie_kit/clerical/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/clerical/populate_contents()
 	new /obj/item/weapon/stamp/chameleon(src)
 	new /obj/item/weapon/pen/chameleon(src)
 	new /obj/item/device/destTagger(src)
@@ -161,8 +151,7 @@
 	name = "spy kit"
 	desc = "For when you want to conduct voyeurism from afar."
 
-/obj/item/weapon/storage/box/syndie_kit/spy/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/spy/populate_contents()
 	new /obj/item/device/spy_bug(src)
 	new /obj/item/device/spy_bug(src)
 	new /obj/item/device/spy_bug(src)
@@ -178,8 +167,7 @@
 	name  = "dartgun kit"
 	desc = "Just like a mosquito bite."
 
-/obj/item/weapon/storage/box/syndie_kit/dartgun/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/dartgun/populate_contents()
 	new /obj/item/weapon/gun/projectile/dartgun(src)
 	new /obj/item/ammo_magazine/chemdart(src)
 
@@ -188,8 +176,7 @@
 	name = "\improper Smooth operator"
 	desc = ".35 Auto with silencer kit."
 
-/obj/item/weapon/storage/box/syndie_kit/pistol/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/pistol/populate_contents()
 	new /obj/item/weapon/gun/projectile/clarissa(src)
 	new /obj/item/weapon/silencer(src)
 	new /obj/item/ammo_magazine/hpistol(src)
@@ -198,8 +185,7 @@
 	name = "C-20r box"
 	desc = "C-20r kit"
 
-/obj/item/weapon/storage/box/syndie_kit/c20r/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/c20r/populate_contents()
 	new /obj/item/weapon/gun/projectile/automatic/c20r(src)
 	new /obj/item/ammo_magazine/smg(src)
 
@@ -207,8 +193,7 @@
 	name = "Revolver box"
 	desc = "Revolver kit"
 
-/obj/item/weapon/storage/box/syndie_kit/revolver/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/revolver/populate_contents()
 	new /obj/item/weapon/gun/projectile/revolver(src)
 	new /obj/item/ammo_magazine/slmagnum(src)
 
@@ -218,8 +203,7 @@
 	icon_state = "box_of_doom_big"
 	w_class = ITEM_SIZE_HUGE
 
-/obj/item/weapon/storage/box/syndie_kit/sts35/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/sts35/populate_contents()
 	new /obj/item/weapon/gun/projectile/automatic/sts35(src)
 	new /obj/item/ammo_magazine/lrifle_short(src)
 
@@ -229,8 +213,7 @@
 	icon_state = "box_of_doom_big"
 	w_class = ITEM_SIZE_HUGE
 
-/obj/item/weapon/storage/box/syndie_kit/pug/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/pug/populate_contents()
 	new /obj/item/weapon/gun/projectile/shotgun/pug(src)
 	new /obj/item/ammo_magazine/m12/pellet(src)
 
@@ -240,8 +223,7 @@
 	icon_state = "box_of_doom_big"
 	w_class = ITEM_SIZE_HUGE
 
-/obj/item/weapon/storage/box/syndie_kit/antimaterial_rifle/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/antimaterial_rifle/populate_contents()
 	new /obj/item/ammo_casing/antim(src)
 	new /obj/item/weapon/weaponparts/heavysniper/disassembled(src)
 	new /obj/item/weapon/weaponparts/heavysniper/stock(src)
@@ -251,8 +233,7 @@
 	name = "toxin kit"
 	desc = "An apple will not be enough to keep the doctor away after this."
 
-/obj/item/weapon/storage/box/syndie_kit/toxin/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/toxin/populate_contents()
 	new /obj/item/weapon/reagent_containers/glass/beaker/vial/random/toxin(src)
 	new /obj/item/weapon/reagent_containers/syringe(src)
 
@@ -260,8 +241,7 @@
 	name = "\improper Tricky smokes"
 	desc = "Comes with the following brands of cigarettes, in this order: 2xFlash, 2xSmoke, 1xMindBreaker, 1xTricordrazine. Avoid mixing them up."
 
-/obj/item/weapon/storage/box/syndie_kit/cigarette/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/cigarette/populate_contents()
 	var/obj/item/weapon/storage/fancy/cigarettes/pack
 	pack = new /obj/item/weapon/storage/fancy/cigarettes(src)
 	fill_cigarre_package(pack, list("aluminum" = 5, "potassium" = 5, "sulfur" = 5))
@@ -301,16 +281,14 @@
 	name = "Electrowarfare and Voice Synthesiser kit"
 	desc = "Kit for confounding organic and synthetic entities alike."
 
-/obj/item/weapon/storage/box/syndie_kit/ewar_voice/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/ewar_voice/populate_contents()
 	new /obj/item/rig_module/electrowarfare_suite(src)
 	new /obj/item/rig_module/voice(src)
 
 /obj/item/weapon/storage/box/syndie_kit/spy_sensor
 	name = "sensor kit"
 
-/obj/item/weapon/storage/box/syndie_kit/spy_sensor/New()
-	..()
+/obj/item/weapon/storage/box/syndie_kit/spy_sensor/populate_contents()
 	new /obj/item/device/spy_sensor(src)
 	new /obj/item/device/spy_sensor(src)
 	new /obj/item/device/spy_sensor(src)
@@ -319,13 +297,9 @@
 
 /obj/item/weapon/storage/secure/briefcase/money
 	name = "suspicious briefcase"
-	desc = "An ominous briefcase that has the unmistakeable smell of old, stale, cigarette smoke, and gives those who look at it a bad feeling."
+	desc = "An ominous briefcase that has the unmistakeable smell of old, stale cigarette smoke, and gives those who look at it a bad feeling."
 
-
-
-
-/obj/item/weapon/storage/secure/briefcase/money/New()
-	..()
+/obj/item/weapon/storage/secure/briefcase/money/populate_contents()
 	new /obj/item/weapon/spacecash/bundle/c1000(src)
 	new /obj/item/weapon/spacecash/bundle/c1000(src)
 	new /obj/item/weapon/spacecash/bundle/c1000(src)
@@ -336,5 +310,3 @@
 	new /obj/item/weapon/spacecash/bundle/c1000(src)
 	new /obj/item/weapon/spacecash/bundle/c1000(src)
 	new /obj/item/weapon/spacecash/bundle/c1000(src)
-
-

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -73,18 +73,16 @@
 	else
 		return ..()
 
-/obj/item/weapon/storage/wallet/random/New()
-	..()
-	var/item1_type = pick( /obj/item/weapon/spacecash/bundle/c10,/obj/item/weapon/spacecash/bundle/c100,/obj/item/weapon/spacecash/bundle/c1000,/obj/item/weapon/spacecash/bundle/c20,/obj/item/weapon/spacecash/bundle/c200,/obj/item/weapon/spacecash/bundle/c50, /obj/item/weapon/spacecash/bundle/c500)
+/obj/item/weapon/storage/wallet/random/populate_contents()
+	var/item1_type = pick(/obj/item/weapon/spacecash/bundle/c10,/obj/item/weapon/spacecash/bundle/c100,/obj/item/weapon/spacecash/bundle/c1000,/obj/item/weapon/spacecash/bundle/c20,/obj/item/weapon/spacecash/bundle/c200,/obj/item/weapon/spacecash/bundle/c50,/obj/item/weapon/spacecash/bundle/c500)
 	var/item2_type
 	if(prob(50))
-		item2_type = pick( /obj/item/weapon/spacecash/bundle/c10,/obj/item/weapon/spacecash/bundle/c100,/obj/item/weapon/spacecash/bundle/c1000,/obj/item/weapon/spacecash/bundle/c20,/obj/item/weapon/spacecash/bundle/c200,/obj/item/weapon/spacecash/bundle/c50, /obj/item/weapon/spacecash/bundle/c500)
-	var/item3_type = pick( /obj/item/weapon/coin/silver, /obj/item/weapon/coin/silver, /obj/item/weapon/coin/gold, /obj/item/weapon/coin/iron, /obj/item/weapon/coin/iron, /obj/item/weapon/coin/iron )
+		item2_type = pick(/obj/item/weapon/spacecash/bundle/c10,/obj/item/weapon/spacecash/bundle/c100,/obj/item/weapon/spacecash/bundle/c1000,/obj/item/weapon/spacecash/bundle/c20,/obj/item/weapon/spacecash/bundle/c200,/obj/item/weapon/spacecash/bundle/c50,/obj/item/weapon/spacecash/bundle/c500)
+	var/item3_type = pick(/obj/item/weapon/coin/silver, /obj/item/weapon/coin/silver, /obj/item/weapon/coin/gold, /obj/item/weapon/coin/iron, /obj/item/weapon/coin/iron, /obj/item/weapon/coin/iron)
 
-	spawn(2)
-		if(item1_type)
-			new item1_type(src)
-		if(item2_type)
-			new item2_type(src)
-		if(item3_type)
-			new item3_type(src)
+	if(item1_type)
+		new item1_type(src)
+	if(item2_type)
+		new item2_type(src)
+	if(item3_type)
+		new item3_type(src)

--- a/code/modules/admin/bluespacetech.dm
+++ b/code/modules/admin/bluespacetech.dm
@@ -305,8 +305,7 @@ ADMIN_VERB_ADD(/client/proc/cmd_dev_bst, R_ADMIN|R_DEBUG, TRUE)
 
 /obj/item/weapon/storage/belt/utility/full/bst
 
-/obj/item/weapon/storage/belt/utility/full/bst/New()
-	..()
+/obj/item/weapon/storage/belt/utility/full/bst/populate_contents()
 	new /obj/item/weapon/tool/multitool(src)
 	new /obj/item/device/t_scanner(src)
 

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -185,8 +185,8 @@
 	origin_tech = list(TECH_ILLEGAL = 3)
 	var/global/list/clothing_choices
 
-/obj/item/weapon/storage/backpack/chameleon/New()
-	..()
+/obj/item/weapon/storage/backpack/chameleon/Initialize()
+	. = ..()
 	if(!clothing_choices)
 		var/blocked = list(src.type, /obj/item/weapon/storage/backpack/satchel/leather/withwallet)
 		clothing_choices = generate_chameleon_choices(/obj/item/weapon/storage/backpack, blocked)

--- a/code/modules/detectivework/tools/crimekit.dm
+++ b/code/modules/detectivework/tools/crimekit.dm
@@ -8,8 +8,7 @@
 	storage_slots = 14
 	price_tag = 50
 
-/obj/item/weapon/storage/briefcase/crimekit/New()
-	..()
+/obj/item/weapon/storage/briefcase/crimekit/populate_contents()
 	new /obj/item/weapon/storage/box/swabs(src)
 	new /obj/item/weapon/storage/box/fingerprints(src)
 	new /obj/item/weapon/reagent_containers/spray/luminol(src)

--- a/code/modules/detectivework/tools/storage.dm
+++ b/code/modules/detectivework/tools/storage.dm
@@ -6,9 +6,8 @@
 	can_hold = list(/obj/item/weapon/forensics/swab)
 	storage_slots = 14
 
-/obj/item/weapon/storage/box/swabs/New()
-	..()
-	for(var/i=0;i<storage_slots,i++) // Fill 'er up.
+/obj/item/weapon/storage/box/swabs/populate_contents()
+	for(var/i in 1 to storage_slots) // Fill 'er up.
 		new /obj/item/weapon/forensics/swab(src)
 
 /obj/item/weapon/storage/box/evidence
@@ -16,9 +15,8 @@
 	desc = "A box claiming to contain evidence bags."
 	can_hold = list(/obj/item/weapon/evidencebag)
 
-/obj/item/weapon/storage/box/evidence/New()
-	..()
-	for(var/i = 1 to 7)
+/obj/item/weapon/storage/box/evidence/populate_contents()
+	for(var/i in 1 to 7)
 		new /obj/item/weapon/evidencebag(src)
 
 /obj/item/weapon/storage/box/fingerprints
@@ -29,7 +27,6 @@
 	can_hold = list(/obj/item/weapon/sample/print)
 	storage_slots = 14
 
-/obj/item/weapon/storage/box/fingerprints/New()
-	..()
-	for(var/i=0;i<storage_slots,i++)
+/obj/item/weapon/storage/box/fingerprints/populate_contents()
+	for(var/i in 1 to storage_slots)
 		new /obj/item/weapon/sample/print(src)

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -25,9 +25,8 @@
 	name = "flora disk box"
 	desc = "A box of flora data disks, apparently."
 
-/obj/item/weapon/storage/box/botanydisk/New()
-	..()
-	for(var/i = 0;i<7;i++)
+/obj/item/weapon/storage/box/botanydisk/populate_contents()
+	for(var/i in 1 to 7)
 		new /obj/item/weapon/disk/botany(src)
 
 /obj/machinery/botany

--- a/code/modules/integrated/integrated_electronics/core/tools.dm
+++ b/code/modules/integrated/integrated_electronics/core/tools.dm
@@ -183,13 +183,8 @@
 		/obj/item/weapon/tool/screwdriver
 		)
 
-/obj/item/weapon/storage/bag/circuits/basic/New()
-	..()
+/obj/item/weapon/storage/bag/circuits/basic/populate_contents()
 	spawn(2 SECONDS) // So the list has time to initialize.
-//		for(var/obj/item/integrated_circuit/IC in all_integrated_circuits)
-//			if(IC.spawn_flags & IC_SPAWN_DEFAULT)
-//				for(var/i = 1 to 3)
-//					new IC.type(src)
 		new /obj/item/weapon/storage/bag/circuits/mini/arithmetic(src)
 		new /obj/item/weapon/storage/bag/circuits/mini/trig(src)
 		new /obj/item/weapon/storage/bag/circuits/mini/input(src)
@@ -209,8 +204,7 @@
 		new /obj/item/weapon/tool/screwdriver(src)
 		make_exact_fit()
 
-/obj/item/weapon/storage/bag/circuits/all/New()
-	..()
+/obj/item/weapon/storage/bag/circuits/all/populate_contents()
 	spawn(2 SECONDS) // So the list has time to initialize.
 		new /obj/item/weapon/storage/bag/circuits/mini/arithmetic/all(src)
 		new /obj/item/weapon/storage/bag/circuits/mini/trig/all(src)
@@ -252,8 +246,7 @@
 /obj/item/weapon/storage/bag/circuits/mini/arithmetic/all // Don't believe this will ever be needed.
 	spawn_flags_to_use = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/weapon/storage/bag/circuits/mini/arithmetic/New()
-	..()
+/obj/item/weapon/storage/bag/circuits/mini/arithmetic/populate_contents()
 	for(var/obj/item/integrated_circuit/arithmetic/IC in all_integrated_circuits)
 		if(IC.spawn_flags & spawn_flags_to_use)
 			for(var/i = 1 to 3)
@@ -269,8 +262,7 @@
 /obj/item/weapon/storage/bag/circuits/mini/trig/all // Ditto
 	spawn_flags_to_use = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/weapon/storage/bag/circuits/mini/trig/New()
-	..()
+/obj/item/weapon/storage/bag/circuits/mini/trig/populate_contents()
 	for(var/obj/item/integrated_circuit/trig/IC in all_integrated_circuits)
 		if(IC.spawn_flags & spawn_flags_to_use)
 			for(var/i = 1 to 3)
@@ -286,8 +278,7 @@
 /obj/item/weapon/storage/bag/circuits/mini/input/all
 	spawn_flags_to_use = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/weapon/storage/bag/circuits/mini/input/New()
-	..()
+/obj/item/weapon/storage/bag/circuits/mini/input/populate_contents()
 	for(var/obj/item/integrated_circuit/input/IC in all_integrated_circuits)
 		if(IC.spawn_flags & spawn_flags_to_use)
 			for(var/i = 1 to 3)
@@ -303,8 +294,7 @@
 /obj/item/weapon/storage/bag/circuits/mini/output/all
 	spawn_flags_to_use = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/weapon/storage/bag/circuits/mini/output/New()
-	..()
+/obj/item/weapon/storage/bag/circuits/mini/output/populate_contents()
 	for(var/obj/item/integrated_circuit/output/IC in all_integrated_circuits)
 		if(IC.spawn_flags & spawn_flags_to_use)
 			for(var/i = 1 to 3)
@@ -320,8 +310,7 @@
 /obj/item/weapon/storage/bag/circuits/mini/memory/all
 	spawn_flags_to_use = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/weapon/storage/bag/circuits/mini/memory/New()
-	..()
+/obj/item/weapon/storage/bag/circuits/mini/memory/populate_contents()
 	for(var/obj/item/integrated_circuit/memory/IC in all_integrated_circuits)
 		if(IC.spawn_flags & spawn_flags_to_use)
 			for(var/i = 1 to 3)
@@ -337,8 +326,7 @@
 /obj/item/weapon/storage/bag/circuits/mini/logic/all
 	spawn_flags_to_use = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/weapon/storage/bag/circuits/mini/logic/New()
-	..()
+/obj/item/weapon/storage/bag/circuits/mini/logic/populate_contents()
 	for(var/obj/item/integrated_circuit/logic/IC in all_integrated_circuits)
 		if(IC.spawn_flags & spawn_flags_to_use)
 			for(var/i = 1 to 3)
@@ -354,8 +342,7 @@
 /obj/item/weapon/storage/bag/circuits/mini/time/all
 	spawn_flags_to_use = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/weapon/storage/bag/circuits/mini/time/New()
-	..()
+/obj/item/weapon/storage/bag/circuits/mini/time/populate_contents()
 	for(var/obj/item/integrated_circuit/time/IC in all_integrated_circuits)
 		if(IC.spawn_flags & spawn_flags_to_use)
 			for(var/i = 1 to 3)
@@ -371,8 +358,7 @@
 /obj/item/weapon/storage/bag/circuits/mini/reagents/all
 	spawn_flags_to_use = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/weapon/storage/bag/circuits/mini/reagents/New()
-	..()
+/obj/item/weapon/storage/bag/circuits/mini/reagents/populate_contents()
 	for(var/obj/item/integrated_circuit/reagent/IC in all_integrated_circuits)
 		if(IC.spawn_flags & spawn_flags_to_use)
 			for(var/i = 1 to 3)
@@ -388,8 +374,7 @@
 /obj/item/weapon/storage/bag/circuits/mini/transfer/all
 	spawn_flags_to_use = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/weapon/storage/bag/circuits/mini/transfer/New()
-	..()
+/obj/item/weapon/storage/bag/circuits/mini/transfer/populate_contents()
 	for(var/obj/item/integrated_circuit/transfer/IC in all_integrated_circuits)
 		if(IC.spawn_flags & spawn_flags_to_use)
 			for(var/i = 1 to 3)
@@ -405,8 +390,7 @@
 /obj/item/weapon/storage/bag/circuits/mini/converter/all
 	spawn_flags_to_use = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/weapon/storage/bag/circuits/mini/converter/New()
-	..()
+/obj/item/weapon/storage/bag/circuits/mini/converter/populate_contents()
 	for(var/obj/item/integrated_circuit/converter/IC in all_integrated_circuits)
 		if(IC.spawn_flags & spawn_flags_to_use)
 			for(var/i = 1 to 3)
@@ -421,8 +405,7 @@
 /obj/item/weapon/storage/bag/circuits/mini/smart/all
 	spawn_flags_to_use = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/weapon/storage/bag/circuits/mini/smart/New()
-	..()
+/obj/item/weapon/storage/bag/circuits/mini/smart/populate_contents()
 	for(var/obj/item/integrated_circuit/smart/IC in all_integrated_circuits)
 		if(IC.spawn_flags & spawn_flags_to_use)
 			for(var/i = 1 to 3)
@@ -437,8 +420,7 @@
 /obj/item/weapon/storage/bag/circuits/mini/manipulation/all
 	spawn_flags_to_use = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/weapon/storage/bag/circuits/mini/manipulation/New()
-	..()
+/obj/item/weapon/storage/bag/circuits/mini/manipulation/populate_contents()
 	for(var/obj/item/integrated_circuit/manipulation/IC in all_integrated_circuits)
 		if(IC.spawn_flags & spawn_flags_to_use)
 			for(var/i = 1 to 3)
@@ -454,8 +436,7 @@
 /obj/item/weapon/storage/bag/circuits/mini/power/all
 	spawn_flags_to_use = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/weapon/storage/bag/circuits/mini/power/New()
-	..()
+/obj/item/weapon/storage/bag/circuits/mini/power/populate_contents()
 	for(var/obj/item/integrated_circuit/passive/power/IC in all_integrated_circuits)
 		if(IC.spawn_flags & spawn_flags_to_use)
 			for(var/i = 1 to 3)

--- a/code/modules/modular_computers/computers/subtypes/preset_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_pda.dm
@@ -127,9 +127,7 @@
 	icon = 'icons/obj/pda.dmi'
 	icon_state = "pdabox"
 
-/obj/item/weapon/storage/box/PDAs/Initialize()
-	. = ..()
-
+/obj/item/weapon/storage/box/PDAs/populate_contents()
 	new /obj/item/modular_computer/pda(src)
 	new /obj/item/modular_computer/pda(src)
 	new /obj/item/modular_computer/pda(src)

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -18,12 +18,14 @@
 	var/maxamount = 15
 	var/reload_delay = 0
 
-/obj/item/ammo_casing/New()
-	..()
+/obj/item/ammo_casing/Initialize()
+	. = ..()
 	if(ispath(projectile_type))
 		BB = new projectile_type(src)
 	pixel_x = rand(-10, 10)
 	pixel_y = rand(-10, 10)
+	if(amount > 1)
+		update_icon()
 
 //removes the projectile from the ammo casing
 /obj/item/ammo_casing/proc/expend()

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -3,8 +3,7 @@
 	desc = "This box contains blood packs."
 	icon_state = "sterile"
 
-/obj/item/weapon/storage/box/bloodpacks/Initialize()
-	. = ..()
+/obj/item/weapon/storage/box/bloodpacks/populate_contents()
 	new /obj/item/weapon/reagent_containers/blood(src)
 	new /obj/item/weapon/reagent_containers/blood(src)
 	new /obj/item/weapon/reagent_containers/blood(src)

--- a/code/modules/research/xenoarchaeology/chemistry.dm
+++ b/code/modules/research/xenoarchaeology/chemistry.dm
@@ -17,8 +17,7 @@
 	name = "solution tray box"
 	icon_state = "solution_trays"
 
-/obj/item/weapon/storage/box/solution_trays/Initialize()
-	. = ..()
+/obj/item/weapon/storage/box/solution_trays/populate_contents()
 	new /obj/item/weapon/reagent_containers/glass/solution_tray(src)
 	new /obj/item/weapon/reagent_containers/glass/solution_tray(src)
 	new /obj/item/weapon/reagent_containers/glass/solution_tray(src)


### PR DESCRIPTION
Storage containers now use `populate_contents()` instead of having to override `New()` or `Initialize()` - same as lockers and crates.

The only gameplay change in this PR is that I made tools in "suspicious toolbox" spawn with better power cell and some spare power cells too. The default cells there were seriously insufficient.