### PR TITLE
The RPG wielding fix

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -64,6 +64,7 @@
 
 	var/projectile_color //Set by a firemode. Sets the fired projectiles color
 
+	var/onehanded = 1 //If false, gun can only be fired when wileded
 
 /obj/item/weapon/gun/get_item_cost(export)
 	if(export)
@@ -197,6 +198,11 @@
 			to_chat(user, SPAN_DANGER("The gun's safety is on!"))
 			handle_click_empty(user)
 			return FALSE
+	if(onehanded > 1)
+		if(!wielded)
+			to_chat(user, SPAN_DANGER("The gun is too heavy to shoot in one hand"))
+			return FALSE
+
 	return TRUE
 
 /obj/item/weapon/gun/emp_act(severity)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -64,7 +64,7 @@
 
 	var/projectile_color //Set by a firemode. Sets the fired projectiles color
 
-	var/onehanded = 1 //If greater than 1, gun can only be fired when wileded
+	var/twohanded = FALSE //If TRUE, gun can only be fired when wileded
 
 /obj/item/weapon/gun/get_item_cost(export)
 	if(export)
@@ -180,6 +180,16 @@
 	if(HULK in M.mutations)
 		to_chat(user, SPAN_DANGER("Your fingers are much too large for the trigger guard!"))
 		return FALSE
+	if(!restrict_safety)
+		if(safety)
+			to_chat(user, SPAN_DANGER("The gun's safety is on!"))
+			handle_click_empty(user)
+			return FALSE
+	if(twohanded)
+		if(!wielded)
+			to_chat(user, SPAN_DANGER("The gun is too heavy to shoot in one hand"))
+			return FALSE
+
 	if((CLUMSY in M.mutations) && prob(40)) //Clumsy handling
 		var/obj/P = consume_next_projectile()
 		if(P)
@@ -193,16 +203,6 @@
 		else
 			handle_click_empty(user)
 		return FALSE
-	if(!restrict_safety)
-		if(safety)
-			to_chat(user, SPAN_DANGER("The gun's safety is on!"))
-			handle_click_empty(user)
-			return FALSE
-	if(onehanded > 1)
-		if(!wielded)
-			to_chat(user, SPAN_DANGER("The gun is too heavy to shoot in one hand"))
-			return FALSE
-
 	return TRUE
 
 /obj/item/weapon/gun/emp_act(severity)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -64,7 +64,7 @@
 
 	var/projectile_color //Set by a firemode. Sets the fired projectiles color
 
-	var/onehanded = 1 //If false, gun can only be fired when wileded
+	var/onehanded = 1 //If greater than 1, gun can only be fired when wileded
 
 /obj/item/weapon/gun/get_item_cost(export)
 	if(export)

--- a/code/modules/projectiles/guns/projectile/other/RPG.dm
+++ b/code/modules/projectiles/guns/projectile/other/RPG.dm
@@ -22,4 +22,4 @@
 	recoil_buildup = 0.2 //with new system it gives slight chance to miss but not really
 	fire_sound = 'sound/effects/bang.ogg'
 	bulletinsert_sound = 'sound/weapons/guns/interact/batrifle_magin.ogg' //placeholder, needs new sound
-	onehanded = 2
+	twohanded = TRUE

--- a/code/modules/projectiles/guns/projectile/other/RPG.dm
+++ b/code/modules/projectiles/guns/projectile/other/RPG.dm
@@ -22,3 +22,4 @@
 	recoil_buildup = 0.2 //with new system it gives slight chance to miss but not really
 	fire_sound = 'sound/effects/bang.ogg'
 	bulletinsert_sound = 'sound/weapons/guns/interact/batrifle_magin.ogg' //placeholder, needs new sound
+	onehanded = 2


### PR DESCRIPTION
Changes the RPG to be fireable only when wielded, also adds the possibilty to give this feature to other guns.


