### PR TITLE
Fixes embedded objects not being properly removed from mobs that aren't human

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -973,13 +973,15 @@ mob/proc/yank_out_object()
 			var/mob/living/carbon/human/human_user = U
 			human_user.bloody_hands(H)
 
-	else if(issilicon(src))
-		var/mob/living/silicon/robot/R = src
-		R.embedded -= selection
-		R.adjustBruteLoss(5)
-		R.adjustFireLoss(10)
+	else
+		embedded -= selection
+		if(issilicon(src))
+			var/mob/living/silicon/robot/R = src
+			R.adjustBruteLoss(5)
+			R.adjustFireLoss(10)
 
 	selection.forceMove(get_turf(src))
+
 	if(!(U.l_hand && U.r_hand))
 		U.put_in_hands(selection)
 


### PR DESCRIPTION
Previously, embedded objects were not being removed from mobs that weren't human, so you could forcemove an object that somebody else had removed from it.

