### PR TITLE
Small Clown buffs

### DIFF
--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -51,7 +51,7 @@
 	name = "clown shoes"
 	icon_state = "clown"
 	item_state = "clown_shoes"
-	slowdown = SHOES_SLOWDOWN+1
+	slowdown = SHOES_SLOWDOWN+0.4
 	force = 0
 	var/footstep = 1	//used for squeeks whilst walking
 	species_restricted = null

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -14,7 +14,7 @@
 	amount_per_transfer_from_this = 10
 	unacidable = 1 //plastic
 	possible_transfer_amounts = list(5,10) //Set to null instead of list, if there is only one.
-	matter = list(MATERIAL_PLASTIC = 1)
+	matter = list(MATERIAL_PLASTIC = 2)
 	var/spray_size = 3
 	var/list/spray_sizes = list(1,3)
 	volume = 250
@@ -101,8 +101,6 @@
 	preloaded_reagents = list("cleaner" = 250)
 
 /obj/item/weapon/reagent_containers/spray/cleaner/drone
-	name = "space cleaner"
-	desc = "BLAM!-brand non-foaming space cleaner!"
 	volume = 50
 	preloaded_reagents = list("cleaner" = 50)
 
@@ -143,9 +141,8 @@
 	icon_state = "sunflower"
 	item_state = "sunflower"
 	amount_per_transfer_from_this = 1
-	possible_transfer_amounts = null
-	volume = 10
-	preloaded_reagents = list("water" = 10)
+	possible_transfer_amounts = list(1, 5, 10)
+	preloaded_reagents = list("water" = 50)
 
 /obj/item/weapon/reagent_containers/spray/chemsprayer
 	name = "chem sprayer"


### PR DESCRIPTION
On Eris, Clown (or, as no one ever calls him, Actor) is crippled more than anywhere else because of how common, expected and sometimes required firearms are. Ship's favorite punching bag deserves some buffs to compensate for it!

* Clown's water flower is now a legitimate spray bottle, just with a different appearance. It's not like spray bottles are super rare anyway.
* Clown shoes slowdown has been cut, from 1.0 to 0.4. Slowdowns feel bad, and we cut a lot of them already - it makes little sense to keep an entire 1.0 of it on an item that's required for a job.

The ONLY reason clown shoes slowdown wasn't removed entirely is that being able to terrorize the crew with constant squeaking is a power that should come at a price.

Unrelated: the amount of plastic in a spray bottle was bumped to 2, to match the large beaker that requires 2 glass.