### PR TITLE
Makes so shotguns doesn't require two-handed grip to pump them

### DIFF
--- a/code/modules/projectiles/guns/projectile/shotgun/pump.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/pump.dm
@@ -27,10 +27,8 @@
 	return null
 
 /obj/item/weapon/gun/projectile/shotgun/pump/attack_self(mob/living/user as mob)
-	if(wielded)
+	if(world.time >= recentpumpmsg + 10)
 		pump(user)
-	else if(world.time >= recentpumpmsg + 5)
-		to_chat(user, SPAN_WARNING("You need to wield this gun to pump it!"))
 		recentpumpmsg = world.time
 
 /obj/item/weapon/gun/projectile/shotgun/pump/proc/pump(mob/M as mob)


### PR DESCRIPTION
<!-- Make sure you read the guidelines before conrtibuting! https://wiki.cev-eris.com/Content_GuidelinesEn -->

## About The Pull Request
<!-- Why is it needed, what it fixes. Write up links to closing issues there as well, but make it short. -->
Due to the popular demand, this removes two-hand requirement for pumping shotguns. Most remarkable example is Kammerer, which can fit five shells in total. You get shotgun, get shells in other hand, instert four, put away shells, twohand it, pump it, untwohand it, put remaining shell in. Sounds cumbersome? Because it is. Tested and works.