### PR TITLE
Perhaps speeds up and makes excelsior long-range teleporter upgradeable

### DIFF
--- a/code/game/machinery/excelsior/ex_teleporter.dm
+++ b/code/game/machinery/excelsior/ex_teleporter.dm
@@ -84,6 +84,17 @@ var/list/global/excelsior_teleporters = list() //This list is used to make turre
 				return
 
 
+/obj/machinery/complant_teleporter/RefreshParts()
+	..()
+	var/man_rating = 0
+	var/man_amount = 0
+	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
+		man_rating += M.rating
+		man_amount++
+	man_rating -= man_amount
+
+	recharged = initial(recharged) - man_rating - las_rating
+
  /**
   * The ui_interact proc is used to open and update Nano UIs
   * If ui_interact is not used then the UI will not update correctly

--- a/code/game/machinery/excelsior/ex_teleporter.dm
+++ b/code/game/machinery/excelsior/ex_teleporter.dm
@@ -93,7 +93,7 @@ var/list/global/excelsior_teleporters = list() //This list is used to make turre
 		man_amount++
 	man_rating -= man_amount
 
-	recharged = initial(recharged) - man_rating - las_rating
+	recharged = initial(recharged) - man_rating - man_amount
 
  /**
   * The ui_interact proc is used to open and update Nano UIs


### PR DESCRIPTION
## About The Pull Request
SHOULD if I can code correctly  make the Excelsior long Range tele speed up a bit by default do to two manips.
Should have also made it upgradeable via better parts making it charge even fasters 



## Details
closes #4180 maybe

Basically it will now always be 18 seconds, 2 manips = "-2 seconds" 
t1 will always make it 16 seconds do to 2 x 1 still meaning 2, 2 + 2 = 4
Better ratings like 2t means its -6 seconds
3t = -8 seconds
Do to math handles or thats how it SHOULD work

## Untested code, could brake everything
