### PR TITLE
Fixes Robots, AIs, and other transform procs from bricking themselves

### DIFF
--- a/code/datums/topic/admin.dm
+++ b/code/datums/topic/admin.dm
@@ -747,14 +747,14 @@
 	require_perms = list(R_FUN)
 
 /datum/admin_topic/corgione/Run(list/input)
-	var/mob/living/carbon/human/H = locate(input["corgione"])
-	if(!istype(H))
-		to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
+	var/mob/L= locate(input["corgione"])
+	if(!istype(L))
+		to_chat(usr, "This can only be used on instances of type /mob")
 		return
 
-	log_admin("[key_name(usr)] attempting to corgize [key_name(H)]")
-	message_admins("\blue [key_name_admin(usr)] attempting to corgize [key_name_admin(H)]", 1)
-	H.corgize()
+	log_admin("[key_name(usr)] attempting to corgize [key_name(L)]")
+	message_admins("\blue [key_name_admin(usr)] attempting to corgize [key_name_admin(L)]", 1)
+	L.corgize()
 
 
 /datum/admin_topic/forcespeech
@@ -798,30 +798,24 @@
 	require_perms = list(R_FUN)
 
 /datum/admin_topic/makeai/Run(list/input)
-	var/mob/living/L = locate(input["revive"])
+	var/mob/living/L = locate(input["makeai"])
 	if(!istype(L))
 		to_chat(usr, "This can only be used on instances of type /mob/living")
 		return
 
-	if(config.allow_admin_rev)
-		L.revive()
-		message_admins("\red Admin [key_name_admin(usr)] healed / revived [key_name_admin(L)]!", 1)
-		log_admin("[key_name(usr)] healed / Revived [key_name(L)]")
-	else
-		to_chat(usr, "Admin Rejuvinates have been disabled")
-
+	L.AIize()
 
 /datum/admin_topic/makeslime
 	keyword = "makeslime"
 	require_perms = list(R_FUN)
 
 /datum/admin_topic/makeslime/Run(list/input)
-	var/mob/living/carbon/human/H = locate(input["makeslime"])
-	if(!istype(H))
-		to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
+	var/mob/living/L = locate(input["makeslime"])
+	if(!istype(L))
+		to_chat(usr, "This can only be used on instances of type /mob/living")
 		return
 
-	usr.client.cmd_admin_slimeize(H)
+	usr.client.cmd_admin_slimeize(L)
 
 
 /datum/admin_topic/makerobot
@@ -829,9 +823,9 @@
 	require_perms = list(R_FUN)
 
 /datum/admin_topic/makerobot/Run(list/input)
-	var/mob/living/carbon/human/H = locate(input["makerobot"])
+	var/mob/living/H = locate(input["makerobot"])
 	if(!istype(H))
-		to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
+		to_chat(usr, "This can only be used on instances of type /mob/living")
 		return
 
 	usr.client.cmd_admin_robotize(H)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -39,14 +39,13 @@ ADMIN_VERB_ADD(/client/proc/Debug2, R_DEBUG, FALSE)
 	usr.show_message(t, 1)
 
 
-/client/proc/cmd_admin_robotize(var/mob/M in SSmobs.mob_list)
+/client/proc/cmd_admin_robotize(var/mob/living/M)
 	set category = "Fun"
 	set name = "Make Robot"
 
 	if(ishuman(M))
 		log_admin("[key_name(src)] has robotized [M.key].")
-		spawn(10)
-			M:Robotize()
+		M.Robotize()
 
 	else
 		alert("Invalid mob")
@@ -68,7 +67,7 @@ ADMIN_VERB_ADD(/client/proc/Debug2, R_DEBUG, FALSE)
 		M.Animalize()
 
 
-/client/proc/makepAI(var/turf/T in SSmobs.mob_list)
+/client/proc/makepAI(var/turf/T)
 	set category = "Fun"
 	set name = "Make pAI"
 	set desc = "Specify a location to spawn a pAI device, then specify a key to play that pAI"
@@ -95,14 +94,14 @@ ADMIN_VERB_ADD(/client/proc/Debug2, R_DEBUG, FALSE)
 			SSpai.pai_candidates.Remove(candidate)
 
 
-/client/proc/cmd_admin_slimeize(var/mob/M in SSmobs.mob_list)
+/client/proc/cmd_admin_slimeize(var/mob/living/M)
 	set category = "Fun"
 	set name = "Make slime"
 
 	if(ishuman(M))
 		log_admin("[key_name(src)] has slimeized [M.key].")
 		spawn(10)
-			M:slimeize()
+			M.slimeize()
 
 		log_admin("[key_name(usr)] made [key_name(M)] into a slime.")
 		message_admins("\blue [key_name_admin(usr)] made [key_name(M)] into a slime.", 1)

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -33,89 +33,88 @@
 	var/obj/item/organ/internal/brain/brainobj = null	//The current brain organ.
 	var/obj/mecha = null//This does not appear to be used outside of reference in mecha.dm.
 
-	attackby(var/obj/item/O as obj, var/mob/user as mob)
-		if(istype(O,/obj/item/organ/internal/brain) && !brainmob) //Time to stick a brain in it --NEO
+/obj/item/device/mmi/attackby(var/obj/item/O as obj, var/mob/user as mob)
+	if(istype(O,/obj/item/organ/internal/brain) && !brainmob) //Time to stick a brain in it --NEO
 
-			var/obj/item/organ/internal/brain/B = O
-			if(B.health <= 0)
-				to_chat(user, "\red That brain is well and truly dead.")
-				return
-			else if(!B.brainmob)
-				to_chat(user, "\red You aren't sure where this brain came from, but you're pretty sure it's a useless brain.")
-				return
-
-			for(var/mob/V in viewers(src, null))
-				V.show_message(text("\blue [user] sticks \a [O] into \the [src]."))
-
-			brainmob = O:brainmob
-			O:brainmob = null
-			brainmob.loc = src
-			brainmob.container = src
-			brainmob.stat = 0
-			GLOB.dead_mob_list -= brainmob//Update dem lists
-			GLOB.living_mob_list += brainmob
-
-			user.drop_item()
-			brainobj = O
-			brainobj.loc = src
-
-			name = "Man-Machine Interface: [brainmob.real_name]"
-			icon_state = "mmi_full"
-
-			locked = 1
-
-
-
+		var/obj/item/organ/internal/brain/B = O
+		if(B.health <= 0)
+			to_chat(user, "\red That brain is well and truly dead.")
+			return
+		else if(!B.brainmob)
+			to_chat(user, "\red You aren't sure where this brain came from, but you're pretty sure it's a useless brain.")
 			return
 
-		if((istype(O,/obj/item/weapon/card/id)||istype(O,/obj/item/modular_computer/pda)) && brainmob)
-			if(allowed(user))
-				locked = !locked
-				to_chat(user, "\blue You [locked ? "lock" : "unlock"] the brain holder.")
-			else
-				to_chat(user, "\red Access denied.")
-			return
-		if(brainmob)
-			O.attack(brainmob, user)//Oh noooeeeee
-			return
-		..()
+		for(var/mob/V in viewers(src, null))
+			V.show_message(text("\blue [user] sticks \a [O] into \the [src]."))
+
+		brainmob = O:brainmob
+		O:brainmob = null
+		brainmob.loc = src
+		brainmob.container = src
+		brainmob.stat = 0
+		GLOB.dead_mob_list -= brainmob//Update dem lists
+		GLOB.living_mob_list += brainmob
+
+		user.drop_item()
+		brainobj = O
+		brainobj.loc = src
+
+		name = "Man-Machine Interface: [brainmob.real_name]"
+		icon_state = "mmi_full"
+
+		locked = 1
+
+
+
+		return
+
+	if((istype(O,/obj/item/weapon/card/id)||istype(O,/obj/item/modular_computer/pda)) && brainmob)
+		if(allowed(user))
+			locked = !locked
+			to_chat(user, "\blue You [locked ? "lock" : "unlock"] the brain holder.")
+		else
+			to_chat(user, "\red Access denied.")
+		return
+	if(brainmob)
+		O.attack(brainmob, user)//Oh noooeeeee
+		return
+	..()
 
 	//TODO: ORGAN REMOVAL UPDATE. Make the brain remain in the MMI so it doesn't lose organ data.
-	attack_self(mob/user as mob)
-		if(!brainmob)
-			to_chat(user, "\red You upend the MMI, but there's nothing in it.")
-		else if(locked)
-			to_chat(user, "\red You upend the MMI, but the brain is clamped into place.")
-		else
-			to_chat(user, "\blue You upend the MMI, spilling the brain onto the floor.")
-			var/obj/item/organ/internal/brain/brain
-			if (brainobj)	//Pull brain organ out of MMI.
-				brainobj.loc = user.loc
-				brain = brainobj
-				brainobj = null
-			else	//Or make a new one if empty.
-				brain = new(user.loc)
-			brainmob.container = null//Reset brainmob mmi var.
-			brainmob.loc = brain//Throw mob into brain.
-			GLOB.living_mob_list -= brainmob//Get outta here
-			brain.brainmob = brainmob//Set the brain to use the brainmob
-			brainmob = null//Set mmi brainmob var to null
+/obj/item/device/mmi/attack_self(mob/user as mob)
+	if(!brainmob)
+		to_chat(user, "\red You upend the MMI, but there's nothing in it.")
+	else if(locked)
+		to_chat(user, "\red You upend the MMI, but the brain is clamped into place.")
+	else
+		to_chat(user, "\blue You upend the MMI, spilling the brain onto the floor.")
+		var/obj/item/organ/internal/brain/brain
+		if (brainobj)	//Pull brain organ out of MMI.
+			brainobj.loc = user.loc
+			brain = brainobj
+			brainobj = null
+		else	//Or make a new one if empty.
+			brain = new(user.loc)
+		brainmob.container = null//Reset brainmob mmi var.
+		brainmob.loc = brain//Throw mob into brain.
+		GLOB.living_mob_list -= brainmob//Get outta here
+		brain.brainmob = brainmob//Set the brain to use the brainmob
+		brainmob = null//Set mmi brainmob var to null
 
-			icon_state = "mmi_empty"
-			name = "Man-Machine Interface"
+		icon_state = "mmi_empty"
+		name = "Man-Machine Interface"
 
-	proc
-		transfer_identity(var/mob/living/carbon/human/H)//Same deal as the regular brain proc. Used for human-->robot people.
-			brainmob = new(src)
-			brainmob.name = H.real_name
-			brainmob.real_name = H.real_name
-			brainmob.dna = H.dna
-			brainmob.container = src
+/obj/item/device/mmi/proc/transfer_identity(var/mob/living/carbon/human/H)//Same deal as the regular brain proc. Used for human-->robot people.
+	brainmob = new(src)
+	brainmob.name = H.real_name
+	brainmob.real_name = H.real_name
+	brainmob.dna = H.dna
+	brainmob.container = src
 
-			name = "Man-Machine Interface: [brainmob.real_name]"
-			icon_state = "mmi_full"
-			locked = 1
-			return
+	name = "Man-Machine Interface: [brainmob.real_name]"
+	icon_state = "mmi_full"
+	locked = 1
+	return
 
 /obj/item/device/mmi/relaymove(var/mob/user, var/direction)
 	if(user.stat || user.stunned)
@@ -140,37 +139,37 @@
 
 	var/obj/item/device/radio/radio = null//Let's give it a radio.
 
-	New()
-		..()
-		radio = new(src)//Spawns a radio inside the MMI.
-		radio.broadcasting = 1//So it's broadcasting from the start.
+/obj/item/device/mmi/radio_enabled/New()
+	..()
+	radio = new(src)//Spawns a radio inside the MMI.
+	radio.broadcasting = 1//So it's broadcasting from the start.
 
-	verb//Allows the brain to toggle the radio functions.
-		Toggle_Broadcasting()
-			set name = "Toggle Broadcasting"
-			set desc = "Toggle broadcasting channel on or off."
-			set category = "MMI"
-			set src = usr.loc//In user location, or in MMI in this case.
-			set popup_menu = 0//Will not appear when right clicking.
+//Allows the brain to toggle the radio functions.
+/obj/item/device/mmi/radio_enabled/verb/Toggle_Broadcasting()
+	set name = "Toggle Broadcasting"
+	set desc = "Toggle broadcasting channel on or off."
+	set category = "MMI"
+	set src = usr.loc//In user location, or in MMI in this case.
+	set popup_menu = 0//Will not appear when right clicking.
 
-			if(brainmob.stat)//Only the brainmob will trigger these so no further check is necessary.
-				to_chat(brainmob, "Can't do that while incapacitated or dead.")
+	if(brainmob.stat)//Only the brainmob will trigger these so no further check is necessary.
+		to_chat(brainmob, "Can't do that while incapacitated or dead.")
 
-			radio.broadcasting = radio.broadcasting==1 ? 0 : 1
-			to_chat(brainmob, "\blue Radio is [radio.broadcasting==1 ? "now" : "no longer"] broadcasting.")
+	radio.broadcasting = radio.broadcasting==1 ? 0 : 1
+	to_chat(brainmob, "\blue Radio is [radio.broadcasting==1 ? "now" : "no longer"] broadcasting.")
 
-		Toggle_Listening()
-			set name = "Toggle Listening"
-			set desc = "Toggle listening channel on or off."
-			set category = "MMI"
-			set src = usr.loc
-			set popup_menu = 0
+/obj/item/device/mmi/radio_enabled/verb/Toggle_Listening()
+	set name = "Toggle Listening"
+	set desc = "Toggle listening channel on or off."
+	set category = "MMI"
+	set src = usr.loc
+	set popup_menu = 0
 
-			if(brainmob.stat)
-				to_chat(brainmob, "Can't do that while incapacitated or dead.")
+	if(brainmob.stat)
+		to_chat(brainmob, "Can't do that while incapacitated or dead.")
 
-			radio.listening = radio.listening==1 ? 0 : 1
-			to_chat(brainmob, "\blue Radio is [radio.listening==1 ? "now" : "no longer"] receiving broadcast.")
+	radio.listening = radio.listening==1 ? 0 : 1
+	to_chat(brainmob, "\blue Radio is [radio.listening==1 ? "now" : "no longer"] receiving broadcast.")
 
 /obj/item/device/mmi/emp_act(severity)
 	if(!brainmob)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -1,18 +1,11 @@
 /mob/living/carbon/human/proc/monkeyize()
 	if (HAS_TRANSFORMATION_MOVEMENT_HANDLER(src))
 		return
-	for(var/obj/item/W in src)
-		if (W==w_uniform) // will be torn
-			continue
-		drop_from_inventory(W)
-	regenerate_icons()
 	ADD_TRANSFORMATION_MOVEMENT_HANDLER(src)
 	canmove = 0
 	stunned = 1
 	icon = null
 	invisibility = 101
-	for(var/t in organs)
-		qdel(t)
 	var/atom/movable/overlay/animation = new /atom/movable/overlay( loc )
 	animation.plane = plane
 	animation.layer = ABOVE_MOB_LAYER
@@ -48,31 +41,13 @@
 	spawning = 1
 	return ..()
 
-/mob/living/carbon/human/AIize(move=1) // 'move' argument needs defining here too because BYOND is dumb
-	if (HAS_TRANSFORMATION_MOVEMENT_HANDLER(src))
-		return
-	for(var/t in organs)
-		qdel(t)
-
-	return ..(move)
-
-/mob/living/carbon/AIize()
-	if (HAS_TRANSFORMATION_MOVEMENT_HANDLER(src))
-		return
-	for(var/obj/item/W in src)
-		drop_from_inventory(W)
-	ADD_TRANSFORMATION_MOVEMENT_HANDLER(src)
-	canmove = 0
-	icon = null
-	invisibility = 101
-	return ..()
-
 /mob/proc/AIize(move=1)
-
+	if (HAS_TRANSFORMATION_MOVEMENT_HANDLER(src))
+		return
+	ADD_TRANSFORMATION_MOVEMENT_HANDLER(src)
 	if(client)
 		sound_to(src, sound(null, repeat = 0, wait = 0, volume = 85, channel = GLOB.lobby_sound_channel))
 	var/mob/living/silicon/ai/O = new (loc, base_law_type,,1)//No MMI but safety is in effect.
-	O.invisibility = 0
 	O.aiRestorePowerRoutine = 0
 
 	if(mind)
@@ -103,36 +78,15 @@
 	O.add_ai_verbs()
 
 	O.rename_self("ai",1)
-	spawn(0)	// Mobs still instantly del themselves, thus we need to spawn or O will never be returned
-		qdel(src)
+	qdel(src)
 	return O
 
 //human -> robot
-/mob/living/carbon/human/proc/Robotize()
+/mob/living/proc/Robotize()
 	if (HAS_TRANSFORMATION_MOVEMENT_HANDLER(src))
 		return
-	for(var/t in organs)
-		qdel(t)
-	for(var/obj/item/W in src)
-		drop_from_inventory(W)
-		qdel(W)
-	regenerate_icons()
 	ADD_TRANSFORMATION_MOVEMENT_HANDLER(src)
-	canmove = 0
-	icon = null
-	invisibility = 101
-
-
 	var/mob/living/silicon/robot/O = new /mob/living/silicon/robot( loc )
-
-	// cyborgs produced by Robotize get an automatic power cell
-	O.cell = new(O)
-	O.cell.maxcharge = 7500
-	O.cell.charge = 7500
-
-
-	O.gender = gender
-	O.invisibility = 0
 
 	if(mind)		//TODO
 		mind.transfer_to(O)
@@ -152,23 +106,13 @@
 	callHook("borgify", list(O))
 	O.Namepick()
 
-	spawn(0)	// Mobs still instantly del themselves, thus we need to spawn or O will never be returned
-		qdel(src)
+	qdel(src)
 	return O
 
-/mob/living/carbon/human/proc/slimeize(adult as num, reproduce as num)
+/mob/living/proc/slimeize(adult as num, reproduce as num)
 	if (HAS_TRANSFORMATION_MOVEMENT_HANDLER(src))
 		return
-	for(var/obj/item/W in src)
-		drop_from_inventory(W)
-	regenerate_icons()
 	ADD_TRANSFORMATION_MOVEMENT_HANDLER(src)
-	canmove = 0
-	icon = null
-	invisibility = 101
-	for(var/t in organs)
-		qdel(t)
-
 	var/mob/living/carbon/slime/new_slime
 	if(reproduce)
 		var/number = pick(14;2,3,4)	//reproduce (has a small chance of producing 3 or 4 offspring)
@@ -190,18 +134,13 @@
 	qdel(src)
 	return
 
-/mob/living/carbon/human/proc/corgize()
+/mob/proc/corgize()
 	if (HAS_TRANSFORMATION_MOVEMENT_HANDLER(src))
 		return
-	for(var/obj/item/W in src)
-		drop_from_inventory(W)
-	regenerate_icons()
 	ADD_TRANSFORMATION_MOVEMENT_HANDLER(src)
 	canmove = 0
 	icon = null
 	invisibility = 101
-	for(var/t in organs)	//this really should not be necessary
-		qdel(t)
 
 	var/mob/living/simple_animal/corgi/new_corgi = new /mob/living/simple_animal/corgi (loc)
 	new_corgi.a_intent = I_HURT
@@ -211,90 +150,14 @@
 	qdel(src)
 	return
 
-/mob/living/carbon/human/Animalize()
-
-	var/list/mobtypes = typesof(/mob/living/simple_animal)
-	var/mobpath = input("Which type of mob should [src] turn into?", "Choose a type") in mobtypes
-
-	if(!safe_animal(mobpath))
-		to_chat(usr, "\red Sorry but this mob type is currently unavailable.")
-		return
-
-	if(transforming)
-		return
-	for(var/obj/item/W in src)
-		drop_from_inventory(W)
-
-	regenerate_icons()
-	ADD_TRANSFORMATION_MOVEMENT_HANDLER(src)
-	canmove = 0
-	icon = null
-	invisibility = 101
-
-	for(var/t in organs)
-		qdel(t)
-
-	var/mob/new_mob = new mobpath(src.loc)
-
-	new_mob.key = key
-	new_mob.a_intent = I_HURT
-
-
-	to_chat(new_mob, "You suddenly feel more... animalistic.")
-	spawn()
-		qdel(src)
-	return
-
 /mob/proc/Animalize()
 
 	var/list/mobtypes = typesof(/mob/living/simple_animal)
 	var/mobpath = input("Which type of mob should [src] turn into?", "Choose a type") in mobtypes
 
-	if(!safe_animal(mobpath))
-		to_chat(usr, "\red Sorry but this mob type is currently unavailable.")
-		return
-
 	var/mob/new_mob = new mobpath(src.loc)
 
 	new_mob.key = key
-	new_mob.a_intent = I_HURT
 	to_chat(new_mob, "You feel more... animalistic")
 
 	qdel(src)
-
-/* Certain mob types have problems and should not be allowed to be controlled by players.
- *
- * This proc is here to force coders to manually place their mob in this list, hopefully tested.
- * This also gives a place to explain -why- players shouldnt be turn into certain mobs and hopefully someone can fix them.
- */
-/mob/proc/safe_animal(var/MP)
-
-//Bad mobs! - Remember to add a comment explaining what's wrong with the mob
-	if(!MP)
-		return 0	//Sanity, this should never happen.
-
-	if(ispath(MP, /mob/living/simple_animal/space_worm))
-		return 0 //Unfinished. Very buggy, they seem to just spawn additional space worms everywhere and eating your own tail results in new worms spawning.
-
-//Good mobs!
-	if(ispath(MP, /mob/living/simple_animal/cat))
-		return 1
-	if(ispath(MP, /mob/living/simple_animal/corgi))
-		return 1
-	if(ispath(MP, /mob/living/simple_animal/crab))
-		return 1
-	if(ispath(MP, /mob/living/simple_animal/hostile/carp))
-		return 1
-	if(ispath(MP, /mob/living/simple_animal/mushroom))
-		return 1
-	if(ispath(MP, /mob/living/simple_animal/tomato))
-		return 1
-	if(ispath(MP, /mob/living/simple_animal/mouse))
-		return 1 //It is impossible to pull up the player panel for mice (Fixed! - Nodrak)
-	if(ispath(MP, /mob/living/simple_animal/hostile/bear))
-		return 1 //Bears will auto-attack mobs, even if they're player controlled (Fixed! - Nodrak)
-	if(ispath(MP, /mob/living/simple_animal/parrot))
-		return 1 //Parrots are no longer unfinished! -Nodrak
-
-	//Not in here? Must be untested!
-	return 0


### PR DESCRIPTION
 - Issue:
 Robots and AIs, when they attempted to join, found themselves becoming a brain ghost, and not a robot or AI

- Cause:
Robots and AIs used Robotize and AIize respectively, which would qdel your organs then spawn you in as a robot.

After #4736 , if a brain is qdel'd, the person is ghosted, so the client never made it to the AI to be placed into it.

- Fix:
Remove the redundant qdeling of organs, as that is handled by humans own qdel(), which is called at the end of the transformation process anyway.

After going through them all, I also fixed MMIs being partial pathed, and the corgize and animalize having arbitrary sanity