### PR TITLE
Implements missing Vigilance litany

### DIFF
--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -165,8 +165,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/church/janitor
 
 	stat_modifiers = list(
-		STAT_ROB = 10,
+		STAT_ROB = 15,
 		STAT_BIO = 10,
+		STAT_VIG = 15
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/camera_monitor)

--- a/code/modules/core_implant/cruciform/rituals/crusader.dm
+++ b/code/modules/core_implant/cruciform/rituals/crusader.dm
@@ -37,6 +37,7 @@
 
 	user.stats.changeStat(STAT_TGH, count)
 	user.stats.changeStat(STAT_ROB, count)
+	user.stats.changeStat(STAT_VIG, (count / 2))
 	to_chat(user, SPAN_NOTICE("You feel an extraordinary burst of energy."))
 	set_personal_cooldown(user)
 	addtimer(CALLBACK(src, .proc/discard_effect, user, count), src.cooldown_time)
@@ -45,7 +46,7 @@
 /datum/ritual/cruciform/crusader/battle_call/proc/discard_effect(mob/living/carbon/human/user, amount)
 	user.stats.changeStat(STAT_TGH, -amount)
 	user.stats.changeStat(STAT_ROB, -amount)
-
+	user.stats.changeStat(STAT_VIG, -amount)
 
 /datum/ritual/cruciform/crusader/flash
 	name = "Searing Revelation"

--- a/code/modules/core_implant/cruciform/rituals/inquisitor.dm
+++ b/code/modules/core_implant/cruciform/rituals/inquisitor.dm
@@ -32,7 +32,7 @@
 /datum/ritual/targeted/cruciform/inquisitor/penance
 	name = "Penance"
 	phrase = "Mihi vindicta \[Target human]"
-	desc = "Imparts extreme pain on the target disciple. Does no actual harm.."
+	desc = "Imparts extreme pain on the target disciple. Does no actual harm."
 	power = 35
 
 /datum/ritual/targeted/cruciform/inquisitor/penance/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C,list/targets)

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -289,17 +289,17 @@
 /datum/ritual/cruciform/priest/short_boost/mechanical
 	name = "Pounding Whisper"
 	phrase = "Vocavitque nomen eius Noe dicens iste consolabitur nos ab operibus et laboribus manuum nostrarum in terra cui maledixit Dominus"
-	stats_to_boost = list(STAT_MEC = 15)
+	stats_to_boost = list(STAT_MEC = 10)
 
 /datum/ritual/cruciform/priest/short_boost/cognition
 	name = "Revelation of Secrets"
 	phrase = "Quia Dominus dat sapientiam et ex ore eius scientia et prudentia"
-	stats_to_boost = list(STAT_COG = 15)
+	stats_to_boost = list(STAT_COG = 10)
 
 /datum/ritual/cruciform/priest/short_boost/biology
 	name = "Lisp of Vitae"
 	phrase = "Ecce ego obducam ei cicatricem et sanitatem et curabo eos et revelabo illis deprecationem pacis et veritatis"
-	stats_to_boost = list(STAT_BIO = 15)
+	stats_to_boost = list(STAT_BIO = 10)
 
 /datum/ritual/cruciform/priest/short_boost/courage
 	name = "Canto of Courage"

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -289,23 +289,27 @@
 /datum/ritual/cruciform/priest/short_boost/mechanical
 	name = "Pounding Whisper"
 	phrase = "Vocavitque nomen eius Noe dicens iste consolabitur nos ab operibus et laboribus manuum nostrarum in terra cui maledixit Dominus"
-	stats_to_boost = list(STAT_MEC = 10)
+	stats_to_boost = list(STAT_MEC = 15)
 
 /datum/ritual/cruciform/priest/short_boost/cognition
 	name = "Revelation of Secrets"
 	phrase = "Quia Dominus dat sapientiam et ex ore eius scientia et prudentia"
-	stats_to_boost = list(STAT_COG = 10)
+	stats_to_boost = list(STAT_COG = 15)
 
 /datum/ritual/cruciform/priest/short_boost/biology
 	name = "Lisp of Vitae"
 	phrase = "Ecce ego obducam ei cicatricem et sanitatem et curabo eos et revelabo illis deprecationem pacis et veritatis"
-	stats_to_boost = list(STAT_BIO = 10)
+	stats_to_boost = list(STAT_BIO = 15)
 
 /datum/ritual/cruciform/priest/short_boost/courage
 	name = "Canto of Courage"
 	phrase = "Huic David ad te Domine clamabo Deus meus ne sileas a me nequando taceas a me et adsimilabor descendentibus in lacum"
 	stats_to_boost = list(STAT_ROB = 10, STAT_TGH = 10)
 
+/datum/ritual/cruciform/priest/short_boost/vigilance
+	name = "Commitment to Determination"
+	phrase = "Cor meum et caro mea, potest deficere, sed non in viribus Deus cordis mei et pars mea Deus in aeternum"
+	stats_to_boost = list(STAT_VIG = 10)
 
 /datum/ritual/targeted/cruciform/priest/atonement
 	name = "Atonement"


### PR DESCRIPTION
## About The Pull Request
<!-- Why is it needed, what it fixes. Write up links to closing issues there as well, but make it short. -->

Gives Custodian additional stats after a discussion with ACCount and Reere, Crusader Call to Arms litany now grants a vigilance bonus, Priests may now short boost Vigilance while other non-combat short boosts were buffed.

Removed an extra period in Inquisitor litany description.
