### PR TITLE
Dallas Nerf

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic/dallas.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/dallas.dm
@@ -1,9 +1,7 @@
-//It's a good day to die
-
-/obj/item/weapon/gun/projectile/automatic/dallas
+/obj/item/weapon/gun/projectile/automatic/dallas //it's a good way to die
 	name = "PAR .25 CS \"Dallas\""
 	desc = "Dallas is a pulse-action air-cooled automatic assault rifle made by unknown manufacturer. This weapon is very rare, but deadly efficient. \
-		It's used by elite mercenaries, assassins or bald marines."
+			It's used by elite mercenaries, assassins or bald marines. Uses .25 Caseless rounds."
 	icon = 'icons/obj/guns/projectile/dallas.dmi'
 	icon_state = "dallas"
 	item_state = "dallas"
@@ -14,21 +12,20 @@
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_RIFLE
 	auto_eject = 1
-	magazine_type = /obj/item/ammo_magazine/c10x24
 	matter = list(MATERIAL_PLASTEEL = 25, MATERIAL_PLASTIC = 15)
 	price_tag = 5000 //99 rounds of pure pain and destruction served in auto-fire, so it basically an upgraded LMG
-	fire_sound = 'sound/weapons/guns/fire/m41_shoot.ogg'
+	fire_sound 		= 'sound/weapons/guns/fire/m41_shoot.ogg'
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/m41_reload.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/m41_cocked.ogg'
-	damage_multiplier = 1.7
+	damage_multiplier = 1.3 //35.1 with lethal, 41.3 with hv
+	penetration_multiplier = 1
 	recoil_buildup = 6
 	one_hand_penalty = 5
 
 	firemodes = list(
 		FULL_AUTO_400,
 		SEMI_AUTO_NODELAY,
-		BURST_3_ROUND
 		)
 
 /obj/item/weapon/gun/projectile/automatic/dallas/update_icon()

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -74,14 +74,14 @@ There are important things regarding this file:
 	embed = FALSE
 	sharp = FALSE
 
-// .25 rifle
+// .25 caseless rifle
 
 /obj/item/projectile/bullet/clrifle
 	damage = 27
 	armor_penetration = 25
 	penetrating = 1
-	sharp = FALSE
-	can_ricochet = TRUE
+	sharp = TRUE
+	can_ricochet = FALSE //to reduce collateral damage and FF, since IH use it in their primary firearm
 
 /obj/item/projectile/bullet/clrifle/practice
 	name = "practice bullet"
@@ -97,6 +97,7 @@ There are important things regarding this file:
 	armor_penetration = 30
 	penetrating = 2
 	step_delay = 0.75
+	can_ricochet = TRUE
 
 /obj/item/projectile/bullet/clrifle/rubber
 	name = "rubber bullet"
@@ -105,6 +106,7 @@ There are important things regarding this file:
 	armor_penetration = 0
 	embed = FALSE
 	sharp = FALSE
+	can_ricochet = TRUE
 
 // .30 rifle
 


### PR DESCRIPTION
## About The Pull Request
Currently Dallas deals humongous amount of damage, 45 with usuall ammo and (!) 60 if you manage to aquire HV ammo which is fairly easy to be honest. I think that this is a bit too much for 99-round mag fed fully automatic (400RPM) rifle with 25 armor penetration, even if it's very rare, because once you get it - you're unstoppable. I toned it down to 35 and 41 respectively, also removing three round burst which is largely unused if gun already have full auto.

Also touched up .25 caseless ammo a bit. Weird, but it had sharp flag set to false, which effectively means this bullets shouldn't cause bleeding despite being lethal ammunition. I changed that, but instead removed ricochet possibility from them for main reason of it being used as ammo for primary IH firearm Sol, so hopefully it would reduce collateral damage and friendly fire a bit. HV ammo would ricochet still.