### PR TITLE
Removes a whole bunch of useless attack_ai

### DIFF
--- a/code/ATMOSPHERICS/components/unary/cold_sink.dm
+++ b/code/ATMOSPHERICS/components/unary/cold_sink.dm
@@ -54,9 +54,6 @@
 		icon_state = "freezer_0"
 	return
 
-/obj/machinery/atmospherics/unary/freezer/attack_ai(mob/user as mob)
-	ui_interact(user)
-
 /obj/machinery/atmospherics/unary/freezer/attack_hand(mob/user as mob)
 	ui_interact(user)
 

--- a/code/ATMOSPHERICS/components/unary/heat_source.dm
+++ b/code/ATMOSPHERICS/components/unary/heat_source.dm
@@ -77,9 +77,6 @@
 
 	update_icon()
 
-/obj/machinery/atmospherics/unary/heater/attack_ai(mob/user as mob)
-	ui_interact(user)
-
 /obj/machinery/atmospherics/unary/heater/attack_hand(mob/user as mob)
 	ui_interact(user)
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -120,9 +120,6 @@
 	playsound(loc, 'sound/machines/button.ogg', 100, 1)
 	return 1
 
-/obj/machinery/sleeper/attack_ai(var/mob/user)
-	return attack_hand(user)
-
 /obj/machinery/sleeper/attackby(var/obj/item/I, var/mob/user)
 	add_fingerprint(user)
 	if(istype(I, /obj/item/weapon/reagent_containers/glass))

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -164,9 +164,6 @@
 			if(connected)
 				return
 
-/obj/machinery/body_scanconsole/attack_ai(user as mob)
-	return src.attack_hand(user)
-
 /obj/machinery/body_scanconsole/attack_hand(user as mob)
 	if(..())
 		return

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -57,9 +57,6 @@
 			return
 	return
 
-/obj/machinery/ai_slipper/attack_ai(mob/user as mob)
-	return attack_hand(user)
-
 /obj/machinery/ai_slipper/attack_hand(mob/user as mob)
 	if(stat & (NOPOWER|BROKEN))
 		return

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -953,9 +953,6 @@ FIRE ALARM
 			src.alarm()			// added check of detector status here
 	return
 
-/obj/machinery/firealarm/attack_ai(mob/user)
-	ui_interact(user)
-
 /obj/machinery/firealarm/attack_hand(mob/user)
 	. = ..()
 	if (.)

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -24,9 +24,6 @@
 	wifi_sender = null
 	return ..()
 
-/obj/machinery/button/attack_ai(mob/user as mob)
-	return attack_hand(user)
-
 /obj/machinery/button/attackby(obj/item/weapon/W, mob/user as mob)
 	return attack_hand(user)
 

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -18,13 +18,6 @@
 			table.computer = src
 			break
 
-/obj/machinery/computer/operating/attack_ai(mob/user)
-	add_fingerprint(user)
-	if(stat & (BROKEN|NOPOWER))
-		return
-	interact(user)
-
-
 /obj/machinery/computer/operating/attack_hand(mob/user)
 	add_fingerprint(user)
 	if(..())

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -59,9 +59,6 @@
 	..()
 	return
 
-/obj/machinery/computer/aifixer/attack_ai(var/mob/user as mob)
-	return attack_hand(user)
-
 /obj/machinery/computer/aifixer/attack_hand(var/mob/user as mob)
 	if(..())
 		return

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -51,10 +51,6 @@
 		var/atom/movable/prize = pick(contents)
 		prize.loc = src.loc
 
-/obj/machinery/computer/arcade/attack_ai(mob/user as mob)
-	return src.attack_hand(user)
-
-
 /obj/machinery/computer/arcade/emp_act(severity)
 	if(stat & (NOPOWER|BROKEN))
 		..(severity)

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -24,9 +24,6 @@
 	density = 0
 	CheckFaceFlag = 0
 
-/obj/machinery/computer/atmoscontrol/attack_ai(var/mob/user as mob)
-	ui_interact(user)
-
 /obj/machinery/computer/atmoscontrol/attack_hand(mob/user)
 	if(..())
 		return 1

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -101,9 +101,6 @@
 		..()
 	return
 
-/obj/machinery/computer/cloning/attack_ai(mob/user as mob)
-	return attack_hand(user)
-
 /obj/machinery/computer/cloning/attack_hand(mob/user as mob)
 	if(..())
 		return

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -90,9 +90,6 @@
 		return
 	..()
 
-/obj/machinery/computer/guestpass/attack_ai(var/mob/user as mob)
-	return attack_hand(user)
-
 /obj/machinery/computer/guestpass/attack_hand(var/mob/user as mob)
 	if(..())
 		return

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -43,9 +43,6 @@
 	else
 		..()
 
-/obj/machinery/computer/med_data/attack_ai(user as mob)
-	return src.attack_hand(user)
-
 /obj/machinery/computer/med_data/attack_hand(mob/user as mob)
 	if(..())
 		return

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -258,9 +258,6 @@
 	onclose(user, "message")
 	return
 
-/obj/machinery/computer/message_monitor/attack_ai(mob/user as mob)
-	return src.attack_hand(user)
-
 /obj/machinery/computer/message_monitor/proc/BruteForce(mob/user as mob)
 	if(isnull(linkedServer))
 		to_chat(user, SPAN_WARNING("Could not complete brute-force: Linked Server Disconnected!"))

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -108,10 +108,7 @@
 */
 
 
-/obj/machinery/computer/pod/attack_ai(var/mob/user as mob)
-	return attack_hand(user)
-
-/obj/machinery/computer/pod/attack_hand(var/mob/user as mob)
+/obj/machinery/computer/pod/attack_hand(mob/user)
 	if(..())
 		return
 

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -10,9 +10,6 @@
 
 	var/safety = 1
 
-/obj/machinery/computer/robotics/attack_ai(var/mob/user as mob)
-	ui_interact(user)
-
 /obj/machinery/computer/robotics/attack_hand(var/mob/user as mob)
 	if(..())
 		return

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -47,9 +47,6 @@
 		to_chat(user, "You insert [O].")
 	..()
 
-/obj/machinery/computer/secure_data/attack_ai(mob/user as mob)
-	return attack_hand(user)
-
 //Someone needs to break down the dat += into chunks instead of long ass lines.
 /obj/machinery/computer/secure_data/attack_hand(mob/user as mob)
 	if(..())

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -42,9 +42,6 @@
 		qdel(alarm_monitor)
 		alarm_monitor = null
 
-/obj/machinery/computer/station_alert/attack_ai(mob/user)
-	ui_interact(user)
-
 /obj/machinery/computer/station_alert/attack_hand(mob/user)
 	if(..())
 		return

--- a/code/game/machinery/computer/supply.dm
+++ b/code/game/machinery/computer/supply.dm
@@ -17,9 +17,6 @@
 	var/contraband = FALSE
 	var/hacked = FALSE
 
-/obj/machinery/computer/supplycomp/attack_ai(mob/user)
-	return attack_hand(user)
-
 /obj/machinery/computer/supplycomp/attack_hand(mob/user)
 	if(!allowed(user))
 		to_chat(user, SPAN_WARNING("Access Denied."))

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -41,9 +41,6 @@
 	storage_name = "Robotic Storage Control"
 	allow_items = 0
 
-/obj/machinery/computer/cryopod/attack_ai()
-	src.attack_hand()
-
 /obj/machinery/computer/cryopod/attack_hand(mob/user = usr)
 	if(stat & (NOPOWER|BROKEN))
 		return

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -157,10 +157,6 @@
 
 	return
 
-//Allows AIs to use door_timer, see human attack_hand function below
-/obj/machinery/door_timer/attack_ai(var/mob/user as mob)
-	return src.attack_hand(user)
-
 //Check access for shower temp change of for other dangerous functions
 /obj/machinery/door_timer/proc/allowed_advanced(var/mob/user as mob)
 	var/obj/item/id = user.GetIdCard()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -198,9 +198,6 @@
 	take_damage(damage)
 	return
 
-/obj/machinery/door/attack_ai(mob/user as mob)
-	return src.attack_hand(user)
-
 /obj/machinery/door/attack_hand(mob/user as mob)
 	if(src.allowed(user) && operable())
 		if(src.density)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -148,9 +148,6 @@
 		shatter()
 		return
 
-/obj/machinery/door/window/attack_ai(mob/user as mob)
-	return src.attack_hand(user)
-
 /obj/machinery/door/window/attack_hand(mob/user as mob)
 
 	if(ishuman(user))

--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -29,10 +29,7 @@ obj/machinery/embedded_controller/radio/Destroy()
 
 	update_icon()
 
-/obj/machinery/embedded_controller/attack_ai(mob/user as mob)
-	src.ui_interact(user)
-
-/obj/machinery/embedded_controller/attack_hand(mob/user as mob)
+/obj/machinery/embedded_controller/attack_hand(mob/user)
 
 	if(!user.IsAdvancedToolUser())
 		return 0

--- a/code/game/machinery/excelsior/ex_teleporter.dm
+++ b/code/game/machinery/excelsior/ex_teleporter.dm
@@ -156,9 +156,6 @@ var/list/global/excelsior_teleporters = list() //This list is used to make turre
 	new order_path(loc, amount)
 	processing_order = FALSE
 
-/obj/machinery/complant_teleporter/attack_ai(mob/user)
-	return src.attack_hand(user)
-
 /obj/machinery/complant_teleporter/attack_hand(mob/user)
 	if(stat & BROKEN)
 		return

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -312,9 +312,6 @@
 		to_chat(user, "You short out the product lock on [src].")
 		return 1
 
-/obj/machinery/smartfridge/attack_ai(mob/user as mob)
-	attack_hand(user)
-
 /obj/machinery/smartfridge/attack_hand(mob/user as mob)
 	if(stat & (NOPOWER|BROKEN))
 		return

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -225,9 +225,6 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			return
 	return
 
-/obj/machinery/newscaster/attack_ai(mob/user as mob)
-	return src.attack_hand(user)
-
 /obj/machinery/newscaster/attack_hand(mob/user as mob)            //########### THE MAIN BEEF IS HERE! And in the proc below this...############
 
 	if(!src.ispowered || src.isbroken)
@@ -755,9 +752,6 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		else
 			to_chat(user, SPAN_NOTICE("This does nothing."))
 	src.update_icon()
-
-/obj/machinery/newscaster/attack_ai(mob/user as mob)
-	return src.attack_hand(user) //or maybe it'll have some special functions? No idea.
 
 /datum/news_photo
 	var/is_synth = 0

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -196,12 +196,6 @@ var/list/turret_icons
 
 	return 0
 
-/obj/machinery/porta_turret/attack_ai(mob/user)
-	if(isLocked(user))
-		return
-
-	ui_interact(user)
-
 /obj/machinery/porta_turret/attack_hand(mob/user)
 	if(isLocked(user))
 		return

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -132,9 +132,6 @@
 				to_chat(user, SPAN_WARNING("You need five coils of wire for this."))
 
 
-/obj/machinery/telecomms/attack_ai(var/mob/user as mob)
-	attack_hand(user)
-
 /obj/machinery/telecomms/attack_hand(var/mob/user as mob)
 
 	// You need a multitool to use this, or be silicon

--- a/code/modules/detectivework/microscope/dnascanner.dm
+++ b/code/modules/detectivework/microscope/dnascanner.dm
@@ -122,10 +122,7 @@
 		update_icon()
 	return
 
-/obj/machinery/dnaforensics/attack_ai(mob/user as mob)
-	ui_interact(user)
-
-/obj/machinery/dnaforensics/attack_hand(mob/user as mob)
+/obj/machinery/dnaforensics/attack_hand(mob/user)
 	ui_interact(user)
 
 /obj/machinery/dnaforensics/verb/toggle_lid()

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -30,9 +30,6 @@
 	supported_programs = list()
 	restricted_programs = list()
 
-/obj/machinery/computer/HolodeckControl/attack_ai(var/mob/user as mob)
-	return src.attack_hand(user)
-
 /obj/machinery/computer/HolodeckControl/attack_hand(var/mob/user as mob)
 	if(..())
 		return 1

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -54,9 +54,6 @@
 	if(world.time > last_action + action_time)
 		finished_task()
 
-/obj/machinery/botany/attack_ai(mob/user as mob)
-	return attack_hand(user)
-
 /obj/machinery/botany/attack_hand(mob/user as mob)
 	ui_interact(user)
 

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -126,9 +126,6 @@
 		need_player_check = 1
 		update_icon()
 
-/obj/machinery/mining/drill/attack_ai(var/mob/user as mob)
-	return src.attack_hand(user)
-
 /obj/machinery/mining/drill/attackby(obj/item/I, mob/user as mob)
 
 	if(!active)

--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -12,9 +12,6 @@
 	//Used to enable or disable drone fabrication.
 	var/obj/machinery/drone_fabricator/dronefab
 
-/obj/machinery/computer/drone_control/attack_ai(var/mob/user as mob)
-	return src.attack_hand(user)
-
 /obj/machinery/computer/drone_control/attack_hand(var/mob/user as mob)
 	if(..())
 		return

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -14,9 +14,6 @@
 	var/toner = 30 //how much toner is left! woooooo~
 	var/maxcopies = 10	//how many copies can be copied at once- idea shamelessly stolen from bs12's copier!
 
-/obj/machinery/photocopier/attack_ai(mob/user as mob)
-	return attack_hand(user)
-
 /obj/machinery/photocopier/attack_hand(mob/user as mob)
 	user.set_machine(src)
 

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -153,9 +153,6 @@
 		update_icon()
 	add_avail(effective_gen)
 
-/obj/machinery/power/generator/attack_ai(mob/user)
-	attack_hand(user)
-
 /obj/machinery/power/generator/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/tool/wrench))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)

--- a/code/modules/power/generator_type2.dm
+++ b/code/modules/power/generator_type2.dm
@@ -88,11 +88,6 @@
 	src.updateDialog()
 
 
-/obj/machinery/power/generator_type2/attack_ai(mob/user)
-	if(stat & (BROKEN|NOPOWER)) return
-	interact(user)
-
-
 /obj/machinery/power/generator_type2/attack_hand(mob/user)
 	add_fingerprint(user)
 	if(stat & (BROKEN|NOPOWER)) return

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -342,13 +342,10 @@
 			if(ABORT_CHECK)
 				return
 
-/obj/machinery/power/port_gen/pacman/attack_hand(mob/user as mob)
+/obj/machinery/power/port_gen/pacman/attack_hand(mob/user)
 	..()
 	if (!anchored)
 		return
-	ui_interact(user)
-
-/obj/machinery/power/port_gen/pacman/attack_ai(mob/user as mob)
 	ui_interact(user)
 
 /obj/machinery/power/port_gen/pacman/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = NANOUI_FOCUS)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -241,10 +241,6 @@
 	return 0
 
 
-/obj/machinery/power/smes/attack_ai(mob/user)
-	add_hiddenprint(user)
-	ui_interact(user)
-
 /obj/machinery/power/smes/attack_hand(mob/user)
 	add_fingerprint(user)
 	ui_interact(user)

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -163,9 +163,6 @@
 			SSnano.update_uis(src) // update all UIs attached to src
 			return
 
-/obj/machinery/chemical_dispenser/attack_ai(mob/living/user)
-	return src.attack_hand(user)
-
 /obj/machinery/chemical_dispenser/attack_hand(mob/living/user)
 	if(stat & BROKEN)
 		return

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -235,10 +235,7 @@
 	src.updateUsrDialog()
 	return
 
-/obj/machinery/chem_master/attack_ai(mob/user as mob)
-	return src.attack_hand(user)
-
-/obj/machinery/chem_master/attack_hand(mob/user as mob)
+/obj/machinery/chem_master/attack_hand(mob/user)
 	if(inoperable())
 		return
 	user.set_machine(src)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -377,10 +377,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				))
 	return designs_list
 
-/obj/machinery/computer/rdconsole/attack_ai(mob/user)
-	. = ..()
-	ui_interact(user)
-
 /obj/machinery/computer/rdconsole/attack_hand(mob/user)
 	if(..())
 		return

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -71,9 +71,6 @@
 	else
 		..()
 
-/obj/machinery/computer/telescience/attack_ai(mob/user)
-	src.attack_hand(user)
-
 /obj/machinery/computer/telescience/attack_hand(mob/user)
 	if(..())
 		return

--- a/code/modules/virus2/curer.dm
+++ b/code/modules/virus2/curer.dm
@@ -36,10 +36,7 @@
 	..()
 	return
 
-/obj/machinery/computer/curer/attack_ai(var/mob/user as mob)
-	return src.attack_hand(user)
-
-/obj/machinery/computer/curer/attack_hand(var/mob/user as mob)
+/obj/machinery/computer/curer/attack_hand(mob/user)
 	if(..())
 		return
 	user.machine = src

--- a/code/modules/virus2/diseasesplicer.dm
+++ b/code/modules/virus2/diseasesplicer.dm
@@ -35,10 +35,7 @@
 
 	src.attack_hand(user)
 
-/obj/machinery/computer/diseasesplicer/attack_ai(var/mob/user as mob)
-	return src.attack_hand(user)
-
-/obj/machinery/computer/diseasesplicer/attack_hand(var/mob/user as mob)
+/obj/machinery/computer/diseasesplicer/attack_hand(mob/user)
 	if(..()) return
 	ui_interact(user)
 


### PR DESCRIPTION
`/obj/machinery` routes `attack_ai` into `attack_hand` by default. But a lot of machines override `attack_ai` in order to either do the same thing, or run a carbon copy of `attack_hand`. And with cargo cult coding, the number is evergrowing.

This PR puts a stop to this, or so I hope.