### PR TITLE
Adds a clothing UI for the user to see held clothing's stats

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -19,6 +19,11 @@
 /obj/item/clothing/Initialize(mapload, ...)
 	. = ..()
 
+	var/obj/screen/item_action/action = new /obj/screen/item_action/top_bar/clothing_info
+	action.owner = src
+	if(!islist(hud_actions)) hud_actions = list()
+	hud_actions += action
+
 	if(matter)
 		return
 
@@ -66,6 +71,82 @@
 		return ..()
 	if(!pre_equip(usr, over_object))
 		..()
+
+/proc/body_part_coverage_to_string(var/body_parts)
+	var/list/body_partsL = list()
+	if(body_parts & HEAD)
+		body_partsL.Add("head")
+	if(body_parts & FACE)
+		body_partsL.Add("face")
+	if(body_parts & EYES)
+		body_partsL.Add("eyes")
+	if(body_parts & EARS)
+		body_partsL.Add("ears")
+	if(body_parts & UPPER_TORSO)
+		body_partsL.Add("upper torso")
+	if(body_parts & LOWER_TORSO)
+		body_partsL.Add("lower torso")
+	if(body_parts & LEGS)
+		body_partsL.Add("legs")
+	else
+		if(body_parts & LEG_LEFT)
+			body_partsL.Add("left leg")
+		if(body_parts & LEG_RIGHT)
+			body_partsL.Add("right leg")
+	if(body_parts & ARMS)
+		body_partsL.Add("arms")
+	else
+		if(body_parts & ARM_LEFT)
+			body_partsL.Add("left arm")
+		if(body_parts & ARM_RIGHT)
+			body_partsL.Add("right arm")
+
+	return english_list(body_partsL)
+
+/obj/item/clothing/ui_data()
+	var/list/data = list()
+	if(armor.len)
+		var/list/armor_vals = list()
+		for(var/i in armor)
+			if(armor[i])
+				armor_vals += list(list(
+					"name" = i,
+					"value" = armor[i]
+					))
+		data["armor_info"] = armor_vals
+	if(body_parts_covered)
+		var/body_part_string = body_part_coverage_to_string(body_parts_covered)
+		data["body_coverage"] = body_part_string
+	data["slowdown"] = slowdown
+	if(heat_protection)
+		data["heat_protection"] = body_part_coverage_to_string(heat_protection)
+		data["heat_protection_temperature"] = max_heat_protection_temperature
+	if(cold_protection)
+		data["cold_protection"] = body_part_coverage_to_string(cold_protection)
+		data["cold_protection_temperature"] = min_cold_protection_temperature
+	data["equip_delay"] = equip_delay
+	return data
+
+/obj/item/clothing/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, state = GLOB.default_state)
+	var/list/data = ui_data(user)
+
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
+	if(!ui)
+		ui = new(user, src, ui_key, "clothing_stats.tmpl", name, 650, 550, state = state)
+		ui.auto_update_layout = 1
+		ui.set_initial_data(data)
+		ui.open()
+
+/obj/item/clothing/ui_action_click(mob/living/user, action_name)
+	ui_interact(user)
+
+/obj/screen/item_action/top_bar/clothing_info
+	icon = 'icons/mob/screen/gun_actions.dmi'
+	screen_loc = "8,1:13"
+	minloc = "7,2:13"
+	name = "Clothing information"
+	icon_state = "info"
+
 
 ///////////////////////////////////////////////////////////////////////
 // Ears: headsets, earmuffs and tiny objects

--- a/nano/templates/clothing_stats.tmpl
+++ b/nano/templates/clothing_stats.tmpl
@@ -1,0 +1,48 @@
+<div class="item">
+	<h3>Specifications:</h3>
+	<div class="statusDisplay" style="overflow: auto;">
+		<h4>Armor details:</h4>
+		{{if data.armor_info.length}}
+			{{for data.armor_info}}
+				<div class="itemLabel">
+					{{:value.name}}
+				</div>
+				<div class="itemContent">
+				{{:helper.displayBar(value.value, 0, 100, value.value <= 25 ? 'bad' : value.value < 50 ? 'average' : 'good', value.value + '%')}}
+				</div>
+			{{/for}}
+			<br>
+		{{else}}
+			<div class="average">
+				Provides no armor protection.
+			</div>
+		{{/if}}
+		{{if data.slowdown != 1}}
+			<div class="itemLabel">
+				Slowdown:
+			</div>
+			<div class="itemContent">
+				{{:helper.displayBar(data.slowdown, -5, 20, data.slowdown < 1 ? 'good' : data.slowdown > 1 ? 'bad': 'average', data.slowdown+' delay units')}}
+			</div>
+		{{/if}}
+		<br>
+		{{if data.body_coverage}}
+			<div class="itemLabel">
+				Coverage:
+			</div>
+			<div class="itemContent">
+				{{:data.body_coverage}} 
+			</div>
+		{{else}}
+			<div class="average">
+				Provides no body coverage.
+			</div>
+		{{/if}}
+		<div class="itemLabel">
+			Time to equip:
+		</div>
+		<div class="itemContent">
+			{{:helper.displayBar(data.equip_delay, 0, 100, data.equip_delay < 10 ? 'good' : data.equip_delay > 50 ? 'bad': 'average', data.equip_delay/10+' seconds')}}
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
## About The Pull Request
I saw this was requested by a player, so decided to code it while I was trying to figure out other projects.


## Details
<!-- If you need, describe details inside. Remove whole block if not used. -->
<details>
  <summary>Expand</summary>
  
  You can now see the following aspects of a piece of clothing:
   - Its armor values, in a range from 0 to 100
   - Its slowdown, in a range from -5 to 20 (the current lowest and fastest slowdown values)
   - What limbs it covers
   - How long it takes to equip, in Seconds, in a range from 0 to 10 Seconds
</details>


## Screenshots
<!-- Map an UI changes MUST have screenshots in them. Graphical changes should have it as well, when icon diff is not enough. Remove whole block if not used. -->
<details>
  <summary>Expand</summary>
  
  
![image](https://user-images.githubusercontent.com/30557196/73615771-d96e8800-4602-11ea-8ba5-387a8132bab1.png)

</details>


