### PR TITLE
The C20R magazine now spawns empty when printed

### DIFF
--- a/code/modules/research/designs/weapon.dm
+++ b/code/modules/research/designs/weapon.dm
@@ -92,7 +92,7 @@
 /datum/design/research/item/ammo/c20r_ammo
 	name = "C20R 35 Auto Magazine"
 	desc = "35 Auto SMG magazine for the C-20r"
-	build_path = /obj/item/ammo_magazine/smg
+	build_path = /obj/item/ammo_magazine/smg/empty
 	sort_string = "TAACD"
 
 /datum/design/research/item/ammo/shotgun_incendiary


### PR DESCRIPTION
As requested by a scientist, who accidentally murdered the guild merchant as "he had no non-lethal option"