### PR TITLE
Disabled extools for 513 until these devs makes it compatible

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -63,9 +63,10 @@ var/game_id = null
 
 /world/New()
 	// Begin loading of extools DLL and components
-	extools_initialize()
-	maptick_initialize()
-	debugger_initialize()
+	// DISABLED UNTIL EXTOOLS IS COMPATIBLE WITH 513
+	//extools_initialize()
+	//maptick_initialize()
+	//debugger_initialize()
 	// End extools
 	//logs
 	var/date_string = time2text(world.realtime, "YYYY/MM-Month/DD-Day")


### PR DESCRIPTION
## About The Pull Request
<!-- Why is it needed, what it fixes. Write up links to closing issues there as well, but make it short. -->

It stops these errors messages from preventing 513 server from booting and it should boot just fine.

The reason why it was commented out is everyone who want to debug can install 513.1506 in a folder named BYOND_DEV and configure his VS Code extension to use this path

Merge if you want keep using 513 beyond this version of 513.1506. After this version, extools will not work as per https://github.com/MCHSL/extools/issues/29