### PR TITLE
Adds a sane fallback in case extools fails to load

### DIFF
--- a/code/__DEFINES/tick.dm
+++ b/code/__DEFINES/tick.dm
@@ -1,7 +1,8 @@
 // Maptick stuff
-#define MAPTICK_MC_MIN_RESERVE 20 //Percentage of tick to leave for master controller to run 
-#define MAPTICK_LAST_INTERNAL_TICK_USAGE ((GLOB.internal_tick_usage / world.tick_lag) * 100) //internal_tick_usage is updated every tick by extools 
-#define TICK_LIMIT_RUNNING (max(90 - MAPTICK_LAST_INTERNAL_TICK_USAGE, MAPTICK_MC_MIN_RESERVE)) 
+#define MAPTICK_FALLBACK_ITU 20 //If no maptick DLL is present, it's assumed to be this value during server runtime
+#define MAPTICK_MC_MIN_RESERVE 20 //Percentage of tick to leave for master controller to run
+#define MAPTICK_LAST_INTERNAL_TICK_USAGE ((GLOB.internal_tick_usage / world.tick_lag) * 100) //internal_tick_usage is updated every tick by extools
+#define TICK_LIMIT_RUNNING (max(90 - MAPTICK_LAST_INTERNAL_TICK_USAGE, MAPTICK_MC_MIN_RESERVE))
 
 #define TICK_LIMIT_TO_RUN 78
 #define TICK_LIMIT_MC 70

--- a/code/_global_vars/misc.dm
+++ b/code/_global_vars/misc.dm
@@ -13,7 +13,10 @@ GLOBAL_VAR(topic_status_lastcache)
 GLOBAL_LIST(topic_status_cache)
 
 // Extools vars
-GLOBAL_VAR_INIT(internal_tick_usage, 0.2 * world.tick_lag) //This var is updated every tick by a DLL if present, used to reduce lag 
+//This var is updated every tick by a DLL if present, used to reduce lag
+//If no DLL is present, the default during MC init is 5% of tick_lag
+//It's bumped to MAPTICK_DEFAULT_ITU during runtime (set once MC init is done)
+GLOBAL_VAR_INIT(internal_tick_usage, 0.05 * world.tick_lag)
 GLOBAL_PROTECT(internal_tick_usage) // NO TOUCHY
 
 GLOBAL_VAR_INIT(fallback_alerted, FALSE)

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -196,7 +196,11 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 #else
 	world.sleep_offline = TRUE
 #endif
+
 	world.tick_lag = config.Ticklag
+	// Fallback ITU value - will be overwritten next tick by extools lib if it's present
+	GLOB.internal_tick_usage = world.tick_lag * MAPTICK_FALLBACK_ITU * 0.01
+
 	var/initialized_tod = REALTIMEOFDAY
 	sleep(1)
 	initializations_finished_with_no_players_logged_in = initialized_tod < REALTIMEOFDAY - 10

--- a/code/modules/admin/verbs/ticklag.dm
+++ b/code/modules/admin/verbs/ticklag.dm
@@ -13,6 +13,8 @@
 		log_admin("[key_name(src)] has modified world.tick_lag to [newtick]", 0)
 		message_admins("[key_name(src)] has modified world.tick_lag to [newtick]", 0)
 		world.tick_lag = newtick
+		// Fallback ITU value - will be overwritten next tick by extools lib if it's present
+		GLOB.internal_tick_usage = world.tick_lag * MAPTICK_FALLBACK_ITU * 0.01
 	else
 		to_chat(src, "\red Error: ticklag(): Invalid world.ticklag value. No changes made.")
 


### PR DESCRIPTION
ITU now defaults to 5% when MC is initializing, and to 20% once MC init is done. Those values are on the safer side of sane, unlike the "66.7%" or "60.7%" that were observed on live servers before.

This PR only matters if extools lib doesn't work, which, on live servers, it currently doesn't.