### PR TITLE
Adds tip explaining how to cuff people wearing RIGs

### DIFF
--- a/code/modules/tips_and_tricks/gameplay.dm
+++ b/code/modules/tips_and_tricks/gameplay.dm
@@ -33,4 +33,7 @@
     tipText = "If you walk instead of run on underplating, you won't trip."
 
 /tipsAndTricks/gameplay/zoneTargetingNum
-    tipText = " You can target specific damage zones by using the Numpad keys."
+    tipText = "You can target specific damage zones by using the Numpad keys."
+
+/tipsAndTricks/gameplay/cuffHardsuit
+    tipText = "People in RIG/Hardsuits need to be cuffed using zipties or cable cuffs. Normal cuffs are not large enough to cover their gauntlets."


### PR DESCRIPTION
## About The Pull Request
The tip says "People in RIG/Hardsuits need to be cuffed using zipties or cable cuffs. Normal cuffs are not large enough to cover their gauntlets."