### PR TITLE
Blitzshell fixes

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -155,16 +155,24 @@
 //Give cyborgs hotkey clicks without breaking existing uses of hotkey clicks
 // for non-doors/apcs
 /mob/living/silicon/robot/CtrlShiftClickOn(var/atom/A)
-	A.BorgCtrlShiftClick(src)
+	if(ai_access)
+		return A.BorgCtrlShiftClick(src)
+	..()
 
 /mob/living/silicon/robot/ShiftClickOn(var/atom/A)
-	A.BorgShiftClick(src)
+	if(ai_access)
+		return A.BorgShiftClick(src)
+	..()
 
 /mob/living/silicon/robot/CtrlClickOn(var/atom/A)
-	A.BorgCtrlClick(src)
+	if(ai_access)
+		return A.BorgCtrlClick(src)
+	..()
 
 /mob/living/silicon/robot/AltClickOn(var/atom/A)
-	A.BorgAltClick(src)
+	if(ai_access)
+		return A.BorgAltClick(src)
+	..()
 
 /atom/proc/BorgCtrlShiftClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden
 	CtrlShiftClick(user)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -162,7 +162,7 @@
 		if(antag)
 			var/ok = FALSE
 			if(antag.outer && active)
-				var/answer = alert("[antag.role_text] is outer antagonist. [name] will be taken from the current mob and spawned as antagonist. Continue?","No","Yes")
+				var/answer = alert("[antag.role_text] is an outer antagonist. [name] will be taken from the current mob and spawned as antagonist. Continue?","Confirmation", "No","Yes")
 				ok = (answer == "Yes")
 			else
 				var/answer = alert("Are you sure you want to make [name] the [antag.role_text]","Confirmation","No","Yes")

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -223,6 +223,23 @@
 		return 1
 	return 0
 
+/datum/uplink_item/item/tools/blitz_laserweapon
+	name = "Blitzshell Weapons Upgrade"
+	desc = "Activates the embedded laser weapon system."
+	item_cost = 20
+	antag_roles = list(ROLE_BLITZ)
+
+
+/datum/uplink_item/item/tools/blitz_laserweapon/get_goods(var/obj/item/device/uplink/U, var/loc, var/mob/living/user)
+	if(user && istype(user, /mob/living/silicon/robot/drone/blitzshell))
+		var/mob/living/silicon/robot/drone/blitzshell/BS = user
+		if(locate(/obj/item/weapon/gun/energy/laser/mounted/blitz) in BS.module.modules)
+			to_chat(BS, SPAN_WARNING("You already have a laser system installed."))
+			return 0
+		BS.module.modules += new /obj/item/weapon/gun/energy/laser/mounted/blitz(BS.module)
+		return 1
+	return 0
+
 /datum/uplink_item/item/tools/blitz_nanorepair
 	name = "Blitzshell Nanorepair Capsule"
 	desc = "Reload your nanorepair system, gaining extra charges."

--- a/code/modules/mob/living/silicon/robot/drone/blitzshell.dm
+++ b/code/modules/mob/living/silicon/robot/drone/blitzshell.dm
@@ -9,6 +9,7 @@
 	communication_channel = LANGUAGE_BLITZ
 	station_drone = FALSE
 	eyecolor = null
+	ai_access = FALSE
 
 /mob/living/silicon/robot/drone/blitzshell/updatename()
 	real_name = "\"Blitzshell\" assault drone ([rand(100,999)])"
@@ -42,7 +43,7 @@
 	networks = list()
 
 /obj/item/weapon/robot_module/drone/blitzshell/New()
-	modules += new /obj/item/weapon/gun/energy/laser/mounted/blitz(src)
+	//modules += new /obj/item/weapon/gun/energy/laser/mounted/blitz(src) //Deemed too strong
 	modules += new /obj/item/weapon/gun/energy/plasma/mounted/blitz(src)
 	modules += new /obj/item/weapon/tool/knife/tacknife(src) //For claiming heads for assassination missions
 	//Objective stuff

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -21,7 +21,7 @@
 	var/crisis_override = 0
 	var/integrated_light_power = 6
 	var/datum/wires/robot/wires
-
+	var/ai_access = TRUE
 	var/power_efficiency = 1.0
 
 


### PR DESCRIPTION
Removes the Blitzshell laser weapon, now it must be purchased seperately
Fixes the Blitzshell being able to bolt and electrify doors