### PR TITLE
Marshal cannot target another marshal

### DIFF
--- a/code/datums/objective/assassinate_marshal.dm
+++ b/code/datums/objective/assassinate_marshal.dm
@@ -29,7 +29,8 @@
 		 ishuman(possible_target.current) &&\
 		  (possible_target.current.stat != DEAD) &&\
 		   (player_is_ship_antag(possible_target)))
-			possible_targets.Add(possible_target)
+			if (!player_is_antag_id(possible_target, ROLE_MARSHAL)) // If player is antag, we can test their antag ID
+				possible_targets.Add(possible_target) // A marshal should not target another marshal
 	return possible_targets
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix high-priority issue #3327

Add an additional test in the function that select the marshal's assassination target to ensure that the chosen antag is not a marshal.

**I was not able to test this PR** since I did not manage to spawn a marshal with dummy human mobs. It compiles though. If you know how to quickly test it.

## Why It's Good For The Game

Marshal sould not target another marshal, they're both IH and crew sided.

## Changelog
:cl: Hyperio
fix: Fixed marshal having another marshal as assassination target
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
