### PR TITLE
Adds a purging perk to all professional doctors that allows them to heal ToxLoss similar to CPR

### DIFF
--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -37,6 +37,6 @@
 /datum/perk/ancientpractice/activate()
 	if(world.time < cooldown_time)
 		return FALSE
-	cooldown_time = world.time + 4 MINUTES
-	addtimer(CALLBACK(src, .proc/deactivate), 2 MINUTES)
+	cooldown_time = world.time + 5 MINUTES
+	addtimer(CALLBACK(src, .proc/deactivate), 3 MINUTES)
 	return ..()

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -28,3 +28,15 @@
 	cooldown_time = world.time + 7 MINUTES
 	addtimer(CALLBACK(src, .proc/deactivate), 1 MINUTES)
 	return ..()
+
+/datum/perk/ancientpractice
+	name = "Ancient Healing"
+	var/cooldown_time = 0
+	active = FALSE
+	toggleable = TRUE
+/datum/perk/ancientpractice/activate()
+	if(world.time < cooldown_time)
+		return FALSE
+	cooldown_time = world.time + 4 MINUTES
+	addtimer(CALLBACK(src, .proc/deactivate), 2 MINUTES)
+	return ..()

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -109,6 +109,8 @@ You are expected to be knowledgeable and competent in at least basic treatment, 
 
 Your second loyalty is to your career with Moebius corp, and to your coworkers in both branches of moebius. Help out your scientific colleagues, and aid in their pursuit of knowledge."
 
+	perks = list(/datum/perk/ancientpractice)
+
 /obj/landmark/join/start/doctor
 	name = "Moebius Doctor"
 	icon_state = "player-green"

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -51,6 +51,9 @@ In times of crisis, lock down the medbay to protect those within, from outside t
 
 Your second loyalty is to your career with Moebius corp, and to your coworkers in both branches of moebius. Help out your scientific colleagues, and aid in their pursuit of knowledge."
 
+	perks = list(/datum/perk/ancientpractice)
+	
+
 /obj/landmark/join/start/cmo
 	name = "Moebius Biolab Officer"
 	icon_state = "player-green-officer"

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -24,6 +24,7 @@
 	var/lastpuke = 0
 
 	var/cpr_time = 1.0
+	var/purge_time = 1.0
 	nutrition = 400.0//Carbon
 
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -681,6 +681,13 @@ var/list/rank_prefix = list(\
 	if(!H || !(H.functions & BODYPART_REAGENT_INTAKE))
 		return FALSE
 	return TRUE
+/mob/living/carbon/human/proc/check_has_hand()
+	var/obj/item/organ/external/H1 = get_organ(BP_L_ARM)
+	var/obj/item/organ/external/H2 = get_organ(BP_R_ARM)
+	if((!H1 && !H2) || !((H1.functions & BODYPART_GRASP) && (H2.functions & BODYPART_GRASP)))
+		return FALSE
+	return TRUE
+
 
 /mob/living/carbon/human/vomit()
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -57,7 +57,7 @@
 		if(I_HELP)
 			if(can_operate(src, M) && do_surgery(src, M, null))
 				return 1
-			else if(istype(H) && health < HEALTH_THRESHOLD_CRIT && health > HEALTH_THRESHOLD_DEAD)
+			else if(istype(H) && health < HEALTH_THRESHOLD_CRIT && health > HEALTH_THRESHOLD_DEAD && !(H.targeted_organ == BP_CHEST))
 				if(!H.check_has_mouth())
 					to_chat(H, SPAN_DANGER("You don't have a mouth, you cannot perform CPR!"))
 					return
@@ -89,6 +89,29 @@
 				H.visible_message(SPAN_DANGER("\The [H] performs CPR on \the [src]!"))
 				to_chat(src, SPAN_NOTICE("You feel a breath of fresh air enter your lungs. It feels good."))
 				to_chat(H, SPAN_WARNING("Repeat at least every 7 seconds."))
+			else if (istype(H) && health < HEALTH_THRESHOLD_SOFTCRIT && health > HEALTH_THRESHOLD_DEAD && (H.targeted_organ == BP_L_ARM || H.targeted_organ == BP_R_ARM) && H.stats.getPerk(/datum/perk/ancientpractice)?.is_active())
+				if(!H.check_has_hand())
+					to_chat(H, SPAN_DANGER("You don't have any working hands, you cannot purge!"))
+				if(!check_has_hand())
+					to_chat(H, SPAN_DANGER("They don't have any good arms, you cannot purge!"))
+
+				if (!purge_time)
+					return 0
+
+				purge_time = 0
+
+				spawn(30)
+					purge_time = 1
+
+				H.visible_message(SPAN_DANGER("\The [H] is trying purge \the [src]'s veins of toxins!"))	
+
+				if(!do_after(H, 30, src))
+					return
+				var/purge_efficiency = 3 + max(0, 2 * (H.stats.getStat(STAT_BIO) / 10))
+				adjustToxLoss(-(min(getToxLoss(), purge_efficiency)))
+				updatehealth()
+				H.visible_message(SPAN_DANGER("\The [H] purges\the [src]'s veins of some toxins!"))
+				to_chat(src, SPAN_NOTICE("Your veins feel cleaner and healthier. It feels good."))
 			else
 				help_shake_act(M)
 			return 1

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -100,12 +100,12 @@
 
 				purge_time = 0
 
-				spawn(30)
+				spawn(15)
 					purge_time = 1
 
 				H.visible_message(SPAN_DANGER("\The [H] is trying purge \the [src]'s veins of toxins!"))	
 
-				if(!do_after(H, 30, src))
+				if(!do_after(H, 15, src))
 					return
 				var/purge_efficiency = 3 + max(0, 2 * (H.stats.getStat(STAT_BIO) / 10))
 				adjustToxLoss(-(min(getToxLoss(), purge_efficiency)))

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -89,7 +89,7 @@
 				H.visible_message(SPAN_DANGER("\The [H] performs CPR on \the [src]!"))
 				to_chat(src, SPAN_NOTICE("You feel a breath of fresh air enter your lungs. It feels good."))
 				to_chat(H, SPAN_WARNING("Repeat at least every 7 seconds."))
-			else if (istype(H) && health < HEALTH_THRESHOLD_SOFTCRIT && health > HEALTH_THRESHOLD_DEAD && (H.targeted_organ == BP_L_ARM || H.targeted_organ == BP_R_ARM) && H.stats.getPerk(/datum/perk/ancientpractice)?.is_active())
+			else if (istype(H) && health < 40 && health > HEALTH_THRESHOLD_DEAD && (H.targeted_organ == BP_L_ARM || H.targeted_organ == BP_R_ARM) && H.stats.getPerk(/datum/perk/ancientpractice)?.is_active())
 				if(!H.check_has_hand())
 					to_chat(H, SPAN_DANGER("You don't have any working hands, you cannot purge!"))
 				if(!check_has_hand())


### PR DESCRIPTION
## About The Pull Request

Adds a new purging perk that allows medical doctors to heal toxin damage similar to CPR. 
I tested this code, and it seems to work fine. It should spice up medical and use the perk system and actually use the perk system.

## Details
<!-- If you need, describe details inside. Remove whole block if not used. -->
<details>
  <summary>Faster than, but same healing as CPR </summary>
       You can do the action twice as fast as CPR, but you heal the same as CPR and its a perk that lasts 3 minutes with a 5-minute cooldown after activation.  You can heal them up to a point where they have less than 40 health.  You must target the hurt person's arms, and you must not have disabled or no arms yourself.
</details>

