### PR TITLE
Various fixes

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -1,4 +1,4 @@
 //Used to replenish biomass in clonners, bioprinters etc
 #define BIOMASS_TYPES list(/obj/item/weapon/reagent_containers/food/snacks/meat = 50 ,/obj/item/weapon/reagent_containers/food/snacks/meat/roachmeat= 40 ,/obj/item/weapon/reagent_containers/food/snacks/meat/xenomeat = 20)
 //Basis of certain affect_blood calculations for stimulants.
-#define STIM_TIME 1 SECONDS
+#define STIM_TIME 3 SECONDS

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -5,3 +5,12 @@
 	layer = FULLSCREEN_LAYER
 	plane = FULLSCREEN_PLANE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/obj/screen/fullscreen/New(new_icon_state)
+	..(null)
+	if(new_icon_state)
+		src.icon_state = new_icon_state
+
+/obj/screen/fullscreen/tile
+	icon = 'icons/mob/screen1.dmi'
+	screen_loc = ui_entire_screen

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -23,83 +23,45 @@ var/list/global_huds
 	var/obj/screen/meson
 	var/obj/screen/science
 
-/datum/global_hud/proc/setup_overlay(var/icon_state)
-	var/obj/screen/screen = new /obj/screen/fullscreen()
-	screen.icon_state = icon_state
-
-	return screen
-
 /datum/global_hud/New()
 	//420erryday psychedellic colours screen overlay for when you are high
-	druggy = new /obj/screen()
-	druggy.screen_loc = ui_entire_screen
-	druggy.icon_state = "druggy"
-	druggy.layer = FULLSCREEN_LAYER
-	druggy.plane = FULLSCREEN_PLANE
-	druggy.mouse_opacity = 0
+	druggy = new /obj/screen/fullscreen/tile("druggy")
 
 	//that white blurry effect you get when you eyes are damaged
-	blurry = new /obj/screen()
-	blurry.screen_loc = ui_entire_screen
-	blurry.icon_state = "blurry"
-	blurry.layer = FULLSCREEN_LAYER
-	blurry.plane = FULLSCREEN_PLANE
-	blurry.mouse_opacity = 0
+	blurry = new /obj/screen/fullscreen/tile("blurry")
 
-	nvg = setup_overlay("nvg_hud")
+	nvg = new /obj/screen/fullscreen("nvg_hud")
 	nvg.plane = LIGHTING_PLANE
-	thermal = setup_overlay("thermal_hud")
-	meson = setup_overlay("meson_hud")
-	science = setup_overlay("science_hud")
+	thermal = new /obj/screen/fullscreen("thermal_hud")
+	meson = new /obj/screen/fullscreen("meson_hud")
+	science = new /obj/screen/fullscreen("science_hud")
 
-	var/obj/screen/O
-	var/i
 	//that nasty looking dither you  get when you're short-sighted
-	vimpaired = newlist(/obj/screen,/obj/screen,/obj/screen,/obj/screen)
-	O = vimpaired[1]
-	O.screen_loc = "1,1 to 5,15"
-	O = vimpaired[2]
-	O.screen_loc = "5,1 to 10,5"
-	O = vimpaired[3]
-	O.screen_loc = "6,11 to 10,15"
-	O = vimpaired[4]
-	O.screen_loc = "11,1 to 15,15"
+	vimpaired = newlist(
+		/obj/screen{icon_state = "dither50"; screen_loc = "1,1 to 5,15"},
+		/obj/screen{icon_state = "dither50"; screen_loc = "5,1 to 10,5"},
+		/obj/screen{icon_state = "dither50"; screen_loc = "6,11 to 10,15"},
+		/obj/screen{icon_state = "dither50"; screen_loc = "11,1 to 15,15"}
+	)
 
 	//welding mask overlay black/dither
-	darkMask = newlist(/obj/screen, /obj/screen, /obj/screen, /obj/screen, /obj/screen, /obj/screen, /obj/screen, /obj/screen)
-	O = darkMask[1]
-	O.screen_loc = "WEST+2,SOUTH+2 to WEST+4,NORTH-2"
-	O = darkMask[2]
-	O.screen_loc = "WEST+4,SOUTH+2 to EAST-5,SOUTH+4"
-	O = darkMask[3]
-	O.screen_loc = "WEST+5,NORTH-4 to EAST-5,NORTH-2"
-	O = darkMask[4]
-	O.screen_loc = "EAST-4,SOUTH+2 to EAST-2,NORTH-2"
-	O = darkMask[5]
-	O.screen_loc = "WEST,SOUTH to EAST,SOUTH+1"
-	O = darkMask[6]
-	O.screen_loc = "WEST,SOUTH+2 to WEST+1,NORTH"
-	O = darkMask[7]
-	O.screen_loc = "EAST-1,SOUTH+2 to EAST,NORTH"
-	O = darkMask[8]
-	O.screen_loc = "WEST+2,NORTH-1 to EAST-2,NORTH"
+	darkMask = newlist(
+		/obj/screen{icon_state = "dither50"; screen_loc = "WEST+2,SOUTH+2 to WEST+4,NORTH-2"},
+		/obj/screen{icon_state = "dither50"; screen_loc = "WEST+4,SOUTH+2 to EAST-5,SOUTH+4"},
+		/obj/screen{icon_state = "dither50"; screen_loc = "WEST+5,NORTH-4 to EAST-5,NORTH-2"},
+		/obj/screen{icon_state = "dither50"; screen_loc = "EAST-4,SOUTH+2 to EAST-2,NORTH-2"},
 
-	for(i = 1, i <= 4, i++)
-		O = vimpaired[i]
-		O.icon_state = "dither50"
-		O.layer = 17
-		O.mouse_opacity = 0
+		/obj/screen{icon_state = "black"; screen_loc = "WEST,SOUTH to EAST,SOUTH+1"},
+		/obj/screen{icon_state = "black"; screen_loc = "WEST,SOUTH+2 to WEST+1,NORTH"},
+		/obj/screen{icon_state = "black"; screen_loc = "EAST-1,SOUTH+2 to EAST,NORTH"},
+		/obj/screen{icon_state = "black"; screen_loc = "WEST+2,NORTH-1 to EAST-2,NORTH"}
+	)
 
-		O = darkMask[i]
-		O.icon_state = "dither50"
-		O.layer = 17
-		O.mouse_opacity = 0
+	for(var/obj/screen/O in (vimpaired + darkMask))
+		O.layer = FULLSCREEN_LAYER
+		O.plane = FULLSCREEN_PLANE
+		O.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
-	for(i = 5, i <= 8, i++)
-		O = darkMask[i]
-		O.icon_state = "black"
-		O.layer = 17
-		O.mouse_opacity = 0
 
 /*
 	The hud datum

--- a/code/datums/autolathe/autolathe_datums.dm
+++ b/code/datums/autolathe/autolathe_datums.dm
@@ -77,7 +77,8 @@
 	else if(istype(O, /obj/item/ammo_casing))
 		var/obj/item/ammo_casing/casing = O
 		multiplier = casing.amount
-		is_stack = TRUE
+		if(casing.amount > 1 || casing.maxamount > 1)
+			is_stack = TRUE
 
 	var/list/mats = O.get_matter()
 	if(length(mats))


### PR DESCRIPTION
Fixes stats flickering when stims are used. Because stim effect on stat dissipated before it could be renewed by a Life tick, stats would flicker between ticks.

Fixes glasses/mask screen overlays displaying over HUD, fucking finally. Closes #1956.