### PR TITLE
adds wheelchair to utility loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -38,7 +38,7 @@
 	cost = 2
 /datum/gear/utility/wheelchair
 	display_name = "wheelchair"
-	path = /obj/structure/bed/chair/wheelchair
+	path = /obj/item/wheelchair
 	cost = 3
 
 /datum/gear/utility/normaltablet

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -37,6 +37,11 @@
 	path = /obj/item/modular_computer/tablet/preset/custom_loadout/cheap
 	cost = 2
 
+/obj/structure/bed/chair/wheelchair
+	display_name = "wheelchair"
+	pathc = /obj/structure/bed/chair/wheelchair
+	cost = 3
+
 /datum/gear/utility/normaltablet
 	display_name = "advanced tablet computer"
 	path = /obj/item/modular_computer/tablet/preset/custom_loadout/advanced

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -36,8 +36,7 @@
 	display_name = "cheap tablet computer"
 	path = /obj/item/modular_computer/tablet/preset/custom_loadout/cheap
 	cost = 2
-
-/obj/structure/bed/chair/wheelchair
+/datum/gear/utility/wheelchair
 	display_name = "wheelchair"
 	path = /obj/structure/bed/chair/wheelchair
 	cost = 3

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -39,7 +39,7 @@
 
 /obj/structure/bed/chair/wheelchair
 	display_name = "wheelchair"
-	pathc = /obj/structure/bed/chair/wheelchair
+	path = /obj/structure/bed/chair/wheelchair
 	cost = 3
 
 /datum/gear/utility/normaltablet


### PR DESCRIPTION

## About The Pull Request
As of right now you can remove your legs by amputation at start but can't start in a wheelchair so I think it's nice to have it able to get it from the get go instead of crawling until you make/find one and makes sense lore-wise since poor vagabonds might not be able to afford prosthetics while still getting badly wounded on the regular.

