### PR TITLE
More compact crafting menu by grouping variations of the same item

### DIFF
--- a/code/__DEFINES/craft.dm
+++ b/code/__DEFINES/craft.dm
@@ -3,3 +3,6 @@
 #define CRAFT_BATCH        4
 
 #define CRAFT_MATERIAL		"material"
+
+#define CRAFT_REFERENCE 0
+#define CRAFT_VARIATION 1

--- a/code/datums/craft/menu.dm
+++ b/code/datums/craft/menu.dm
@@ -62,7 +62,7 @@
 	for(var/datum/craft_recipe/recipe in SScraft.categories[curr_category])
 		if((recipe.avaliableToEveryone || (recipe.type in user.mind.knownCraftRecipes)) && (recipe.variation_type == CRAFT_REFERENCE))
 			items += list(list(
-				"name" = capitalize(recipe.name),
+				"name" = capitalize(recipe.name_craft_menu ? recipe.name_craft_menu : recipe.name),
 				"ref" = "\ref[recipe]"
 			))
 	data["items"] = items

--- a/code/datums/craft/menu.dm
+++ b/code/datums/craft/menu.dm
@@ -62,7 +62,7 @@
 	for(var/datum/craft_recipe/recipe in SScraft.categories[curr_category])
 		if((recipe.avaliableToEveryone || (recipe.type in user.mind.knownCraftRecipes)) && (recipe.variation_type == CRAFT_REFERENCE))
 			items += list(list(
-				"name" = capitalize(recipe.name_craft_menu ? recipe.name_craft_menu : recipe.name),
+				"name" = capitalize(recipe.name_craft_menu ? recipe.name_craft_menu : recipe.name), // Display subtype name if the item is the reference of a subtype of items
 				"ref" = "\ref[recipe]"
 			))
 	data["items"] = items
@@ -102,37 +102,21 @@
 		SSnano.update_uis(src)
 	else if(href_list["item"])
 		var/list/subtypes_item = subtypesof(locate(href_list["item"]))
-		var/num_choice = subtypes_item.len
-		to_chat(usr, "[num_choice] subtypes detected.")
-		if (subtypes_item.len > 1)
-			/*var/datum/craft_recipe/CR = input(src,"Please chose variation") as null|anything in subtypes_item
-			if(CanInteract(usr, GLOB.default_state))
-				if (!CR)
-					return
-				//var/usr_choice = variation_choices
-				to_chat(usr, "You made your choice of [CR.name].")
-
-				set_item(CR, usr)*/
-			var/list/namelist = list()
-			var/obj/item/CR
-			for (var/I in subtypes_item)
-				to_chat(usr, "Processing [I]")
-				to_chat(usr, "Pass.")
+		if (subtypes_item.len > 1)  // Check if the crafted item has variations
+			var/list/namelist = list()  // To store names of variations
+			var/obj/item/CR  // Temporary item
+			for (var/I in subtypes_item)  // Go through all variations of the reference item
 				CR = new I (null)
 				namelist += "[CR.name]"
-				to_chat(usr, "Processing [CR.name].")
-			var/variation_choices = input(usr, "Please chose variation") as null|anything in namelist
+			var/variation_choices = input(usr, "Please chose variation") as null|anything in namelist  // Ask the user which variation he wants to craft
 			if(CanInteract(usr, GLOB.default_state))
 				if (!variation_choices)
 					return
 				var/usr_choice = variation_choices
-				to_chat(usr, "You made your choice of [usr_choice].")
-
-				for (var/I in subtypes_item)
+				for (var/I in subtypes_item)  // Retrieve the desired item by checking the name of all variations
 					CR = new I (null)
 					if (CR.name == usr_choice)
-						to_chat(usr, "Choice registered.")
-						set_item("\ref[CR]", usr)
+						set_item("\ref[CR]", usr)  // Update UI with desired variation
 		else
 			set_item(href_list["item"], usr)
 		SSnano.update_uis(src)

--- a/code/datums/craft/menu.dm
+++ b/code/datums/craft/menu.dm
@@ -60,7 +60,7 @@
 		)
 	var/list/items = list()
 	for(var/datum/craft_recipe/recipe in SScraft.categories[curr_category])
-		if(recipe.avaliableToEveryone || (recipe.type in user.mind.knownCraftRecipes))
+		if((recipe.avaliableToEveryone || (recipe.type in user.mind.knownCraftRecipes)) && (recipe.variation_type == CRAFT_REFERENCE))
 			items += list(list(
 				"name" = capitalize(recipe.name),
 				"ref" = "\ref[recipe]"
@@ -101,5 +101,38 @@
 		set_category(href_list["category"], usr)
 		SSnano.update_uis(src)
 	else if(href_list["item"])
-		set_item(href_list["item"], usr)
+		var/list/subtypes_item = subtypesof(locate(href_list["item"]))
+		var/num_choice = subtypes_item.len
+		to_chat(usr, "[num_choice] subtypes detected.")
+		if (subtypes_item.len > 1)
+			/*var/datum/craft_recipe/CR = input(src,"Please chose variation") as null|anything in subtypes_item
+			if(CanInteract(usr, GLOB.default_state))
+				if (!CR)
+					return
+				//var/usr_choice = variation_choices
+				to_chat(usr, "You made your choice of [CR.name].")
+
+				set_item(CR, usr)*/
+			var/list/namelist = list()
+			var/obj/item/CR
+			for (var/I in subtypes_item)
+				to_chat(usr, "Processing [I]")
+				to_chat(usr, "Pass.")
+				CR = new I (null)
+				namelist += "[CR.name]"
+				to_chat(usr, "Processing [CR.name].")
+			var/variation_choices = input(usr, "Please chose variation") as null|anything in namelist
+			if(CanInteract(usr, GLOB.default_state))
+				if (!variation_choices)
+					return
+				var/usr_choice = variation_choices
+				to_chat(usr, "You made your choice of [usr_choice].")
+
+				for (var/I in subtypes_item)
+					CR = new I (null)
+					if (CR.name == usr_choice)
+						to_chat(usr, "Choice registered.")
+						set_item("\ref[CR]", usr)
+		else
+			set_item(href_list["item"], usr)
 		SSnano.update_uis(src)

--- a/code/datums/craft/recipe.dm
+++ b/code/datums/craft/recipe.dm
@@ -11,6 +11,7 @@
 	var/avaliableToEveryone = TRUE
 
 	var/variation_type = CRAFT_REFERENCE
+	var/name_craft_menu
 
 /datum/craft_recipe/New()
 	var/step_definations = steps

--- a/code/datums/craft/recipe.dm
+++ b/code/datums/craft/recipe.dm
@@ -10,6 +10,8 @@
 	var/related_stats = list(STAT_COG)	// used to decrease crafting time for non tool steps
 	var/avaliableToEveryone = TRUE
 
+	var/variation_type = CRAFT_REFERENCE
+
 /datum/craft_recipe/New()
 	var/step_definations = steps
 	steps = new

--- a/code/datums/craft/recipe.dm
+++ b/code/datums/craft/recipe.dm
@@ -10,8 +10,9 @@
 	var/related_stats = list(STAT_COG)	// used to decrease crafting time for non tool steps
 	var/avaliableToEveryone = TRUE
 
-	var/variation_type = CRAFT_REFERENCE
-	var/name_craft_menu
+	var/variation_type = CRAFT_REFERENCE  // if the object is the reference of a subtype
+	// set it to CRAFT_VARIATION if the object is a variation of the reference
+	var/name_craft_menu  // name of the subtype formed by a reference and its variations
 
 /datum/craft_recipe/New()
 	var/step_definations = steps

--- a/code/datums/craft/recipes/airlocks.dm
+++ b/code/datums/craft/recipes/airlocks.dm
@@ -7,70 +7,82 @@
 	)
 	related_stats = list(STAT_MEC)
 
-/datum/craft_recipe/airlock/standard
+/datum/craft_recipe/airlock/assembly
 	name = "standard airlock assembly"
 	result = /obj/structure/door_assembly
+	name_craft_menu = "Airlock assemblies"
 
-/datum/craft_recipe/airlock/command
+/datum/craft_recipe/airlock/assembly/command
 	name = "command airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_com
+	variation_type = CRAFT_VARIATION
 
-/datum/craft_recipe/airlock/security
+/datum/craft_recipe/airlock/assembly/security
 	name = "security airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_sec
+	variation_type = CRAFT_VARIATION
 
-/datum/craft_recipe/airlock/engineering
+/datum/craft_recipe/airlock/assembly/engineering
 	name = "engineering airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_eng
+	variation_type = CRAFT_VARIATION
 
-/datum/craft_recipe/airlock/mining
+/datum/craft_recipe/airlock/assembly/mining
 	name = "mining airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_min
+	variation_type = CRAFT_VARIATION
 
-/datum/craft_recipe/airlock/atmospherics
+/datum/craft_recipe/airlock/assembly/atmospherics
 	name = "atmospherics airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_atmo
+	variation_type = CRAFT_VARIATION
 
-/datum/craft_recipe/airlock/research
+/datum/craft_recipe/airlock/assembly/research
 	name = "research airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_research
+	variation_type = CRAFT_VARIATION
 
-/datum/craft_recipe/airlock/medical
+/datum/craft_recipe/airlock/assembly/medical
 	name = "medical airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_med
+	variation_type = CRAFT_VARIATION
 
-/datum/craft_recipe/airlock/maintenance
+/datum/craft_recipe/airlock/assembly/maintenance
 	name = "maintenance airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_mai
+	variation_type = CRAFT_VARIATION
 
-/datum/craft_recipe/airlock/external
+/datum/craft_recipe/airlock/assembly/external
 	name = "external airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_ext
+	variation_type = CRAFT_VARIATION
 
-/datum/craft_recipe/airlock/freezer
+/datum/craft_recipe/airlock/assembly/freezer
 	name = "freezer airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_fre
+	variation_type = CRAFT_VARIATION
 
-/datum/craft_recipe/airlock/airtight
+/datum/craft_recipe/airlock/hatch/airtight
 	name = "airtight hatch assembly"
 	result = /obj/structure/door_assembly/door_assembly_hatch
 
-/datum/craft_recipe/airlock/maintenance
+/datum/craft_recipe/airlock/hatch/maintenance
 	name = "maintenance hatch assembly"
 	result = /obj/structure/door_assembly/door_assembly_mhatch
 
-/datum/craft_recipe/airlock/high_security
+/datum/craft_recipe/airlock/assembly/high_security
 	name = "high security airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_highsecurity
+	variation_type = CRAFT_VARIATION
 
-/datum/craft_recipe/airlock/emergency_shutter
+/datum/craft_recipe/airlock/shutter/emergency_shutter
 	name = "emergency shutter"
 	result = /obj/structure/firedoor_assembly
 
-/datum/craft_recipe/airlock/multitile
+/datum/craft_recipe/airlock/assembly/multitile
 	name = "multi-tile airlock assembly"
 	result = /obj/structure/door_assembly/multi_tile
 	steps = list(
 		list(CRAFT_MATERIAL, 20, MATERIAL_STEEL),
 	)
-
+	variation_type = CRAFT_VARIATION

--- a/code/datums/craft/recipes/floor.dm
+++ b/code/datums/craft/recipes/floor.dm
@@ -7,124 +7,148 @@
 	time = 1 //Crafting individual tiles is fast
 	related_stats = list(STAT_MEC)
 
-/datum/craft_recipe/floor/wood
+/datum/craft_recipe/floor/classic/
 	name = "wood floor tile"
 	result = /obj/item/stack/tile/wood
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_WOOD)
 	)
+	name_craft_menu = "Classic tiles"
 
-/datum/craft_recipe/floor/cafe
+/datum/craft_recipe/floor/classic/cafe
 	name = "cafe floor tile"
 	result = /obj/item/stack/tile/floor/cafe
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTIC)
 	)
+	variation_type = CRAFT_VARIATION
 
-/datum/craft_recipe/floor/techmaint
+/datum/craft_recipe/floor/classic/techmaint
 	name = "maint floor tile"
 	result = /obj/item/stack/tile/floor/techmaint
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_STEEL)
 	)
+	variation_type = CRAFT_VARIATION
 
-/datum/craft_recipe/floor/techmaint_perforated
+/datum/craft_recipe/floor/classic/techmaint_perforated
 	name = "perforated maint floor tile"
 	result = /obj/item/stack/tile/floor/techmaint/perforated
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_STEEL)
 	)
+	variation_type = CRAFT_VARIATION
 
-/datum/craft_recipe/floor/techmaint_panels
+/datum/craft_recipe/floor/classic/techmaint_panels
 	name = "panels maint floor tile"
 	result = /obj/item/stack/tile/floor/techmaint/panels
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_STEEL)
 	)
+	variation_type = CRAFT_VARIATION
 
-/datum/craft_recipe/floor/techmaint_cargo
+/datum/craft_recipe/floor/classic/techmaint_cargo
 	name = "cargo maint floor tile"
 	result = /obj/item/stack/tile/floor/techmaint/cargo
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_STEEL)
 	)
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel
 	name = "regular steel floor tile"
 	result = /obj/item/stack/tile/floor/steel
+	name_craft_menu = "Steel tiles"
 
 /datum/craft_recipe/floor/steel/panels
 	name = "steel panel tile"
 	result = /obj/item/stack/tile/floor/steel/panels
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel/techfloor
 	name = "steel techfloor tile"
 	result = /obj/item/stack/tile/floor/steel/techfloor
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel/techfloor_grid
 	name = "steel techfloor tile with vents"
 	result = /obj/item/stack/tile/floor/steel/techfloor_grid
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel/brown_perforated
 	name = "steel brown perforated tile"
 	result = /obj/item/stack/tile/floor/steel/brown_perforated
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel/gray_perforated
 	name = "steel gray perforated tile"
 	result = /obj/item/stack/tile/floor/steel/gray_perforated
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel/cargo
 	name = "steel cargo tile"
 	result = /obj/item/stack/tile/floor/steel/cargo
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel/brown_platform
 	name = "steel brown platform tile"
 	result = /obj/item/stack/tile/floor/steel/brown_platform
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel/gray_platform
 	name = "steel gray platform tile"
 	result = /obj/item/stack/tile/floor/steel/gray_platform
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel/danger
 	name = "steel danger tile"
 	result = /obj/item/stack/tile/floor/steel/danger
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel/golden
 	name = "steel golden tile"
 	result = /obj/item/stack/tile/floor/steel/golden
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel/bluecorner
 	name = "steel blue corner tile"
 	result = /obj/item/stack/tile/floor/steel/bluecorner
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel/orangecorner
 	name = "steel orange corner tile"
 	result = /obj/item/stack/tile/floor/steel/orangecorner
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel/cyancorner
 	name = "steel cyan corner tile"
 	result = /obj/item/stack/tile/floor/steel/cyancorner
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel/violetcorener
 	name = "steel violet corener tile"
 	result = /obj/item/stack/tile/floor/steel/violetcorener
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel/monofloor
 	name = "steel monofloor tile"
 	result = /obj/item/stack/tile/floor/steel/monofloor
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel/bar_flat
 	name = "steel bar flat tile"
 	result = /obj/item/stack/tile/floor/steel/bar_flat
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel/bar_dance
 	name = "steel bar dance tile"
 	result = /obj/item/stack/tile/floor/steel/bar_dance
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/steel/bar_light
 	name = "steel bar light tile"
 	result = /obj/item/stack/tile/floor/steel/bar_light
-
+	variation_type = CRAFT_VARIATION
 
 
 
@@ -134,66 +158,82 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTIC)
 	)
+	name_craft_menu = "White tiles"
 
 /datum/craft_recipe/floor/white/panels
 	name = "white panel tile"
 	result = /obj/item/stack/tile/floor/white/panels
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/techfloor
 	name = "white techfloor tile"
 	result = /obj/item/stack/tile/floor/white/techfloor
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/techfloor_grid
 	name = "white techfloor tile with vents"
 	result = /obj/item/stack/tile/floor/white/techfloor_grid
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/brown_perforated
 	name = "white brown perforated tile"
 	result = /obj/item/stack/tile/floor/white/brown_perforated
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/gray_perforated
 	name = "white gray perforated tile"
 	result = /obj/item/stack/tile/floor/white/gray_perforated
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/cargo
 	name = "white cargo tile"
 	result = /obj/item/stack/tile/floor/white/cargo
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/brown_platform
 	name = "white brown platform tile"
 	result = /obj/item/stack/tile/floor/white/brown_platform
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/gray_platform
 	name = "white gray platform tile"
 	result = /obj/item/stack/tile/floor/white/gray_platform
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/danger
 	name = "white danger tile"
 	result = /obj/item/stack/tile/floor/white/danger
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/golden
 	name = "white golden tile"
 	result = /obj/item/stack/tile/floor/white/golden
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/bluecorner
 	name = "white blue corner tile"
 	result = /obj/item/stack/tile/floor/white/bluecorner
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/orangecorner
 	name = "white orange corner tile"
 	result = /obj/item/stack/tile/floor/white/orangecorner
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/cyancorner
 	name = "white cyan corner tile"
 	result = /obj/item/stack/tile/floor/white/cyancorner
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/violetcorener
 	name = "white violet corener tile"
 	result = /obj/item/stack/tile/floor/white/violetcorener
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/monofloor
 	name = "white monofloor tile"
 	result = /obj/item/stack/tile/floor/white/monofloor
+	variation_type = CRAFT_VARIATION
 
 
 
@@ -202,66 +242,82 @@
 /datum/craft_recipe/floor/dark
 	name = "regular dark floor tile"
 	result = /obj/item/stack/tile/floor/dark
+	name_craft_menu = "Dark tiles"
 
 /datum/craft_recipe/floor/dark/panels
 	name = "dark panel tile"
 	result = /obj/item/stack/tile/floor/dark/panels
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/dark/techfloor
 	name = "dark techfloor tile"
 	result = /obj/item/stack/tile/floor/dark/techfloor
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/dark/techfloor_grid
 	name = "dark techfloor tile with vents"
 	result = /obj/item/stack/tile/floor/dark/techfloor_grid
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/dark/brown_perforated
 	name = "dark brown perforated tile"
 	result = /obj/item/stack/tile/floor/dark/brown_perforated
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/dark/gray_perforated
 	name = "dark gray perforated tile"
 	result = /obj/item/stack/tile/floor/dark/gray_perforated
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/dark/cargo
 	name = "dark cargo tile"
 	result = /obj/item/stack/tile/floor/dark/cargo
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/dark/brown_platform
 	name = "dark brown platform tile"
 	result = /obj/item/stack/tile/floor/dark/brown_platform
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/dark/gray_platform
 	name = "dark gray platform tile"
 	result = /obj/item/stack/tile/floor/dark/gray_platform
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/dark/danger
 	name = "dark danger tile"
 	result = /obj/item/stack/tile/floor/dark/danger
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/dark/golden
 	name = "dark golden tile"
 	result = /obj/item/stack/tile/floor/dark/golden
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/dark/bluecorner
 	name = "dark blue corner tile"
 	result = /obj/item/stack/tile/floor/dark/bluecorner
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/dark/orangecorner
 	name = "dark orange corner tile"
 	result = /obj/item/stack/tile/floor/dark/orangecorner
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/dark/cyancorner
 	name = "dark cyan corner tile"
 	result = /obj/item/stack/tile/floor/dark/cyancorner
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/dark/violetcorener
 	name = "dark violet corener tile"
 	result = /obj/item/stack/tile/floor/dark/violetcorener
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/dark/monofloor
 	name = "dark monofloor tile"
 	result = /obj/item/stack/tile/floor/dark/monofloor
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/grille
 	name = "regular grille"

--- a/code/datums/craft/recipes/furniture.dm
+++ b/code/datums/craft/recipes/furniture.dm
@@ -143,10 +143,12 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 5, MATERIAL_STEEL),
 	)
+	name_craft_menu = "Office chairs"
 
 /datum/craft_recipe/furniture/office_chair/light
 	name = "light office chair"
 	result = /obj/structure/bed/chair/office/light
+	variation_type = CRAFT_VARIATION
 
 // Wheelchairs
 /datum/craft_recipe/furniture/wheelchair
@@ -163,6 +165,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 5, MATERIAL_STEEL),
 	)
+	name_craft_menu = "Comfy chairs"
 
 /datum/craft_recipe/furniture/comfy_chair/black
 	name = "black comfy chair"

--- a/code/datums/craft/recipes/furniture.dm
+++ b/code/datums/craft/recipes/furniture.dm
@@ -167,31 +167,39 @@
 /datum/craft_recipe/furniture/comfy_chair/black
 	name = "black comfy chair"
 	result = /obj/structure/bed/chair/comfy/black
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/furniture/comfy_chair/brown
 	name = "brown comfy chair"
 	result = /obj/structure/bed/chair/comfy/brown
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/furniture/comfy_chair/lime
 	name = "lime comfy chair"
 	result = /obj/structure/bed/chair/comfy/lime
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/furniture/comfy_chair/teal
 	name = "teal comfy chair"
 	result = /obj/structure/bed/chair/comfy/teal
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/furniture/comfy_chair/red
 	name = "red comfy chair"
 	result = /obj/structure/bed/chair/comfy/red
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/furniture/comfy_chair/blue
 	name = "blue comfy chair"
 	result = /obj/structure/bed/chair/comfy/blue
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/furniture/comfy_chair/purple
 	name = "purple comfy chair"
 	result = /obj/structure/bed/chair/comfy/purp
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/furniture/comfy_chair/green
 	name = "green comfy chair"
 	result = /obj/structure/bed/chair/comfy/green
+	variation_type = CRAFT_VARIATION

--- a/code/datums/craft/recipes/misc.dm
+++ b/code/datums/craft/recipes/misc.dm
@@ -111,22 +111,27 @@
 		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
 	)
 	related_stats = list(STAT_COG)
+	name_craft_menu = "Folders"
 
 /datum/craft_recipe/folder/blue
 	name = "blue folder"
 	result = /obj/item/weapon/folder/blue
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/folder/red
 	name = "red folder"
 	result = /obj/item/weapon/folder/red
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/folder/cyan
 	name = "cyan folder"
 	result = /obj/item/weapon/folder/cyan
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/folder/yellow
 	name = "yellow folder"
 	result = /obj/item/weapon/folder/yellow
+	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/bandage
 	name = "bandages"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Related to 4. of issue #2828 

This PR modifies the crafting menu by grouping the variation of the same item under a single button. For instance instead of having 9 buttons in the Furniture category for the 9 available colors of comfy chair there is now a single "Comfy chairs" button that open a prompt when you click on it in order to chose the desired color.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Quality of Life improvement by making the crafting menu more convenient to use by making it easier to reach the item you desire without scrolling through a lots of variations of items you don't want.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Hyperio
tweak: Crafting menu now regroups all variations of an item under a single option
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
