### PR TITLE
Fix Brute damage repair for /living/bot

### DIFF
--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -77,7 +77,7 @@
 	else if(istype(O, /obj/item/weapon/tool/weldingtool))
 		if(health < maxHealth)
 			if(open)
-				health = min(maxHealth, health + 10)
+				adjustBruteLoss(-10)
 				user.visible_message(SPAN_NOTICE("[user] repairs [src]."),SPAN_NOTICE("You repair [src]."))
 			else
 				to_chat(user, SPAN_NOTICE("Unable to repair with the maintenance panel closed."))


### PR DESCRIPTION
<!-- Make sure you read the guidelines before conrtibuting! https://wiki.cev-eris.com/Content_GuidelinesEn -->

## About The Pull Request
<!-- Why is it needed, what it fixes. Write up links to closing issues there as well, but make it short. -->

Fix Issue #4631 about the repair of bots. 

I did some tests and the issue actually applied to all kinds of bots (floorbot, medibot, hydroponic bot...) and for any percentage of brute damage.

## Details
<!-- If you need, describe details inside. Remove whole block if not used. -->

There is no way to fix burn damages on bots, I don't know if it is intended.

## Changelog
:cl: Hyperio
fix: Fixed not being able to repair bots
/:cl:

