### PR TITLE
Gun disk rebalance (Feedback wellcome)

### DIFF
--- a/code/game/objects/random/guns.dm
+++ b/code/game/objects/random/guns.dm
@@ -14,7 +14,7 @@
 				/obj/item/weapon/gun/projectile/olivaw = 4,\
 				/obj/item/weapon/gun/energy/gun/martin = 2,\
 				/obj/item/weapon/gun/launcher/crossbow = 1,\
-				/obj/item/weapon/gun/projectile/boltgun = 1))
+				/obj/item/weapon/gun/projectile/boltgun/serbian = 1))
 
 /obj/random/gun_cheap/low_chance
 	name = "low chance random cheap gun"
@@ -41,7 +41,7 @@
 				/obj/item/weapon/gun/projectile/revolver/deckard = 2,\
 				/obj/item/weapon/gun/projectile/automatic/wintermute = 1,\
 				/obj/item/weapon/gun/projectile/automatic/sol = 1,\
-				/obj/item/weapon/gun/projectile/automatic/sts35 = 1\
+				/obj/item/weapon/gun/projectile/automatic/sts35 = 1,\
 				/obj/item/weapon/gun/projectile/automatic/molly = 2,\
 				/obj/item/weapon/gun/projectile/automatic/straylight = 1,\
 				/obj/item/weapon/gun/energy/gun = 2,\

--- a/code/game/objects/random/guns.dm
+++ b/code/game/objects/random/guns.dm
@@ -28,11 +28,10 @@
 				/obj/item/weapon/gun/projectile/automatic/atreides = 1,\
 				/obj/item/weapon/gun/projectile/avasarala = 2,\
 				/obj/item/weapon/gun/projectile/shotgun/pump/gladstone = 2,\
-				/obj/item/weapon/gun/projectile/colt = 4,\
-				/obj/item/weapon/gun/projectile/revolver/consul = 4,\
-				/obj/item/weapon/gun/projectile/revolver = 4,\
+				/obj/item/weapon/gun/projectile/colt = 3,\
+				/obj/item/weapon/gun/projectile/revolver/consul = 3,\
+				/obj/item/weapon/gun/projectile/revolver = 3,\
 				/obj/item/weapon/gun/projectile/automatic/wintermute = 1,\
-				/obj/item/weapon/gun/projectile/paco = 2,\
 				/obj/item/weapon/gun/projectile/automatic/molly = 2,\
 				/obj/item/weapon/gun/projectile/automatic/straylight = 1))
 

--- a/code/game/objects/random/guns.dm
+++ b/code/game/objects/random/guns.dm
@@ -3,17 +3,23 @@
 	icon_state = "gun-grey"
 
 /obj/random/gun_cheap/item_to_spawn()
-	return pickweight(list(/obj/item/weapon/gun/projectile/mk58 = 3,\
-				/obj/item/weapon/gun/projectile/mk58/wood = 1,\
-				/obj/item/weapon/gun/projectile/revolver/havelock = 1,\
-				/obj/item/weapon/gun/projectile/giskard = 4,\
-				/obj/item/weapon/gun/projectile/shotgun/pump = 2,\
-				/obj/item/weapon/gun/projectile/olivaw = 2))
+	return pickweight(list(/obj/item/weapon/gun/projectile/mk58 = 5,\
+				/obj/item/weapon/gun/projectile/mk58/wood = 2,\
+				/obj/item/weapon/gun/projectile/clarissa = 3,\
+				/obj/item/weapon/gun/projectile/paco = 2,\
+				/obj/item/weapon/gun/projectile/revolver/havelock = 2,\
+				/obj/item/weapon/gun/projectile/giskard = 7,\
+				/obj/item/weapon/gun/projectile/shotgun/pump = 3,\
+				/obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawn = 2,\
+				/obj/item/weapon/gun/projectile/olivaw = 4,\
+				/obj/item/weapon/gun/energy/gun/martin = 2,\
+				/obj/item/weapon/gun/launcher/crossbow = 1,\
+				/obj/item/weapon/gun/projectile/boltgun = 1))
 
 /obj/random/gun_cheap/low_chance
 	name = "low chance random cheap gun"
 	icon_state = "gun-grey-low"
-	spawn_nothing_percentage = 80
+	spawn_nothing_percentage = 75
 
 
 
@@ -29,16 +35,23 @@
 				/obj/item/weapon/gun/projectile/avasarala = 2,\
 				/obj/item/weapon/gun/projectile/shotgun/pump/gladstone = 2,\
 				/obj/item/weapon/gun/projectile/colt = 3,\
+				/obj/item/weapon/gun/projectile/avasarala = 1,\
 				/obj/item/weapon/gun/projectile/revolver/consul = 3,\
 				/obj/item/weapon/gun/projectile/revolver = 3,\
+				/obj/item/weapon/gun/projectile/revolver/deckard = 2,\
 				/obj/item/weapon/gun/projectile/automatic/wintermute = 1,\
+				/obj/item/weapon/gun/projectile/automatic/sol = 1,\
+				/obj/item/weapon/gun/projectile/automatic/sts35 = 1\
 				/obj/item/weapon/gun/projectile/automatic/molly = 2,\
-				/obj/item/weapon/gun/projectile/automatic/straylight = 1))
+				/obj/item/weapon/gun/projectile/automatic/straylight = 1,\
+				/obj/item/weapon/gun/energy/gun = 2,\
+				/obj/item/weapon/gun/energy/laser = 2,\
+				/obj/item/weapon/gun/energy/plasma/cassad = 2))
 
 /obj/random/gun_normal/low_chance
 	name = "low chance random normal gun"
 	icon_state = "gun-green-low"
-	spawn_nothing_percentage = 80
+	spawn_nothing_percentage = 75
 
 
 

--- a/code/game/objects/random/lathe_disks.dm
+++ b/code/game/objects/random/lathe_disks.dm
@@ -15,7 +15,7 @@
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/computer = 8,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/security = 6,
 
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_cheap_guns = 3,
+				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_cheap_guns = 4,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_mk58 = 3,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_colt = 3,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_silenced = 2,
@@ -24,21 +24,15 @@
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_revolver_consul = 1,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_revolver_deckard = 1,
 
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_doublebarrel = 2,
+				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_doublebarrel = 3,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_kammerer = 3,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_regulator = 2,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_gladstone = 2,
 
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_paco = 1,
+				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_paco = 2,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_straylight = 1,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_molly = 1,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/sa_zoric = 1,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_atreides = 1,
 
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_bulldog = 1,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_sol = 1,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/sa_boltgun = 4,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_kalashnikov = 1,
+				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/sa_boltgun = 5,
 
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_counselor = 2,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_spiderrose = 1,
@@ -46,12 +40,12 @@
 
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_themis = 1,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_lightfall = 1,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_halicon = 2,
+				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_halicon = 3,
 
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/ms_dartgun = 3,
+				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/ms_dartgun = 4,
 
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/nonlethal_ammo = 6,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/lethal_ammo = 4,
+				/obj/item/weapon/computer_hardware/hard_drive/portable/design/nonlethal_ammo = 7,
+				/obj/item/weapon/computer_hardware/hard_drive/portable/design/lethal_ammo = 5,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/ammo_boxes_smallarms = 4,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/ammo_boxes_rifle = 4,))
 
@@ -70,27 +64,18 @@
 /obj/random/lathe_disk/advanced/item_to_spawn()
 	return pickweight(list(
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/adv_tools = 4,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/security = 6,
 
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_cheap_guns = 8,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_mk58 = 8,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_colt = 8,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_silenced = 6,
 
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_revolver_miller = 5,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_revolver_consul = 4,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_revolver_deckard = 4,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_revolver_mateba = 1,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_lamia = 1,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_deagle = 2,
 
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_doublebarrel = 5,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_kammerer = 8,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_regulator = 6,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_gladstone = 6,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/sa_pug = 1,
 
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_paco = 4,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_straylight = 4,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_molly = 4,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/sa_zoric = 4,
@@ -101,7 +86,6 @@
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_wintermute = 1,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_sol = 4,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/dallas = 1,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/sa_boltgun = 10,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_kalashnikov = 4,
 
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_heavysniper = 1,
@@ -111,24 +95,23 @@
 
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_counselor = 6,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_spiderrose = 4,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_martin = 8,
 
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_nemesis = 2,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_themis = 4,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_lightfall = 4,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_valkirye = 2,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_halicon = 6,
+				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_halicon = 3,
 
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_dominion = 2,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_purger = 2,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_cassad = 1,
 
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/ms_dartgun = 6,
+				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/ms_dartgun = 2,
 
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/nonlethal_ammo = 10,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/lethal_ammo = 8,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/ammo_boxes_smallarms = 8,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/ammo_boxes_rifle = 8,))
+				/obj/item/weapon/computer_hardware/hard_drive/portable/design/nonlethal_ammo = 5,
+				/obj/item/weapon/computer_hardware/hard_drive/portable/design/lethal_ammo = 4,
+				/obj/item/weapon/computer_hardware/hard_drive/portable/design/ammo_boxes_smallarms = 4,
+				/obj/item/weapon/computer_hardware/hard_drive/portable/design/ammo_boxes_rifle = 4,))
 
 /obj/random/lathe_disk/advanced/low_chance
 	name = "low chance advanced lathe disk"

--- a/code/game/objects/random/packs.dm
+++ b/code/game/objects/random/packs.dm
@@ -44,7 +44,7 @@ They generally give more random result and can provide more divercity in spawn.
 
 /obj/random/pack/tech_loot/item_to_spawn()
 	return pickweight(list(
-					/obj/random/lathe_disk = 3,
+					/obj/random/lathe_disk = 2,
 					/obj/random/circuitboard = 6,
 					/obj/random/knife = 6,
 					/obj/random/lowkeyrandom = 8,
@@ -87,16 +87,16 @@ They generally give more random result and can provide more divercity in spawn.
 
 /obj/random/pack/gun_loot/item_to_spawn()
 	return pickweight(list(
-					/obj/random/gun_cheap = 3,
-					/obj/random/gun_normal = 1,
-					/obj/random/gun_energy_cheap = 3,
-					/obj/random/gun_shotgun = 2,
-					/obj/random/knife = 3,
-					/obj/random/ammo = 8,
-					/obj/random/ammo/shotgun = 8,
-					/obj/random/ammo_ihs = 8,
-					/obj/random/ammo_lowcost = 10,
-					/obj/random/cloth/holster = 4
+					/obj/random/gun_cheap = 8,
+					/obj/random/gun_normal = 2,
+					/obj/random/gun_energy_cheap = 6,
+					/obj/random/gun_shotgun = 5,
+					/obj/random/knife = 6,
+					/obj/random/ammo = 15,
+					/obj/random/ammo/shotgun = 15,
+					/obj/random/ammo_ihs = 15,
+					/obj/random/ammo_lowcost = 18,
+					/obj/random/cloth/holster = 8
 				))
 
 /obj/random/pack/gun_loot/low_chance
@@ -117,8 +117,8 @@ They generally give more random result and can provide more divercity in spawn.
 					/obj/random/common_oddities = 8,
 					/obj/random/material_rare = 3,
 					/obj/random/tool/advanced = 5,
-					/obj/random/gun_normal = 2,
-					/obj/random/lathe_disk/advanced = 3,
+					/obj/random/gun_normal = 3,
+					/obj/random/lathe_disk/advanced = 2,
 					/obj/item/weapon/cell/small/moebius/nuclear = 1,
 					/obj/item/weapon/cell/medium/moebius/hyper = 1,
 					/obj/random/rig = 1.5,

--- a/code/game/objects/random/packs.dm
+++ b/code/game/objects/random/packs.dm
@@ -88,7 +88,7 @@ They generally give more random result and can provide more divercity in spawn.
 /obj/random/pack/gun_loot/item_to_spawn()
 	return pickweight(list(
 					/obj/random/gun_cheap = 8,
-					/obj/random/gun_normal = 2,
+					/obj/random/gun_normal = 3,
 					/obj/random/gun_energy_cheap = 6,
 					/obj/random/gun_shotgun = 5,
 					/obj/random/knife = 6,

--- a/code/game/objects/random/techparts.dm
+++ b/code/game/objects/random/techparts.dm
@@ -51,44 +51,6 @@
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/medical = 4,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/computer = 4,
 
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_cheap_guns = 3,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_mk58 = 3,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_colt = 3,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_silenced = 2,
-
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_revolver_miller = 2,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_revolver_consul = 1,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_revolver_deckard = 1,
-
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_doublebarrel = 2,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_kammerer = 3,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_regulator = 2,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_gladstone = 2,
-
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_paco = 1,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_straylight = 1,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_molly = 1,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/sa_zoric = 1,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_atreides = 1,
-
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_bulldog = 1,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_sol = 1,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/sa_boltgun = 4,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_kalashnikov = 1,
-
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_counselor = 2,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_spiderrose = 1,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_martin = 3,
-
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_themis = 1,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_lightfall = 1,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_halicon = 2,
-
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_dominion = 2,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_purger = 2,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_cassad = 1,
-
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/ms_dartgun = 6,
 
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/nonlethal_ammo = 6,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/lethal_ammo = 4,

--- a/code/game/objects/structures/crates_lockers/closets/maint_loot.dm
+++ b/code/game/objects/structures/crates_lockers/closets/maint_loot.dm
@@ -21,6 +21,7 @@
 	new /obj/random/pack/cloth/low_chance(src)
 	new /obj/random/pack/cloth/low_chance(src)
 	new /obj/random/pack/gun_loot/low_chance(src)
+	new /obj/random/pack/gun_loot/low_chance(src)
 
 
 

--- a/code/game/objects/structures/salvageable.dm
+++ b/code/game/objects/structures/salvageable.dm
@@ -216,8 +216,8 @@ obj/structure/salvageable/server/Initialize()
 		/obj/item/weapon/computer_hardware/processor_unit/adv/small = 30,
 		/obj/item/weapon/computer_hardware/hard_drive = 60,
 		/obj/item/weapon/computer_hardware/hard_drive/advanced = 40,
-		/obj/random/lathe_disk = 50,
-		/obj/random/lathe_disk/advanced = 30,
+		/obj/random/lathe_disk = 40,
+		/obj/random/lathe_disk/advanced = 10,
 	)
 
 obj/structure/salvageable/personal/Initialize()


### PR DESCRIPTION

## About The Pull Request
Makes gun disks more rare (mainly by removing them from /obj/random/techpart), rebalances other loot to make up for it, expect more finsished guns in maints and more ammo disks for guns you do find. All feedback is wellcome.



## In Game Tests

<details>
  <summary>Expand</summary>
Both tests done on a set of 10 random tech lockers.

Current Situation:

![test old](https://user-images.githubusercontent.com/61743710/76961149-22616e00-691d-11ea-8f3c-fb3e2d3c1ad9.png)

FS
.40 miller
Rifle ammo x3
Gladstone SG
PDW martin

TM
Circuts x2
Components x2
Conveyors
Adv tools

Guild
Misc pack x2

Moebius
Artemis dartgun x4 (???)

NT
Lightfall LG
Regulator SG

SRB
Novakovic boltgun

Total: 22 (2.2 disks per locker)


After this update:

![loot_tech_post](https://user-images.githubusercontent.com/61743710/76961672-0c07e200-691e-11ea-9f4d-4722d0335bf5.png)

FS
Lethal ammo disk
Non lethal ammo x2
.35 and .40 ammo
.35 colt

TM
Components x2
Conveyors
Adv tools x2

Guild
Devices and instruments
Misc pack x2

Moebius
Computer parts
Artemis dartgun

IH
Misc pack

Total 16 (1.6 disks per locker)
(It should be considered that there are more parts insdead of disks)

</details>




