### PR TITLE
IH Bulletproof Helmets

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -852,7 +852,14 @@
 /obj/item/clothing/suit/armor/bulletproof/ironhammer,
 /obj/item/clothing/suit/armor/bulletproof/ironhammer,
 /obj/item/clothing/suit/armor/bulletproof/ironhammer,
-/obj/item/clothing/suit/armor/bulletproof/ironhammer,
+/obj/item/clothing/head/armor/bulletproof/ironhammer,
+/obj/item/clothing/head/armor/bulletproof/ironhammer,
+/obj/item/clothing/head/armor/bulletproof/ironhammer,
+/obj/item/clothing/head/armor/bulletproof/ironhammer,
+/obj/item/clothing/head/armor/bulletproof/ironhammer,
+/obj/item/clothing/head/armor/bulletproof/ironhammer,
+/obj/item/clothing/head/armor/bulletproof/ironhammer,
+/obj/item/clothing/head/armor/bulletproof/ironhammer,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/security/armory)
 "acm" = (


### PR DESCRIPTION
## About The Pull Request
Adds new bulletproof helmets for IH from recent Armor PR. They're on the rack with ballistic vests. Also removed one reduntant vest, now it's eight of both helmets and vests (6 OPs + 1 SGT + 1 LT) as it should be and as it is for other types of armors. Tested and works, mapmerged.