### PR TITLE
Fixes being able to teleport when grabbing two things at once

### DIFF
--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -317,32 +317,12 @@
 	. = 0
 	// TODO: Look into making grabs use movement events instead, this is a mess.
 	for (var/obj/item/weapon/grab/G in mob)
-		//. = max(., G.grab_slowdown())	// TODO: Bay grab system
 		. = max(., G.slowdown)
-		var/list/L = mob.ret_grab()
-		if(istype(L, /list))
-			if(L.len == 2)
-				L -= mob
-				var/mob/M = L[1]
-				if(M)
-					if (get_dist(old_turf, M) <= 1)
-						if (isturf(M.loc) && isturf(mob.loc))
-							if (mob.loc != old_turf && M.loc != mob.loc)
-								step(M, get_dir(M.loc, old_turf))
-			else
-				for(var/mob/M in L)
-					M.other_mobs = 1
-					if(mob != M)
-						M.animate_movement = 3
-				for(var/mob/M in L)
-					spawn( 0 )
-						step(M, direction)
-						return
-					spawn( 1 )
-						M.other_mobs = null
-						M.animate_movement = 2
-						return
-			G.adjust_position()
+		var/mob/M = G.affecting
+		if(M && get_dist(old_turf, M) <= 1)
+			if (isturf(M.loc) && isturf(mob.loc) && mob.loc != old_turf && M.loc != mob.loc)
+				step(M, get_dir(M.loc, old_turf))
+		G.adjust_position()
 
 /mob/proc/AdjustMovementDirection(var/direction)
 	. = direction


### PR DESCRIPTION
<!-- Make sure you read the guidelines before conrtibuting! https://wiki.cev-eris.com/Content_GuidelinesEn -->

## About The Pull Request
This fixes being able to grab two things, then teleporting 3 tiles in a given direction when moving

## Details

<details>
  <summary>Expand</summary>
The reason this was happening: The previous code would itterate over all grabs the player had in their inventory (good so far), then for each grab object, it would collect all mobs involved in grabs, including the assailant (not good).

Then, it would move them all in the given direction, then the second grab would move them again.
</details>

