### PR TITLE
Nanite roaches now become motor oil on death

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/roach/types/nanites.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/nanites.dm
@@ -37,6 +37,7 @@
 	desc = "A swarm of disgusting locusts infested with nanomachines."
 	icon = 'icons/mob/critter.dmi'
 	icon_state = "naniteroach"
+	icon_living = "naniteroach"
 	pass_flags = PASSTABLE
 	density = FALSE
 	health = 10
@@ -56,3 +57,8 @@
 	min_n2 = 0
 	max_n2 = 0
 	minbodytemp = 0
+
+/mob/living/simple_animal/hostile/naniteswarm/death()
+	..()
+	new /obj/effect/decal/cleanable/blood/oil(get_turf(src))
+	qdel(src)


### PR DESCRIPTION
## About The Pull Request
Rather than appearing invisible (because they have no icon for being dead), nanite roach swarms now qdel and leave a splash of motor oil behind, so the janitor has more to do.

Suggested by Roma#4395 in the discord
![image](https://user-images.githubusercontent.com/30557196/72221120-69169e80-354f-11ea-827f-8f0124880326.png)
