### PR TITLE
Fixes loadout laptops and tablets not spawning with job software

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -303,6 +303,7 @@ SUBSYSTEM_DEF(job)
 	var/datum/job_flavor/flavor = pick(job.random_flavors)
 
 	if(job)
+		H.job = rank
 
 		//Equip custom gear loadout.
 		//var/list/custom_equip_slots = list() //If more than one item takes the same slot, all after the first one spawn in storage.
@@ -336,8 +337,6 @@ SUBSYSTEM_DEF(job)
 
 	else
 		to_chat(H, "Your job is [rank] and the game just can't handle it! Please report this bug to an administrator.")
-
-	H.job = rank
 
 	// If they're head, give them the account info for their department
 	if(H.mind && (job.head_position || job.department_account_access))

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -33,6 +33,7 @@
 	// TODO: enable after baymed
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							///datum/computer_file/program/aidiag,
+							/datum/computer_file/program/signaller,
 							/datum/computer_file/program/camera_monitor,
 							/datum/computer_file/program/chem_catalog,
 							/datum/computer_file/program/reports)
@@ -70,7 +71,7 @@ Your second loyalty is to moebius corp. In order to ensure it can continue its m
 	//alt_titles = list("Moebius Xenobiologist")
 	outfit_type = /decl/hierarchy/outfit/job/science/scientist
 
-	software_on_spawn = list(/datum/computer_file/program/chem_catalog)
+	software_on_spawn = list(/datum/computer_file/program/signaller, /datum/computer_file/program/chem_catalog)
 
 	access = list(
 		access_robotics, access_tox, access_tox_storage, access_moebius, access_xenobiology, access_xenoarch, access_research_equipment,

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -44,13 +44,17 @@
 /obj/item/modular_computer/proc/install_default_programs()
 	return TRUE
 
-/obj/item/modular_computer/proc/install_default_programs_by_job(var/mob/living/carbon/human/H)
+/obj/item/modular_computer/proc/install_default_programs_by_job(mob/living/carbon/human/H)
+	if(!istype(H))
+		return
+
 	var/datum/job/jb = SSjob.GetJob(H.job)
-	if(!jb) return
+	if(!jb)
+		return
+
 	for(var/prog_type in jb.software_on_spawn)
-		var/datum/computer_file/program/prog_file = prog_type
-		if(initial(prog_file.usage_flags) & hardware_flag)
-			prog_file = new prog_file
+		var/datum/computer_file/program/prog_file = new prog_type
+		if(prog_file.is_supported_by_hardware(src))
 			hard_drive.store_file(prog_file)
 
 /obj/item/modular_computer/Initialize()

--- a/code/modules/modular_computers/computers/subtypes/preset_laptop.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_laptop.dm
@@ -31,9 +31,7 @@
 	hard_drive.store_file(new/datum/computer_file/program/chatclient())
 	hard_drive.store_file(new/datum/computer_file/program/wordprocessor())
 	hard_drive.store_file(new/datum/computer_file/program/newsbrowser())
-	var/mob/living/carbon/human/H = get(src, /mob)
-	if(!istype(H)) return
-	install_default_programs_by_job(H)
+	install_default_programs_by_job(get(src, /mob/living/carbon/human))
 
 //Map presets
 /obj/item/modular_computer/laptop/preset/records/install_default_hardware()

--- a/code/modules/modular_computers/computers/subtypes/preset_tablet.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_tablet.dm
@@ -24,9 +24,7 @@
 
 /obj/item/modular_computer/tablet/preset/custom_loadout/install_default_programs()
 	..()
-	var/mob/living/carbon/human/H = get(src, /mob)
-	if(!istype(H)) return
-	install_default_programs_by_job(H)
+	install_default_programs_by_job(get(src, /mob/living/carbon/human))
 	hard_drive.store_file(new/datum/computer_file/program/wordprocessor())
 
 //Map presets


### PR DESCRIPTION
Fixes another regression that was introduced in #4680. Also adds signaller app as a default for Scientist and MEO jobs.