### PR TITLE
Fix bedsheet duplication and storage issue

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -20,7 +20,7 @@ LINEN BINS
 	var/inuse = FALSE
 
 /obj/item/weapon/bedsheet/afterattack(atom/A, mob/user)
-	if(!user || user.incapacitated() || !user.Adjacent(A))
+	if(!user || user.incapacitated() || !user.Adjacent(A) || istype(A, /obj/structure/bedsheetbin) || istype(A, /obj/item/weapon/storage/))
 		return
 	if(toggle_fold(user))
 		user.drop_item()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix issue #4026 about a bedsheet duplication when storing it in a bedsheet bin. Basically the _toggle_fold_ of the bedsheet was triggered so one sheet was added to the bin and another appeared on top of it folded/unfolded.

Also fixed a similar problem with containers. Trying to put a folded sheet in your backpack also triggered the _toggle_fold_ and it was impossible to add it to the storage.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Duplication is bad, being able to store folded sheets in containers is nice.

## Changelog
:cl:
fix: Fixed bedsheet duplication and storage issues
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
