### PR TITLE
Adds zip ties

### DIFF
--- a/code/datums/autolathe/security.dm
+++ b/code/datums/autolathe/security.dm
@@ -6,6 +6,10 @@
 	name = "handcuffs"
 	build_path = /obj/item/weapon/handcuffs
 
+/datum/design/autolathe/sec/zipties
+	name = "zip ties"
+	build_path = /obj/item/weapon/handcuffs/zipties
+
 /datum/design/autolathe/sec/electropack
 	name = "electropack"
 	build_path = /obj/item/device/radio/electropack

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1139,6 +1139,7 @@
 	icon_deny = "sec-deny"
 	req_access = list(access_security)
 	products = list(/obj/item/weapon/handcuffs = 8,
+					/obj/item/weapon/handcuffs/zipties = 8,
 					/obj/item/weapon/grenade/flashbang = 8,
 					/obj/item/weapon/grenade/chem_grenade/teargas = 8,
 					/obj/item/device/flash = 8,

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -296,6 +296,7 @@
 		/datum/design/autolathe/sec/secflashlight,
 		/datum/design/research/item/flash,
 		/datum/design/autolathe/sec/handcuffs,
+		/datum/design/autolathe/sec/zipties,
 		/datum/design/autolathe/misc/taperecorder,
 		/datum/design/autolathe/tool/tacknife,
 		/datum/design/autolathe/sec/beartrap,

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -118,6 +118,16 @@ var/last_chew = 0
 
 	last_chew = world.time
 
+/obj/item/weapon/handcuffs/zipties
+	name = "zip ties"
+	desc = "Plastic, disposable zipties that can be used to restrain someone."
+	icon_state = "cuff_white"
+	matter = list(MATERIAL_PLASTIC = 2)
+	breakouttime = 700 //Deciseconds = 70s, this is higher than usual ss13 because breakout time is subtracted by 1 second for every robustness stat
+	cuff_sound = 'sound/weapons/cablecuff.ogg'
+	cuff_type = "zip ties"
+	elastic = 1
+
 /obj/item/weapon/handcuffs/cable
 	name = "cable restraints"
 	desc = "Looks like some cables tied together. Could be used to tie something up."

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -132,6 +132,11 @@
 		breakouttime = HC.breakouttime - src.stats.getStat(STAT_ROB) * 10
 		displaytime = round(breakouttime / 600) //Minutes
 
+	var/mob/living/carbon/human/H = src
+	if(istype(H) && H.gloves && istype(H.gloves,/obj/item/clothing/gloves/rig))
+		breakouttime /= 2
+		displaytime /= 2
+
 	visible_message(
 		SPAN_DANGER("\The [src] attempts to remove \the [HC]!"),
 		SPAN_WARNING("You attempt to remove \the [HC]. (This will take around [displaytime] minutes and you need to stand still)")

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -132,11 +132,6 @@
 		breakouttime = HC.breakouttime - src.stats.getStat(STAT_ROB) * 10
 		displaytime = round(breakouttime / 600) //Minutes
 
-	var/mob/living/carbon/human/H = src
-	if(istype(H) && H.gloves && istype(H.gloves,/obj/item/clothing/gloves/rig))
-		breakouttime /= 2
-		displaytime /= 2
-
 	visible_message(
 		SPAN_DANGER("\The [src] attempts to remove \the [HC]!"),
 		SPAN_WARNING("You attempt to remove \the [HC]. (This will take around [displaytime] minutes and you need to stand still)")

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -21155,6 +21155,9 @@
 /area/eris/maintenance/section1deck4central)
 "aWV" = (
 /obj/structure/table/reinforced,
+/obj/item/stack/material/plastic{
+	amount = 120
+	},
 /obj/item/stack/material/steel{
 	amount = 120
 	},


### PR DESCRIPTION
## Details
<details>
  <summary>Expand</summary>

Currently people wearing RIGs are very hard to take down non-lethally because:
1. They cannot be cuffed with normal handcuffs(an operative has to find cable coils and make cable cuffs with them)
2. RIGs reduce breakout time by half
3. Cable cuffs can be broken out of instantly if the RIG wearer has 30+ robustness stat(they have a 30 second breakout time and each point in robustness reduces breakouts by one second)
4. RIGs can only be removed by forcing someone onto a table(surgery or not) and forcing them to lay down and then welding it off

This is an issue because if someone wearing a rig needs to be arrested, there is a very possible chance that you just cant arrest them and have to kill them on the spot(even if you just wanted to search them to prove they did a crime or etc). To remedy this I:
1. Added zipties which can cuff people wearing RIGs to the sec vendor and IH misc disk along with a stack of plastic sheets so that you can print them.
2. The zipties also have a breakout time of 70 seconds so that you would literally have to have 70 robustness to break out instantly.
3. I also removed the ability for RIGs to reduce breakout time by half because if someone brought a special kind of gear to arrest you they shouldn't be punished for doing so, also because it was a snowflake check in resist code which really shouldn't go there.

I don't address issue 4 because that seemed out of the scope of handcuffs.
</details>

## RFC
<details>
  <summary>Expand</summary>
Should I buff cable cuffs to have a breakout time of 70 seconds also so that they aren't garbage against people with the robustness stat? Would it be better to force a minimum breakout time instead?
</details>