### PR TITLE
Embed nerf

### DIFF
--- a/code/game/objects/items/weapons/tools/pickaxe.dm
+++ b/code/game/objects/items/weapons/tools/pickaxe.dm
@@ -19,7 +19,7 @@
 	sharp = TRUE
 	structure_damage_factor = STRUCTURE_DAMAGE_BORING //Drills and picks are made for getting through hard materials
 	//They are the best anti-structure melee weapons
-	embed_mult = 1.2 //Digs deep
+	embed_mult = 0.8 //Digs deep
 	mode = EXCAVATE //Mode should be whatever is the starting tool and off quality.
 
 /obj/item/weapon/tool/pickaxe/equipped(mob/user)

--- a/code/game/objects/items/weapons/tools/saws.dm
+++ b/code/game/objects/items/weapons/tools/saws.dm
@@ -12,7 +12,7 @@
 	sharp = TRUE
 	edge = TRUE
 	tool_qualities = list(QUALITY_SAWING = 30, QUALITY_CUTTING = 20, QUALITY_WIRE_CUTTING = 20)
-	embed_mult = 1 //Serrated blades catch on bone more easily
+	embed_mult = 0.8 //Serrated blades catch on bone more easily
 
 /obj/item/weapon/tool/saw/improvised //tier 1
 	name = "choppa"

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -51,7 +51,7 @@
 	force_wielded = WEAPON_FORCE_BRUTAL
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
-	embed_mult = 1 //Axes cut deep, and their hooked shape catches on things
+	embed_mult = 0.6 //Axes cut deep, and their hooked shape catches on things
 
 /obj/item/weapon/tool/fireaxe/afterattack(atom/A as mob|obj|turf|area, mob/user as mob, proximity)
 	if(!proximity) return

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -39,7 +39,7 @@ true, and the mob is not yet deleted, so we need to check that as well*/
 
 		//blunt objects should really not be embedding in things unless a huge amount of force is involved
 
-		var/embed_threshold = weapon_sharp? 5*I.w_class : 15*I.w_class
+		var/embed_threshold = weapon_sharp? 8*I.w_class : 18*I.w_class
 
 		//The user's robustness stat adds to the threshold, allowing you to use more powerful weapons without embedding risk
 		embed_threshold += user.stats.getStat(STAT_ROB)


### PR DESCRIPTION
Reduces the embedding of most big weapons and just generally reduces the chances of anything getting embedded slightly.