### PR TITLE
Replaces uplink softsuit with a merc voidsuit

### DIFF
--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -66,7 +66,7 @@
 			This device will also be able to immediately access the last 6 to 8 hacked airlocks."
 
 /datum/uplink_item/item/tools/space_suit
-	name = "Space Suit"
+	name = "Mercenary Voidsuit"
 	item_cost = 6
 	path = /obj/item/weapon/storage/box/syndie_kit/space
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -115,13 +115,11 @@
 	U3.passive_gain = 0
 
 /obj/item/weapon/storage/box/syndie_kit/space
-	name = "boxed space suit and helmet"
+	name = "boxed voidsuit"
 
 /obj/item/weapon/storage/box/syndie_kit/space/populate_contents()
-	new /obj/item/clothing/suit/space/syndicate(src)
-	new /obj/item/clothing/head/helmet/space/syndicate(src)
+	new /obj/item/clothing/suit/space/void/merc/boxed(src)
 	new /obj/item/clothing/mask/gas/syndicate(src)
-	new /obj/item/weapon/tank/emergency_oxygen/double(src)
 
 /obj/item/weapon/storage/box/syndie_kit/chameleon
 	name = "chameleon kit"

--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -83,3 +83,6 @@
 /obj/item/clothing/suit/space/void/merc/equipped
 	boots = /obj/item/clothing/shoes/magboots
 	tank = /obj/item/weapon/tank/oxygen
+
+/obj/item/clothing/suit/space/void/merc/boxed
+	tank = /obj/item/weapon/tank/emergency_oxygen/double


### PR DESCRIPTION
Old uplink softsuit sucked all around. This replacement sucks less.

It has an added benefit of being a rare maint loot - you can possibly obtain it as crew, so just having it isn't quite enough of a ground for IH to shoot to kill.