### PR TITLE
Booze icon fix

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -19,9 +19,9 @@
 	update_icon()
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/Initialize()
-	. = ..()
 	icon_state_full = "[icon_state]"
 	icon_state_empty = "[icon_state]_empty"
+	. = ..()
 	if(isGlass)
 		unacidable = TRUE
 


### PR DESCRIPTION
## About The Pull Request
Vodka is back.
Missing icon was caused by `update_icon` called from reagent addition in `/atom/proc/Initialize` before icon states were initialized.