### PR TITLE
Fixes R&D DB breaking

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/power.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/power.dm
@@ -43,7 +43,7 @@
 	)
 
 /obj/item/weapon/circuitboard/breakerbox
-	name = T_BOARD("breakerbox")
+	name = T_BOARD("breaker box")
 	build_path = /obj/machinery/power/breakerbox
 	board_type = "machine"
 	origin_tech = list(TECH_POWER = 4, TECH_ENGINEERING = 4)

--- a/code/modules/research/designs/circuits.dm
+++ b/code/modules/research/designs/circuits.dm
@@ -277,6 +277,12 @@
 	sort_string = "JBABB"
 	category = CAT_POWER
 
+/datum/design/research/circuit/breakerbox
+	name = "breaker box"
+	build_path = /obj/item/weapon/circuitboard/breakerbox
+	sort_string = "JBABC"
+	category = CAT_POWER
+
 /datum/design/research/circuit/gas_heater
 	name = "gas heating system"
 	build_path = /obj/item/weapon/circuitboard/unary_atmos/heater

--- a/code/modules/research/nodes/power.dm
+++ b/code/modules/research/nodes/power.dm
@@ -68,7 +68,7 @@
 	required_tech_levels = list()
 	cost = 1000
 
-	unlocks_designs = list(/obj/item/weapon/circuitboard/breakerbox)
+	unlocks_designs = list(/datum/design/research/circuit/breakerbox)
 
 /datum/technology/super_power
 	name = "Super Power Storing"


### PR DESCRIPTION
A non-design was supposed to be unlocked by "Energy Distribution" node. No wonder the research system didn't like it.