### PR TITLE
NSA Rewrite (COMPLETE) 

### DIFF
--- a/code/_onclick/hud/screen_objects/base_screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/base_screen_objects.dm
@@ -470,7 +470,7 @@
 	if(!istype(C) || C.stat == DEAD)
 		return
 	overlays.Cut()
-	switch(C.get_nsa())
+	switch(C.metabolism_effects.get_nsa())
 		if(200 to INFINITY)
 			overlays += ovrls["nsa10"]
 		if(-INFINITY to 20)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -11,71 +11,9 @@
 	..()
 
 	handle_viruses()
-	handle_nsa()
 	// Increase germ_level regularly
 	if(germ_level < GERM_LEVEL_AMBIENT && prob(30))	//if you're just standing there, you shouldn't get more germs beyond an ambient level
 		germ_level++
-
-/mob/living/carbon/proc/adjust_nsa(value, tag)
-	if(!tag)
-		crash_with("no tag given to adjust_nsa()")
-		return
-	nerve_system_accumulations[tag] = value
-
-/mob/living/carbon/proc/remove_nsa(tag)
-	if(nerve_system_accumulations[tag])
-		nerve_system_accumulations.Remove(tag)
-
-/mob/living/carbon/proc/get_nsa_value(tag)
-	if(nerve_system_accumulations[tag])
-		return nerve_system_accumulations[tag]
-
-/mob/living/carbon/proc/get_nsa()
-	return nsa_current
-
-/mob/living/carbon/proc/get_nsa_target()
-	var/accumulatedNSA
-	for(var/tag in nerve_system_accumulations)
-		accumulatedNSA += nerve_system_accumulations[tag]
-	return accumulatedNSA
-
-/mob/living/carbon/proc/handle_nsa()
-	var/nsa_target = get_nsa_target()
-	if(nsa_target != nsa_current)
-		nsa_current = nsa_target > nsa_current \
-		            ? min(nsa_current + nsa_target / 30, nsa_target) \
-		            : max(nsa_current - 6.66, nsa_target)
-		nsa_changed()
-	if(get_nsa() > nsa_threshold)
-		nsa_breached_effect()
-
-/mob/living/carbon/proc/nsa_changed()
-	if(get_nsa() > nsa_threshold)
-		var/stat_mod = get_nsa() > 140 ? -20 : -10
-		for(var/stat in ALL_STATS)
-			stats.addTempStat(stat, stat_mod, INFINITY, "nsa_breach")
-	else
-		for(var/stat in ALL_STATS)
-			stats.removeTempStat(stat, "nsa_breach")
-	HUDneed["nsa"]?.update_icon()
-
-/mob/living/carbon/proc/nsa_breached_effect()
-	if(get_nsa() < 120)
-		return
-	vomit()
-
-	if(get_nsa() < 160)
-		return
-	drop_l_hand()
-	drop_r_hand()
-
-	if(get_nsa() < 180)
-		return
-	adjustToxLoss(1)
-
-	if(get_nsa() < 200)
-		return
-	Sleeping(2)
 
 /mob/living/carbon/Destroy()
 	qdel(ingested)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -30,6 +30,4 @@
 	var/obj/item/weapon/tank/internal = null//Human/Monkey
 
 	//TODO: move to brain
-	var/list/nerve_system_accumulations = list() // Nerve system accumulations
-	var/nsa_threshold = 100
-	var/nsa_current = 0
+

--- a/code/modules/reagents/metabolism.dm
+++ b/code/modules/reagents/metabolism.dm
@@ -46,8 +46,10 @@
 	nerve_system_accumulations[tag] = value
 
 /datum/metabolism_effects/proc/remove_nsa(tag)
-	if(nerve_system_accumulations[tag])
-		nerve_system_accumulations.Remove(tag)
+	for(var/i in nerve_system_accumulations)
+		if(findtext(i, tag, 1, 0) == 1)
+			nerve_system_accumulations.Remove(i)
+		
 
 /datum/metabolism_effects/proc/get_nsa_value(tag)
 	if(nerve_system_accumulations[tag])

--- a/code/modules/reagents/metabolism.dm
+++ b/code/modules/reagents/metabolism.dm
@@ -20,15 +20,17 @@
 	for(var/current in reagent_list)
 		var/datum/reagent/R = current
 
-		parent.metabolism_effects.check_reagent(R)
+		parent.metabolism_effects.check_reagent(R, metabolism_class)
 		R.on_mob_life(parent, metabolism_type, metabolism_class)
 
 	update_total()
 
-
-
 // Lasting side effects from reagents: addictions, withdrawals.
 /datum/metabolism_effects
+	var/list/nerve_system_accumulations = list() // Nerve system accumulations
+	var/nsa_threshold = 100
+	var/nsa_current = 0
+
 	var/mob/living/carbon/parent
 	var/list/present_reagent_ids = list()
 
@@ -37,13 +39,78 @@
 	var/list/datum/reagent/addiction_list = list()
 	var/addiction_tick = 1
 
+/datum/metabolism_effects/proc/adjust_nsa(value, tag)
+	if(!tag)
+		crash_with("no tag given to adjust_nsa()")
+		return
+	nerve_system_accumulations[tag] = value
+
+/datum/metabolism_effects/proc/remove_nsa(tag)
+	if(nerve_system_accumulations[tag])
+		nerve_system_accumulations.Remove(tag)
+
+/datum/metabolism_effects/proc/get_nsa_value(tag)
+	if(nerve_system_accumulations[tag])
+		return nerve_system_accumulations[tag]
+
+/datum/metabolism_effects/proc/get_nsa()
+	return nsa_current
+
+/datum/metabolism_effects/proc/get_nsa_target()
+	var/accumulatedNSA
+	for(var/tag in nerve_system_accumulations)
+		accumulatedNSA += nerve_system_accumulations[tag]
+	return accumulatedNSA
+
+/datum/metabolism_effects/proc/handle_nsa()
+	var/nsa_target = get_nsa_target()
+	if(nsa_target != nsa_current)
+		nsa_current = nsa_target > nsa_current \
+		            ? min(nsa_current + nsa_target / 30, nsa_target) \
+		            : max(nsa_current - 6.66, nsa_target)
+		nsa_changed()
+	if(get_nsa() > nsa_threshold)
+		nsa_breached_effect()
+
+/datum/metabolism_effects/proc/nsa_changed()
+	if(get_nsa() > nsa_threshold)
+		var/stat_mod = get_nsa() > 140 ? -20 : -10
+		for(var/stat in ALL_STATS)
+			parent.stats.addTempStat(stat, stat_mod, INFINITY, "nsa_breach")
+	else
+		for(var/stat in ALL_STATS)
+			parent.stats.removeTempStat(stat, "nsa_breach")
+	parent.HUDneed["nsa"]?.update_icon()
+
+/datum/metabolism_effects/proc/nsa_breached_effect()
+	if(get_nsa() < 120)
+		return
+	parent.vomit()
+
+	if(get_nsa() < 160)
+		return
+	parent.drop_l_hand()
+	parent.drop_r_hand()
+
+	if(get_nsa() < 180)
+		return
+	parent.adjustToxLoss(1)
+
+	if(get_nsa() < 200)
+		return
+	parent.Sleeping(2)
+
+
 /datum/metabolism_effects/New(mob/living/carbon/parent_mob)
 	..()
 	if(istype(parent_mob))
 		parent = parent_mob
 
-/datum/metabolism_effects/proc/check_reagent(datum/reagent/R)
+/datum/metabolism_effects/proc/check_reagent(datum/reagent/R, metabolism_class)
 	present_reagent_ids += R.id
+
+	//Nerve System Accumulation 
+	parent.metabolism_effects.adjust_nsa(R.nerve_system_accumulations, "[R.id]_[metabolism_class]")
 
 	// Withdrawals
 	if(R.withdrawal_threshold && R.volume >= R.withdrawal_threshold && !is_type_in_list(R, withdrawal_list))
@@ -63,7 +130,7 @@
 		var/add_addiction_flag = R.volume >= R.addiction_threshold
 
 		if(!add_addiction_flag && R.addiction_chance)
-			var/percent = (R.addiction_chance + parent.get_nsa()/3) - (R.addiction_chance/2 * parent.stats.getMult(STAT_TGH))
+			var/percent = (R.addiction_chance + parent.metabolism_effects.get_nsa()/3) - (R.addiction_chance/2 * parent.stats.getMult(STAT_TGH))
 			percent = CLAMP(percent, 1, 100)
 			add_addiction_flag = prob(percent)
 
@@ -83,7 +150,8 @@
 
 /datum/metabolism_effects/proc/process()
 	process_withdrawals()
-
+	handle_nsa()
+	
 	if(addiction_tick == 6)
 		addiction_tick = 1
 		process_addictions()

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -113,16 +113,12 @@
 
 // Called when this reagent is first added to a mob
 /datum/reagent/proc/on_mob_add(mob/living/L)
-	var/mob/living/carbon/C = L
-	if(istype(C))
-		C.adjust_nsa(nerve_system_accumulations, id)
-	return
 
 // Called when this reagent is removed while inside a mob
 /datum/reagent/proc/on_mob_delete(mob/living/L)
 	var/mob/living/carbon/C = L
 	if(istype(C))
-		C.remove_nsa(id)
+		C.metabolism_effects.remove_nsa(id)
 	return
 
 // Currently, on_mob_life is only called on carbons. Any interaction with non-carbon mobs (lube) will need to be done in touch_mob.

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -670,19 +670,19 @@
 	metabolism = REM/2
 
 /datum/reagent/medicine/detox/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	if(M.nsa_threshold == initial(M.nsa_threshold))
-		M.nsa_threshold += rand(20, 60)
+	if(M.metabolism_effects.nsa_threshold == initial(M.metabolism_effects.nsa_threshold))
+		M.metabolism_effects.nsa_threshold += rand(20, 60)
 
 /datum/reagent/medicine/detox/on_mob_delete(mob/living/L)
 	..()
 	var/mob/living/carbon/C = L
 	if(istype(C))
-		C.nsa_threshold = initial(C.nsa_threshold)
+		C.metabolism_effects.nsa_threshold = initial(C.metabolism_effects.nsa_threshold)
 
 /datum/reagent/medicine/detox/overdose(var/mob/living/carbon/M, var/alien)
 	var/mob/living/carbon/C = M
 	if(istype(C))
-		C.nsa_threshold = initial(C.nsa_threshold) - rand(20, 40)
+		C.metabolism_effects.nsa_threshold = initial(C.metabolism_effects.nsa_threshold) - rand(20, 40)
 
 /datum/reagent/medicine/purger
 	name = "Purger"
@@ -781,17 +781,17 @@
 	..()
 	var/mob/living/carbon/C = L
 	if(istype(C))
-		for (var/tag in C.nerve_system_accumulations)
-			var/nsa_value = C.get_nsa_value(tag)/2
-				C.adjust_nsa(nsa_value, tag)
+		for (var/tag in C.metabolism_effects.nerve_system_accumulations)
+			var/nsa_value = C.metabolism_effects.get_nsa_value(tag)/2
+				C.metabolism_effects.adjust_nsa(nsa_value, tag)
 
 /datum/reagent/medicine/haloperidol/on_mob_delete(mob/living/L)
 	..()
 	var/mob/living/carbon/C = L
 	if(istype(C))
-		for (var/tag in C.nerve_system_accumulations)
-			var/nsa_value = C.get_nsa_value(tag)*2
-				C.adjust_nsa(nsa_value, tag)
+		for (var/tag in C.metabolism_effects.nerve_system_accumulations)
+			var/nsa_value = C.metabolism_effects.get_nsa_value(tag)*2
+				C.metabolism_effects.adjust_nsa(nsa_value, tag)
 
 
 /datum/reagent/medicine/vomitol

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -772,27 +772,8 @@
 		M.drowsyness = max(M.drowsyness, 60)
 	M.add_chemical_effect(CE_PULSE, -1)
 
-
-
 /datum/reagent/medicine/haloperidol/overdose(var/mob/living/carbon/M, var/alien)
 	M.adjustToxLoss(6)
-
-/datum/reagent/medicine/haloperidol/on_mob_add(mob/living/L)
-	..()
-	var/mob/living/carbon/C = L
-	if(istype(C))
-		for (var/tag in C.metabolism_effects.nerve_system_accumulations)
-			var/nsa_value = C.metabolism_effects.get_nsa_value(tag)/2
-				C.metabolism_effects.adjust_nsa(nsa_value, tag)
-
-/datum/reagent/medicine/haloperidol/on_mob_delete(mob/living/L)
-	..()
-	var/mob/living/carbon/C = L
-	if(istype(C))
-		for (var/tag in C.metabolism_effects.nerve_system_accumulations)
-			var/nsa_value = C.metabolism_effects.get_nsa_value(tag)*2
-				C.metabolism_effects.adjust_nsa(nsa_value, tag)
-
 
 /datum/reagent/medicine/vomitol
 	name = "Vomitol"


### PR DESCRIPTION
This is the half finished version of the NSA Rewrite, currently i moved almost all NSA code to metabolism.dm and it now adds NSA values paired with id (reagent ID) and metabolism_class (CHEM_INGEST, CHEM_INJECT, ect) combo. The result is NSA stacking for the same chemical over the 3 different holders. Now the reason why this is a draft is because while i have been able to make it add NSA in this way with A LOT of help from ACCount and others it still doesn't remove NSA from the list correctly (namely it still searches for a normal id to remove instead of the new combo). Any help appreciated and have a good Eris weekend!

