### PR TITLE
Jester is more aggressive with burrows

### DIFF
--- a/code/controllers/subsystems/migration.dm
+++ b/code/controllers/subsystems/migration.dm
@@ -209,6 +209,12 @@ This proc will attempt to create a burrow against a wall, within view of the tar
 /datum/controller/subsystem/migration/proc/choose_burrow_target(var/obj/structure/burrow/source, var/reroll_type = TRUE, var/reroll_prob = 99.5)
 	var/obj/structure/burrow/candidate
 
+	switch (GLOB.storyteller.config_tag)
+		if ("jester") // Jester is much more likely to not reroll the maintenance check.
+			reroll_prob = 59.5
+		if ("warrior")
+			reroll_prob = 98.5
+
 	//Lets copy the list into a candidates buffer
 	var/list/candidates = all_burrows.Copy(1,0)
 


### PR DESCRIPTION

## About The Pull Request
<!-- Why is it needed, what it fixes. Write up links to closing issues there as well, but make it short. -->

When a migration event is called, the game rerolls if it is selected within a crew area, thus making it more likely to move through to a maintenance area instead. On Jester this reroll chance is significantly reduced, and since this is performed on each candidate (being the burrow) down a list of candidates, it's almost assured to to begin an assault upon any crew area.

