### PR TITLE
Department account perms for guild techs

### DIFF
--- a/code/game/jobs/job/guild.dm
+++ b/code/game/jobs/job/guild.dm
@@ -74,6 +74,7 @@ Your second loyalty is to the guild. Ensure it retains good relations with priva
 	selection_color = "#c3b9a6"
 	also_known_languages = list(LANGUAGE_CYRILLIC = 15, LANGUAGE_SERBIAN = 5, LANGUAGE_JIVE = 80)
 	wage = WAGE_LABOUR_DUMB
+	department_account_access = TRUE
 	outfit_type = /decl/hierarchy/outfit/job/cargo/cargo_tech
 
 	access = list(


### PR DESCRIPTION
I find that the guild ceases to function every time the merchant is merced or goes to sleep, now the guild technicians will also be able to keep the eris guild alive