### PR TITLE
buffs the laser sabre

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -167,8 +167,6 @@
 	name = "laser sabre"
 	desc = "You feel the radiant glow below your skin."
 	origin_tech = list(TECH_MAGNET = 5, TECH_POWER = 6, TECH_COMBAT = 3)
-	active_force = WEAPON_FORCE_ROBUST
-	active_throwforce = WEAPON_FORCE_ROBUST
 
 /*
  *Energy Blade


### PR DESCRIPTION
<!-- Make sure you read the guidelines before conrtibuting! https://wiki.cev-eris.com/Content_GuidelinesEn -->

## About The Pull Request
the laser sabre now inherits the lethal force from the energy sword instead of being just robust
(26 -> 40)
why: the laser sabre requires late game research, an rng tool attachment and a gun, its a lot of work for an item that has less force than a chainsaw available roundstart with the brutal level of damage if you got enough money for an advanced disk, so getting the sabre is not worth it at all when you have to go on a fetch quest for it


