### PR TITLE
[FIX] Cryopod : Fixed the cause of runtime that breaks the MC ?

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -267,7 +267,6 @@
 // This function can not be undone; do not call this unless you are sure
 // Also make sure there is a valid control computer
 /obj/machinery/cryopod/robot/despawn_occupant()
-	/// Move then into mob/living/silicon/despawn()
 	var/mob/living/silicon/robot/R = occupant
 	if(!istype(R)) return ..()
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -150,13 +150,11 @@
 	name = "cryogenic freezer"
 	desc = "A man-sized pod for entering suspended animation."
 	icon = 'icons/obj/Cryogenic2.dmi'
-	icon_state = "cryopod_0"
+	icon_state = "cryopod"
 	density = 1
 	anchored = 1
 	dir = WEST
 
-	var/base_icon_state = "cryopod_0"
-	var/occupied_icon_state = "cryopod_1"
 	var/on_store_message = "has entered long-term storage."
 	var/on_store_name = "Cryogenic Oversight"
 	var/on_enter_occupant_message = "You feel cool air surround you. You go numb as your senses turn inward."
@@ -192,9 +190,7 @@
 	name = "robotic storage unit"
 	desc = "A storage unit for robots."
 	icon = 'icons/obj/robot_storage.dmi'
-	icon_state = "pod_0"
-	base_icon_state = "pod_0"
-	occupied_icon_state = "pod_1"
+	icon_state = "pod"
 	on_store_message = "has entered robotic storage."
 	on_store_name = "Robotic Storage Oversight"
 	on_enter_occupant_message = "The storage unit broadcasts a sleep signal to you. Your systems start to shut down, and you enter low-power mode."
@@ -204,6 +200,7 @@
 
 /obj/machinery/cryopod/New()
 	announce = new /obj/item/device/radio/intercom(src)
+	update_icon()
 	..()
 
 /obj/machinery/cryopod/Destroy()
@@ -216,6 +213,12 @@
 	. = ..()
 
 	find_control_computer()
+
+/obj/machinery/cryopod/update_icon()
+	if(occupant)
+		icon_state = "[initial(icon_state)]_1"
+	else
+		icon_state = "[initial(icon_state)]_0"
 
 /obj/machinery/cryopod/proc/find_control_computer(urgent=0)
 	// Workaround for http://www.byond.com/forum/?post=2007448
@@ -264,14 +267,18 @@
 // This function can not be undone; do not call this unless you are sure
 // Also make sure there is a valid control computer
 /obj/machinery/cryopod/robot/despawn_occupant()
+	/// Move then into mob/living/silicon/despawn()
 	var/mob/living/silicon/robot/R = occupant
 	if(!istype(R)) return ..()
 
 	qdel(R.mmi)
+
+	// Cryopod code to extract items from cyborgs before calling ..() so the cybrog is in clean state for proc/despawn_occupant()
 	for(var/obj/item/I in R.module) // the tools the borg has; metal, glass, guns etc
 		for(var/obj/item/O in I) // the things inside the tools, if anything; mainly for janiborg trash bags
 			O.forceMove(R)
 		qdel(I)
+
 	qdel(R.module)
 
 	return ..()
@@ -285,6 +292,7 @@
 		occupant_organs = H.organs | H.internal_organs
 
 	//Drop all items into the pod.
+	//// Local pod code
 	for(var/obj/item/W in occupant)
 		// Don't delete the organs!
 		if(W in occupant_organs)
@@ -304,6 +312,7 @@
 	items -= occupant // Don't delete the occupant
 	items -= announce // or the autosay radio.
 
+	// Preserve the mmi brain, quite snowflake code here
 	for(var/obj/item/W in items)
 		var/preserve = null
 		// Snowflaaaake.
@@ -328,46 +337,6 @@
 			else
 				W.forceMove(src.loc)
 
-	//Update any existing objectives involving this mob.
-	for(var/datum/objective/O in all_objectives)
-		// We don't want revs to get objectives that aren't for heads of staff. Letting
-		// them win or lose based on cryo is silly so we remove the objective.
-		if(O.target == occupant.mind)
-			if(O.owner && O.owner.current)
-				to_chat(O.owner.current, "<span class='warning'>You get the feeling your target is no longer within your reach...</span>")
-			qdel(O)
-
-	//Same for contract-based objectives.
-	for(var/datum/antag_contract/contract in GLOB.all_antag_contracts)
-		contract.on_mob_despawned(occupant.mind)
-
-
-	//Handle job slot/tater cleanup.
-	var/job = occupant.mind.assigned_role
-
-	SSjob.FreeRole(job)
-
-	clear_antagonist(occupant.mind)
-
-	// Delete them from datacore.
-
-	if(PDA_Manifest.len)
-		PDA_Manifest.Cut()
-	for(var/datum/data/record/R in data_core.medical)
-		if ((R.fields["name"] == occupant.real_name))
-			qdel(R)
-	for(var/datum/data/record/T in data_core.security)
-		if ((T.fields["name"] == occupant.real_name))
-			qdel(T)
-	for(var/datum/data/record/G in data_core.general)
-		if ((G.fields["name"] == occupant.real_name))
-			qdel(G)
-
-	icon_state = base_icon_state
-
-	//TODO: Check objectives/mode, update new targets if this mob is the target, spawn new antags?
-
-
 	//Make an announcement and log the person entering storage.
 	control_computer.frozen_crew += "[occupant.real_name], [occupant.mind.assigned_role] - [stationtime2text()]"
 	control_computer._admin_logs += "[key_name(occupant)] ([occupant.mind.assigned_role]) at [stationtime2text()]"
@@ -375,7 +344,6 @@
 
 	announce.autosay("[occupant.real_name], [occupant.mind.assigned_role], [on_store_message]", "[on_store_name]")
 	visible_message("<span class='notice'>\The [initial(name)] hums and hisses as it moves [occupant.real_name] into storage.</span>")
-
 
 	//When the occupant is put into storage, their respawn time is reduced.
 	//This check exists for the benefit of people who get put into cryostorage while SSD and come back later
@@ -393,13 +361,9 @@
 				//Going safely to cryo will allow the patient to respawn more quickly
 				M.set_respawn_bonus("CRYOSLEEP", CRYOPOD_SPAWN_BONUS)
 
-	//This should guarantee that ghosts don't spawn.
-	occupant.ckey = null
-
-	// Delete the mob.
-	qdel(occupant)
+	// This despawn is not a gib() in this sense, it is used to remove objectives tied on these despawned mobs in cryos
+	occupant.despawn()
 	set_occupant(null)
-
 
 /obj/machinery/cryopod/affect_grab(var/mob/user, var/mob/target)
 	try_put_inside(target, user)
@@ -548,8 +512,6 @@
 			var/mob/living/carbon/human/H = occupant
 			H.in_stasis = 1
 		new_occupant.forceMove(src)
-		icon_state = occupied_icon_state
-
 
 		if (notifications)
 			to_chat(occupant, SPAN_NOTICE("[on_enter_occupant_message]"))
@@ -561,7 +523,6 @@
 			If you wish to respawn as a different crewmember, you should treat your injuries at medical first</b>"))
 
 	else
-		icon_state = base_icon_state
 		if(!QDELETED(occupant))
 			occupant.forceMove(get_turf(src))
 			occupant.reset_view(null)
@@ -569,3 +530,5 @@
 				var/mob/living/carbon/human/H = occupant
 				H.in_stasis = 0
 		occupant = null
+
+	update_icon()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -280,7 +280,9 @@
 // Also make sure there is a valid control computer
 /obj/machinery/cryopod/proc/despawn_occupant()
 	var/mob/living/carbon/human/H = occupant
-	var/list/occupant_organs = H.organs | H.internal_organs
+	var/list/occupant_organs
+	if(istype(H))
+		occupant_organs = H.organs | H.internal_organs
 
 	//Drop all items into the pod.
 	for(var/obj/item/W in occupant)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -453,7 +453,7 @@ default behaviour is:
 	return
 
 // The proc despawn() is called by /obj/machinery/cryopod/proc/despawn_occupant() for clean removal of a mob out of the round with the removal of objectives affecting it.
-// This is not recommended to directly call this proc on a mob without a good reason. It kicks out the player from the game without turning him into a ghost.
+// Not recommended to directly call this proc on a mob without a good reason. It kicks out the player from the game without turning him into a ghost.
 /mob/living/despawn()
 	//Update any existing objectives involving this mob.
 	for(var/datum/objective/O in all_objectives)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -452,6 +452,48 @@ default behaviour is:
 
 	return
 
+// This function is not to be invoked when the mob is killed. It runs when the mob is leaving the game or similar means.
+/mob/living/despawn()
+	//Update any existing objectives involving this mob.
+	for(var/datum/objective/O in all_objectives)
+		// We don't want revs to get objectives that aren't for heads of staff. Letting
+		// them win or lose based on cryo is silly so we remove the objective.
+		if(O.target == src.mind)
+			if(O.owner && O.owner.current)
+				to_chat(O.owner.current, SPAN_WARNING("You get the feeling your target is no longer within your reach..."))
+			qdel(O)
+
+	//Same for contract-based objectives.
+	for(var/datum/antag_contract/contract in GLOB.all_antag_contracts)
+		contract.on_mob_despawned(src.mind)
+
+	//Handle job slot/tater cleanup.
+	var/job = src.mind.assigned_role
+
+	SSjob.FreeRole(job)
+
+	clear_antagonist(src.mind)
+
+	// Delete them from datacore.
+
+	if(PDA_Manifest.len)
+		PDA_Manifest.Cut()
+	for(var/datum/data/record/R in data_core.medical)
+		if ((R.fields["name"] == src.real_name))
+			qdel(R)
+	for(var/datum/data/record/T in data_core.security)
+		if ((T.fields["name"] == src.real_name))
+			qdel(T)
+	for(var/datum/data/record/G in data_core.general)
+		if ((G.fields["name"] == src.real_name))
+			qdel(G)
+
+	//This should guarantee that ghosts don't spawn.
+	src.ckey = null
+
+	// Delete the mob.
+	qdel(src)
+
 /mob/living/proc/UpdateDamageIcon()
 	return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -452,7 +452,8 @@ default behaviour is:
 
 	return
 
-// This function is not to be invoked when the mob is killed. It runs when the mob is leaving the game or similar means.
+// The proc despawn() is called by /obj/machinery/cryopod/proc/despawn_occupant() for clean removal of a mob out of the round with the removal of objectives affecting it.
+// This is not recommended to directly call this proc on a mob without a good reason. It kicks out the player from the game without turning him into a ghost.
 /mob/living/despawn()
 	//Update any existing objectives involving this mob.
 	for(var/datum/objective/O in all_objectives)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -467,12 +467,12 @@ default behaviour is:
 	for(var/datum/antag_contract/contract in GLOB.all_antag_contracts)
 		contract.on_mob_despawned(src.mind)
 
-	//Handle job slot/tater cleanup.
-	var/job = src.mind.assigned_role
+	if(src.mind)
+		//Handle job slot/tater cleanup.
+		var/job = src.mind.assigned_role
+		SSjob.FreeRole(job)
 
-	SSjob.FreeRole(job)
-
-	clear_antagonist(src.mind)
+		clear_antagonist(src.mind)
 
 	// Delete them from datacore.
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -13,6 +13,9 @@
 	..()
 	return QDEL_HINT_HARDDEL
 
+/mob/proc/despawn()
+	return
+
 /mob/get_fall_damage(var/turf/from, var/turf/dest)
 	return 0
 


### PR DESCRIPTION
<!-- Make sure you read the guidelines before conrtibuting! https://wiki.cev-eris.com/Content_GuidelinesEn -->

## About The Pull Request
<!-- Why is it needed, what it fixes. Write up links to closing issues there as well, but make it short. -->
Before this PR, a robot in a robotic cryo will cause a runtime because the despawn_occupant() will call the parent which lands in the proc with human-only code causing a runtime unless the line `occupant_organs = H.organs | H.internal_organs` is behind the type check

The PR fixes the spammy runtime, not sure if it also breaks the MC beforehand.

Last thing, should this fix to be changed to a refactor of cryo code so we have /obj/machinery/cryopod/organic and original /obj/machinery/cryopod/robot, the /obj/machinery/cryopod will just simply call the generic removal code ?