### PR TITLE
Adds Mech Clamps to Rnd, As well as a new NT disk that holds their circuit to Chaplin locker

### DIFF
--- a/code/datums/autolathe/circuits.dm
+++ b/code/datums/autolathe/circuits.dm
@@ -20,10 +20,6 @@
 	name = "custom Vendomat"
 	build_path = /obj/item/weapon/circuitboard/vending
 
-/datum/design/autolathe/circuit/autolathe_excelsior
-	name = "excelsior autolathe"
-	build_path = /obj/item/weapon/circuitboard/excelsiorautolathe
-
 /datum/design/autolathe/circuit/autolathe_disk_cloner
 	name = "autolathe disk cloner"
 	build_path = /obj/item/weapon/circuitboard/autolathe_disk_cloner
@@ -40,6 +36,19 @@
 	name = "navigation console"
 	build_path = /obj/item/weapon/circuitboard/nav
 
+/datum/design/autolathe/circuit/centrifuge
+	name = "centrifuge"
+	build_path = /obj/item/weapon/circuitboard/centrifuge
+
+/datum/design/autolathe/circuit/electrolyzer
+	name = "electrolyzer"
+	build_path = /obj/item/weapon/circuitboard/electrolyzer
+
+/datum/design/autolathe/circuit/reagentgrinder
+	name = "reagent grinder"
+	build_path = /obj/item/weapon/circuitboard/reagentgrinder
+
+//Exelsior ciruits
 /datum/design/autolathe/circuit/shieldgen_excelsior
 	name = "excelsior shield wall generator"
 	build_path = /obj/item/weapon/circuitboard/excelsiorshieldwallgen
@@ -60,17 +69,66 @@
 	name = "excelsior turret"
 	build_path = /obj/item/weapon/circuitboard/excelsior_turret
 
-/datum/design/autolathe/circuit/centrifuge
-	name = "centrifuge"
-	build_path = /obj/item/weapon/circuitboard/centrifuge
+/datum/design/autolathe/circuit/autolathe_excelsior
+	name = "excelsior autolathe"
+	build_path = /obj/item/weapon/circuitboard/excelsiorautolathe
 
-/datum/design/autolathe/circuit/electrolyzer
-	name = "electrolyzer"
-	build_path = /obj/item/weapon/circuitboard/electrolyzer
+//NT Circuits
 
-/datum/design/autolathe/circuit/reagentgrinder
-	name = "reagent grinder"
-	build_path = /obj/item/weapon/circuitboard/reagentgrinder
+/datum/design/autolathe/circuit/bioprinter
+	name = "NeoTeology Biomatter Printer"
+	build_path = /obj/item/weapon/circuitboard/neotheology/bioprinter
 
+/datum/design/autolathe/circuit/solidifier
+	name = "NeoTeology Biomatter Solidifier"
+	build_path = /obj/item/weapon/circuitboard/neotheology/solidifier
 
+/datum/design/autolathe/circuit/cloner
+	name = "NeoTeology Cloner, Pod"
+	build_path = /obj/item/weapon/circuitboard/neotheology/cloner
+
+/datum/design/autolathe/circuit/reader
+	name = "NeoTeology Cloner, Cruciform Reader"
+	build_path = /obj/item/weapon/circuitboard/neotheology/reader
+
+/datum/design/autolathe/circuit/biocan
+	name = "NeoTeology Cloner, Biomass container"
+	build_path = /obj/item/weapon/circuitboard/neotheology/biocan
+
+/datum/design/autolathe/circuit/biogen
+	name = "NeoTeology Biomatter Generator, Power Generator"
+	build_path = bj/item/weapon/circuitboard/neotheology/biogen
+
+/datum/design/autolathe/circuit/biogen_console
+	name = "NeoTeology Biomatter Generator, Power Generator Console"
+	build_path = /obj/item/weapon/circuitboard/neotheology/biogen_console
+
+/datum/design/autolathe/circuit/biogen_port
+	name = "NeoTeology Biomatter Generator, Power Generator Port"
+	build_path = /obj/item/weapon/circuitboard/neotheology/biogen_port
+
+/datum/design/autolathe/circuit/bioreactor_loader
+	name = "NeoTeology Biomatter Reactor, Loader"
+	build_path = /obj/item/weapon/circuitboard/neotheology/bioreactor_loader
+
+/datum/design/autolathe/circuit/bioreactor_metrics
+	name = "NeoTeology Biomatter Reactor, Metrics"
+	build_path = /obj/item/weapon/circuitboard/neotheology/bioreactor_metrics
+
+/datum/design/autolathe/circuit/bioreactor_port
+	name = "NeoTeology Biomatter Reactor, Port"
+	build_path = /obj/item/weapon/circuitboard/neotheology/bioreactor_port
+
+/datum/design/autolathe/circuit/bioreactor_biotank
+	name = "NeoTeology Biomatter Reactor, Biomatter Tank"
+	build_path = /obj/item/weapon/circuitboard/neotheology/bioreactor_biotank
+
+/datum/design/autolathe/circuit/bioreactor_unloader
+	name = "NeoTeology Biomatter Reactor, Unloader"
+	build_path = /obj/item/weapon/circuitboard/neotheology/bioreactor_unloader
+
+/datum/design/autolathe/circuit/bioreactor_platform
+	name = "NeoTeology Biomatter Reactor, Platform"
+	build_path = /obj/item/weapon/circuitboard/neotheology/bioreactor_platform
+	
 

--- a/code/datums/autolathe/circuits.dm
+++ b/code/datums/autolathe/circuits.dm
@@ -97,7 +97,7 @@
 
 /datum/design/autolathe/circuit/biogen
 	name = "NeoTeology Biomatter Generator, Power Generator"
-	build_path = bj/item/weapon/circuitboard/neotheology/biogen
+	build_path = /obj/item/weapon/circuitboard/neotheology/biogen
 
 /datum/design/autolathe/circuit/biogen_console
 	name = "NeoTeology Biomatter Generator, Power Generator Console"

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -285,6 +285,88 @@
 		/datum/design/autolathe/gun/ionrifle,
 	)
 
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/nt_bioprinter
+	disk_name = "NeoTeology Bioprinter Production"
+	icon_state = "neotheology"
+
+	license = -1
+	designs = list(
+		/datum/design/bioprinter/meat,
+		/datum/design/bioprinter/milk,
+		/datum/design/bioprinter/soap,
+
+		/datum/design/bioprinter/ez,
+		/datum/design/bioprinter/l4z,
+		/datum/design/bioprinter/rh,
+
+		/datum/design/bioprinter/wallet,
+		/datum/design/bioprinter/botanic_leather,
+		/datum/design/bioprinter/leather/satchel,
+		/datum/design/bioprinter/leather/leather_jacket,
+		/datum/design/bioprinter/leather/cash_bag,
+		/datum/design/bioprinter/belt/utility,
+		/datum/design/bioprinter/belt/medical,
+		/datum/design/bioprinter/belt/security,
+		/datum/design/bioprinter/belt/medical/emt,
+		/datum/design/bioprinter/belt/misc/champion,
+
+		/datum/design/bioprinter/medical/bruise,
+		/datum/design/bioprinter/medical/splints,
+		/datum/design/bioprinter/medical/ointment,
+		/datum/design/bioprinter/medical/advanced/bruise,
+		/datum/design/bioprinter/medical/advanced/ointment,
+	)
+
+// Same as the other NT disk, minus the medical designs. Spawns in public access bioprinters.
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/nt_bioprinter_public
+	disk_name = "NeoTeology Bioprinter Pack"
+	icon_state = "neotheology"
+
+	license = -1
+	designs = list(
+		/datum/design/bioprinter/meat,
+		/datum/design/bioprinter/milk,
+
+		/datum/design/bioprinter/ez,
+		/datum/design/bioprinter/l4z,
+		/datum/design/bioprinter/rh,
+
+		/datum/design/bioprinter/wallet,
+		/datum/design/bioprinter/botanic_leather,
+		/datum/design/bioprinter/leather/satchel,
+		/datum/design/bioprinter/leather/leather_jacket,
+		/datum/design/bioprinter/leather/cash_bag,
+		/datum/design/bioprinter/belt/utility,
+		/datum/design/bioprinter/belt/medical,
+		/datum/design/bioprinter/belt/security,
+		/datum/design/bioprinter/belt/medical/emt,
+		/datum/design/bioprinter/belt/misc/champion,
+	)
+
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/nt_boards
+	disk_name = "NeoTeology Circuit Pack"
+	icon_state = "neotheology"
+
+	license = -1
+	designs = list(
+		/datum/design/autolathe/circuit/bioprinter,
+		/datum/design/autolathe/circuit/solidifier,
+
+		/datum/design/autolathe/circuit/cloner,
+		/datum/design/autolathe/circuit/reader,
+		/datum/design/autolathe/circuit/biocan,
+
+		/datum/design/autolathe/circuit/bioreactor_platform,
+		/datum/design/autolathe/circuit/bioreactor_unloader,
+		/datum/design/autolathe/circuit/bioreactor_biotank,
+		/datum/design/autolathe/circuit/bioreactor_port,
+		/datum/design/autolathe/circuit/bioreactor_metrics,
+		/datum/design/autolathe/circuit/bioreactor_loader,
+		
+		/datum/design/autolathe/circuit/biogen,
+		/datum/design/autolathe/circuit/biogen_port,
+		/datum/design/autolathe/circuit/biogen_console,
+	)
 
 // Ironhammer
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/security
@@ -478,64 +560,4 @@
 		/datum/design/autolathe/tool/jackhammer_onestar,
 		/datum/design/autolathe/tool/drill_onestar,
 		/datum/design/autolathe/tool/weldertool_onestar
-	)
-
-
-
-/obj/item/weapon/computer_hardware/hard_drive/portable/design/nt_bioprinter
-	disk_name = "NeoTeology Bioprinter Production"
-	icon_state = "neotheology"
-
-	license = -1
-	designs = list(
-		/datum/design/bioprinter/meat,
-		/datum/design/bioprinter/milk,
-		/datum/design/bioprinter/soap,
-
-		/datum/design/bioprinter/ez,
-		/datum/design/bioprinter/l4z,
-		/datum/design/bioprinter/rh,
-
-		/datum/design/bioprinter/wallet,
-		/datum/design/bioprinter/botanic_leather,
-		/datum/design/bioprinter/leather/satchel,
-		/datum/design/bioprinter/leather/leather_jacket,
-		/datum/design/bioprinter/leather/cash_bag,
-		/datum/design/bioprinter/belt/utility,
-		/datum/design/bioprinter/belt/medical,
-		/datum/design/bioprinter/belt/security,
-		/datum/design/bioprinter/belt/medical/emt,
-		/datum/design/bioprinter/belt/misc/champion,
-
-		/datum/design/bioprinter/medical/bruise,
-		/datum/design/bioprinter/medical/splints,
-		/datum/design/bioprinter/medical/ointment,
-		/datum/design/bioprinter/medical/advanced/bruise,
-		/datum/design/bioprinter/medical/advanced/ointment,
-	)
-
-// Same as the other NT disk, minus the medical designs. Spawns in public access bioprinters.
-/obj/item/weapon/computer_hardware/hard_drive/portable/design/nt_bioprinter_public
-	disk_name = "NeoTeology Bioprinter Pack"
-	icon_state = "neotheology"
-
-	license = -1
-	designs = list(
-		/datum/design/bioprinter/meat,
-		/datum/design/bioprinter/milk,
-
-		/datum/design/bioprinter/ez,
-		/datum/design/bioprinter/l4z,
-		/datum/design/bioprinter/rh,
-
-		/datum/design/bioprinter/wallet,
-		/datum/design/bioprinter/botanic_leather,
-		/datum/design/bioprinter/leather/satchel,
-		/datum/design/bioprinter/leather/leather_jacket,
-		/datum/design/bioprinter/leather/cash_bag,
-		/datum/design/bioprinter/belt/utility,
-		/datum/design/bioprinter/belt/medical,
-		/datum/design/bioprinter/belt/security,
-		/datum/design/bioprinter/belt/medical/emt,
-		/datum/design/bioprinter/belt/misc/champion,
 	)

--- a/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
@@ -17,6 +17,7 @@
 	new /obj/item/weapon/storage/fancy/candle_box(src)
 	new /obj/item/weapon/storage/fancy/candle_box(src)
 	new /obj/item/weapon/deck/tarot(src)
+	new /obj/item/weapon/computer_hardware/hard_drive/portable/design/nt_boards (src)
 	for (var/i in 1 to 10)
 		new /obj/item/weapon/implant/core_implant/cruciform(src)
 	new /obj/item/weapon/material/knife/neotritual(src)

--- a/code/modules/research/nodes/robotics.dm
+++ b/code/modules/research/nodes/robotics.dm
@@ -140,7 +140,7 @@
 	required_tech_levels = list()
 	cost = 500
 
-	unlocks_designs = list()
+	unlocks_designs = list(/datum/design/research/item/mecha/clamp)
 
 /datum/technology/mech_utility_modules
 	name = "Exosuit Utility Modules"

--- a/code/modules/research/nodes/robotics.dm
+++ b/code/modules/research/nodes/robotics.dm
@@ -140,7 +140,7 @@
 	required_tech_levels = list()
 	cost = 500
 
-	unlocks_designs = list(/datum/design/research/item/mecha/clamp)
+	unlocks_designs = list(/datum/design/research/item/mecha/hydraulic_clamp)
 
 /datum/technology/mech_utility_modules
 	name = "Exosuit Utility Modules"


### PR DESCRIPTION
## About The Pull Request
Rnd Is now able to make Clamps in basic Mech tech.
NT now has a disk that holds the blueprints to make more NT related circuits


## Details
Mech clamps missing SEEMS like a over sight as theirs a already done code for it to print...
NT circuits are none-replaceable nor able to be found as far as I know of. This makes getting more bio reactors, sorters, and the like harder to replace if not impossible.
This also allows NT to make more then one bio-reactor for more power generation 


