### PR TITLE
Nuka-Cola nerf

### DIFF
--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -832,6 +832,7 @@
 	color = "#100800"
 	adj_temp = -5
 	adj_sleepy = -2
+	nerve_system_accumulations = 50
 
 	glass_icon_state = "nuka_colaglass"
 	glass_name = "Nuka-Cola"
@@ -840,7 +841,7 @@
 
 /datum/reagent/drink/nuka_cola/affect_ingest(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	..()
-	M.add_chemical_effect(CE_SPEEDBOOST, 1)
+	M.add_chemical_effect(CE_SPEEDBOOST, 0.8)
 	M.make_jittery(20 * effect_multiplier)
 	M.druggy = max(M.druggy, 30 * effect_multiplier)
 	M.dizziness += 5 * effect_multiplier


### PR DESCRIPTION
Nuka-Cola now gives you 20% less speed and has an NSA value close to that of hyperzine. It's still pretty good, just not "exploit central" good.

Combined with slowdown calculation changes from #4525, this should solve the issue of people being 2fast2furious for good.