### PR TITLE
Fix crafting system not checking the required material

### DIFF
--- a/code/datums/craft/step.dm
+++ b/code/datums/craft/step.dm
@@ -92,6 +92,14 @@
 	if(building)
 		return
 	building = TRUE
+
+	if(reqed_material && istype(I, /obj/item/stack/material))
+		var/obj/item/stack/material/M = I
+		if(M.get_default_type() != reqed_material)
+			to_chat(user, "Wrong material!")
+			building = FALSE
+			return
+
 	if(req_amount && istype(I, /obj/item/stack))
 		var/obj/item/stack/S = I
 		if(!S.can_use(req_amount))

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -42,6 +42,9 @@
 /obj/item/stack/material/get_material()
 	return material
 
+/obj/item/stack/material/proc/get_default_type()
+	return default_type
+
 /obj/item/stack/material/proc/update_strings()
 	// Update from material datum.
 	singular_name = material.sheet_singular_name


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix issue #4851 about the crafting system not checking which material is required to finish a multi-step recipe.

For instance to craft a modular console, you need 10 sheets of steel and 4 sheets of glass. When you click craft with, let's say, 10 sheets of steel in hand, it consumes the sheets and spawns a "crafting modular console" object on the ground. You're then supposed to click on this object with the 4 missing glass sheets in hand to finish the construction. However if you want to can use other materials like 4 sheets of plastic because material is not checked.

## Why It's Good For The Game

You cannot finish recipes with any material you want.

## Changelog
:cl: Hyperio
fix: Fixed crafting system not checking the required material
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
