### PR TITLE
Removes OldPDA cartridges from map

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -83,4 +83,3 @@
 	new /obj/item/clothing/suit/storage/hazardvest(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/clothing/glasses/powered/meson(src)
-	new /obj/item/weapon/cartridge/engineering(src)

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -3890,8 +3890,6 @@
 /area/eris/command/commander)
 "aiZ" = (
 /obj/structure/table/woodentable,
-/obj/item/weapon/cartridge/detective,
-/obj/item/weapon/cartridge/detective,
 /obj/item/weapon/tool/tape_roll,
 /turf/simulated/floor/wood,
 /area/eris/command/commander)
@@ -56387,15 +56385,6 @@
 /area/eris/quartermaster/storage)
 "cwa" = (
 /obj/structure/table/standard,
-/obj/item/weapon/cartridge/signal/science,
-/obj/item/weapon/cartridge/signal/science{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/weapon/cartridge/signal/science{
-	pixel_x = 4;
-	pixel_y = 6
-	},
 /obj/item/clothing/glasses/welding/superior,
 /obj/machinery/keycard_auth{
 	pixel_x = 0;
@@ -74631,10 +74620,10 @@
 /area/eris/command/mbo/quarters)
 "dlb" = (
 /obj/structure/table/woodentable,
-/obj/item/weapon/cartridge/chemistry{
+/obj/item/weapon/computer_hardware/scanner/reagent{
 	pixel_y = 2
 	},
-/obj/item/weapon/cartridge/medical{
+/obj/item/weapon/computer_hardware/scanner/medical{
 	pixel_x = 6;
 	pixel_y = 3
 	},
@@ -81179,15 +81168,15 @@
 /area/eris/command/mbo)
 "dzB" = (
 /obj/structure/table/standard,
-/obj/item/weapon/cartridge/medical{
+/obj/item/weapon/computer_hardware/scanner/medical{
 	pixel_x = 6;
 	pixel_y = 3
 	},
-/obj/item/weapon/cartridge/medical{
+/obj/item/weapon/computer_hardware/scanner/medical{
 	pixel_x = 6;
 	pixel_y = 3
 	},
-/obj/item/weapon/cartridge/chemistry{
+/obj/item/weapon/computer_hardware/scanner/reagent{
 	pixel_y = 2
 	},
 /turf/simulated/floor/carpet/sblucarpet,


### PR DESCRIPTION
Chemical and medical cartridges were replaces with equivalent NewPDA scanners. The rest are just gone.