### PR TITLE
Inspector locker ammo fix

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -175,9 +175,9 @@
 	new /obj/item/device/taperecorder(src)
 	new /obj/item/weapon/gun/projectile/revolver/consul(src)
 	new /obj/item/clothing/accessory/holster/armpit(src)
-	new /obj/item/ammo_magazine/magnum/rubber(src)
-	new /obj/item/ammo_magazine/magnum/rubber(src)
-	new /obj/item/ammo_magazine/magnum/rubber(src)
+	new /obj/item/ammo_magazine/slmagnum/rubber(src)
+	new /obj/item/ammo_magazine/slmagnum/rubber(src)
+	new /obj/item/ammo_magazine/slmagnum/rubber(src)
 	new /obj/item/weapon/storage/pouch/pistol_holster(src)
 
 /obj/structure/closet/secure_closet/injection


### PR DESCRIPTION
## About The Pull Request
The inspector locker had magazines for the Lamia in it by mistake, it now has speed loaders for the Consol (inspector's revolver) in it instead.