### PR TITLE
Voidsuit buffs/nerfs

### DIFF
--- a/code/game/objects/random/voidsuit.dm
+++ b/code/game/objects/random/voidsuit.dm
@@ -8,7 +8,7 @@
 
 /obj/random/voidsuit/item_to_spawn()
 	return pickweight(list(/obj/item/clothing/suit/space/void = 2,
-		/obj/item/clothing/suit/space/void/engineering = 1,
+		/obj/item/clothing/suit/space/void/engineering = 2,
 		/obj/item/clothing/suit/space/void/mining = 2,
 		/obj/item/clothing/suit/space/void/medical = 2.3,
 		/obj/item/clothing/suit/space/void/security = 1,

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -70,7 +70,7 @@
 	name = "mining voidsuit"
 	desc = "A special suit that protects against hazardous, low pressure environments. Has reinforced plating."
 	item_state = "mining_voidsuit"
-		slowdown = 0.35
+	slowdown = 0.35
 	armor = list(
 		melee = 50,
 		bullet = 35,

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -70,10 +70,11 @@
 	name = "mining voidsuit"
 	desc = "A special suit that protects against hazardous, low pressure environments. Has reinforced plating."
 	item_state = "mining_voidsuit"
+		slowdown = 0.35
 	armor = list(
 		melee = 50,
-		bullet = 30,
-		energy = 20,
+		bullet = 35,
+		energy = 30,
 		bomb = 25,
 		bio = 100,
 		rad = 75
@@ -136,7 +137,7 @@
 		)
 
 	armor = list(
-		melee = 30,
+		melee = 35,
 		bullet = 40,
 		energy = 30,
 		bomb = 25,
@@ -152,7 +153,7 @@
 	desc = "A bulky suit that protects against hazardous, low pressure environments. Sacrifices mobility for protection."
 	item_state = "ihvoidsuit"
 	armor = list(
-		melee = 40,
+		melee = 35,
 		bullet = 40,
 		energy = 30,
 		bomb = 25,

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -10,10 +10,10 @@
 		slot_r_hand_str = "eng_helm",
 		)
 	armor = list(
-		melee = 40,
-		bullet = 40,
+		melee = 35,
+		bullet = 30,
 		energy =30,
-		bomb = 25,
+		bomb = 40,
 		bio = 100,
 		rad = 100
 	)
@@ -25,10 +25,10 @@
 	icon_state = "technosuit"
 	item_state = "technosuit"
 	armor = list(
-		melee = 40,
-		bullet = 40,
+		melee = 35,
+		bullet = 30,
 		energy = 30,
-		bomb = 25,
+		bomb = 40,
 		bio = 100,
 		rad = 100
 	)
@@ -57,8 +57,8 @@
 		)
 	armor = list(
 		melee = 50,
-		bullet = 30,
-		energy = 20,
+		bullet = 35,
+		energy = 30,
 		bomb = 25,
 		bio = 100,
 		rad = 75
@@ -91,9 +91,9 @@
 		slot_r_hand_str = "medical_helm",
 		)
 	armor = list(
-		melee = 20,
+		melee = 30,
 		bullet = 10,
-		energy = 10,
+		energy = 35,
 		bomb = 25,
 		bio = 100,
 		rad = 75
@@ -114,7 +114,7 @@
 	armor = list(
 		melee = 20,
 		bullet = 10,
-		energy = 10,
+		energy = 35,
 		bomb = 25,
 		bio = 100,
 		rad = 75
@@ -152,7 +152,7 @@
 	desc = "A bulky suit that protects against hazardous, low pressure environments. Sacrifices mobility for protection."
 	item_state = "ihvoidsuit"
 	armor = list(
-		melee = 30,
+		melee = 40,
 		bullet = 40,
 		energy = 30,
 		bomb = 25,


### PR DESCRIPTION
<!-- Make sure you read the guidelines before conrtibuting! https://wiki.cev-eris.com/Content_GuidelinesEn -->

## About The Pull Request
Does a bit more of a balance pass on voidsuits.


## Details
Buffs the mining voidsuits bullet proc to be 35 rather than 20, considering there's a bunch of away mission mobs that try to shoot your face off. Same with minorly better energy due to one star drones melting miners if they don't have kelotane on them.
Gives the techno armor 40 bomb resist but less overall resist.
Medical voidsuit has more energy protection now.
</details>


## Screenshots
nothing changed. Spooky.

</details>


