### PR TITLE
Fixes hivemind wires being unable to take over seeded tiles

### DIFF
--- a/code/__DEFINES/_hydro_setup.dm
+++ b/code/__DEFINES/_hydro_setup.dm
@@ -59,5 +59,6 @@
 #define TRAIT_FLESH_COLOUR         	39
 #define TRAIT_CHEM_SPRAYER         	40
 #define TRAIT_WALL_HUGGER			41
+#define TRAIT_INVASIVE				42//Allows to invade already seeded tiles
 
 #define WALL_HUG_OFFSET 			12 //How many pixels a wallhugging plant is offset towards a wall

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -1276,3 +1276,4 @@
 	set_trait(TRAIT_YIELD,-1)
 	set_trait(TRAIT_SPREAD,3)
 	set_trait(TRAIT_POTENCY,50)
+	set_trait(TRAIT_INVASIVE,1)

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -19,8 +19,12 @@
 			continue
 
 		//We check zdest, not floor, for existing plants
-		if((locate(/obj/effect/plant) in zdest.contents) || (locate(/obj/effect/dead_plant) in zdest.contents) )
-			continue
+		if((locate(/obj/effect/plant) in zdest.contents) || (locate(/obj/effect/dead_plant) in zdest.contents))
+			if(!(seed.get_trait(TRAIT_INVASIVE)))//Invasive ones can invade onto other tiles
+				continue
+			var/obj/effect/plant/neighbor_plant = (locate(/obj/effect/plant) in zdest.contents)
+			if(neighbor_plant.seed.get_trait(TRAIT_INVASIVE))//If it's also invasive, don't invade (for better performance and plants not eating at itself)
+				continue
 
 		//We dont want to melt external walls and cause breaches
 		if(!near_external && floor.density)
@@ -186,6 +190,12 @@
 			break
 		var/turf/target_turf = pick(neighbors)
 		target_turf = get_connecting_turf(target_turf, loc)
+		var/obj/effect/neighbor_plant = (locate(/obj/effect/plant) in target_turf.contents)
+		if(!neighbor_plant)
+			neighbor_plant = (locate(/obj/effect/dead_plant) in target_turf.contents)
+		if(neighbor_plant)//Not else, because if there's no dead plant either, it shouldn't run the check at all
+			visible_message("[src] takes over [neighbor_plant]!")
+			qdel(neighbor_plant)
 		var/obj/effect/plant/child = new type(get_turf(src),seed,src)
 		after_spread(child, target_turf)
 		// Update neighboring squares.


### PR DESCRIPTION
## About The Pull Request
<!-- Why is it needed, what it fixes. Write up links to closing issues there as well, but make it short. -->



## Details
<!-- If you need, describe details inside. Remove whole block if not used. -->
<details>
  <summary>Expand</summary>
Fixes hivemind wires being unable to take over seeded tiles - also adds invasiveness as an (unobtainable) trait for plant for future use.
</details>

