### PR TITLE
Plasma guns fix and rebalance

### DIFF
--- a/code/modules/projectiles/guns/energy/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/energy/plasma
 	name = "NT PR \"Dominion\""
-	desc = "A weapon that uses advanced plasma generation technology to emit powerful blasts of energized matter. Due to its complexity and cost, it is rarely seen in use, except by specialists."
+	desc = "A \"NeoTheology\" weapon that uses advanced plasma generation technology to emit highly controllable blasts of energized matter. Due to its complexity and cost, it is rarely seen in use, except by specialists."
 	icon = 'icons/obj/guns/energy/pulse.dmi'
 	icon_state = "pulse"
 	item_state = null	//so the human update icon uses the icon_state instead.
@@ -19,9 +19,9 @@
 	one_hand_penalty = 10
 
 	firemodes = list(
-		list(mode_name="maim", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/Taser.ogg', fire_delay=null, charge_cost=null, icon="stun", projectile_color = "#0000FF"),
-		list(mode_name="kill", projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/Laser.ogg', fire_delay=null, charge_cost=null, icon="kill", projectile_color = "#FF0000"),
-		list(mode_name="DESTROY", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/pulse.ogg', fire_delay=25, charge_cost=10, icon="destroy", projectile_color = "#FFFFFF"),
+		list(mode_name="burn", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/Taser.ogg', fire_delay=8, charge_cost=null, icon="stun", projectile_color = "#0000FF"),
+		list(mode_name="melt", projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/Laser.ogg', fire_delay=12, charge_cost=25, icon="kill", projectile_color = "#FF0000"),
+		list(mode_name="INCINERATE", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/pulse.ogg', fire_delay=14, charge_cost=30, icon="destroy", projectile_color = "#FFFFFF"),
 	)
 
 
@@ -32,17 +32,17 @@
 
 /obj/item/weapon/gun/energy/plasma/destroyer
 	name = "NT PR \"Purger\""
-	desc = "A more recent \"NeoTheology\" brand plasma rifle, developed in direct response to compete against the highly successful \"Cassad\" design."
+	desc = "A more recent \"NeoTheology\" brand plasma rifle, focused on the superior firepower at the cost of high energy usage."
 	icon = 'icons/obj/guns/energy/destroyer.dmi'
 	fire_sound = 'sound/weapons/pulse.ogg'
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 8, MATERIAL_SILVER = 10, MATERIAL_URANIUM = 5)
 	sel_mode = 1
 	projectile_type = /obj/item/projectile/beam/pulse
-	fire_delay = 20
+	fire_delay = 15
 
 	firemodes = list(
-		list(mode_name="DESTROY", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/pulse.ogg', fire_delay=null, charge_cost=null, icon="destroy", projectile_color = "#0000FF"),
-		list(mode_name="RAPID", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/pulse.ogg', fire_delay=10, charge_cost=30, icon="destroy", projectile_color = "#FF0000"),
+		list(mode_name="INCINERATE", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/pulse.ogg', fire_delay=null, charge_cost=30, icon="kill", projectile_color = "#FFFF00"),
+		list(mode_name="VAPORIZE", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/pulse.ogg', fire_delay=5, charge_cost=70, icon="destroy", projectile_color = "#FF0000", recoil_buildup=3),
 	)
 
 
@@ -56,13 +56,14 @@
 	fire_sound = 'sound/weapons/pulse.ogg'
 	projectile_type = /obj/item/projectile/beam/pulse
 	sel_mode = 1
-	charge_cost = 25 //32 shots per high medium cell
-	fire_delay = 15
+	charge_cost = 20 //40 shots per high medium-sized cell
+	fire_delay = 12
 	price_tag = 3000
 	zoom_factor = null
 
 	firemodes = list(
-		list(mode_name="DESTROY", projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/pulse.ogg', fire_delay=null, charge_cost=null, icon="destroy", projectile_color = "#FFA500"),
+		list(mode_name="burn", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/Taser.ogg', fire_delay=8, charge_cost=15, icon="stun", projectile_color = "#00FFFF"),
+		list(mode_name="melt", projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/Laser.ogg', fire_delay=null, charge_cost=null, icon="kill", projectile_color = "#00AAFF"),
 	)
 
 /obj/item/weapon/gun/energy/plasma/cassad/update_icon()

--- a/code/modules/projectiles/projectile/plasma.dm
+++ b/code/modules/projectiles/projectile/plasma.dm
@@ -3,17 +3,20 @@
 	icon_state = "plasma_bolt"
 	mob_hit_sound = list('sound/effects/gore/sear.ogg')
 	hitsound_wall = 'sound/weapons/guns/misc/laser_searwall.ogg'
-	damage = 30
-	armor_penetration = 10
+	damage = 33
+	armor_penetration = 25
 	damage_type = BURN
+	check_armour = ARMOR_ENERGY
 
 	muzzle_type = /obj/effect/projectile/plasma/muzzle
 	impact_type = /obj/effect/projectile/plasma/impact
 
 /obj/item/projectile/plasma/light
 	name = "light plasma bolt"
-	damage = 20
+	damage = 33
+	armor_penetration = 0
 
 /obj/item/projectile/plasma/heavy
 	name = "heavy plasma bolt"
-	damage = 40
+	damage = 33
+	armor_penetration = 50


### PR DESCRIPTION
## About The Pull Request
Fixes the plasma projectiles to actually check for energy armour, and rebalances the 3 plasma guns we have to be viable across all firing modes.



## Details
<details>
  <summary>Expand</summary>
- Changed all 3 plasma projectiles to deal 33 damage.
- Light projectile has no Armor Piercing.
- Medium projectile has 25 Armor Piercing.
- Heavy Projectile has 50 Armor Piercing.

- The design thought behind these is that the heavier the projectile, the bigger the fire delay and charge cost. Plasma weapon user is meant to adapt to the target - light projectile has the highest DPS on unarmored targets, medium is best for lightly armored (30-40% energy resist) and heavy is great against epic levels of armor.

- NT Dominion is a specialist rifle with all 3 projectile types.
- NT Cassad is an efficient rifle with lower charge cost, but it lacks the heavy firemode.
- NT Purger is a crusade shock rifle, sporting 2 heavy firemodes. One is regular, similar to Dominion, and the other one is 3x faster, but at a ridiculous charge cost, and with great recoil added. It's meant to be a powerful, but terribly unsustainable weapon.
</details>


