### PR TITLE
Silicons and Roombas no longer bleed

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -552,7 +552,7 @@
 	if (result == PROJECTILE_CONTINUE)
 		return FALSE
 
-	if(isliving(target_mob))
+	if(target_mob.mob_classification & CLASSIFICATION_ORGANIC)
 		var/turf/target_loca = get_turf(target_mob)
 		var/mob/living/L = target_mob
 		if(damage && damage_type == BRUTE)


### PR DESCRIPTION
## About The Pull Request
Stops the blood splatter effect from being shot happening to Silicons, Roombas, Bots, Hivebots, etc.
