### PR TITLE
Uniform Holsters and NT Belts

### DIFF
--- a/code/datums/autolathe/biomatter.dm
+++ b/code/datums/autolathe/biomatter.dm
@@ -56,6 +56,21 @@
 	name = "Cash Bag"
 	build_path = /obj/item/weapon/storage/bag/money
 
+/datum/design/bioprinter/leather/holster
+	name = "shoulder holster"
+	build_path = /obj/item/clothing/accessory/holster
+
+/datum/design/bioprinter/leather/holster/armpit
+	name = "armpit holster"
+	build_path = /obj/item/clothing/accessory/holster/armpit
+
+/datum/design/bioprinter/leather/holster/waist
+	name = "waist holster"
+	build_path = /obj/item/clothing/accessory/holster/waist
+
+/datum/design/bioprinter/leather/holster/hip
+	name = "hip holster"
+	build_path = /obj/item/clothing/accessory/holster/hip
 
 /datum/design/bioprinter/belt
 	materials = list("biomatter" = 30)
@@ -64,13 +79,21 @@
 	name = "Utility belt"
 	build_path = /obj/item/weapon/storage/belt/utility
 
+/datum/design/bioprinter/belt/utility/neotheology
+	name = "Neotheologian utility belt"
+	build_path = /obj/item/weapon/storage/belt/utility/neotheology
+
 /datum/design/bioprinter/belt/medical
 	name = "Medical belt"
 	build_path = /obj/item/weapon/storage/belt/medical
 
 /datum/design/bioprinter/belt/security
-	name = "Security belt"
+	name = "Tactical belt"
 	build_path = /obj/item/weapon/storage/belt/security
+
+/datum/design/bioprinter/belt/security/neotheology
+	name = "Neotheologian tactical belt"
+	build_path = /obj/item/weapon/storage/belt/security/neotheology
 
 /datum/design/bioprinter/belt/medical/emt
 	name = "EMT belt"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1016,7 +1016,12 @@
 					/obj/item/ammo_magazine/sllrifle = 10,
 					/obj/item/weapon/storage/box/shotgunammo/beanbags = 10,
 					/obj/item/weapon/storage/box/shotgunammo/flashshells = 10,
-					/obj/item/weapon/storage/box/shotgunammo/blanks = 10)
+					/obj/item/weapon/storage/box/shotgunammo/blanks = 10,
+					/obj/item/clothing/accessory/holster = 5,
+					/obj/item/clothing/accessory/holster/armpit = 5,
+					/obj/item/clothing/accessory/holster/waist = 5,
+					/obj/item/clothing/accessory/holster/hip = 5)
+
 
 	contraband = list(
 					/obj/item/ammo_magazine/slpistol = 20,

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -290,10 +290,17 @@
 		/datum/design/bioprinter/leather/leather_jacket,
 		/datum/design/bioprinter/leather/cash_bag,
 		/datum/design/bioprinter/belt/utility,
+		/datum/design/bioprinter/belt/utility/neotheology,
 		/datum/design/bioprinter/belt/medical,
 		/datum/design/bioprinter/belt/security,
+		/datum/design/bioprinter/belt/security/neotheology,
 		/datum/design/bioprinter/belt/medical/emt,
 		/datum/design/bioprinter/belt/misc/champion,
+
+		/datum/design/bioprinter/leather/holster,
+		/datum/design/bioprinter/leather/holster/armpit,
+		/datum/design/bioprinter/leather/holster/waist,
+		/datum/design/bioprinter/leather/holster/hip,
 
 		/datum/design/bioprinter/medical/bruise,
 		/datum/design/bioprinter/medical/splints,
@@ -322,10 +329,17 @@
 		/datum/design/bioprinter/leather/leather_jacket,
 		/datum/design/bioprinter/leather/cash_bag,
 		/datum/design/bioprinter/belt/utility,
+		/datum/design/bioprinter/belt/utility/neotheology,
 		/datum/design/bioprinter/belt/medical,
 		/datum/design/bioprinter/belt/security,
+		/datum/design/bioprinter/belt/security/neotheology,
 		/datum/design/bioprinter/belt/medical/emt,
 		/datum/design/bioprinter/belt/misc/champion,
+
+		/datum/design/bioprinter/leather/holster,
+		/datum/design/bioprinter/leather/holster/armpit,
+		/datum/design/bioprinter/leather/holster/waist,
+		/datum/design/bioprinter/leather/holster/hip,
 
 		/datum/design/autolathe/gun/nt_sprayer
 	)

--- a/code/game/objects/random/cloth.dm
+++ b/code/game/objects/random/cloth.dm
@@ -409,21 +409,37 @@
 	icon_state = "armor-grey-low"
 	spawn_nothing_percentage = 60
 
-
-
-
 /obj/random/cloth/belt
 	name = "random belt"
-	desc = "This is a random belt"
+	desc = "This is a random belt."
 	icon_state = "armor-grey"
 
 /obj/random/cloth/belt/item_to_spawn()
 	return pickweight(list(/obj/item/weapon/storage/belt/medical = 8,
 				/obj/item/weapon/storage/belt/medical/emt = 8,
 				/obj/item/weapon/storage/belt/security = 4,
-				/obj/item/weapon/storage/belt/utility = 8,))
+				/obj/item/weapon/storage/belt/security/neotheology = 2,
+				/obj/item/weapon/storage/belt/utility = 8,
+				/obj/item/weapon/storage/belt/utility/neotheology = 4))
 
 /obj/random/cloth/belt/low_chance
 	name = "low chance random belt"
+	icon_state = "armor-grey-low"
+	spawn_nothing_percentage = 60
+
+/obj/random/cloth/holster
+	name = "random holster"
+	desc = "This is a random holster."
+	icon_state = "armor-grey"
+
+/obj/random/cloth/holster/item_to_spawn()
+	return pickweight(list(/obj/item/clothing/accessory/holster = 1,
+				/obj/item/clothing/accessory/holster/armpit = 1,
+				/obj/item/clothing/accessory/holster/waist = 1,
+				/obj/item/clothing/accessory/holster/hip = 1,))
+
+/obj/random/cloth/holster/low_chance
+	name = "low chance random holster"
+	desc = "This is a random holster."
 	icon_state = "armor-grey-low"
 	spawn_nothing_percentage = 60

--- a/code/game/objects/random/packs.dm
+++ b/code/game/objects/random/packs.dm
@@ -25,6 +25,7 @@ They generally give more random result and can provide more divercity in spawn.
 					/obj/random/cloth/shoes = 6,
 					/obj/random/cloth/backpack = 4,
 					/obj/random/cloth/belt = 4,
+					/obj/random/cloth/holster = 4
 				))
 
 /obj/random/pack/cloth/low_chance
@@ -95,6 +96,7 @@ They generally give more random result and can provide more divercity in spawn.
 					/obj/random/ammo/shotgun = 8,
 					/obj/random/ammo_ihs = 8,
 					/obj/random/ammo_lowcost = 10,
+					/obj/random/cloth/holster = 4
 				))
 
 /obj/random/pack/gun_loot/low_chance
@@ -127,6 +129,7 @@ They generally give more random result and can provide more divercity in spawn.
 					/obj/random/rig_module/rare = 4,
 					/obj/random/credits/c1000 = 3,
 					/obj/random/mecha_equipment = 3,
+					/obj/random/cloth/holster = 4,
 					/obj/item/stash_spawner = 4 //Creates a stash of goodies for a scavenger hunt
 	))
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1374,8 +1374,19 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	group = "Operations"
 
 
+/datum/supply_pack/randomised/holsters
+	num_contained = 4
+	contains = list(/obj/random/cloth/holster,
+					/obj/random/cloth/holster,
+					/obj/random/cloth/holster,
+					/obj/random/cloth/holster)
+	name = "Surplus Unform Holsters"
+	cost = 1000
+	crate_name = "Surplus Uniform Holsters Crate"
+	containertype = /obj/structure/closet/crate
+	group = "Operations"
 
-datum/supply_pack/randomised/voidsuit
+/datum/supply_pack/randomised/voidsuit
 	num_contained = 1
 	contains = list(/obj/random/voidsuit,
 					/obj/random/voidsuit/damaged)
@@ -1385,7 +1396,7 @@ datum/supply_pack/randomised/voidsuit
 	containertype = /obj/structure/closet/crate
 	group = "Operations"
 
-datum/supply_pack/randomised/rig
+/datum/supply_pack/randomised/rig
 	num_contained = 1
 	contains = list(/obj/random/rig,
 					/obj/random/rig/damaged)
@@ -1395,7 +1406,7 @@ datum/supply_pack/randomised/rig
 	containertype = /obj/structure/closet/crate
 	group = "Operations"
 
-datum/supply_pack/randomised/rigmods
+/datum/supply_pack/randomised/rigmods
 	num_contained = 2
 	contains = list(/obj/random/rig_module,
 				/obj/random/rig_module)

--- a/code/modules/clothing/accessories/holster.dm
+++ b/code/modules/clothing/accessories/holster.dm
@@ -3,7 +3,8 @@
 	desc = "A handgun holster."
 	icon_state = "holster"
 	slot = "utility"
-	price_tag = 100
+	matter = list(MATERIAL_BIOMATTER = 5)
+	price_tag = 200
 	var/obj/item/holstered = null
 
 /obj/item/clothing/accessory/holster/proc/holster(var/obj/item/I, var/mob/living/user)
@@ -113,7 +114,7 @@
 
 /obj/item/clothing/accessory/holster/armpit
 	name = "armpit holster"
-	desc = "A worn-out handgun holster. Perfect for concealed carry"
+	desc = "A worn-out handgun holster. Perfect for concealed carry."
 	icon_state = "holster"
 
 /obj/item/clothing/accessory/holster/waist


### PR DESCRIPTION
<!-- Make sure you read the guidelines before conrtibuting! https://wiki.cev-eris.com/Content_GuidelinesEn -->

## About The Pull Request
Uniform holsters are no longer IH exclusive now. Not sure who and why removed them from various sources in first place, but now you can get them either from FS vendor, guild, NT bioprinter, maintenance loot. IH still can get them from loadout. While i can agree that uniform having a whole slot for a handgun is maybe a bad thing, but this can be done at least until we get suit attachments or any other alternative to that.

NT now also can print their own belts because they couldn't do it previously. Added NT belts to maintenance loot as well.

