### PR TITLE
Fixes and improvements

### DIFF
--- a/code/controllers/subsystems/research.dm
+++ b/code/controllers/subsystems/research.dm
@@ -84,20 +84,8 @@ SUBSYSTEM_DEF(research)
 	// If designs are already generated, initialized right away.
 	// If not, add them to the list to be initialized later.
 	if(research_initialized)
-		var/datum/design/design
-
-		for(var/d in all_designs)
-			var/datum/design/_design = d
-			if(_design.type == design_file.design || _design.id == design_file.design)
-				design = _design
-				break
-
-		if(design)
-			design_file.design = design
-			design_file.on_design_set()
-		else
-			error("Incorrect design ID or path: [design_file.design]")
-
+		design_file.design = SSresearch.get_design(design_file.design)
+		design_file.on_design_set()
 	else
 		design_files_to_init += design_file
 
@@ -115,3 +103,11 @@ SUBSYSTEM_DEF(research)
 
 	for(var/design in starting_designs)
 		R.AddDesign2Known(design)
+
+/datum/controller/subsystem/research/proc/get_design(id)
+	for(var/_design in all_designs)
+		var/datum/design/design = _design
+		if(design.id == id)
+			return design
+
+	error("Incorrect design ID or path: [id]")

--- a/code/game/machinery/autolathe/autolathe.dm
+++ b/code/game/machinery/autolathe/autolathe.dm
@@ -84,15 +84,12 @@
 
 	image_load = new(src)
 	image_load_material = new(src)
-	vis_contents += image_load
-	vis_contents += image_load_material
 
 	if(have_disk && default_disk)
 		disk = new default_disk(src)
 
 /obj/machinery/autolathe/Destroy()
 	QDEL_NULL(wires)
-	vis_contents.Cut()
 	QDEL_NULL(image_load)
 	QDEL_NULL(image_load_material)
 	return ..()
@@ -868,8 +865,15 @@
 	icon_state = ""
 	mouse_opacity = 0
 
-/obj/effect/flicker_overlay/New(atom/loc)
+/obj/effect/flicker_overlay/New(atom/movable/loc)
 	..()
 	icon = loc.icon
 	layer = loc.layer
 	plane = loc.plane
+	loc.vis_contents += src
+
+/obj/effect/flicker_overlay/Destroy()
+	if(istype(loc, /atom/movable))
+		var/atom/movable/A = loc
+		A.vis_contents -= src
+	return ..()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -260,7 +260,7 @@ Class Procs:
 			return rating
 		else
 			rating = P.rating
-		
+
 	return rating
 
 /obj/machinery/proc/assign_uid()
@@ -296,15 +296,16 @@ Class Procs:
 
 
 //Tool qualities are stored in \code\__defines\tools_and_qualities.dm
-/obj/machinery/proc/default_deconstruction(var/obj/item/I, var/mob/user)
+/obj/machinery/proc/default_deconstruction(obj/item/I, mob/user)
 
-	var/tool_type = I.get_tool_type(user, list(QUALITY_PRYING, QUALITY_SCREW_DRIVING), src)
+	var/qualities = list(QUALITY_SCREW_DRIVING)
+
+	if(panel_open)
+		qualities += QUALITY_PRYING
+
+	var/tool_type = I.get_tool_type(user, qualities, src)
 	switch(tool_type)
-
 		if(QUALITY_PRYING)
-			if(!panel_open)
-				to_chat(user, SPAN_NOTICE("You cant get to the components of \the [src], remove the cover."))
-				return TRUE
 			if(I.use_tool(user, src, WORKTIME_NORMAL, tool_type, FAILCHANCE_HARD, required_stat = STAT_MEC))
 				to_chat(user, SPAN_NOTICE("You remove the components of \the [src] with [I]."))
 				dismantle()

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -28,10 +28,8 @@
 	recalculateChannels(1)
 
 /obj/item/device/radio/headset/Destroy()
-	qdel(keyslot1)
-	qdel(keyslot2)
-	keyslot1 = null
-	keyslot2 = null
+	QDEL_NULL(keyslot1)
+	QDEL_NULL(keyslot2)
 	return ..()
 
 /obj/item/device/radio/headset/list_channels(var/mob/user)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -66,11 +66,11 @@ var/global/list/default_medbay_channels = list(
 
 /obj/item/device/radio/Destroy()
 	remove_hearing()
-	qdel(wires)
-	wires = null
+	QDEL_NULL(wires)
 	SSradio.remove_object(src, frequency)
 	for (var/ch_name in channels)
 		SSradio.remove_object(src, radiochannels[ch_name])
+
 	return ..()
 
 

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -25,7 +25,7 @@
 	icon_state = "box"
 	item_state = "syringe_kit"
 	max_w_class = ITEM_SIZE_SMALL
-	max_storage_space = DEFAULT_SMALL_STORAGE
+	max_storage_space = DEFAULT_SMALL_STORAGE + 1
 	var/foldable = /obj/item/stack/material/cardboard	// BubbleWrap - if set, can be folded (when empty) into a sheet of cardboard
 	health = 20
 
@@ -81,10 +81,12 @@
 /obj/item/weapon/storage/box/survival/populate_contents()
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/weapon/tank/emergency_oxygen(src)
+	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
 
-/obj/item/weapon/storage/box/engineer/populate_contents()
+/obj/item/weapon/storage/box/survival/extended/populate_contents()
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/weapon/tank/emergency_oxygen/engi(src)
+	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
 
 /obj/item/weapon/storage/box/gloves
 	name = "box of latex gloves"

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -34,19 +34,18 @@
 		if(1 to 4)	overlays += "plasma-[plasmatanks]"
 		if(5 to INFINITY) overlays += "plasma-5"
 
-/obj/structure/dispenser/attack_ai(mob/user as mob)
+/obj/structure/dispenser/attack_ai(mob/user)
 	if(user.Adjacent(src))
 		return attack_hand(user)
 	..()
 
-/obj/structure/dispenser/attack_hand(mob/user as mob)
+/obj/structure/dispenser/attack_hand(mob/user)
 	user.set_machine(src)
 	var/dat = "[src]<br><br>"
 	dat += "Oxygen tanks: [oxygentanks] - [oxygentanks ? "<A href='?src=\ref[src];oxygen=1'>Dispense</A>" : "empty"]<br>"
 	dat += "Plasma tanks: [plasmatanks] - [plasmatanks ? "<A href='?src=\ref[src];plasma=1'>Dispense</A>" : "empty"]"
 	user << browse(dat, "window=dispenser")
 	onclose(user, "dispenser")
-	return
 
 
 /obj/structure/dispenser/attackby(obj/item/I, mob/user)
@@ -94,15 +93,15 @@
 
 	var/obj/item/weapon/tank/tank
 	if(href_list["oxygen"] && oxygentanks > 0)
-		if(oxytanks.len == oxygentanks)
-			tank = oxytanks[1]
+		if(oxytanks.len)
+			tank = oxytanks[oxytanks.len]	// Last stored tank is always the first one to be dispensed
 			oxytanks.Remove(tank)
 		else
 			tank = new /obj/item/weapon/tank/oxygen(loc)
 		oxygentanks--
 	if(href_list["plasma"] && plasmatanks > 0)
-		if(platanks.len == plasmatanks)
-			tank = platanks[1]
+		if(platanks.len)
+			tank = platanks[platanks.len]
 			platanks.Remove(tank)
 		else
 			tank = new /obj/item/weapon/tank/plasma(loc)
@@ -115,4 +114,3 @@
 
 	playsound(usr.loc, 'sound/machines/Custom_extout.ogg', 100, 1)
 	updateUsrDialog()
-	return

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -395,16 +395,15 @@
 	active = 1
 	usable = 1
 
-
 	interface_name = "Autodoc"
 	interface_desc = "Module with set of instruments that is capable to preform surgery on user"
 	var/datum/autodoc/autodoc_processor
+	var/autodoc_type = /datum/autodoc
 	var/turf/wearer_loc = null
 
 /obj/item/rig_module/autodoc/Initialize()
 	. = ..()
-	autodoc_processor = new()
-	autodoc_processor.holder = src
+	autodoc_processor = new autodoc_type(src)
 	autodoc_processor.damage_heal_amount = 20
 
 /obj/item/rig_module/autodoc/Destroy()
@@ -443,8 +442,5 @@
 /obj/item/rig_module/autodoc/deactivate()
 	return
 
-/obj/item/rig_module/autodoc/comercial/New()
-	..()
-	autodoc_processor = new/datum/autodoc/capitalist_autodoc()
-	autodoc_processor.holder = src
-	autodoc_processor.damage_heal_amount = 20
+/obj/item/rig_module/autodoc/commercial
+	autodoc_type = /datum/autodoc/capitalist_autodoc

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -363,8 +363,8 @@
 		jets.toggle()
 	return 1
 
-/obj/item/rig_module/maneuvering_jets/New()
-	..()
+/obj/item/rig_module/maneuvering_jets/Initialize()
+	. = ..()
 	jets = new(src)
 
 //Some slightly complex setup here to make hardsuit jetpacks work right

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -113,8 +113,7 @@
 		return visor.vision.glasses
 
 /obj/item/weapon/rig/examine()
-	to_chat(usr, "This is \icon[src][src.name].")
-	to_chat(usr, "[src.desc]")
+	..()
 	if(wearer)
 		for(var/obj/item/piece in list(helmet,gloves,chest,boots))
 			if(!piece || piece.loc != wearer)
@@ -125,8 +124,8 @@
 		to_chat(usr, "The maintenance panel is [open ? "open" : "closed"].")
 		to_chat(usr, "Hardsuit systems are [offline ? "<font color='red'>offline</font>" : "<font color='green'>online</font>"].")
 
-/obj/item/weapon/rig/New()
-	..()
+/obj/item/weapon/rig/Initialize()
+	. = ..()
 
 	item_state = icon_state
 	wires = new(src)
@@ -136,7 +135,7 @@
 		allowed |= extra_allowed
 
 	if((!req_access || !req_access.len) && (!req_one_access || !req_one_access.len))
-		locked = 0
+		locked = FALSE
 
 	spark_system = new()
 	spark_system.set_up(5, 0, src)

--- a/code/modules/clothing/spacesuits/rig/rig_wiring.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_wiring.dm
@@ -11,7 +11,7 @@
  * Interface lock can be pulsed to toggle whether or not the interface can be accessed.
  */
 
-/datum/wires/rig/UpdateCut(var/index, var/mended)
+/datum/wires/rig/UpdateCut(index, mended)
 
 	var/obj/item/weapon/rig/rig = holder
 	switch(index)
@@ -22,8 +22,15 @@
 		if(RIG_INTERFACE_SHOCK)
 			rig.electrified = mended ? 0 : -1
 			rig.shock(usr,100)
+		if(RIG_SYSTEM_CONTROL)
+			if(mended)
+				rig.malfunctioning = 0
+				rig.malfunction_delay = 0
+			else
+				rig.malfunctioning = 10
+				rig.malfunction_delay = 30
 
-/datum/wires/rig/UpdatePulsed(var/index)
+/datum/wires/rig/UpdatePulsed(index)
 
 	var/obj/item/weapon/rig/rig = holder
 	switch(index)
@@ -48,9 +55,7 @@
 
 /datum/wires/rig/CanUse(var/mob/living/L)
 	var/obj/item/weapon/rig/rig = holder
-	if(rig.open)
-		return 1
-	return 0
+	return rig.open
 
 #undef RIG_SECURITY
 #undef RIG_AI_OVERRIDE

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -377,13 +377,16 @@
 			L[hairstyle] = S
 	return L
 
-/datum/species/proc/equip_survival_gear(var/mob/living/carbon/human/H,var/extendedtank = 1)
+/datum/species/proc/equip_survival_gear(mob/living/carbon/human/H, extendedtank = TRUE)
+	var/box_type = /obj/item/weapon/storage/box/survival
+
+	if(extendedtank)
+		box_type = /obj/item/weapon/storage/box/survival/extended
+
 	if(istype(H.get_equipped_item(slot_back), /obj/item/weapon/storage))
-		if (extendedtank)	H.equip_to_storage(new /obj/item/weapon/storage/box/engineer(H.back))
-		else	H.equip_to_storage(new /obj/item/weapon/storage/box/survival(H.back))
+		H.equip_to_storage(new box_type(H.back))
 	else
-		if (extendedtank)	H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H), slot_r_hand)
-		else	H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
+		H.equip_to_slot_or_del(new box_type(H), slot_r_hand)
 
 /datum/species/proc/has_equip_slot(slot)
 	if(hud && hud.equip_slots)

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -2,7 +2,7 @@
 /datum/computer_file/program
 	filetype = "PRG"
 	filename = "UnknownProgram"						// File name. FILE NAME MUST BE UNIQUE IF YOU WANT THE PROGRAM TO BE DOWNLOADABLE FROM NTNET!
-	var/required_access = null						// List of required accesses to run/download the program.
+	var/required_access = null						// Access level required to run/download the program.
 	var/requires_access_to_run = 1					// Whether the program checks for required_access when run.
 	var/requires_access_to_download = 1				// Whether the program checks for required_access when downloading.
 	var/datum/nano_module/NM = null					// If the program uses NanoModule, put it here and it will be automagically opened. Otherwise implement ui_interact.
@@ -40,7 +40,7 @@
 
 /datum/computer_file/program/clone()
 	var/datum/computer_file/program/temp = ..()
-	temp.required_access = required_access.Copy()
+	temp.required_access = required_access
 	temp.nanomodule_path = nanomodule_path
 	temp.filedesc = filedesc
 	temp.program_icon_state = program_icon_state

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -40,7 +40,7 @@
 
 /datum/computer_file/program/clone()
 	var/datum/computer_file/program/temp = ..()
-	temp.required_access = required_access
+	temp.required_access = required_access.Copy()
 	temp.nanomodule_path = nanomodule_path
 	temp.filedesc = filedesc
 	temp.program_icon_state = program_icon_state

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -8,7 +8,7 @@
 	var/possible_transfer_amounts = list(5,10,15,25,30)
 	var/volume = 30
 	var/filling_states				// List of percentages full that have icons
-	
+
 
 /obj/item/weapon/reagent_containers/verb/set_APTFT() //set amount_per_transfer_from_this
 	set name = "Set transfer amount"
@@ -18,14 +18,11 @@
 	if(N)
 		amount_per_transfer_from_this = N
 
-/obj/item/weapon/reagent_containers/New()
+/obj/item/weapon/reagent_containers/Initialize()
+	create_reagents(volume)
+	. = ..() // This creates initial reagents
 	if(!possible_transfer_amounts)
 		src.verbs -= /obj/item/weapon/reagent_containers/verb/set_APTFT
-	create_reagents(volume)
-	if(preloaded_reagents)
-		for(var/reagent in preloaded_reagents)
-			reagents.add_reagent(reagent, preloaded_reagents[reagent])
-	..()
 
 
 /obj/item/weapon/reagent_containers/attack_self(mob/user as mob)
@@ -201,7 +198,7 @@
 		return FALSE
 	if(!reagents.total_volume)
 		return FALSE
-	
+
 	// nothing to separate
 	if(reagents.reagent_list.len <= 1)
 		return FALSE
@@ -221,12 +218,11 @@
 			if(!C.reagents.get_free_space())
 				containers.Remove(C)
 				continue
-			
+
 			var/amount = min(C.reagents.get_free_space(), amount_to_transfer)
 			if(!C.reagents.total_volume || C.reagents.has_reagent(R.id))
 				C.reagents.add_reagent(R.id, amount, R.get_data())
 				reagents.remove_reagent(R.id, amount)
 				amount_to_transfer = max(0,amount_to_transfer - amount)
 	return TRUE
-		
-		
+

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -22,8 +22,8 @@
 	filling_states = "-10;10;25;50;75;80;100"
 	var/blood_type = null
 
-/obj/item/weapon/reagent_containers/blood/New()
-	..()
+/obj/item/weapon/reagent_containers/blood/Initialize()
+	. = ..()
 	if(blood_type)
 		reagents.add_reagent("blood", 200, list("donor"=null,"viruses"=null,"blood_DNA"=null,"blood_type"=blood_type,"resistances"=null,"trace_chem"=null))
 

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -18,11 +18,12 @@
 /obj/item/weapon/reagent_containers/food/drinks/bottle/on_reagent_change()
 	update_icon()
 
-/obj/item/weapon/reagent_containers/food/drinks/bottle/New()
+/obj/item/weapon/reagent_containers/food/drinks/bottle/Initialize()
+	. = ..()
 	icon_state_full = "[icon_state]"
 	icon_state_empty = "[icon_state]_empty"
-	..()
-	if(isGlass) unacidable = 1
+	if(isGlass)
+		unacidable = TRUE
 
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/Destroy()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -20,8 +20,8 @@
 	var/sanity_gain = 0.2 //Per bite
 	var/cooked = FALSE
 
-/obj/item/weapon/reagent_containers/food/snacks/New()
-	..()
+/obj/item/weapon/reagent_containers/food/snacks/Initialize()
+	. = ..()
 	if(nutriment_amt)
 		reagents.add_reagent("nutriment", nutriment_amt, nutriment_desc)
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -42,12 +42,12 @@
 		/obj/machinery/biogenerator,
 		/obj/machinery/constructable_frame,
 		/obj/machinery/radiocarbon_spectrometer,
-		/obj/machinery/centrifuge, 
+		/obj/machinery/centrifuge,
 		/obj/machinery/electrolyzer
 		)
 
-/obj/item/weapon/reagent_containers/glass/New()
-	..()
+/obj/item/weapon/reagent_containers/glass/Initialize()
+	. = ..()
 	base_name = name
 
 /obj/item/weapon/reagent_containers/glass/proc/has_lid()

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -12,10 +12,10 @@
 	filling_states = "-10;10;25;50;75;80;100"
 	lid_icon_state = "lid_bottle"
 
-/obj/item/weapon/reagent_containers/glass/bottle/New()
+/obj/item/weapon/reagent_containers/glass/bottle/Initialize()
+	. = ..()
 	if(!icon_state || icon_state == "bottle")
 		icon_state = "bottle-[rand(1,4)]"
-	..()
 
 /obj/item/weapon/reagent_containers/glass/bottle/update_icon()
 	cut_overlays()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -14,11 +14,7 @@
 	possible_transfer_amounts = null
 	reagent_flags = OPENCONTAINER
 	slot_flags = SLOT_BELT
-
-///obj/item/weapon/reagent_containers/hypospray/New() //comment this to make hypos start off empty
-//	..()
-//	reagents.add_reagent("tricordrazine", 30)
-//	return
+	preloaded_reagents = list("tricordrazine" = 30)
 
 /obj/item/weapon/reagent_containers/hypospray/attack(mob/living/M as mob, mob/user as mob)
 	if(!reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -19,8 +19,8 @@
 	var/list/spray_sizes = list(1,3)
 	volume = 250
 
-/obj/item/weapon/reagent_containers/spray/New()
-	..()
+/obj/item/weapon/reagent_containers/spray/Initialize()
+	. = ..()
 	src.verbs -= /obj/item/weapon/reagent_containers/verb/set_APTFT
 
 /obj/item/weapon/reagent_containers/spray/afterattack(atom/A as mob|obj, mob/user as mob, proximity)

--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -28,11 +28,12 @@
 		totalFlavor += data[data[i]]
 
 	if(totalFlavor != 0)
-		for(var/i in 1 to data.len) //cull the tasteless
-			if(data[data[i]]/totalFlavor * 100 < 10)
-				data[data[i]] = null
-				data -= data[i]
-				data -= null
+		var/flavors_to_remove = list()
+		for(var/flavor in data) //cull the tasteless
+			if(data[flavor]/totalFlavor * 100 < 10)
+				flavors_to_remove += flavor
+
+		data -= flavors_to_remove
 
 /datum/reagent/organic/nutriment/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	if(!injectable)

--- a/code/modules/research/designs/rigmodules.dm
+++ b/code/modules/research/designs/rigmodules.dm
@@ -8,10 +8,10 @@
 	build_path = /obj/item/rig_module/autodoc
 	sort_string = "VDAAF"
 
-/datum/design/research/item/autodoc_comercial
+/datum/design/research/item/autodoc_commercial
 	name = "commercial autodoc module"
 	desc = "A complex surgery system for almost all your needs."
-	build_path = /obj/item/rig_module/autodoc/comercial
+	build_path = /obj/item/rig_module/autodoc/commercial
 	sort_string = "VDAAG"
 
 /datum/design/research/item/chem_dispenser

--- a/code/modules/research/nodes/biotech.dm
+++ b/code/modules/research/nodes/biotech.dm
@@ -183,7 +183,7 @@
 	cost = 1000
 
 	unlocks_designs = list(	/datum/design/research/item/autodoc,
-							/datum/design/research/item/autodoc_comercial,
+							/datum/design/research/item/autodoc_commercial,
 							/datum/design/research/item/chem_dispenser,
 							/datum/design/research/item/medhud,
 							/datum/design/research/structure/bidonadv

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -644,7 +644,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 			var/list/unlock_list = list()
 			for(var/T in tech_node.unlocks_designs)
-				var/datum/design/D = locate(T) in SSresearch.all_designs
+				var/datum/design/D = SSresearch.get_design(T)
 				if(D) // remove?
 					var/list/build_types = list()
 					if(D.build_type & IMPRINTER)

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -89,10 +89,9 @@ Procs:
 	else
 		tree.level += 1
 
-	for(var/D in T.unlocks_designs)
-		var/datum/design/design = locate(D) in SSresearch.all_designs
-		if(design)
-			AddDesign2Known(design)
+	for(var/id in T.unlocks_designs)
+		AddDesign2Known(SSresearch.get_design(id))
+
 	return TRUE
 
 /datum/research/proc/download_from(datum/research/O)

--- a/code/modules/surgery/autodoc.dm
+++ b/code/modules/surgery/autodoc.dm
@@ -43,6 +43,10 @@
 	var/mob/living/carbon/human/patient = null
 	var/list/possible_operations = list(AUTODOC_DAMAGE, AUTODOC_EMBED_OBJECT, AUTODOC_FRACTURE, AUTODOC_OPEN_WOUNDS, AUTODOC_TOXIN, AUTODOC_DIALYSIS, AUTODOC_BLOOD)
 
+/datum/autodoc/New(obj/new_holder)
+	. = ..()
+	holder = new_holder
+
 /datum/autodoc/proc/set_patient(var/mob/living/carbon/human/human = null)
 	patient = human
 /datum/autodoc/proc/scan_user()


### PR DESCRIPTION
* Screwed up RIGs are now easier to repair: cutting and mending all wires should do the trick, like it does for most things.
* Hypospray now spawns with 30u of tricordrazine. This was removed because it interfered with injectors - after a bunch of chem refactors, it no longer does.
* Backpack oxygen boxes now spawn with an injector. Those things are rarely used, but I think it's a thing that is better to have just in case. Storage space of a box increased by 1 (one tiny item size), so there is no downside to this change.
* Oxygen tank storage now dispenses the tanks that were put into it manually first, making it easier to sabotage.

Fixes #3871.

The rest of the changes are under-the-hood code improvements and fixes for bugs I haven't seen reported.