### PR TITLE
Homewrecker Icon Patch + Spelling

### DIFF
--- a/code/game/objects/items/weapons/tools/hammer.dm
+++ b/code/game/objects/items/weapons/tools/hammer.dm
@@ -14,8 +14,8 @@
 
 /obj/item/weapon/tool/hammer/homewrecker
 	name = "homewrecker"
-	desc = "A large steel chunk welded to a long handle which resembles sledgehammer. Extremely heavy."
-	icon_state = "homewrecker"
+	desc = "A large steel chunk welded to a long handle which resembles a sledgehammer. Extremely heavy."
+	icon_state = "homewrecker0"
 	item_state = "homewrecker"
 	wielded_icon = "homewrecker1"
 	structure_damage_factor = STRUCTURE_DAMAGE_HEAVY


### PR DESCRIPTION
<!-- Make sure you read the guidelines before conrtibuting! https://wiki.cev-eris.com/Content_GuidelinesEn -->

## About The Pull Request
<!-- Why is it needed, what it fixes. Write up links to closing issues there as well, but make it short. -->
Changes the code for the Homewrecker item so that it has an icon when the object is on the ground. Before this, the Homewrecker had no icon (though it showed up on a player's sprite if held), even though it had icons in the code.

Also changes the spelling on the description for the Homewrecker.