### PR TITLE
Makes changelings real good at self-surgery

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -112,6 +112,11 @@
 	if(owner && user == owner)
 		difficulty_adjust = 20
 
+		// ...unless you are a changeling
+		// It makes sense that lings have a way of making their flesh cooperate
+		if(user.check_special_role(ROLE_CHANGELING))
+			difficulty_adjust = -50
+
 	var/atom/surgery_target = get_surgery_target()
 	if(S.required_tool_quality)
 		success = tool.use_tool_extended(
@@ -266,8 +271,13 @@ proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 
 
 /obj/item/organ/external/proc/try_autodiagnose(mob/living/user)
-	if(istype(user) && user.stats)
-		if(user.stats.getStat(BP_IS_ROBOTIC(src) ? STAT_MEC : STAT_BIO) >= STAT_LEVEL_EXPERT)
+	if(istype(user))
+		// Changelings know their flesh, as long as it is connected to their bodies
+		if(!BP_IS_ROBOTIC(src) && user == owner && user.check_special_role(ROLE_CHANGELING))
+			diagnosed = TRUE
+			return TRUE
+
+		if(user.stats?.getStat(BP_IS_ROBOTIC(src) ? STAT_MEC : STAT_BIO) >= STAT_LEVEL_EXPERT)
 			to_chat(user, SPAN_NOTICE("One brief look at [get_surgery_name()] is enough for you to see all the issues immediately."))
 			diagnosed = TRUE
 			return TRUE
@@ -277,6 +287,12 @@ proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 //check if mob is lying down on something we can operate him on.
 /proc/can_operate(mob/living/carbon/M, mob/living/user)
 	if(M == user)	// Self-surgery
+
+		// Lings don't need to sit in a chair to perform a surgery on themselves
+		if(user.check_special_role(ROLE_CHANGELING))
+			return TRUE
+
+		// Normal humans do
 		var/atom/chair = locate(/obj/structure/bed/chair, M.loc)
 		return chair && chair.buckled_mob == M
 


### PR DESCRIPTION
Changelings no longer need a chair to perform self-surgery, they can do it just by standing still. They also have a significant increase to success chances and don't need to diagnose a body part they are operating on.