### PR TITLE
Straylight Nerf

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic/straylight.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/straylight.dm
@@ -1,8 +1,8 @@
 /obj/item/weapon/gun/projectile/automatic/straylight
 	name = "FS SMG .35 Auto \"Straylight\""
-	desc = "A compact, lightweight rapid submachine gun. Was primarily used for testing ammunition and weapon modifications. \
-			Suffers from poor recoil control, and underperforming ballistic impact, but makes up for this through sheer firerate. \
-			Especially effective with rubber ammunition. Uses .35 Auto rounds."
+	desc = "A compact, lightweight and cheap rapid-firing submachine gun. In past was primarily used for testing ammunition and weapon modifications, \
+			novadays mass produced for IH security forces. Suffers from poor recoil control and underperforming ballistic impact, \
+			but makes up for this through sheer firerate. Especially effective with rubber ammunition. Uses .35 Auto rounds."
 	icon = 'icons/obj/guns/projectile/straylight.dmi'
 	icon_state = "straylight"
 	item_state = "straylight"
@@ -10,21 +10,20 @@
 	caliber = CAL_PISTOL
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	slot_flags = SLOT_BELT
-	ammo_type = "/obj/item/ammo_casing/pistol"
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_SMG
 	magazine_type = /obj/item/ammo_magazine/smg
 	auto_eject = 1
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 8)
-	price_tag = 1600
+	price_tag = 1400
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
-	damage_multiplier = 0.65 //made with rubber rounds in mind, specifically for rubber rounds. For lethality refer to Wintermute.
+	damage_multiplier = 0.65	 //made with rubber rounds in mind. For lethality refer to Wintermute. Still quite lethal if you manage to land most shots.
 	penetration_multiplier = 0.5 //practically no AP, 2.5 with regular rounds and 5 with HV. Still deadly to unarmored targets.
 	recoil_buildup = 3
 	silencer_type = /obj/item/weapon/silencer
 
 	firemodes = list(
-		FULL_AUTO_800,
+		FULL_AUTO_600,
 		SEMI_AUTO_NODELAY
 		)
 


### PR DESCRIPTION
## About The Pull Request
This is follow up PR to #4587. Turns out 800RPM (0.8 delay between shots) turned out too OP for SMG. I don't want to turn down damage down or recoil up because i fear that this would render weapon pretty useless and turn it into meme peashooter (also because shrapnel that gravitates toward chest is still a thing), so i turned down speed to 600. It's still very robust with rubbers and quite deadly with lethals if you can handle it well, but any armor pretty much defeats it.