### PR TITLE
Fix cyborgs not being able to pick up stuff (ores, sheets, ...)

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -92,16 +92,23 @@
 		return
 
 	// cyborgs are prohibited from using storage items so we can I think safely remove (A.loc && isturf(A.loc.loc))
-	if(isturf(A) || isturf(A.loc))
+	var/sdepth = A.storage_depth_turf()
+	if(isturf(A) || isturf(A.loc) || (sdepth != -1 && sdepth <= 1))
 		if(A.Adjacent(src)) // see adjacent.dm
-
-			var/resolved = A.attackby(W, src)
-			if(!resolved && A && W)
-				W.afterattack(A, src, 1, params)
+			if (W)
+				var/resolved = (SEND_SIGNAL(W, COMSIG_IATTACK, A, src, params)) || (SEND_SIGNAL(A, COMSIG_ATTACKBY, W, src, params)) || W.resolve_attackby(A, src, params)
+				if(!resolved && A && W)
+					W.afterattack(A, src, 1, params)
+			else
+				if(ismob(A))
+					setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+				UnarmedAttack(A, 1)
 			return
 		else
-			W.afterattack(A, src, 0, params)
-			return
+			if (W)
+				W.afterattack(A, src, 0, params)
+			else
+				RangedAttack(A, params)
 	return
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix high priority issue #3848 about mining borgs not being able to pick up stuff like ores with their mining satchel or metal sheets with their sheet snatcher 9000.

To fix the issue I adjusted the OnClick function of cyborgs to have it closer to humans' one. Tell me if you think it could have any undesired consequences.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It is way more fun/efficient to play a mining borg than can pick up the ores it mines rather than one that cannot.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Hyperio
fix: Fixed cyborgs not being able to pick up items (ores, sheets, ...)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
