### PR TITLE
Adding NT radio encryption key to their disk

### DIFF
--- a/code/datums/autolathe/devices.dm
+++ b/code/datums/autolathe/devices.dm
@@ -56,4 +56,8 @@
 
 /datum/design/autolathe/device/excelbaton
 	name = "Expropriator"
-	build_path = /obj/item/weapon/melee/baton/excelbaton 
+	build_path = /obj/item/weapon/melee/baton/excelbaton
+
+/datum/design/autolathe/device/headset_church
+	name = "NeoTheology Radio Encryption Key"
+	build_path = /obj/item/device/encryptionkey/headset_church

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -11,7 +11,7 @@
 	var/translate_hive = 0
 	var/syndie = 0
 	var/list/channels = list()
-	matter = list(MATERIAL_STEEL = 1, MATERIAL_SILVER = 1)
+	matter = list(MATERIAL_STEEL = 0.5, MATERIAL_SILVER = 0.5)
 
 /obj/item/device/encryptionkey/attackby(obj/item/weapon/W as obj, mob/user as mob)
 

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -11,7 +11,7 @@
 	var/translate_hive = 0
 	var/syndie = 0
 	var/list/channels = list()
-	matter = list(MATERIAL_STEEL = 1)
+	matter = list(MATERIAL_STEEL = 1, MATERIAL_SILVER = 1)
 
 /obj/item/device/encryptionkey/attackby(obj/item/weapon/W as obj, mob/user as mob)
 
@@ -47,7 +47,7 @@
 	channels = list("Medical" = 1)
 
 /obj/item/device/encryptionkey/headset_church
-	name = "Neotheology radio encryption key"
+	name = "neotheology radio encryption key"
 	icon_state = "nt_cypherkey"
 	channels = list("NT Voice" = 1)
 

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -315,7 +315,7 @@
 		/datum/design/autolathe/gun/nt_sprayer
 	)
 
-// Same as the other NT disk, minus the medical designs. Spawns in public access bioprinters.
+// Same as the other NT disk, minus the medical designs and encryption key. Should spawn in public access bioprinters if they get added by any chance.
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nt_bioprinter_public
 	disk_name = "NeoTheology Bioprinter Pack"
 	icon_state = "neotheology"
@@ -346,6 +346,8 @@
 		/datum/design/bioprinter/leather/holster/armpit,
 		/datum/design/bioprinter/leather/holster/waist,
 		/datum/design/bioprinter/leather/holster/hip,
+
+		/datum/design/autolathe/device/headset_church
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nt_boards

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -538,3 +538,11 @@
 /obj/item/weapon/storage/box/data_disk/basic/populate_contents()
 	for(var/i in 1 to 7)
 		new /obj/item/weapon/computer_hardware/hard_drive/portable/basic(src)
+
+/obj/item/weapon/storage/box/headset/church
+	name = "neotheology radio encryption key box"
+	illustration = "disk"
+
+/obj/item/weapon/storage/box/headset/church/populate_contents()
+	for(var/i in 1 to 7)
+		new /obj/item/device/encryptionkey/headset_church(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
@@ -23,6 +23,7 @@
 	new /obj/item/weapon/storage/fancy/candle_box(src)
 	new /obj/item/weapon/storage/fancy/candle_box(src)
 	new /obj/item/weapon/deck/tarot(src)
+	new /obj/item/weapon/storage/box/headset/church
 	new /obj/item/weapon/computer_hardware/hard_drive/portable/design/nt_boards (src)
 	for (var/i in 1 to 10)
 		new /obj/item/weapon/implant/core_implant/cruciform(src)


### PR DESCRIPTION
<!-- Make sure you read the guidelines before conrtibuting! https://wiki.cev-eris.com/Content_GuidelinesEn -->

## About The Pull Request
Benefits NT in the way that they have a way to have closer contact with their followers now, as they now can actually produce encryption keys and people can ask for them in order to communicate with them later. I'd even say this should increase quantity of mass lithanies, given anyone would want to play non-church NT.

Decapitalized Neotheology in the name of the encryption key item itself, but it appears fully capitalized in the autolathe design name. Looks nicer both ways. Also added silver cost of 1 to any encryption keys because just steel feels too cheap and bland. Silver is still most common from "rare" category materials as it could be easily extracted from powercells and else.
