### PR TITLE
Add t-ray hider for storage and add example stash

### DIFF
--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -142,6 +142,10 @@ are technically visible but obscured, for example by catwalks or trash sitting o
 				continue
 			if(!O.invisibility && !O.hides_under_flooring())
 				continue //if it's already visible don't need an overlay for it
+			if(istype(O, /obj/item/weapon/storage))
+				var/obj/item/weapon/storage/S = O
+				if(S.is_tray_hidden)
+					continue
 			. += O
 
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -19,6 +19,7 @@
 	var/allow_quick_gather = null //Set this variable to allow the object to have the 'toggle mode' verb, which quickly collects all items from a tile.
 	var/collection_mode = TRUE //0 = pick one at a time, 1 = pick all on tile
 	var/use_sound = "rustle" //sound played when used. null for no sound.
+	var/is_tray_hidden = FALSE //hides from even t-rays
 
 /obj/item/weapon/storage/New()
 	can_hold |= can_hold_extra

--- a/code/modules/stashes/stash_items.dm
+++ b/code/modules/stashes/stash_items.dm
@@ -8,3 +8,7 @@
 	icon_state = "sack"
 	item_state = "sack"
 	max_w_class = ITEM_SIZE_HUGE
+/obj/item/weapon/storage/deferred/stash/sack/hidden
+	desc = "Now includes special aluminium hidding tech to hide from t-ray scanners"
+	//only value that matters, if true will hide from t-ray scanners
+	is_tray_hidden = TRUE

--- a/code/modules/stashes/stash_items.dm
+++ b/code/modules/stashes/stash_items.dm
@@ -8,6 +8,7 @@
 	icon_state = "sack"
 	item_state = "sack"
 	max_w_class = ITEM_SIZE_HUGE
+
 /obj/item/weapon/storage/deferred/stash/sack/hidden
 	desc = "Now includes special aluminium hidding tech to hide from t-ray scanners"
 	//only value that matters, if true will hide from t-ray scanners

--- a/code/modules/stashes/stash_items.dm
+++ b/code/modules/stashes/stash_items.dm
@@ -8,8 +8,4 @@
 	icon_state = "sack"
 	item_state = "sack"
 	max_w_class = ITEM_SIZE_HUGE
-
-/obj/item/weapon/storage/deferred/stash/sack/hidden
-	desc = "Now includes special aluminium hidding tech to hide from t-ray scanners"
-	//only value that matters, if true will hide from t-ray scanners
 	is_tray_hidden = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Add a way for storage containers to hide from t-ray scanners, it still needs some stress testing to see if it actuely effects performance
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
On request of reere, so you cant find stashes nearly as easily
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: A exmaple stash sack that hides from t-ray scanners

fix: storage items can now hide from t-ray scanners
code: storage now has a is_tray_hidden, if set to true it wont be found my the scanner
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
