### PR TITLE
Temporary Disables Roaches Spam

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/maint_loot.dm
+++ b/code/game/objects/structures/crates_lockers/closets/maint_loot.dm
@@ -170,5 +170,3 @@
 	new /obj/random/rations(src)
 	new /obj/random/rations(src)
 	new /obj/random/cluster/roaches(src)
-	new /obj/random/cluster/roaches/low_chance(src)
-	new /obj/random/cluster/roaches/low_chance(src)

--- a/code/modules/mob/living/carbon/superior_animal/roach/ai.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/ai.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/superior_animal/roach/findTarget()
 	. = ..()
 	if(.)
-		visible_emote("charges at [.]!")
+		//visible_emote("charges at [.]!") //commented out to reduce chat lag
 		playsound(src, 'sound/voice/insect_battle_screeching.ogg', 30, 1, -3)


### PR DESCRIPTION
## About The Pull Request
Reere suggested that it might help with chat lag. Simply comments out "%roachname% charges at %yourname%" messages which is being spammed when multiple stacks of roaches see you all at once. Also removes chance to spawn two more stack in some of the maintenance lockers, it's now just guaranteed one stack inside to reduce spam as well.