### PR TITLE
fix fireaxe dealing no damage to grilles

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -168,11 +168,7 @@
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)
 		playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
-		switch(I.damtype)
-			if("fire")
-				health -= I.force
-			if("brute")
-				health -= I.force * 0.1
+		health -= I.force * I.structure_damage_factor
 	healthcheck()
 	..()
 	return


### PR DESCRIPTION
## About The Pull Request
Changes grille damage so it scales off of the structure_damage_factor and removes the 90% damage reduction to brute weapons. I'm doing this PR because right now it takes a fire axe 20 hits to break a grille, after this change it will only take it 1 hit. I don't like how grilles have a snowflake health system but thats really not the issue this is trying to fix.