### PR TITLE
shake_camera for bullet/on_hit adjustment

### DIFF
--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -219,7 +219,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 //Shakes the mob's camera
 //Strength is not recommended to set higher than 4, and even then its a bit wierd
-/proc/shake_camera(mob/M, duration, strength=1, var/taper = 0.25)
+/proc/shake_camera(mob/M, duration, strength = 1, var/taper = 0.25)
 	if(!M || !M.client || M.shakecamera || M.stat || isEye(M) || isAI(M))
 		return
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -15,7 +15,7 @@
 /obj/item/projectile/bullet/on_hit(atom/target)
 	if (..(target))
 		var/mob/living/L = target
-		shake_camera(L, 3, 2)
+		shake_camera(L, 1, 1, 0.5)
 
 /obj/item/projectile/bullet/attack_mob(var/mob/living/target_mob, distance, miss_modifier)
 	if(penetrating > 0 && damage > 20 && prob(damage))


### PR DESCRIPTION
## About The Pull Request
Toned down screenshake, which occurs when ANY bullet hits you. While this is not guaranteed win if you hit someone first anymore, it is still significant and very noticeable. I've done pretty extensive testing with adjusting it by hand each time, so it should be good. Made use of "taper" var by Nanako also.

And fixed small typo in animations.dm


