### PR TITLE
Changes Vomitol Recipe, Makes Vomitol Decayable

### DIFF
--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -783,6 +783,8 @@
 	reagent_state = LIQUID
 	color = "#a6b85b"
 	overdose = REAGENTS_OVERDOSE
+	heating_point = 683.15
+	heating_products = list("carbon", "hclacid", "acetone")
 
 /datum/reagent/medicine/vomitol/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	if(prob(10 * effect_multiplier))

--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -1886,8 +1886,10 @@
 
 /datum/chemical_reaction/vomitol
 	result = "vomitol"
-	required_reagents = list("carbon" = 1, "sugar" = 1, "acetone" = 1)
+	required_reagents = list("carbon" = 1, "hclacid" = 1, "acetone" = 1)
 	result_amount = 3
+	maximum_temperature = 683.14 //So it doesn't form back into vomitol, decompose, and form back again when over decomposition point
+	minimum_temperature = 0
 
 /datum/chemical_reaction/arectine
 	result = "arectine"


### PR DESCRIPTION
<!-- Make sure you read the guidelines before conrtibuting! https://wiki.cev-eris.com/Content_GuidelinesEn -->

## About The Pull Request
<!-- Why is it needed, what it fixes. Write up links to closing issues there as well, but make it short. -->
This PR changes the vomitol recipe, so that it doesn't conflict with the inaprovaline recipe, even though it worked before (but required a specific order to make the vomitol). The new recipe is based off of looking at the chemical formula for adamsite (https://www.cdc.gov/niosh/ershdb/emergencyresponsecard_29750017.html).
This PR also makes it so vomitol decays into its base components when heated above 683.15 K, since adamsite in real-life apparently does that.