### PR TITLE
makes shrapnel only damage you if you are not on walk intent

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1008,10 +1008,11 @@ var/list/rank_prefix = list(\
 						SPAN_WARNING("Your movement jostles [O] in your [organ.name] painfully."), \
 						SPAN_WARNING("Your movement jostles [O] in your [organ.name] painfully."))
 					to_chat(src, msg)
-
-				organ.take_damage(rand(1,3), 0, 0)
-				if(organ.setBleeding())
-					src.adjustToxLoss(rand(1,3))
+				var/mob/living/carbon/human/H = organ.owner
+				if(!MOVING_DELIBERATELY(H))
+					organ.take_damage(rand(1,3), 0, 0)
+					if(organ.setBleeding())
+						src.adjustToxLoss(rand(1,3))
 
 /mob/living/carbon/human/verb/check_pulse()
 	set category = "Object"


### PR DESCRIPTION
## About The Pull Request
How the fuck am I supposed to prepare for the techno gun update t-minus 6 months without fixing broken ass shrapnel. 
This PR adds a movement check to make sure you only take shrapnel damage when running and not walking. No more gay ass shrapnel deaths. Take as much as you want, but don't expect to survive if someones gunning for your ass.







