### PR TITLE
Stops low damage bullets from doing blood splats

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -555,7 +555,7 @@
 	if(isliving(target_mob))
 		var/turf/target_loca = get_turf(target_mob)
 		var/mob/living/L = target_mob
-		if(damage && damage_type == BRUTE)
+		if(damage > 15 && damage_type == BRUTE)
 			var/splatter_dir = dir
 			if(starting)
 				splatter_dir = get_dir(starting, target_loca)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -555,7 +555,7 @@
 	if(isliving(target_mob))
 		var/turf/target_loca = get_turf(target_mob)
 		var/mob/living/L = target_mob
-		if(damage > 15 && damage_type == BRUTE)
+		if(damage > 10 && damage_type == BRUTE)
 			var/splatter_dir = dir
 			if(starting)
 				splatter_dir = get_dir(starting, target_loca)


### PR DESCRIPTION
## About The Pull Request
Bullets that deal less than or equal to 10 damage will no longer make the big blood splatter effect that comes out when you get shot by a bullet. This really only means that if you get hit by a rubber bullet you will no longer shoot out blood. This is also to help people tell if someone is using rubber bullets or not in an intuitive way.