### PR TITLE
Increases robot limb malfunction threshold

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -819,8 +819,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 			return 1
 	return 0
 
+// Robotic limbs malfunction - handled by subtype
 /obj/item/organ/external/proc/is_malfunctioning()
-	return (BP_IS_ROBOTIC(src) && (brute_dam + burn_dam) >= 10 && prob(brute_dam + burn_dam))
+	return FALSE
 
 /obj/item/organ/external/proc/embed(obj/item/W, silent = 0)
 	if(!owner || loc != owner)

--- a/code/modules/organs/external/subtypes/robotic.dm
+++ b/code/modules/organs/external/subtypes/robotic.dm
@@ -8,7 +8,7 @@
 	brute_mod = 0.8
 	burn_mod = 0.8
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2) // Multiplied by w_class
-	var/list/forced_children = null
+	var/min_malfunction_damage = 20 // Any more damage than that and you start getting nasty random malfunctions
 
 /obj/item/organ/external/robotic/get_cache_key()
 	return "Robotic[model]"
@@ -21,6 +21,9 @@
 	mob_icon = icon(force_icon, icon_state)
 	icon = mob_icon
 	return mob_icon
+
+/obj/item/organ/external/robotic/is_malfunctioning()
+	return prob(brute_dam + burn_dam - min_malfunction_damage)
 
 /obj/item/organ/external/robotic/set_description(datum/organ_description/desc)
 	..()


### PR DESCRIPTION
Robot limbs now need 20 damage to start malfunctioning (up from 10), and the malfunction chances are lower.
