### PR TITLE
Changed how the radio prefix is read irregardless of capitlization used 

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -149,12 +149,12 @@
 //parses the message mode code (e.g. :h, :w) from text, such as that supplied to say.
 //returns the message mode string or null for no message mode.
 //standard mode is the mode returned for the special ';' radio code.
-/mob/proc/parse_message_mode(var/message, var/standard_mode="headset")
-	if(length(message) >= 1 && copytext(message,1,2) == get_prefix_key(/decl/prefix/radio_main_channel))
+/mob/proc/parse_message_mode(var/message, var/standard_mode = "headset")
+	if(length(message) >= 1 && lowertext(copytext(message,1,2)) == get_prefix_key(/decl/prefix/radio_main_channel))
 		return standard_mode
 
-	if(length(message) >= 2 && copytext(message,1,2) == get_prefix_key(/decl/prefix/radio_channel_selection))
-		var/channel_prefix =  copytext(message, 2, 3)
+	if(length(message) >= 2 && lowertext(copytext(message,1,2)) == get_prefix_key(/decl/prefix/radio_channel_selection))
+		var/channel_prefix = lowertext(copytext(message, 2, 3))
 		return department_radio_keys[channel_prefix]
 
 	return null


### PR DESCRIPTION
## About The Pull Request

Added lowertext() to this function that handles radio prefixes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The radio prefix will work whatever if they are in capitals or not.
The drawback is it limits to 26 letters and 10 single digits.

## Changelog
:cl:
tweak: Radio prefix will now work with any capitalization 
/:cl: