### PR TITLE
Traitor update

### DIFF
--- a/code/datums/contract.dm
+++ b/code/datums/contract.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_EMPTY(all_antag_contracts)
 	while(candidates.len)
 		var/datum/mind/target_mind = pick(candidates)
 		var/mob/living/carbon/human/H = target_mind.current
-		if(!istype(H) || H.stat == DEAD)
+		if(!istype(H) || H.stat == DEAD || H.get_core_implant(/obj/item/weapon/implant/core_implant/cruciform))
 			candidates -= target_mind
 			continue
 		target = H

--- a/code/datums/contract.dm
+++ b/code/datums/contract.dm
@@ -28,6 +28,7 @@ GLOBAL_LIST_EMPTY(all_antag_contracts)
 		break
 
 
+// A contract to steal a specific item - allows you to check all contents (recursively) for the target item
 /datum/antag_contract/item
 
 /datum/antag_contract/item/proc/on_container(obj/item/weapon/storage/bsdm/container)
@@ -35,7 +36,25 @@ GLOBAL_LIST_EMPTY(all_antag_contracts)
 		complete(container.owner)
 
 /datum/antag_contract/item/proc/check(obj/item/weapon/storage/container)
-	warning("Item contract does not implement check(): [name] [desc]")
+	return check_contents(container.GetAllContents(includeSelf = FALSE))
+
+/datum/antag_contract/item/proc/check_contents(list/contents)
+	warning("Item contract does not implement check_contents(): [name] [desc]")
+	return FALSE
+
+
+// A contract to steal a specific file - allows you to check all disks for the target file
+/datum/antag_contract/item/file
+
+/datum/antag_contract/item/file/check_contents(list/contents)
+	var/list/all_files = list()
+	for(var/obj/item/weapon/computer_hardware/hard_drive/H in contents)
+		all_files += H.stored_files
+
+	return check_files(all_files)
+
+/datum/antag_contract/item/file/proc/check_files(list/files)
+	warning("File contract does not implement check_files(): [name] [desc]")
 	return FALSE
 
 
@@ -145,8 +164,8 @@ GLOBAL_LIST_EMPTY(all_antag_contracts)
 /datum/antag_contract/item/assasinate/can_place()
 	return ..() && target
 
-/datum/antag_contract/item/assasinate/check(obj/item/weapon/storage/container)
-	return target in container
+/datum/antag_contract/item/assasinate/check_contents(list/contents)
+	return target in contents
 
 
 /datum/antag_contract/item/steal
@@ -192,15 +211,15 @@ GLOBAL_LIST_EMPTY(all_antag_contracts)
 /datum/antag_contract/item/steal/can_place()
 	return ..() && target_type
 
-/datum/antag_contract/item/steal/check(obj/item/weapon/storage/container)
-	return locate(target_type) in container
+/datum/antag_contract/item/steal/check_contents(list/contents)
+	return locate(target_type) in contents
 
 
 /datum/antag_contract/item/steal/docs
 	unique = TRUE
 	reward = 12
 	target_type = /obj/item/weapon/oddity/secdocs
-	desc = "Steal the secret documents and send them via BSDM."
+	desc = "Steal a folder of secret documents and send them via BSDM."
 
 
 /datum/antag_contract/item/dump
@@ -214,9 +233,9 @@ GLOBAL_LIST_EMPTY(all_antag_contracts)
 	sum = rand(30, 40) * 500
 	desc = "Extract a sum of [sum] credits from Eris economy and send it via BSDM."
 
-/datum/antag_contract/item/dump/check(obj/item/weapon/storage/container)
+/datum/antag_contract/item/dump/check_contents(list/contents)
 	var/received = 0
-	for(var/obj/item/weapon/spacecash/cash in container)
+	for(var/obj/item/weapon/spacecash/cash in contents)
 		received += cash.worth
 	return received >= sum
 
@@ -232,9 +251,9 @@ GLOBAL_LIST_EMPTY(all_antag_contracts)
 	count = rand(3, 6)
 	desc = "Send blood samples of [count] different people in separate containers via BSDM."
 
-/datum/antag_contract/item/blood/check(obj/item/weapon/storage/container)
+/datum/antag_contract/item/blood/check_contents(list/contents)
 	var/list/samples = list()
-	for(var/obj/item/weapon/reagent_containers/C in container)
+	for(var/obj/item/weapon/reagent_containers/C in contents)
 		var/list/data = C.reagents?.get_data("blood")
 		if(!data || data["species"] != "Human" || data["blood_DNA"] in samples)
 			continue
@@ -244,34 +263,34 @@ GLOBAL_LIST_EMPTY(all_antag_contracts)
 	return FALSE
 
 
-/datum/antag_contract/item/research
+
+/datum/antag_contract/item/file/research
 	name = "Steal research"
 	unique = TRUE
 	reward = 6
 	var/list/targets = list()
 	var/static/counter = 0
 
-/datum/antag_contract/item/research/New()
+/datum/antag_contract/item/file/research/New()
 	..()
 	var/list/candidates = SSresearch.all_designs.Copy()
-	for(var/datum/antag_contract/item/research/C in GLOB.all_antag_contracts)
+	for(var/datum/antag_contract/item/file/research/C in GLOB.all_antag_contracts)
 		candidates -= C.targets
 	while(candidates.len && targets.len < 8)
 		var/datum/design/D = pick(candidates)
 		targets += D
 		candidates -= D
-	desc = "Send a disk with one of the following designs via BSDM: [english_list(targets, and_text = " or ")]."
+	desc = "Send a disk with one of the following designs via BSDM:<br>[english_list(targets, and_text = " or ")]."
 
-/datum/antag_contract/item/research/can_place()
+/datum/antag_contract/item/file/research/can_place()
 	return ..() && targets.len && counter < 3
 
-/datum/antag_contract/item/research/place()
+/datum/antag_contract/item/file/research/place()
 	..()
 	++counter
 
-/datum/antag_contract/item/research/check(obj/item/weapon/storage/container)
-	for(var/obj/item/weapon/computer_hardware/hard_drive/H in container)
-		for(var/datum/computer_file/binary/design/D in H.stored_files)
-			if(D.design in targets)
-				return TRUE
+/datum/antag_contract/item/file/research/check_files(list/files)
+	for(var/datum/computer_file/binary/design/D in files)
+		if(!D.copy_protected && (D.design in targets))
+			return TRUE
 	return FALSE

--- a/code/datums/contract.dm
+++ b/code/datums/contract.dm
@@ -77,7 +77,7 @@ GLOBAL_LIST_EMPTY(all_antag_contracts)
 	while(candidates.len)
 		var/datum/mind/target_mind = pick(candidates)
 		var/mob/living/carbon/human/H = target_mind.current
-		if(!istype(H) || H.stat == DEAD || H.get_core_implant(/obj/item/weapon/implant/core_implant/cruciform))
+		if(!istype(H) || H.stat == DEAD || !isOnStationLevel(H) || H.get_core_implant(/obj/item/weapon/implant/core_implant/cruciform))
 			candidates -= target_mind
 			continue
 		target = H
@@ -158,7 +158,7 @@ GLOBAL_LIST_EMPTY(all_antag_contracts)
 	while(candidates.len)
 		target_mind = pick(candidates)
 		var/mob/living/carbon/human/H = target_mind.current
-		if(!istype(H) || H.stat == DEAD)
+		if(!istype(H) || H.stat == DEAD || !isOnStationLevel(H))
 			candidates -= target_mind
 			continue
 		target = H.get_core_implant(/obj/item/weapon/implant/core_implant/cruciform)

--- a/code/datums/contract.dm
+++ b/code/datums/contract.dm
@@ -5,6 +5,7 @@ GLOBAL_LIST_EMPTY(all_antag_contracts)
 	var/desc
 	var/reward = 0
 	var/completed = FALSE
+	var/datum/mind/completed_by = null
 	var/unique = FALSE
 
 /datum/antag_contract/proc/can_place()
@@ -21,6 +22,11 @@ GLOBAL_LIST_EMPTY(all_antag_contracts)
 	if(completed)
 		warning("Contract completed twice: [name] [desc]")
 	completed = TRUE
+	completed_by = M
+
+	if(M && M.current)
+		to_chat(M.current, SPAN_NOTICE("Contract completed: [name] ([reward] TC)"))
+
 	for(var/obj/item/device/uplink/U in world_uplinks)
 		if(U.uplink_owner != M)
 			continue

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -106,6 +106,8 @@
 
 /datum/uplink_item/item/tools/mind_fryer
 	name = "Mind Fryer"
+	desc = "When activated, attacks the minds of people nearby, causing sanity loss and inducing mental breakdowns. \
+			The device owner is immune to this effect."
 	item_cost = 3
 	path = /obj/item/device/mind_fryer
 	antag_roles = list()
@@ -118,6 +120,8 @@
 
 /datum/uplink_item/item/tools/spy_sensor
 	name = "Spying Sensor (4x)"
+	desc = "A set of sensor packages designed to collect some information for your client and self-destruct afterwards. \
+			Place the sensors in target area, make sure to activate each one and do not move or otherwise disturb them."
 	item_cost = 1
 	path = /obj/item/weapon/storage/box/syndie_kit/spy_sensor
 	antag_roles = ROLES_CONTRACT

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -120,7 +120,7 @@
 
 /datum/uplink_item/item/tools/spy_sensor
 	name = "Spying Sensor (4x)"
-	desc = "A set of sensor packages designed to collect some information for your client and self-destruct afterwards. \
+	desc = "A set of sensor packages designed to collect some information for your client. \
 			Place the sensors in target area, make sure to activate each one and do not move or otherwise disturb them."
 	item_cost = 1
 	path = /obj/item/weapon/storage/box/syndie_kit/spy_sensor

--- a/code/game/antagonist/antagonist_print.dm
+++ b/code/game/antagonist/antagonist_print.dm
@@ -17,7 +17,7 @@
 
 	var/mob/player = owner.current
 	// Basic intro text.
-	to_chat(player, "<span class='danger'><font size=3>You are a [role_text]!</font></span>")
+	to_chat(player, "<span class='danger'><font size=3>You are \a [role_text]!</font></span>")
 	if(faction)
 		if(src in faction.leaders)
 			to_chat(player, "You are a leader of the [faction.name]!")
@@ -36,7 +36,7 @@
 	var/tipsAndTricks/T = SStips.getRoleTip(src)
 	if(T)
 		var/mob/player = owner.current
-		to_chat(player, SStips.formatTip(T, "Tip for \a [src.id]: "))
+		to_chat(player, SStips.formatTip(T, "Tip for \a [role_text]: "))
 
 /datum/antagonist/proc/get_special_objective_text()
 	return ""
@@ -52,9 +52,28 @@
 	return text
 
 /datum/antagonist/proc/print_objectives(var/append_success = TRUE)
-	var/text = ""
-	text += get_special_objective_text()
-	if(objectives && objectives.len)
+	var/text = get_special_objective_text()
+
+	var/list/contracts = list()
+	for(var/c in GLOB.all_antag_contracts)
+		var/datum/antag_contract/contract = c
+		if(contract.completed && contract.completed_by == owner)
+			contracts += contract
+
+	if(length(contracts))
+		var/total_tc = 0
+		var/num = 1
+
+		text += "<br><b>Contracts fulfilled:</b>"
+		for(var/c in contracts)
+			var/datum/antag_contract/contract = c
+			total_tc += contract.reward
+			text += "<br><b>Contract [num]:</b> [contract.desc] <font color='green'>(+[contract.reward] TC)</font>"
+			num++
+
+		text += "<br><b>Total: [num] contracts, <font color='green'>[total_tc] TC</font></b><br>"
+
+	if(length(objectives))
 		var/failed = FALSE
 		var/num = 1
 		for(var/datum/objective/O in objectives)

--- a/code/game/objects/items/devices/mental_imprinter.dm
+++ b/code/game/objects/items/devices/mental_imprinter.dm
@@ -13,6 +13,8 @@
 
 	user.sanity.onPsyDamage(30)
 	user.stats.changeStat(stat, 5)
+
+	to_chat(user, SPAN_DANGER("[src] plunges into your eye, imprinting your mind with new information!"))
 	spent = TRUE
 
 /obj/item/device/mental_imprinter/attack(mob/M, mob/living/carbon/human/user, target_zone)

--- a/code/game/objects/items/devices/mental_imprinter.dm
+++ b/code/game/objects/items/devices/mental_imprinter.dm
@@ -4,15 +4,25 @@
 	icon_state = "mental_imprinter"
 	origin_tech = list(TECH_BIO = 5, TECH_ILLEGAL = 2)
 	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLASMA = 4, MATERIAL_BIOMASS = 6)
+	var/stat_increase = 5
+	var/apply_sanity_damage = 30
 	var/spent = FALSE
 
 /obj/item/device/mental_imprinter/proc/imprint(mob/living/carbon/human/user)
 	var/stat = input(user, "Select stat to boost", "Mental imprinter") as null|anything in ALL_STATS
-	if(!stat || user.incapacitated() || spent || user.get_active_hand() != src || user.get_covering_equipped_items(EYES).len)
+	if(!stat || spent)
 		return
 
-	user.sanity.onPsyDamage(30)
-	user.stats.changeStat(stat, 5)
+	if(!istype(user) || !user.stats || user.incapacitated() || user.get_active_hand() != src || length(user.get_covering_equipped_items(EYES)))
+		return
+
+	// User gains more and loses less if the base stat is fairly low
+	if(user.stats.getStat(stat, pure=TRUE) <= STAT_LEVEL_BASIC)
+		user.stats.changeStat(stat, stat_increase * 2)
+		user.sanity.onPsyDamage(apply_sanity_damage / 2)
+	else
+		user.stats.changeStat(stat, stat_increase)
+		user.sanity.onPsyDamage(apply_sanity_damage)
 
 	to_chat(user, SPAN_DANGER("[src] plunges into your eye, imprinting your mind with new information!"))
 	spent = TRUE
@@ -20,7 +30,7 @@
 /obj/item/device/mental_imprinter/attack(mob/M, mob/living/carbon/human/user, target_zone)
 	if(!istype(user) || M != user || target_zone != BP_EYES || user.incapacitated() || spent)
 		return ..()
-	if(user.get_covering_equipped_items(EYES).len)
+	if(length(user.get_covering_equipped_items(EYES)))
 		to_chat(user, SPAN_WARNING("You need to remove the eye covering first."))
 		return ..()
 

--- a/code/game/objects/items/devices/mental_imprinter.dm
+++ b/code/game/objects/items/devices/mental_imprinter.dm
@@ -1,7 +1,9 @@
 /obj/item/device/mental_imprinter
 	name = "mental imprinter"
-	desc = "A device that is applied to eyes to imprint skills into one's mind."
+	desc = "A device that is applied to an eye to imprint skills into one's mind."
 	icon_state = "mental_imprinter"
+	origin_tech = list(TECH_BIO = 5, TECH_ILLEGAL = 2)
+	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLASMA = 4, MATERIAL_BIOMASS = 6)
 	var/spent = FALSE
 
 /obj/item/device/mental_imprinter/proc/imprint(mob/living/carbon/human/user)

--- a/code/game/objects/items/devices/mental_imprinter.dm
+++ b/code/game/objects/items/devices/mental_imprinter.dm
@@ -3,7 +3,8 @@
 	desc = "A device that is applied to an eye to imprint skills into one's mind."
 	icon_state = "mental_imprinter"
 	origin_tech = list(TECH_BIO = 5, TECH_ILLEGAL = 2)
-	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLASMA = 4, MATERIAL_BIOMASS = 6)
+	matter = list(MATERIAL_STEEL = 4, MATERIAL_GLASS = 2)
+	matter_reagents = list("uncap nanites" = 10)
 	var/stat_increase = 5
 	var/apply_sanity_damage = 30
 	var/spent = FALSE

--- a/code/game/objects/items/devices/mind_fryer.dm
+++ b/code/game/objects/items/devices/mind_fryer.dm
@@ -1,3 +1,5 @@
+GLOBAL_LIST_EMPTY(active_mind_fryers)
+
 /obj/item/device/mind_fryer
 	name = "mind fryer"
 	desc = "A device that attacks the minds of people nearby, causing sanity loss and inducing mental breakdowns."
@@ -24,7 +26,13 @@
 	icon_state = "mind_fryer_deploy"
 	find_contract()
 	START_PROCESSING(SSobj, src)
+	GLOB.active_mind_fryers += src
 	verbs -= .verb/activate
+
+/obj/item/device/mind_fryer/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	GLOB.active_mind_fryers -= src
+	return ..()
 
 /obj/item/device/mind_fryer/Process()
 	for(var/mob/living/carbon/human/H in view(src))

--- a/code/game/objects/items/devices/mind_fryer.dm
+++ b/code/game/objects/items/devices/mind_fryer.dm
@@ -1,6 +1,9 @@
 /obj/item/device/mind_fryer
 	name = "mind fryer"
+	desc = "A device that attacks the minds of people nearby, causing sanity loss and inducing mental breakdowns."
 	icon_state = "mind_fryer"
+	origin_tech = list(TECH_BIO = 5, TECH_COMBAT = 3, TECH_ILLEGAL = 3)
+	matter = list(MATERIAL_STEEL = 6, MATERIAL_URANIUM = 4)
 	var/datum/antag_contract/derail/contract
 	var/datum/mind/owner
 	var/list/mob/living/carbon/human/victims

--- a/code/game/objects/items/devices/spy_sensor.dm
+++ b/code/game/objects/items/devices/spy_sensor.dm
@@ -40,12 +40,21 @@
 	active = TRUE
 	start()
 
-/obj/item/device/spy_sensor/proc/start()
+	var/sensor_amount = length(get_local_sensors())
+	to_chat(usr, SPAN_NOTICE("Sensor activated. [sensor_amount] sensor\s active in the area."))
+	if(sensor_amount >= 3 && timer)
+		to_chat(usr, SPAN_NOTICE("Data collection initiated."))
+
+/obj/item/device/spy_sensor/proc/get_local_sensors()
 	var/list/local_sensors = list()
 	for(var/obj/item/device/spy_sensor/S in get_area(src))
-		if(S.owner != owner || !S.active || S.timer)
+		if(S.owner != owner || !S.active)
 			continue
 		local_sensors += S
+	return local_sensors
+
+/obj/item/device/spy_sensor/proc/start()
+	var/list/local_sensors = get_local_sensors()
 	if(local_sensors.len >= 3)
 		timer = addtimer(CALLBACK(src, .proc/finish), 10 MINUTES)
 		for(var/obj/item/device/spy_sensor/S in local_sensors)

--- a/code/game/objects/items/devices/spy_sensor.dm
+++ b/code/game/objects/items/devices/spy_sensor.dm
@@ -1,6 +1,8 @@
 /obj/item/device/spy_sensor
 	name = "spying sensor"
 	icon_state = "motion0" //placeholder
+	origin_tech = list(TECH_MAGNETS = 5, TECH_ILLEGAL = 2)
+	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLATINUM = 2)
 	var/active = FALSE
 	var/datum/mind/owner
 	var/list/obj/item/device/spy_sensor/group

--- a/code/game/objects/items/devices/spy_sensor.dm
+++ b/code/game/objects/items/devices/spy_sensor.dm
@@ -56,7 +56,7 @@
 /obj/item/device/spy_sensor/proc/start()
 	var/list/local_sensors = get_local_sensors()
 	if(local_sensors.len >= 3)
-		timer = addtimer(CALLBACK(src, .proc/finish), 10 MINUTES)
+		timer = addtimer(CALLBACK(src, .proc/finish), 10 MINUTES, TIMER_STOPPABLE)
 		for(var/obj/item/device/spy_sensor/S in local_sensors)
 			S.timer = timer
 			S.group = local_sensors

--- a/code/game/objects/items/weapons/storage/bsdm.dm
+++ b/code/game/objects/items/weapons/storage/bsdm.dm
@@ -10,18 +10,21 @@
 	matter = list(MATERIAL_STEEL = 6)
 	var/datum/mind/owner
 
+/obj/item/weapon/storage/bsdm/proc/can_launch()
+	return owner && (locate(/area/space) in view(get_turf(src)))
+
 /obj/item/weapon/storage/bsdm/attack_self(mob/user)
 	ui_interact(user)
 
 /obj/item/weapon/storage/bsdm/interact(mob/user)
 	ui_interact(user)
 
-/obj/item/weapon/storage/bsdm/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = NANOUI_FOCUS)
-	var/data[0]
+/obj/item/weapon/storage/bsdm/ui_data(mob/user)
+	var/list/data = list()
 
-	data["can_launch"] = !!(locate(/area/space) in view(get_turf(src)))
-	data["owner"] = owner.name
-	data["is_owner"] = owner == user.mind
+	data["can_launch"] = can_launch()
+	data["owner"] = owner ? owner.name : "no one"
+	data["is_owner"] = owner && (owner == user.mind)
 	data["contracts"] = list()
 
 	for(var/datum/antag_contract/item/C in GLOB.all_antag_contracts)
@@ -33,6 +36,11 @@
 			"reward" = C.reward
 		)))
 
+	return data
+
+/obj/item/weapon/storage/bsdm/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = NANOUI_FOCUS)
+	var/list/data = ui_data(user)
+
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "bsdm.tmpl", "[name]", 400, 430)
@@ -43,16 +51,20 @@
 	if(..())
 		return 1
 
-	if (href_list["launch"])
-		if(!(locate(/area/space) in view(get_turf(src))))
+	if(href_list["launch"])
+		if(!can_launch())
 			return
+
+		if(ismob(loc))
+			to_chat(loc, SPAN_NOTICE("[src] flickers away in a brief flash of light."))
+
 		for(var/datum/antag_contract/item/C in GLOB.all_antag_contracts)
 			if(C.completed)
 				continue
 			C.on_container(src)
 		qdel(src)
 
-	else if (href_list["owner"])
+	else if(href_list["owner"])
 		owner = usr.mind
 		. = 1
 

--- a/code/game/objects/items/weapons/storage/bsdm.dm
+++ b/code/game/objects/items/weapons/storage/bsdm.dm
@@ -1,10 +1,13 @@
 /obj/item/weapon/storage/bsdm
 	name = "\improper BSDM unit"
-	desc = "A Blue Space Direct Mail unit."
+	desc = "A Blue Space Direct Mail unit, commonly used by corporate infiltrators. \
+			Once activated, teleports a small distance away into space and sends a signal for a recovery probe to pick it up."
 	icon_state = "bsdm"
 	item_state = "bsdm"
 	max_storage_space = DEFAULT_BULKY_STORAGE
 	max_w_class = ITEM_SIZE_BULKY
+	origin_tech = list(TECH_BLUESPACE = 3, TECH_ILLEGAL = 3)
+	matter = list(MATERIAL_STEEL = 6)
 	var/datum/mind/owner
 
 /obj/item/weapon/storage/bsdm/attack_self(mob/user)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -98,7 +98,7 @@
 
 /obj/item/weapon/storage/box/syndie_kit/imp_spying
 	name = "box (S)"
-	desc = "A box with spying implanter inside. Implant your contract target and wait 1 minute for the confirmation."
+	desc = "A box with spying implanter inside. Implant your contract target with it and wait 1 minute for the confirmation."
 
 /obj/item/weapon/storage/box/syndie_kit/imp_spying/populate_contents()
 	new /obj/item/weapon/implanter/spying(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -98,6 +98,7 @@
 
 /obj/item/weapon/storage/box/syndie_kit/imp_spying
 	name = "box (S)"
+	desc = "A box with spying implanter inside. Implant your contract target and wait 1 minute for the confirmation."
 
 /obj/item/weapon/storage/box/syndie_kit/imp_spying/populate_contents()
 	new /obj/item/weapon/implanter/spying(src)

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -285,8 +285,9 @@
 /datum/sanity/proc/breakdown()
 	breakdown_time = world.time + SANITY_COOLDOWN_BREAKDOWN
 
-	for(var/obj/item/device/mind_fryer/M in oview(owner))
-		M.reg_break(owner)
+	for(var/obj/item/device/mind_fryer/M in GLOB.active_mind_fryers)
+		if(get_turf(M) in view(get_turf(owner)))
+			M.reg_break(owner)
 
 	var/list/possible_results
 	if(prob(positive_prob))

--- a/nano/templates/bsdm.tmpl
+++ b/nano/templates/bsdm.tmpl
@@ -24,7 +24,7 @@
 		{{if data.is_owner}}
 			{{:data.owner}}
 		{{else}}
-			{{:helper.link(data.owner, null, {'owner' : 1})}}
+			{{:helper.link(data.owner + " (click to change)", null, {'owner' : 1})}}
 		{{/if}}
 	</div>
 </div>


### PR DESCRIPTION
This PR contains: a whole lot of polish and QoL.

* Completed contracts now display in round-end report. Because the best thing about being an antag isn't killing and stealing, it's showing everyone online that you did.
* A whole lot of new feedback messages to let you know that your spying sensors are spying, your mind fryer is frying, your contracts are being completed and your TCs have arrived.
* New traitor items now have proper descriptions, materials and research levels.
* The uplink descriptions now clue you in on how to use the contract items.
* Some contracts pick their targets better now. You will no longer get a contract to assassinate some admeme guy or spy implant a Preacher.
* Contracts now do in depth search on BSDM contents. Sending a PDA that has a disk with the contract data in it would work now.
* Design file contracts no longer accept copy protected design files. Run your disks through the cloner at the very least.
* Mind fryers should register mental breaks a lot more reliably now.
* Mind imprinters now work better if your target stat is <= 15 - they'll give you a better stat increase and less sanity loss, so you'll have an easier time lifting your dump stat off the floor.