### PR TITLE
Moves "remove silencer" to the Object tab

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -561,6 +561,8 @@
 
 
 /obj/item/weapon/gun/proc/remove_silencer(var/mob/user)
+	set category = "Object"
+
 	if (!silenced || !silenced.can_remove)
 		to_chat(user, "No silencer is installed on \the [src]")
 		verbs -= /obj/item/weapon/gun/proc/remove_silencer


### PR DESCRIPTION
## About The Pull Request
<!-- Why is it needed, what it fixes. Write up links to closing issues there as well, but make it short. -->



## Details
<!-- If you need, describe details inside. Remove whole block if not used. -->
<details>
  <summary>Expand</summary>
Someone said in #feedback on discord that the remove silencer verb was causing lag when you pick it up or unholster it or whatever since it had it own tab. It really doesn't need its own tab lag or not so I moved it to the object tab. Anyways I tested it and saw no lag now that its in its own tab(no idea if there was lag beforehand or not since I forgot to test that but like I said it doesn't need its own tab anyway)
</details>


## Comments
<!-- Map an UI changes MUST have screenshots in them. Graphical changes should have it as well, when icon diff is not enough. Remove whole block if not used. -->
<details>
  <summary>Expand</summary>
I'm really surprised that you can set the category of procs and add them to the verbs but I guess thats just byond doing byond things.
</details>


