### PR TITLE
Should fix rig back slots not showing properly

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -516,11 +516,14 @@
 		ui.open()
 		ui.set_auto_update(1)
 
+/obj/item/weapon/rig/proc/get_species_icon()
+	return 'icons/mob/rig_back.dmi'
+
 /obj/item/weapon/rig/update_icon(var/update_mob_icon)
 
 	overlays.Cut()
 	if(!mob_icon || update_mob_icon)
-		var/species_icon = 'icons/mob/rig_back.dmi'
+		var/species_icon = get_species_icon()
 		// Since setting mob_icon will override the species checks in
 		// update_inv_wear_suit(), handle species checks here.
 		mob_icon = image("icon" = species_icon, "icon_state" = icon_state)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -69,7 +69,6 @@
 	var/obj/item/rig_module/voice/speech                      // As above.
 	var/obj/item/rig_module/storage/storage					  // var for installed storage module, if any
 	var/mob/living/carbon/human/wearer                        // The person currently wearing the rig.
-	var/image/mob_icon                                        // Holder for on-mob icon.
 	var/list/installed_modules = list()                       // Power consumption/use bookkeeping.
 
 	// Rig status vars.
@@ -520,26 +519,10 @@
 	return 'icons/mob/rig_back.dmi'
 
 /obj/item/weapon/rig/update_icon(var/update_mob_icon)
-
-	overlays.Cut()
-	if(!mob_icon || update_mob_icon)
-		var/species_icon = get_species_icon()
-		// Since setting mob_icon will override the species checks in
-		// update_inv_wear_suit(), handle species checks here.
-		mob_icon = image("icon" = species_icon, "icon_state" = icon_state)
-
 	if(installed_modules.len)
 		for(var/obj/item/rig_module/module in installed_modules)
 			if(module.suit_overlay)
 				chest.overlays += image("icon" = 'icons/mob/rig_modules.dmi', "icon_state" = module.suit_overlay, "dir" = SOUTH)
-
-	if(wearer)
-		wearer.update_inv_shoes()
-		wearer.update_inv_gloves()
-		wearer.update_inv_head()
-		wearer.update_inv_wear_suit()
-		wearer.update_inv_back()
-	return
 
 /obj/item/weapon/rig/proc/check_suit_access(var/mob/living/carbon/human/user)
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -919,7 +919,6 @@ var/global/list/damage_icon_parts = list()
 /mob/living/carbon/human/proc/get_back_icon(var/obj/item/test = null)
 	if(!test && back)
 		test = back
-
 	if (test)
 		//determine the icon to use
 		var/icon/overlay_icon
@@ -935,15 +934,13 @@ var/global/list/damage_icon_parts = list()
 		else if(test.icon_override)
 			overlay_icon = test.icon_override
 		else if(istype(test, /obj/item/weapon/rig))
-			//If this is a rig and a mob_icon is set, it will take species into account in the rig update_icon() proc.
 			var/obj/item/weapon/rig/rig = test
-			overlay_icon = rig.mob_icon
+			overlay_icon = rig.get_species_icon()
 
 		else if(test.item_icons && (slot_back_str in test.item_icons))
 			overlay_icon = test.item_icons[slot_back_str]
 		else
 			overlay_icon = get_gender_icon(gender, "backpack")
-
 		return overlay_icon
 
 	else return get_gender_icon(gender, "backpack")
@@ -956,8 +953,9 @@ var/global/list/damage_icon_parts = list()
 	var/icon/overlay_icon = get_back_icon()
 	var/overlay_state = ""
 	if(back && overlay_icon)
+		overlay_state = back.item_state
 		if(back.contained_sprite)
-			overlay_state += "[back.item_state][WORN_BACK]"
+			overlay_state = "[back.item_state][WORN_BACK]"
 
 			if(back.icon_override)
 				overlay_icon = back.icon_override
@@ -969,7 +967,6 @@ var/global/list/damage_icon_parts = list()
 		//determine state to use
 		if(back.item_state_slots && back.item_state_slots[slot_back_str])
 			overlay_state = back.item_state_slots[slot_back_str]
-
 		//apply color
 		var/image/standing = image(icon = overlay_icon, icon_state = overlay_state)
 		standing.color = back.color


### PR DESCRIPTION
There was a snowflake override specifically for the rig, that would return an image.

Problem is, the function it was in was expecting to return an icon file directory, so you ended up with a dead image whose icon file was harvested, and then no icon state, so they would default to the blank icon state.