### PR TITLE
Explosive damage changes

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -965,6 +965,7 @@
 #include "code\game\objects\items\weapons\grenades\emgrenade.dm"
 #include "code\game\objects\items\weapons\grenades\explosive.dm"
 #include "code\game\objects\items\weapons\grenades\flashbang.dm"
+#include "code\game\objects\items\weapons\grenades\frag.dm"
 #include "code\game\objects\items\weapons\grenades\grenade.dm"
 #include "code\game\objects\items\weapons\grenades\smokebomb.dm"
 #include "code\game\objects\items\weapons\grenades\spawnergrenade.dm"

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -132,6 +132,6 @@ proc/fragment_explosion(var/turf/epicenter, var/range, var/f_type, var/f_amount 
 		P.launch(T)
 
 		//Some of the fragments will hit mobs in the same turf
-		if (prob(20))
+		if (prob(95))
 			for(var/mob/living/M in epicenter)
 				P.attack_mob(M, 0, 100)

--- a/code/game/objects/items/weapons/grenades/explosive.dm
+++ b/code/game/objects/items/weapons/grenades/explosive.dm
@@ -1,63 +1,24 @@
-/obj/item/weapon/grenade/frag
-	name = "NT DFG \"Pomme\""
-	desc = "A military-grade defensive fragmentation grenade, designed to be thrown from cover."
-	icon_state = "frag"
-	item_state = "frggrenade"
-	loadable = TRUE
+/obj/item/weapon/grenade/explosive
+    name = "NT OBG \"Cracker\""
+    desc = "A military-grade offensive blast grenade, designed to be thrown by assaulting troops."
+    icon_state = "explosive"
+    loadable = TRUE
 
-	var/fragment_type = /obj/item/projectile/bullet/pellet/fragment/strong
-	var/num_fragments = 150  //total number of fragments produced by the grenade
-	var/fragment_damage = 5
-	var/damage_step = 2      //projectiles lose a fragment each time they travel this distance. Can be a non-integer.
+    var/devastation_range = -1
+    var/heavy_range = 1
+    var/weak_range = 4
+    var/flash_range = 10
 
-	//The radius of the circle used to launch projectiles. Lower values mean less projectiles are used but if set too low gaps may appear in the spread pattern
-	var/spread_range = 7
 
-	var/devastation_range = -1
-	var/heavy_range = -1
-	var/weak_range = 1
-	var/flash_range = -1
+/obj/item/weapon/grenade/explosive/prime()
+    set waitfor = 0
+    ..()
+    var/turf/O = get_turf(src)
+    if(!O) return
 
-/obj/item/weapon/grenade/frag/prime()
-	set waitfor = 0
-	..()
+    on_explosion(O)
 
-	var/turf/O = get_turf(src)
-	if(!O) return
+    qdel(src)
 
-	on_explosion(O)
-
-	if(num_fragments)
-		var/lying = FALSE
-		if(isturf(src.loc))
-			for(var/mob/living/M in O)
-				//lying on a frag grenade while the grenade is on the ground causes you to absorb most of the shrapnel.
-				//you will most likely be dead, but others nearby will be spared the fragments that hit you instead.
-				if(M.lying)
-					lying = TRUE
-
-		if(!lying)
-			fragment_explosion(O, spread_range, fragment_type, num_fragments, fragment_damage, damage_step)
-		else
-			fragment_explosion(O, 0, fragment_type, num_fragments, fragment_damage, damage_step)
-
-	qdel(src)
-
-/obj/item/weapon/grenade/frag/proc/on_explosion(var/turf/O)
+/obj/item/weapon/grenade/explosive/proc/on_explosion(var/turf/O)
 	explosion(O, devastation_range, heavy_range, weak_range, flash_range)
-
-/obj/item/weapon/grenade/frag/explosive
-	name = "NT OBG \"Cracker\""
-	desc = "A military-grade offensive blast grenade, designed to be thrown by assaulting troops."
-	icon_state = "explosive"
-
-	fragment_type = /obj/item/projectile/bullet/pellet/fragment/invisible
-	spread_range = 4
-	num_fragments = 4
-	fragment_damage = 30
-	damage_step = 20
-
-	devastation_range = -1
-	heavy_range = 1
-	weak_range = 4
-	flash_range = 10

--- a/code/game/objects/items/weapons/grenades/frag.dm
+++ b/code/game/objects/items/weapons/grenades/frag.dm
@@ -1,0 +1,38 @@
+/obj/item/weapon/grenade/frag
+	name = "NT DFG \"Pomme\""
+	desc = "A military-grade defensive fragmentation grenade, designed to be thrown from cover."
+	icon_state = "frag"
+	item_state = "frggrenade"
+	loadable = TRUE
+
+	var/fragment_type = /obj/item/projectile/bullet/pellet/fragment/strong
+	var/num_fragments = 150  //total number of fragments produced by the grenade
+	var/fragment_damage = 5
+	var/damage_step = 2      //projectiles lose a fragment each time they travel this distance. Can be a non-integer.
+
+	//The radius of the circle used to launch projectiles. Lower values mean less projectiles are used but if set too low gaps may appear in the spread pattern
+	var/spread_range = 7
+
+/obj/item/weapon/grenade/frag/prime()
+	set waitfor = 0
+	..()
+
+	var/turf/O = get_turf(src)
+	if(!O) return
+
+	if(num_fragments)
+		var/lying = FALSE
+		if(isturf(src.loc))
+			for(var/mob/living/M in O)
+				//lying on a frag grenade while the grenade is on the ground causes you to absorb most of the shrapnel.
+				//you will most likely be dead, but others nearby will be spared the fragments that hit you instead.
+				if(M.lying)
+					lying = TRUE
+
+		if(!lying)
+			fragment_explosion(O, spread_range, fragment_type, num_fragments, fragment_damage, damage_step)
+		else
+			fragment_explosion(O, 0, fragment_type, num_fragments, fragment_damage, damage_step)
+
+	qdel(src)
+

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -273,7 +273,7 @@
 
 /obj/item/weapon/storage/box/explosive/populate_contents()
 	for(var/i in 1 to 4)
-		new /obj/item/weapon/grenade/frag/explosive(src)
+		new /obj/item/weapon/grenade/explosive(src)
 
 
 /obj/item/weapon/storage/box/smokes

--- a/code/game/objects/items/weapons/storage/deferred.dm
+++ b/code/game/objects/items/weapons/storage/deferred.dm
@@ -168,7 +168,7 @@
 	name = "grenadier crate"
 	desc = "A crate containing one \"Lenar\" launcher, and copious quantities of hand-propelled explosive devices."
 	icon_state = "serbcrate_deferred_black"
-	initial_contents = list(/obj/item/weapon/grenade/frag/explosive = 5,
+	initial_contents = list(/obj/item/weapon/grenade/explosive = 5,
 	/obj/item/weapon/grenade/frag = 14,
 	/obj/item/weapon/grenade/empgrenade/low_yield = 4,
 	/obj/item/weapon/grenade/smokebomb = 8,

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -121,7 +121,7 @@
 
 		if (2.0)
 			if (!shielded)
-				b_loss += 60
+				b_loss += 150
 
 			if (!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
 				ear_damage += 30
@@ -130,7 +130,7 @@
 				Paralyse(10)
 
 		if(3.0)
-			b_loss += 30
+			b_loss += 100
 			if (!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
 				ear_damage += 15
 				ear_deaf += 60
@@ -139,29 +139,13 @@
 	if (bomb_defense)
 		b_loss = max(b_loss - bomb_defense, 0)
 		f_loss = max(f_loss - bomb_defense, 0)
-	var/update = 0
-
-	// focus most of the blast on one organ
-	var/obj/item/organ/external/take_blast = pick(organs)
-	update |= take_blast.take_damage(b_loss * 0.9, f_loss * 0.9, used_weapon = "Explosive blast")
-
-	// distribute the remaining 10% on all limbs equally
-	b_loss *= 0.1
-	f_loss *= 0.1
-
-	var/weapon_message = "Explosive Blast"
-
-	for(var/obj/item/organ/external/temp in organs)
-		switch(temp.name)
-			if(BP_HEAD)
-				update |= temp.take_damage(b_loss * 0.2, f_loss * 0.2, used_weapon = weapon_message)
-			if(BP_CHEST)
-				update |= temp.take_damage(b_loss * 0.4, f_loss * 0.4, used_weapon = weapon_message)
-			else
-				update |= temp.take_damage(b_loss * 0.05, f_loss * 0.05, used_weapon = weapon_message)
-	if(update)
-		UpdateDamageIcon()
-
+		
+	var/organ_hit = BP_CHEST //Chest is hit first
+	var/exp_damage
+	while (b_loss > 0)
+		b_loss -= exp_damage = rand(0, b_loss)
+		src.apply_damage(exp_damage, BRUTE, organ_hit)
+		organ_hit = pickweight(list(BP_HEAD = 0.2, BPBP_GROIN = 0.2, BP_R_ARM = 0.1, BP_L_ARM = 0.1, BP_R_LEG=0.1, BP_L_LEG=0.1))  //We determine some other body parts that should be hit 
 
 /mob/living/carbon/human/restrained()
 	if (handcuffed)

--- a/maps/testmap/test_map.dmm
+++ b/maps/testmap/test_map.dmm
@@ -271,7 +271,7 @@
 /turf/simulated/floor,
 /area/testing/first)
 "aS" = (
-/obj/item/weapon/grenade/frag/explosive,
+/obj/item/weapon/grenade/explosive,
 /turf/simulated/floor,
 /area/testing/first)
 "aT" = (


### PR DESCRIPTION
This makes explosive damage much more deadly. I also stopped frag grenades from exploding, stopped HE grenades from spawning invisible fragments and made them a child of /grenade themselves.

