### PR TITLE
R&D fixes and improvements

### DIFF
--- a/code/controllers/subsystems/research.dm
+++ b/code/controllers/subsystems/research.dm
@@ -103,8 +103,8 @@ SUBSYSTEM_DEF(research)
 		T.max_level = all_tech_trees[i].len
 		R.researched_tech[T] = list()
 
-	R.known_designs |= starting_designs
-
 	for(var/tech in statting_technologies)
 		R.UnlockTechology(tech, initial = TRUE)
 
+	for(var/design in starting_designs)
+		R.AddDesign2Known(design)

--- a/code/datums/autolathe/autolathe_datums.dm
+++ b/code/datums/autolathe/autolathe_datums.dm
@@ -131,20 +131,19 @@
 
 	if(length(materials))
 		var/list/RS = list()
-		for(var/mat in materials)
-			RS.Add(list(list("name" = mat, "req" = materials[mat])))
+
+		for(var/material in materials)
+			var/material/material_datum = get_material_by_name(material)
+			RS.Add(list(list("id" = material, "name" = material_datum.display_name, "req" = materials[material])))
+
 		ui_data["materials"] = RS
 
 	if(length(chemicals))
 		var/list/RS = list()
 
 		for(var/reagent in chemicals)
-			var/datum/reagent/RG = chemical_reagents_list[reagent]
-			var/chemical_name = "UNKNOWN"
-			if(RG)
-				chemical_name = RG.name
-
-			RS.Add(list(list("id" = reagent, "name" = chemical_name, "req" = chemicals[reagent])))
+			var/datum/reagent/reagent_datum = chemical_reagents_list[reagent]
+			RS.Add(list(list("id" = reagent, "name" = reagent_datum.name, "req" = chemicals[reagent])))
 
 		ui_data["chemicals"] = RS
 

--- a/code/game/machinery/autolathe/autolathe.dm
+++ b/code/game/machinery/autolathe/autolathe.dm
@@ -22,6 +22,8 @@
 	active_power_usage = 2000
 	circuit = /obj/item/weapon/circuitboard/autolathe
 
+	var/build_type = AUTOLATHE
+
 	var/obj/item/weapon/computer_hardware/hard_drive/portable/disk = null
 
 	var/list/stored_material = list()

--- a/code/game/machinery/autolathe/mechfab.dm
+++ b/code/game/machinery/autolathe/mechfab.dm
@@ -62,10 +62,4 @@
 	update_categories()
 
 /obj/machinery/autolathe/mechfab/proc/update_categories()
-	categories = list()
-	for(var/datum/design/D in files.known_designs)
-		if(D.build_type & build_type)
-			categories |= D.category
-
-	if((!show_category || !(show_category in categories)) && length(categories))
-		show_category = categories[1]
+	categories = files.design_categories_mechfab

--- a/code/game/machinery/autolathe/mechfab.dm
+++ b/code/game/machinery/autolathe/mechfab.dm
@@ -4,6 +4,7 @@
 	icon_state = "mechfab"
 	circuit = /obj/item/weapon/circuitboard/mechfab
 
+	build_type = MECHFAB
 	storage_capacity = 240
 	speed = 3
 
@@ -23,16 +24,14 @@
 	files = new /datum/research(src)
 
 /obj/machinery/autolathe/mechfab/design_list()
-	var/list/designs = list()
+	var/list/design_files = list()
 
-	for(var/i in files.known_designs)
-		var/datum/design/D = i
-		if(!(D.build_type & MECHFAB) || !D.file)
-			continue
+	for(var/d in files.known_designs)
+		var/datum/design/design = d
+		if((design.build_type & build_type) && design.file)
+			design_files |= design.file
 
-		designs |= D.file
-
-	return designs
+	return design_files
 
 /obj/machinery/autolathe/mechfab/ui_interact()
 	if(!categories)
@@ -65,9 +64,8 @@
 /obj/machinery/autolathe/mechfab/proc/update_categories()
 	categories = list()
 	for(var/datum/design/D in files.known_designs)
-		if(!(D.build_type & MECHFAB))
-			continue
-		categories |= D.category
+		if(D.build_type & build_type)
+			categories |= D.category
 
 	if((!show_category || !(show_category in categories)) && length(categories))
 		show_category = categories[1]

--- a/code/game/machinery/bioprinter_nt.dm
+++ b/code/game/machinery/bioprinter_nt.dm
@@ -2,8 +2,10 @@
 	name = "NeoTheology Bioprinter"
 	desc = "NeoTheology machine for printing things using biomass."
 	icon_state = "bioprinter"
-	unsuitable_materials = list()
 	circuit = /obj/item/weapon/circuitboard/neotheology/bioprinter
+
+	build_type = AUTOLATHE | BIOPRINTER
+	unsuitable_materials = list()
 
 /obj/machinery/autolathe/bioprinter/disk
 	default_disk = /obj/item/weapon/computer_hardware/hard_drive/portable/design/nt_bioprinter

--- a/code/game/machinery/excelsior/autolathe.dm
+++ b/code/game/machinery/excelsior/autolathe.dm
@@ -5,6 +5,7 @@
 	icon_state = "stanok"
 	circuit = /obj/item/weapon/circuitboard/excelsiorautolathe
 
+	build_type = AUTOLATHE | BIOPRINTER
 	speed = 4
 	storage_capacity = 240
 	unsuitable_materials = list()	// Can use biomatter too.

--- a/code/modules/research/designs/cell.dm
+++ b/code/modules/research/designs/cell.dm
@@ -1,6 +1,5 @@
 /datum/design/research/item/powercell
 	build_type = AUTOLATHE | PROTOLATHE | MECHFAB
-	name_category = "power cell"
 	category = CAT_POWER
 
 /datum/design/research/item/powercell/AssembleDesignDesc()

--- a/code/modules/research/designs/circuits.dm
+++ b/code/modules/research/designs/circuits.dm
@@ -9,11 +9,11 @@
 		return
 
 	if(C.board_type == "machine")
-		name = "Machine circuit design ([item_name])"
+		name = "Machine circuit ([item_name])"
 	else if(C.board_type == "computer")
-		name = "Computer circuit design ([item_name])"
+		name = "Computer circuit ([item_name])"
 	else
-		name = "Circuit design ([item_name])"
+		name = "Circuit ([item_name])"
 
 /datum/design/research/circuit/AssembleDesignDesc()
 	if(!desc)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -343,10 +343,10 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	reset_screen()
 
 
-/obj/machinery/computer/rdconsole/proc/get_possible_designs_data(build_type, category) // Builds the design list for the UI
+/obj/machinery/computer/rdconsole/proc/get_possible_designs_data(obj/machinery/autolathe/rnd/target_machine, category) // Builds the design list for the UI
 	var/list/designs_list = list()
 	for(var/datum/design/D in files.known_designs)
-		if(D.build_type & build_type)
+		if(D.build_type & target_machine.build_type)
 			var/cat = "Unspecified"
 			if(D.category)
 				cat = D.category
@@ -356,35 +356,32 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				var/maximum = 50
 				var/can_build
 				var/can_build_chem
-				var/iconName = getAtomCacheFilename(D.build_path)
+
 				for(var/M in D.materials)
-					if(build_type & PROTOLATHE)
-						can_build = linked_lathe.check_craftable_amount_by_material(D, M)
-					if(build_type & IMPRINTER)
-						can_build = linked_imprinter.check_craftable_amount_by_material(D, M)
+					can_build = target_machine.check_craftable_amount_by_material(D, M)
 					var/material/mat = get_material_by_name(M)
 					if(can_build < 1)
 						temp_material += " <span style=\"color:red\">[D.materials[M]] [mat.display_name]</span>"
 					else
 						temp_material += " [D.materials[M]] [mat.display_name]"
-					can_build = min(can_build,maximum)
+					can_build = min(can_build, maximum)
 				for(var/C in D.chemicals)
-					if(build_type & IMPRINTER)
-						can_build_chem = linked_imprinter.check_craftable_amount_by_chemical(D, C)
+					can_build_chem = target_machine.check_craftable_amount_by_chemical(D, C)
 					var/datum/reagent/R = chemical_reagents_list[C] // this is how you do it, you don't fucking new every possible reagent till you find a match
 					if(can_build_chem < 1)
 						temp_chemical += " <span style=\"color:red\">[D.chemicals[C]] [R.name]</span>"
 					else
 						temp_chemical += " [D.chemicals[C]] [R.name]"
 					can_build = min(can_build, can_build_chem)
+
 				designs_list += list(list(
-					"id" =             "\ref[D]",
-					"name" =           D.name,
-					"desc" =           D.desc,
-					"icon" =			iconName,
-					"can_create" =     can_build,
-					"temp_material" =  temp_material,
-					"temp_chemical" =  temp_chemical
+					"id" =				"\ref[D]",
+					"name" =			D.name,
+					"desc" =			D.desc,
+					"icon" =			getAtomCacheFilename(D.build_path),
+					"can_create" =		can_build,
+					"temp_material" =	temp_material,
+					"temp_chemical" =	temp_chemical
 				))
 	return designs_list
 
@@ -538,7 +535,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 			if(selected_category)
 				data["selected_category"] = selected_category
-				data["possible_designs"] = get_possible_designs_data(target_device == linked_lathe ? PROTOLATHE : IMPRINTER, selected_category)
+				data["possible_designs"] = get_possible_designs_data(target_device, selected_category)
 
 			if(target_device.current_file)
 				data["device_current"] = target_device.current_file.design.name

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -351,37 +351,29 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			if(D.category)
 				cat = D.category
 			if((category == cat) || (category == "Search Results" && findtext(D.name, search_text)))
-				var/temp_material
-				var/temp_chemical
-				var/maximum = 50
-				var/can_build
-				var/can_build_chem
+				var/list/missing_materials = list()
+				var/list/missing_chemicals = list()
+				var/can_build = 50
+				var/can_build_temp
 
-				for(var/M in D.materials)
-					can_build = target_machine.check_craftable_amount_by_material(D, M)
-					var/material/mat = get_material_by_name(M)
-					if(can_build < 1)
-						temp_material += " <span style=\"color:red\">[D.materials[M]] [mat.display_name]</span>"
-					else
-						temp_material += " [D.materials[M]] [mat.display_name]"
-					can_build = min(can_build, maximum)
-				for(var/C in D.chemicals)
-					can_build_chem = target_machine.check_craftable_amount_by_chemical(D, C)
-					var/datum/reagent/R = chemical_reagents_list[C] // this is how you do it, you don't fucking new every possible reagent till you find a match
-					if(can_build_chem < 1)
-						temp_chemical += " <span style=\"color:red\">[D.chemicals[C]] [R.name]</span>"
-					else
-						temp_chemical += " [D.chemicals[C]] [R.name]"
-					can_build = min(can_build, can_build_chem)
+				for(var/material in D.materials)
+					can_build_temp = target_machine.check_craftable_amount_by_material(D, material)
+					if(can_build_temp < 1)
+						missing_materials += material
+					can_build = min(can_build, can_build_temp)
+
+				for(var/chemical in D.chemicals)
+					can_build_temp = target_machine.check_craftable_amount_by_chemical(D, chemical)
+					if(can_build_temp < 1)
+						missing_chemicals += chemical
+					can_build = min(can_build, can_build_temp)
 
 				designs_list += list(list(
-					"id" =				"\ref[D]",
-					"name" =			D.name,
-					"desc" =			D.desc,
-					"icon" =			getAtomCacheFilename(D.build_path),
-					"can_create" =		can_build,
-					"temp_material" =	temp_material,
-					"temp_chemical" =	temp_chemical
+					"data" = D.ui_data(),
+					"id" = "\ref[D]",
+					"can_create" = can_build,
+					"missing_materials" = missing_materials,
+					"missing_chemicals" = missing_chemicals
 				))
 	return designs_list
 

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -35,9 +35,8 @@
 	desc = "A machine used for construction of advanced prototypes. Operated from an R\&D console."
 	icon_state = "protolathe"
 
+	build_type = PROTOLATHE
 	storage_capacity = 120
-
-	have_reagents = TRUE
 
 
 /obj/machinery/autolathe/rnd/imprinter
@@ -45,6 +44,7 @@
 	desc = "A machine used for printing advanced circuit boards. Operated from an R\&D console."
 	icon_state = "imprinter"
 
+	build_type = IMPRINTER
 	storage_capacity = 60
 	speed = 3
 

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -34,6 +34,7 @@
 	name = "protolathe"
 	desc = "A machine used for construction of advanced prototypes. Operated from an R\&D console."
 	icon_state = "protolathe"
+	circuit = /obj/item/weapon/circuitboard/protolathe
 
 	build_type = PROTOLATHE
 	storage_capacity = 120
@@ -43,6 +44,7 @@
 	name = "circuit imprinter"
 	desc = "A machine used for printing advanced circuit boards. Operated from an R\&D console."
 	icon_state = "imprinter"
+	circuit = /obj/item/weapon/circuitboard/circuit_imprinter
 
 	build_type = IMPRINTER
 	storage_capacity = 60

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -33,6 +33,7 @@ Procs:
 	var/list/known_designs = list()			//List of available designs (at base reliability).
 	var/list/design_categories_protolathe = list()
 	var/list/design_categories_imprinter = list()
+	var/list/design_categories_mechfab = list()
 
 	var/list/researched_tech = list() // Tree = list(of_researched_tech)
 	var/list/researched_nodes = list() // All research nodes
@@ -147,8 +148,10 @@ Procs:
 	var/cat = D.category ? D.category : "Unspecified"
 	if(D.build_type & PROTOLATHE)
 		design_categories_protolathe |= cat
-	else if(D.build_type & IMPRINTER)
+	if(D.build_type & IMPRINTER)
 		design_categories_imprinter |= cat
+	if(D.build_type & MECHFAB)
+		design_categories_mechfab |= cat
 
 
 // Unlocks hidden tech trees

--- a/nano/templates/rdconsole.tmpl
+++ b/nano/templates/rdconsole.tmpl
@@ -165,11 +165,11 @@
 								<table class="fixed" style="width: 100%;">
 									{{for data.possible_designs}}
 										<tr style="width: 100%;">
-											<td style="width: 12%">
-												<img class="statusDisplayItem" src={{:value.icon}} height=24 width=24></img>
+											<td style="width: 32px">
+												<img class="statusDisplayItem" src={{:value.data.icon}} height=24 width=24></img>
 											</td>
-											<td style="width: 70%">
-												{{:helper.link(value.name, '', {'build' : value.id, 'amount': 1}, value.can_create >= 1 ? null : 'disabled')}}
+											<td style="width: 100%">
+												{{:helper.link(value.data.name, '', {'build' : value.id, 'amount': 1}, value.can_create >= 1 ? null : 'disabled')}}
 												{{if data.screen == "protolathe"}}
 													{{if value.can_create >= 3}}
 														{{:helper.link('x3', '', {'build' : value.id, 'amount': 3})}}
@@ -180,16 +180,30 @@
 												{{/if}}
 											</td>
 											<td style="width: 100%" align="right">
-												{{if value.temp_material}}
-													{{:value.temp_material}}
-												{{/if}}
+												{{for value.data.materials  :material:material_i}}
+													{{material.amount = value.data.adjust_materials ? Math.round((material.req * data.materials_data.mat_efficiency) * 100) / 100 : material.req;}}
+													{{if value.missing_materials.indexOf(material.id) == -1}}
+														{{:material.amount}} {{:material.name}} 
+													{{else}}
+														<span style="color:red">{{:material.amount}} {{:material.name}}</span> 
+													{{/if}}
+												{{/for}}
+
+												{{for value.data.chemicals  :chemical:chemical_i}}
+													{{if value.missing_chemicals.indexOf(chemical.id) == -1}}
+														{{:chemical.req}} {{:chemical.name}} 
+													{{else}}
+														<span style="color:red">{{:chemical.req}} {{:chemical.name}}</span> 
+													{{/if}}
+												{{/for}}
+
 												{{if value.temp_chemical}}
 													{{:value.temp_chemical}}
 												{{/if}}
 											</td>
 										</tr>
 										<tr style="width: 100%">
-										 <td colspan = '3'><small>{{:value.desc}}</small></td>
+										 <td colspan = '3'><small>{{:value.data.desc}}</small></td>
 										</tr>
 									{{/for}}
 								</table>


### PR DESCRIPTION
* Fixes protolathe and imprinter deconstruction dropping autolathe circuit boards.
* Fixes protolathe being unable to use its chemicals.
* Fixes certain roundstart designs not unlocking properly.
* Unfucks some R&D design names.
* R&D console now displays adjusted material costs when protolathe/imprinter are upgraded.