### PR TITLE
Moves the Cleansing Carbine design to the regular NT disk

### DIFF
--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -311,6 +311,9 @@
 		/datum/design/bioprinter/medical/ointment,
 		/datum/design/bioprinter/medical/advanced/bruise,
 		/datum/design/bioprinter/medical/advanced/ointment,
+
+		/datum/design/autolathe/gun/nt_sprayer
+
 	)
 
 // Same as the other NT disk, minus the medical designs. Spawns in public access bioprinters.

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -313,7 +313,6 @@
 		/datum/design/bioprinter/medical/advanced/ointment,
 
 		/datum/design/autolathe/gun/nt_sprayer
-
 	)
 
 // Same as the other NT disk, minus the medical designs. Spawns in public access bioprinters.
@@ -347,8 +346,6 @@
 		/datum/design/bioprinter/leather/holster/armpit,
 		/datum/design/bioprinter/leather/holster/waist,
 		/datum/design/bioprinter/leather/holster/hip,
-
-		/datum/design/autolathe/gun/nt_sprayer
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nt_boards


### PR DESCRIPTION
<!-- Make sure you read the guidelines before conrtibuting! https://wiki.cev-eris.com/Content_GuidelinesEn -->

## About The Pull Request
<!-- Why is it needed, what it fixes. Write up links to closing issues there as well, but make it short. -->
Currently it's on the public NT disk, which... never actually spawns anywhere, and it's totally absent from the internal NT one.


## Details
<!-- If you need, describe details inside. Remove whole block if not used. -->
<details>
  <summary>Expand</summary>
Just a simple move of the design so NT can make more cleansing carbines. They can sell them, use them, whatever, now that they're actually capable of producing them.
I removed it from the public disk since it's an NT-specific piece of equipment, and uses biomatter as ammo.
</details>


## Screenshots
<!-- Map an UI changes MUST have screenshots in them. Graphical changes should have it as well, when icon diff is not enough. Remove whole block if not used. -->
<details>
  <summary>Expand</summary>

</details>


