### PR TITLE
Tweaks the AI to be more performant.

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -4,17 +4,16 @@
 
 	..()
 	if(config.enable_mob_sleep)
-		if(life_cycles_before_scan > 0)
+
+		if(life_cycles_before_scan)
 			life_cycles_before_scan--
-		else
-			if(check_surrounding_area(7))
-				activate_ai()
-				life_cycles_before_scan = 3
+		else if(check_surrounding_area(7))
+			activate_ai()
+			life_cycles_before_scan = 3
 
 		if(life_cycles_before_sleep)
 			life_cycles_before_sleep--
-
-		if(life_cycles_before_sleep < 1 && !AI_inactive)
+		else
 			AI_inactive = TRUE
 
 

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -9,7 +9,7 @@
 			life_cycles_before_scan--
 		else if(check_surrounding_area(7))
 			activate_ai()
-			life_cycles_before_scan = 3
+			life_cycles_before_scan = 8
 
 		if(life_cycles_before_sleep)
 			life_cycles_before_sleep--

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -8,7 +8,7 @@
 
 	var/hud_updateflag = 0
 
-	var/life_cycles_before_sleep = 10
+	var/life_cycles_before_sleep = 30
 	var/life_cycles_before_scan = 5
 
 	var/stasis = FALSE

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -8,7 +8,7 @@
 
 	var/hud_updateflag = 0
 
-	var/life_cycles_before_sleep = 120
+	var/life_cycles_before_sleep = 10
 	var/life_cycles_before_scan = 100
 
 	var/stasis = FALSE

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -9,7 +9,7 @@
 	var/hud_updateflag = 0
 
 	var/life_cycles_before_sleep = 10
-	var/life_cycles_before_scan = 100
+	var/life_cycles_before_scan = 5
 
 	var/stasis = FALSE
 	var/AI_inactive = FALSE

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -23,18 +23,18 @@
 
 
 /mob/living/proc/check_surrounding_area(var/dist = 7)
-	var/list/L = hearers(src, dist)
-
 	if(faction == "neutral")
 		return 1
 
 	if(faction == "station")
 		return 1
 
+
 	for (var/obj/mecha/M in mechas_list)
 		if (M.z == src.z && get_dist(src, M) <= dist)
 			return 1
 
+	var/list/L = hearers(src, dist)
 	for(var/mob/living/M in L)
 		if (M.faction != faction)
 			return 1

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -24,10 +24,10 @@
 
 /mob/living/proc/check_surrounding_area(var/dist = 7)
 	if(faction == "neutral")
-		return 1
+		return 0
 
 	if(faction == "station")
-		return 1
+		return 0
 
 	for (var/obj/mecha/M in mechas_list)
 		if (M.z == src.z && get_dist(src, M) <= dist)

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -24,10 +24,10 @@
 
 /mob/living/proc/check_surrounding_area(var/dist = 7)
 	if(faction == "neutral")
-		return 0
+		return 1
 
 	if(faction == "station")
-		return 0
+		return 1
 
 	for (var/obj/mecha/M in mechas_list)
 		if (M.z == src.z && get_dist(src, M) <= dist)

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -29,7 +29,6 @@
 	if(faction == "station")
 		return 1
 
-
 	for (var/obj/mecha/M in mechas_list)
 		if (M.z == src.z && get_dist(src, M) <= dist)
 			return 1


### PR DESCRIPTION
## About The Pull Request

Various changes to the AI. ~~Currently untested. Will try to get that done later.~~ Seems to work

## Details

Bumps down hearers() in get_surrounding_area so it only fires for things that actually need it. This is a no-effort fix to this proc being the single most performance intensive one in the entire codebase.

Makes the code around mob_sleep in Life() look nicer.

Mobs now start sleeping after 30 cycles (60 seconds) instead of 120 cycles (4 minutes). And scan every 8 cycles (16 seconds) if their AI activity should be renewed (up from 6 seconds.)

## Screenshots

![profile](https://user-images.githubusercontent.com/47324920/72680941-7ee01280-3abf-11ea-8a8f-9711fca2414c.PNG)

