### PR TITLE
[MAP] New destinations for merc shuttle

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -108180,6 +108180,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/reception)
+"fMl" = (
+/obj/effect/shuttle_landmark/merc/sec3east4,
+/turf/space,
+/area/space)
 "fZX" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
 	dir = 1
@@ -108289,6 +108293,10 @@
 	},
 /turf/space,
 /area/space)
+"iIc" = (
+/obj/effect/shuttle_landmark/merc/sec3east5,
+/turf/space,
+/area/space)
 "iLh" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled/steel/panels,
@@ -108299,6 +108307,10 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/engineering/engine_room)
+"iXv" = (
+/obj/effect/shuttle_landmark/merc/engine,
+/turf/space,
+/area/space)
 "jak" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/cable/yellow{
@@ -108308,6 +108320,10 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
+"jbk" = (
+/obj/effect/shuttle_landmark/merc/mining,
+/turf/space,
+/area/space)
 "jtf" = (
 /obj/structure/table/standard,
 /obj/machinery/chem_heater,
@@ -108321,6 +108337,10 @@
 	},
 /turf/simulated/floor/tiled/steel/panels,
 /area/eris/engineering/post)
+"jBr" = (
+/obj/effect/shuttle_landmark/merc/armory,
+/turf/space,
+/area/space)
 "jDU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_medical{
@@ -108365,6 +108385,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
+"jUO" = (
+/obj/effect/shuttle_landmark/merc/atmos,
+/turf/space,
+/area/space)
 "kcK" = (
 /obj/structure/table/bar_special,
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker{
@@ -108489,6 +108513,10 @@
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/storage)
+"lIn" = (
+/obj/effect/shuttle_landmark/merc/junk,
+/turf/space,
+/area/space)
 "lUc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -108563,6 +108591,10 @@
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/engineering/engine_room)
+"ncx" = (
+/obj/effect/shuttle_landmark/merc/medbay,
+/turf/space,
+/area/space)
 "nde" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -108778,6 +108810,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep/cryo)
+"qor" = (
+/obj/effect/shuttle_landmark/merc/engieva,
+/turf/space,
+/area/space)
 "qTX" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
@@ -108868,6 +108904,10 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/engineering/engine_room)
+"sGt" = (
+/obj/effect/shuttle_landmark/merc/sec2east,
+/turf/space,
+/area/space)
 "sJL" = (
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/reinforced,
@@ -109168,6 +109208,10 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/eris/medical/chemstor)
+"xLv" = (
+/obj/effect/shuttle_landmark/merc/sec2west,
+/turf/space,
+/area/space)
 "xQh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -119371,7 +119415,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+xLv
 aaa
 aaa
 aaa
@@ -125116,7 +125160,7 @@ aQG
 aaa
 aaa
 aaa
-aaa
+jUO
 aaa
 aaa
 aaa
@@ -138321,7 +138365,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+jBr
 aaa
 aaa
 aaa
@@ -139776,7 +139820,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+sGt
 aaa
 aaa
 aaa
@@ -140823,7 +140867,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lIn
 aaa
 aaa
 aaa
@@ -198833,7 +198877,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+qor
 aaa
 aaa
 aaa
@@ -218013,7 +218057,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+jbk
 aaa
 aaa
 aaa
@@ -237798,7 +237842,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+iXv
 aaa
 aaa
 aaa
@@ -239975,7 +240019,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ncx
 aaa
 aaa
 aaa
@@ -262637,7 +262681,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+fMl
 aaa
 aaa
 aaa
@@ -299623,7 +299667,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+iIc
 aaa
 aaa
 aaa

--- a/maps/CEVEris/shuttles-eris.dm
+++ b/maps/CEVEris/shuttles-eris.dm
@@ -177,6 +177,17 @@
 		"nav_merc_southwest",
 		"nav_merc_dock",
 		"nav_merc_start",
+		"nav_merc_atmos",
+		"nav_merc_sec2west",
+		"nav_merc_sec2east",
+		"nav_merc_junk",
+		"nav_merc_armory",
+		"nav_merc_engieva",
+		"nav_merc_mining",
+		"nav_merc_medbay",
+		"nav_merc_engine",
+		"nav_merc_sec3east4",
+		"nav_merc_sec3east5"
 		)
 	shuttle_area = /area/shuttle/mercenary
 	default_docking_controller = "merc_shuttle"
@@ -220,20 +231,75 @@
 	landmark_tag = "nav_merc_transition"
 
 /obj/effect/shuttle_landmark/merc/dock
-	name = "Docking Port"
+	name = "Docking Port Deck 1"
 	icon_state = "shuttle-red"
 	landmark_tag = "nav_merc_dock"
 	dock_target = "second_sec_1_access_console"
 
 /obj/effect/shuttle_landmark/merc/northeast
-	name = "Northeast of the Vessel"
+	name = "Northeast of the Vessel Deck 5"
 	icon_state = "shuttle-red"
 	landmark_tag = "nav_merc_northeast"
 
 /obj/effect/shuttle_landmark/merc/southwest
-	name = "Southwest of the Vessel"
+	name = "Southwest of the Vessel Deck 5"
 	icon_state = "shuttle-red"
 	landmark_tag = "nav_merc_southwest"
+
+/obj/effect/shuttle_landmark/merc/atmos
+	name = "Atmospherics Deck 1"
+	icon_state = "shuttle-red"
+	landmark_tag = "nav_merc_atmos"
+
+/obj/effect/shuttle_landmark/merc/sec2west
+	name = "Section II Deck 1 West"
+	icon_state = "shuttle-red"
+	landmark_tag = "nav_merc_sec2west"
+
+/obj/effect/shuttle_landmark/merc/sec2east
+	name = "Section II Deck 1 East"
+	icon_state = "shuttle-red"
+	landmark_tag = "nav_merc_sec2east"
+
+/obj/effect/shuttle_landmark/merc/junk
+	name = "Junk Beacon Deck 1"
+	icon_state = "shuttle-red"
+	landmark_tag = "nav_merc_junk"
+
+/obj/effect/shuttle_landmark/merc/armory
+	name = "Armory Deck 1"
+	icon_state = "shuttle-red"
+	landmark_tag = "nav_merc_armory"
+
+/obj/effect/shuttle_landmark/merc/engieva
+	name = "Engineering EVA Deck 3"
+	icon_state = "shuttle-red"
+	landmark_tag = "nav_merc_engieva"
+
+/obj/effect/shuttle_landmark/merc/mining
+	name = "Mining Dock Deck 3"
+	icon_state = "shuttle-red"
+	landmark_tag = "nav_merc_mining"
+
+/obj/effect/shuttle_landmark/merc/medbay
+	name = "Medbay Deck 4"
+	icon_state = "shuttle-red"
+	landmark_tag = "nav_merc_medbay"
+
+/obj/effect/shuttle_landmark/merc/engine
+	name = "Engine Deck 4"
+	icon_state = "shuttle-red"
+	landmark_tag = "nav_merc_engine"
+
+/obj/effect/shuttle_landmark/merc/sec3east4
+	name = "Section III Deck 4 East"
+	icon_state = "shuttle-red"
+	landmark_tag = "nav_merc_sec3east4"
+
+/obj/effect/shuttle_landmark/merc/sec3east5
+	name = "Section III Deck 5 East"
+	icon_state = "shuttle-red"
+	landmark_tag = "nav_merc_sec3east5"
 
 
 //Cargo shuttle

--- a/maps/CEVEris/shuttles-eris.dm
+++ b/maps/CEVEris/shuttles-eris.dm
@@ -231,7 +231,7 @@
 	landmark_tag = "nav_merc_transition"
 
 /obj/effect/shuttle_landmark/merc/dock
-	name = "Docking Port Deck 1"
+	name = "Docking Port Deck 5"
 	icon_state = "shuttle-red"
 	landmark_tag = "nav_merc_dock"
 	dock_target = "second_sec_1_access_console"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds new landmarks in space for the merc shuttle. There is now a landmark near all external airlocks of the ship. Merc shuttle parks in space near those airlocks and then mercs have to do a bit of space walk to reach them.

![alt text](https://media.discordapp.net/attachments/684117567253643323/713357115137196032/new_landmarks.png)

## Why It's Good For The Game

New landmarks make the location of merc shuttle less predictible. They could also be used for others ships or events.

## Changelog
:cl: Hyperio
add: Added new destinations in space for merc shuttle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
