### PR TITLE
Adds a morgue message indicating successful respawn timer reduction, fixes spawning as NT without cruciform

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -111,7 +111,7 @@ SUBSYSTEM_DEF(job)
 		if(jobban_isbanned(player, job.title))
 			Debug("GRJ isbanned failed, Player: [player], Job: [job.title]")
 			continue
-		var/datum/category_item/setup_option/core_implant/I = client.prefs.get_option("Core implant")
+		var/datum/category_item/setup_option/core_implant/I = player.client.prefs.get_option("Core implant")
 		// cant be Neotheology without a cruciform
 		if(job.department == DEPARTMENT_CHURCH && istype(I.implant_type,/obj/item/weapon/implant/core_implant/cruciform))
 			continue

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -111,7 +111,10 @@ SUBSYSTEM_DEF(job)
 		if(jobban_isbanned(player, job.title))
 			Debug("GRJ isbanned failed, Player: [player], Job: [job.title]")
 			continue
-
+		var/datum/category_item/setup_option/core_implant/I = client.prefs.get_option("Core implant")
+		// cant be Neotheology without a cruciform
+		if(job.department == DEPARTMENT_CHURCH && istype(I.implant_type,/obj/item/weapon/implant/core_implant/cruciform))
+			continue
 		if((job.current_positions < job.spawn_positions) || job.spawn_positions == -1)
 			Debug("GRJ Random job given, Player: [player], Job: [job]")
 			AssignRole(player, job.title)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -147,11 +147,12 @@
 		if (M.get_respawn_bonus("CORPSE_HANDLING"))
 			return // we got this one already
 		//We send a message to the occupant's current mob - probably a ghost, but who knows.
-		to_chat(M, SPAN_NOTICE("Your remains have been collected and properly stored. Your crew respawn time is reduced by 8 minutes."))
+		to_chat(M, SPAN_NOTICE("Your remains have been collected and properly stored. Your crew respawn time is reduced by 10 minutes."))
+		
 		M << 'sound/effects/magic/blind.ogg' //Play this sound to a player whenever their respawn time gets reduced
 
-		M.set_respawn_bonus("CORPSE_HANDLING", 8 MINUTES)
-
+		M.set_respawn_bonus("CORPSE_HANDLING", 10 MINUTES)
+		to_chat(user, SPAN_NOTICE("The corpse's spirit feels soothed and pleased."))
 
 
 

--- a/code/modules/biomatter_manipulation/bioreactor/platform.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/platform.dm
@@ -111,11 +111,11 @@
 				organ.removed()
 				continue
 		if(H && H.mind && H.mind.key && H.stat == DEAD)
-		var/mob/M = key2mob(H.mind.key)
-		to_chat(M, SPAN_NOTICE("Your remains have been collected and properly stored. Your crew respawn time is reduced by 10 minutes."))
-		M << 'sound/effects/magic/blind.ogg'  //Play this sound to a player whenever their respawn time gets reduced
-		M.set_respawn_bonus("CORPSE_DISSOLVING", 10 MINUTES)
-	
+			var/mob/M = key2mob(H.mind.key)
+			to_chat(M, SPAN_NOTICE("Your remains have been collected and properly stored. Your crew respawn time is reduced by 10 minutes."))
+			M << 'sound/effects/magic/blind.ogg'  //Play this sound to a player whenever their respawn time gets reduced
+			M.set_respawn_bonus("CORPSE_DISSOLVING", 10 MINUTES)
+		
 	qdel(object)
 	//now let's add some dirt to the glass
 	for(var/obj/structure/window/reinforced/bioreactor/glass in loc)

--- a/code/modules/biomatter_manipulation/bioreactor/platform.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/platform.dm
@@ -112,7 +112,7 @@
 				continue
 		if(H && H.mind && H.mind.key && H.stat == DEAD)
 			var/mob/M = key2mob(H.mind.key)
-			to_chat(M, SPAN_NOTICE("Your remains have been collected and properly stored. Your crew respawn time is reduced by 10 minutes."))
+			to_chat(M, SPAN_NOTICE("Your remains have been dissolved and reused. Your crew respawn time is reduced by 10 minutes."))
 			M << 'sound/effects/magic/blind.ogg'  //Play this sound to a player whenever their respawn time gets reduced
 			M.set_respawn_bonus("CORPSE_DISSOLVING", 10 MINUTES)
 		

--- a/code/modules/biomatter_manipulation/bioreactor/platform.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/platform.dm
@@ -110,7 +110,7 @@
 				organ.forceMove(get_turf(neighbor_platform))
 				organ.removed()
 				continue
-		if(H && H.mind && occupant.mind.key && H.stat == DEAD)
+		if(H && H.mind && H.mind.key && H.stat == DEAD)
 		var/mob/M = key2mob(H.mind.key)
 		to_chat(M, SPAN_NOTICE("Your remains have been collected and properly stored. Your crew respawn time is reduced by 10 minutes."))
 		M << 'sound/effects/magic/blind.ogg'  //Play this sound to a player whenever their respawn time gets reduced

--- a/code/modules/biomatter_manipulation/bioreactor/platform.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/platform.dm
@@ -110,6 +110,12 @@
 				organ.forceMove(get_turf(neighbor_platform))
 				organ.removed()
 				continue
+		if(H && H.mind && occupant.mind.key && H.stat == DEAD)
+		var/mob/M = key2mob(H.mind.key)
+		to_chat(M, SPAN_NOTICE("Your remains have been collected and properly stored. Your crew respawn time is reduced by 10 minutes."))
+		M << 'sound/effects/magic/blind.ogg'  //Play this sound to a player whenever their respawn time gets reduced
+		M.set_respawn_bonus("CORPSE_DISSOLVING", 10 MINUTES)
+	
 	qdel(object)
 	//now let's add some dirt to the glass
 	for(var/obj/structure/window/reinforced/bioreactor/glass in loc)


### PR DESCRIPTION

## About The Pull Request

Various fixes.

## Details

Adds an indicator of successful respawn timer reduction by putting someone into the morgue, increases it to 10 minutes.  
No more spawning as an NT without a cruciform due to having enabled random jobs. 
Adds an extra 10 minute respawn reduction for having your body dissolved in the bioreactor platform.


