### PR TITLE
Fixes broken Nanite recipes

### DIFF
--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -2065,7 +2065,7 @@
 
 /datum/chemical_reaction/nanopurgers
 	result = "nanopurgers"
-	required_reagents = list("nanites" = 1, "synaptizine" = 1)
+	required_reagents = list("nanites" = 1, "vomitol" = 1)
 	result_amount = 1
 
 /datum/chemical_reaction/cbu
@@ -2080,7 +2080,7 @@
 
 /datum/chemical_reaction/nanohands
 	result = "nanohands"
-	required_reagents = list("uncap nanites" = 1, "nanohands" = 1)
+	required_reagents = list("uncap nanites" = 1, "sterilizine" = 1)
 	result_amount = 1
 
 /datum/chemical_reaction/nanovoice


### PR DESCRIPTION
## About The Pull Request
Handyprints had itself in its recipe, I replaced it with sterilizine.

Voice mimics and nanopurgers both used synaptizine, I replaced the synaptizine in nanopurgers with vomitol.

First PR. tell me if what I did is just bs.



