### PR TITLE
Fixes the lack of UI for BST teleport or ghosts leaving corpses.

### DIFF
--- a/code/modules/admin/bluespacetech.dm
+++ b/code/modules/admin/bluespacetech.dm
@@ -106,7 +106,6 @@ ADMIN_VERB_ADD(/client/proc/cmd_dev_bst, R_ADMIN|R_DEBUG, TRUE)
 	spawn(10)
 		qdel(src)
 	if(key)
-
 		var/mob/observer/ghost/ghost = ghostize(TRUE)
 		ghost.name = "[ghost.key] BSTech"
 		ghost.real_name = "[ghost.key] BSTech"

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -167,6 +167,8 @@ Works together with spawning an observer, noted above.
 		if(ghost.client && !ghost.client.holder && !config.antag_hud_allowed)		// For new ghosts we remove the verb from even showing up if it's not allowed.
 			ghost.verbs -= /mob/observer/ghost/verb/toggle_antagHUD	// Poor guys, don't know what they are missing!
 
+		ghost.client.create_UI(ghost.type)
+
 		return ghost
 
 /*


### PR DESCRIPTION
## About The Pull Request
<!-- Why is it needed, what it fixes. Write up links to closing issues there as well, but make it short. -->
 It fixes the lack of UI when turning into ghost or moving out of corpse or teleporting out as BST.

But there's duplicate code in code\modules\mob\new_player\new_player.dm:110 and code\modules\mob\observer\ghost\ghost.dm:140. I wish the code gets reworked in new_player.dm to be replaced by a single function call with proper parameter.