### PR TITLE
Changes the default duration of burrow migration from 0 to 1.

### DIFF
--- a/code/game/objects/structures/burrows.dm
+++ b/code/game/objects/structures/burrows.dm
@@ -162,7 +162,7 @@ percentage is a value in the range 0..1 that determines what portion of this mob
 	Passing a percentage of zero is a special case, this burrow will not suck up any mobs.
 	The mobs it is to send should be placed inside it by the caller
 */
-/obj/structure/burrow/proc/migrate_to(var/obj/structure/burrow/_target, var/time = 0, var/percentage = 1)
+/obj/structure/burrow/proc/migrate_to(var/obj/structure/burrow/_target, var/time = 1, var/percentage = 1)
 	if (!_target)
 		return
 


### PR DESCRIPTION
## About The Pull Request

time gets used to divide in process and something seems to call this without providing an argument. Calling this proc without setting a duration now causes an instant migration which I assume was the intended behaviour.

## Details

This is basically just a runtime fix.

This caused me to think that I broke everything with changing processing subsystems so I hate it with a passion.