### PR TITLE
TM Voidsuit spawn rate adjustment

### DIFF
--- a/code/game/objects/random/voidsuit.dm
+++ b/code/game/objects/random/voidsuit.dm
@@ -8,7 +8,7 @@
 
 /obj/random/voidsuit/item_to_spawn()
 	return pickweight(list(/obj/item/clothing/suit/space/void = 2,
-		/obj/item/clothing/suit/space/void/engineering = 2,
+		/obj/item/clothing/suit/space/void/engineering = 1,
 		/obj/item/clothing/suit/space/void/mining = 2,
 		/obj/item/clothing/suit/space/void/medical = 2.3,
 		/obj/item/clothing/suit/space/void/security = 1,


### PR DESCRIPTION
Techno voidsuit is now as rare as the IH voidsuit in trash since it has very similar stats 
