### PR TITLE
Clamps Sanity Damage From Pain

### DIFF
--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -140,8 +140,11 @@
 /datum/sanity/proc/changeLevel(amount)
 	if(sanity_invulnerability && amount < 0)
 		return
-	level = CLAMP(level + amount, 0, max_level)
-	updateLevel()
+	if(onDamage())
+		level = CLAMP(level + amount, 0, 60)
+	else
+		level = CLAMP(level + amount, 0, max_level)
+		updateLevel()
 
 /datum/sanity/proc/setLevel(amount)
 	if(sanity_invulnerability)


### PR DESCRIPTION
## About The Pull Request
Clamps sanity damage from injuries so you don't go insane after wandering around maintenance for a couple hours and then stubbing your toe.