### PR TITLE
Port various antiraid/antigrief measures

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -1243,6 +1243,7 @@
 #include "code\modules\admin\verbs\adminpm.dm"
 #include "code\modules\admin\verbs\adminsay.dm"
 #include "code\modules\admin\verbs\antag-ooc.dm"
+#include "code\modules\admin\verbs\antiraid.dm"
 #include "code\modules\admin\verbs\appearance_testing.dm"
 #include "code\modules\admin\verbs\atmosdebug.dm"
 #include "code\modules\admin\verbs\BrokenInhands.dm"

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -97,6 +97,17 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 	var/githuburl
 	var/discordurl
 
+	var/static/ip_reputation = FALSE		//Should we query IPs to get scores? Generates HTTP traffic to an API service.
+	var/static/ipr_email					//Left null because you MUST specify one otherwise you're making the internet worse.
+	var/static/ipr_block_bad_ips = FALSE	//Should we block anyone who meets the minimum score below? Otherwise we just log it (If paranoia logging is on, visibly in chat).
+	var/static/ipr_bad_score = 1			//The API returns a value between 0 and 1 (inclusive), with 1 being 'definitely VPN/Tor/Proxy'. Values equal/above this var are considered bad.
+	var/static/ipr_allow_existing = FALSE 	//Should we allow known players to use VPNs/Proxies? If the player is already banned then obviously they still can't connect.
+	var/static/ipr_minimum_age = 5			//How many days before a player is considered 'fine' for the purposes of allowing them to use VPNs.
+	var/static/ipqualityscore_apikey		//API key for ipqualityscore.com. Optional additional service that can be used if an API key is provided.
+
+	var/static/panic_bunker = FALSE			//Only allow ckeys who have already been seen by the DB. Only makes sense if you have a DB.
+	var/static/paranoia_logging = FALSE		//Log new byond accounts and first-time joins
+
 	//Alert level description
 	var/alert_desc_green = "All threats to the ship have passed. Security may not have weapons visible, privacy laws are once again fully enforced."
 	var/alert_desc_blue_upto = "The station has received reliable information about possible hostile activity on the station. Security staff may have weapons visible, random searches are permitted."
@@ -415,6 +426,33 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 
 				if ("githuburl")
 					config.githuburl = value
+
+				if("ip_reputation")
+					config.ip_reputation = 1
+
+				if("ipr_email")
+					config.ipr_email = value
+
+				if("ipr_block_bad_ips")
+					config.ipr_block_bad_ips = 1
+
+				if("ipr_bad_score")
+					config.ipr_bad_score = text2num(value)
+
+				if("ipr_allow_existing")
+					config.ipr_allow_existing = 1
+
+				if("ipr_minimum_age")
+					config.ipr_minimum_age = text2num(value)
+			
+				if ("ipqualityscore_apikey")
+					config.ipqualityscore_apikey = value
+
+				if ("panic_bunker")
+					config.panic_bunker = 1
+
+				if ("paranoia_logging")
+					config.paranoia_logging = 1
 
 				if ("ghosts_can_possess_animals")
 					config.ghosts_can_possess_animals = value

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -103,22 +103,28 @@ var/list/admin_ranks = list() //list of all ranks with associated rights
 /hook/startup/proc/loadAdmins()
 	clear_admin_datums()
 
+	if(config.admin_legacy_system)
+		load_admins_legacy()
+		return TRUE
+
 	establish_db_connection()
 	if(!dbcon.IsConnected())
 		error("Failed to connect to database in load_admins(). Reverting to legacy system.")
 		log_misc("Failed to connect to database in load_admins(). Reverting to legacy system.")
 		load_admins_legacy()
-		return
+		return FALSE
 
 	else
 		load_admins()
 
-		if(!admin_datums)
+		if(!LAZYLEN(admin_datums))
 			error("The database query in load_admins() resulted in no admins being added to the list. Reverting to legacy system.")
 			log_misc("The database query in load_admins() resulted in no admins being added to the list. Reverting to legacy system.")
 			config.admin_legacy_system = 1
 			load_admins_legacy()
-			return
+			return FALSE
+	
+	return TRUE
 
 /proc/load_admins()
 	var/DBQuery/query = dbcon.NewQuery("SELECT ckey, rank, flags FROM players WHERE rank != 'player'")

--- a/code/modules/admin/verbs/antiraid.dm
+++ b/code/modules/admin/verbs/antiraid.dm
@@ -1,0 +1,45 @@
+ADMIN_VERB_ADD(/client/proc/panicbunker, R_ADMIN, FALSE)
+/client/proc/panicbunker()
+	set category = "Server"
+	set name = "Toggle Panic Bunker"
+	
+	if(!check_rights(R_ADMIN))
+		return
+
+	if (!config.sql_enabled)
+		to_chat(usr, "<span class='adminnotice'>The Database is not enabled!</span>")
+		return
+
+	config.panic_bunker = (!config.panic_bunker)
+
+	log_and_message_admins("[key_name(usr)] has toggled the Panic Bunker, it is now [(config.panic_bunker?"on":"off")].")
+	if (config.panic_bunker && (!dbcon || !dbcon.IsConnected()))
+		message_admins("The database is not connected! Panic bunker will not work until the connection is reestablished.")
+
+ADMIN_VERB_ADD(/client/proc/paranoia_logging, R_ADMIN, FALSE)
+/client/proc/paranoia_logging()
+	set category = "Server"
+	set name = "New Player Warnings"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	config.paranoia_logging = (!config.paranoia_logging)
+
+	log_and_message_admins("[key_name(usr)] has toggled Paranoia Logging, it is now [(config.paranoia_logging?"on":"off")].")
+	if (config.paranoia_logging && (!dbcon || !dbcon.IsConnected()))
+		message_admins("The database is not connected! Paranoia logging will not be able to give 'player age' (time since first connection) warnings, only Byond account warnings.")
+
+ADMIN_VERB_ADD(/client/proc/ip_reputation, R_ADMIN, FALSE)
+/client/proc/ip_reputation()
+	set category = "Server"
+	set name = "Toggle IP Rep Checks"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	config.ip_reputation = (!config.ip_reputation)
+
+	log_and_message_admins("[key_name(usr)] has toggled IP reputation checks, it is now [(config.ip_reputation?"on":"off")].")
+	if (config.ip_reputation && (!dbcon || !dbcon.IsConnected()))
+		message_admins("The database is not connected! IP reputation logging will not be able to allow existing players to bypass the reputation checks (if that is enabled).")

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -279,6 +279,7 @@
 /client/proc/register_in_db()
 	registration_date = src.get_registration_date()
 	src.get_country()
+	src.get_byond_age() // Get days since byond join
 
 	var/DBQuery/query_insert = dbcon.NewQuery("INSERT INTO players (ckey, first_seen, last_seen, registered, ip, cid, rank, byond_version, country) VALUES ('[src.ckey]', Now(), Now(), '[registration_date]', '[sql_sanitize_text(src.address)]', '[sql_sanitize_text(src.computer_id)]', 'player', [src.byond_version], '[src.country_code]')")
 	if(!query_insert.Execute())
@@ -286,44 +287,105 @@
 		return
 
 	else
-		var/DBQuery/get_player_id = dbcon.NewQuery("SELECT id FROM players WHERE ckey = '[src.ckey]'")
+		var/DBQuery/get_player_id = dbcon.NewQuery("SELECT id, first_seen FROM players WHERE ckey = '[src.ckey]'")
 		get_player_id.Execute()
 		if(get_player_id.NextRow())
 			src.id = get_player_id.item[1]
+			src.first_seen = get_player_id.item[2]
 
+//Not actually age, but rather time since first seen in days
+/client/proc/get_player_age()
+	if(first_seen && dbcon.IsConnected())
+		var/dateSQL = sanitizeSQL(first_seen)
+		var/DBQuery/query_datediff = dbcon.NewQuery("SELECT DATEDIFF(Now(),'[dateSQL]')")
+		if(query_datediff.Execute() && query_datediff.NextRow())
+			src.first_seen_days_ago = text2num(query_datediff.item[1])
+	
+	if(config.paranoia_logging && isnum(src.first_seen_days_ago) && src.first_seen_days_ago == 0)
+		log_and_message_admins("PARANOIA: [key_name(src)] has connected here for the first time.")
+	return src.first_seen_days_ago
+
+//Days since they signed up for their byond account
+/client/proc/get_byond_age()
+	if(!registration_date)
+		get_registration_date()
+	if(registration_date && dbcon.IsConnected())
+		var/dateSQL = sanitizeSQL(registration_date)
+		var/DBQuery/query_datediff = dbcon.NewQuery("SELECT DATEDIFF(Now(),'[dateSQL]')")
+		if(query_datediff.Execute() && query_datediff.NextRow())
+			src.account_age_in_days = text2num(query_datediff.item[1])
+	if(config.paranoia_logging && isnum(src.account_age_in_days) && src.account_age_in_days <= 2)
+		log_and_message_admins("PARANOIA: [key_name(src)] has a very new Byond account. ([src.account_age_in_days] days old)")
+	return src.account_age_in_days
 
 /client/proc/log_client_to_db()
 	if(IsGuestKey(src.key))
 		return
 
 	establish_db_connection()
-	if(!dbcon.IsConnected())
-		return
-
-	// check if client already registered in db
-	var/DBQuery/query = dbcon.NewQuery("SELECT id from players WHERE ckey = '[src.ckey]'")
-	if(!query.Execute())
-		log_world("Failed to get player record for user with ckey '[src.ckey]'. Error message: [query.ErrorMsg()].")
-		// don't know how to properly handle this case so let's just quit
-		return
-	else
-		if(query.NextRow())
+	if(dbcon.IsConnected())
+		// Get existing player from DB
+		var/DBQuery/query = dbcon.NewQuery("SELECT id from players WHERE ckey = '[src.ckey]'")
+		if(!query.Execute())
+			log_world("Failed to get player record for user with ckey '[src.ckey]'. Error message: [query.ErrorMsg()].")
+		
+		// Not their first time here
+		else if(query.NextRow())
 			// client already registered so we fetch all needed data
-			query = dbcon.NewQuery("SELECT id, registered FROM players WHERE id = [query.item[1]]")
+			query = dbcon.NewQuery("SELECT id, registered, first_seen FROM players WHERE id = [query.item[1]]")
 			query.Execute()
 			if(query.NextRow())
 				src.id = query.item[1]
 				src.registration_date = query.item[2]
+				src.first_seen = query.item[3]
 				src.get_country()
 
 				//Player already identified previously, we need to just update the 'lastseen', 'ip' and 'computer_id' variables
 				var/DBQuery/query_update = dbcon.NewQuery("UPDATE players SET last_seen = Now(), ip = '[src.address]', cid = '[src.computer_id]', byond_version = '[src.byond_version]', country = '[src.country_code]' WHERE id = [src.id]")
-
+				
 				if(!query_update.Execute())
 					log_world("Failed to update players table for user with id [src.id]. Error message: [query_update.ErrorMsg()].")
-					return
+		
+		//Panic bunker - player not in DB, so they get kicked
+		else if(config.panic_bunker && !holder && !deadmin_holder)
+			log_adminwarn("Failed Login: [key] - New account attempting to connect during panic bunker")
+			message_admins("<span class='adminnotice'>Failed Login: [key] - New account attempting to connect during panic bunker</span>")
+			to_chat(src, "<span class='warning'>Sorry but the server is currently not accepting connections from never before seen players.</span>")
+			del(src)
+			return 0
+
+	src.get_byond_age() // Get days since byond join
+	src.get_player_age() // Get days since first seen
+
+	// IP Reputation Check
+	if(config.ip_reputation)
+		if(config.ipr_allow_existing && first_seen_days_ago >= config.ipr_minimum_age)
+			log_admin("Skipping IP reputation check on [key] with [address] because of player age")
+		else if(holder)
+			log_admin("Skipping IP reputation check on [key] with [address] because they have a staff rank")
+		else if(update_ip_reputation()) //It is set now
+			if(ip_reputation >= config.ipr_bad_score) //It's bad
+
+				//Log it
+				if(config.paranoia_logging) //We don't block, but we want paranoia log messages
+					log_and_message_admins("[key] at [address] has bad IP reputation: [ip_reputation]. Will be kicked if enabled in config.")
+				else //We just log it
+					log_admin("[key] at [address] has bad IP reputation: [ip_reputation]. Will be kicked if enabled in config.")
+
+				//Take action if required
+				if(config.ipr_block_bad_ips && config.ipr_allow_existing) //We allow players of an age, but you don't meet it
+					to_chat(src, "Sorry, we only allow VPN/Proxy/Tor usage for players who have spent at least [config.ipr_minimum_age] days on the server. If you are unable to use the internet without your VPN/Proxy/Tor, please contact an admin out-of-game to let them know so we can accommodate this.")
+					del(src)
+					return 0
+				else if(config.ipr_block_bad_ips) //We don't allow players of any particular age
+					to_chat(src, "Sorry, we do not accept connections from users via VPN/Proxy/Tor connections. If you think this is in error, contact an administrator out of game.")
+					del(src)
+					return 0
 		else
-			src.register_in_db()
+			log_admin("Couldn't perform IP check on [key] with [address]")
+	
+	if(id < 0)
+		src.register_in_db()
 
 #undef UPLOAD_LIMIT
 
@@ -428,3 +490,110 @@
 	if(UI)
 		qdel(UI)
 		UI = null
+
+//Uses a couple different services
+/client/proc/update_ip_reputation()
+	var/list/scores = list("GII" = ipr_getipintel())
+	if(config.ipqualityscore_apikey)
+		scores["IPQS"] = ipr_ipqualityscore()
+	/* Can add other systems if desirable
+	if(config.blah_apikey)
+		scores["blah"] = some_proc()
+	*/
+
+	var/log_output = "IP Reputation [key] from [address]"
+	var/worst = 0
+
+	for(var/service in scores)
+		var/score = scores[service]
+		if(score > worst)
+			worst = score
+		log_output += " - [service] ([num2text(score)])"
+
+	log_admin(log_output)
+	ip_reputation = worst
+	return TRUE
+
+//Service returns a single float in html body
+/client/proc/ipr_getipintel()
+	if(!config.ipr_email)
+		return -1
+
+	var/request = "http://check.getipintel.net/check.php?ip=[address]&contact=[config.ipr_email]"
+	var/http[] = world.Export(request)
+
+	if(!http || !islist(http)) //If we couldn't check, the service might be down, fail-safe.
+		log_admin("Couldn't connect to getipintel.net to check [address] for [key]")
+		return -1
+
+	//429 is rate limit exceeded
+	if(text2num(http["STATUS"]) == 429)
+		log_and_message_admins("getipintel.net reports HTTP status 429. IP reputation checking is now disabled. If you see this, let a developer know.")
+		config.ip_reputation = FALSE
+		return -1
+
+	var/content = file2text(http["CONTENT"]) //world.Export actually returns a file object in CONTENT
+	var/score = text2num(content)
+	if(isnull(score))
+		return -1
+
+	//Error handling
+	if(score < 0)
+		var/fatal = TRUE
+		var/ipr_error = "getipintel.net IP reputation check error while checking [address] for [key]: "
+		switch(score)
+			if(-1)
+				ipr_error += "No input provided"
+			if(-2)
+				fatal = FALSE
+				ipr_error += "Invalid IP provided"
+			if(-3)
+				fatal = FALSE
+				ipr_error += "Unroutable/private IP (spoofing?)"
+			if(-4)
+				fatal = FALSE
+				ipr_error += "Unable to reach database"
+			if(-5)
+				ipr_error += "Our IP is banned or otherwise forbidden"
+			if(-6)
+				ipr_error += "Missing contact info"
+
+		log_and_message_admins(ipr_error)
+		if(fatal)
+			config.ip_reputation = FALSE
+			log_and_message_admins("With this error, IP reputation checking is disabled for this shift. Let a developer know.")
+		return -1
+
+	//Went fine
+	else
+		return score
+
+//Service returns JSON in html body
+/client/proc/ipr_ipqualityscore()
+	if(!config.ipqualityscore_apikey)
+		return -1
+
+	var/request = "http://www.ipqualityscore.com/api/json/ip/[config.ipqualityscore_apikey]/[address]?strictness=1&fast=true&byond_key=[key]"
+	var/http[] = world.Export(request)
+
+	if(!http || !islist(http)) //If we couldn't check, the service might be down, fail-safe.
+		log_admin("Couldn't connect to ipqualityscore.com to check [address] for [key]")
+		return -1
+
+	var/content = file2text(http["CONTENT"]) //world.Export actually returns a file object in CONTENT
+	var/response = json_decode(content)
+	if(isnull(response))
+		return -1
+
+	//Error handling
+	if(!response["success"])
+		log_admin("IPQualityscore.com returned an error while processing [key] from [address]: " + response["message"])
+		return -1
+
+	var/score = 0
+	if(response["proxy"])
+		score = 100
+	else
+		score = response["fraud_score"]
+
+	return score/100 //To normalize with the 0.0 to 1.0 scores.

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -35,6 +35,8 @@
 	var/irc_admin			//IRC admin that spoke with them last.
 	var/mute_irc = 0
 	var/warned_about_multikeying = 0	// Prevents people from being spammed about multikeying every time their mob changes.
+	var/ip_reputation = 0 //Do we think they're using a proxy/vpn? Only if IP Reputation checking is enabled in config.
+	var/account_age_in_days // Byond account age
 
 
 		////////////////////////////////////
@@ -42,8 +44,10 @@
 		////////////////////////////////////
 	var/id = -1
 	var/registration_date = ""
+	var/first_seen = ""
 	var/country = ""
 	var/country_code = ""
+	var/first_seen_days_ago
 
 	// This was 0
 	// so Bay12 can set it to an URL once the player logs in and have them download the resources from a different server.

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -319,3 +319,32 @@ EMOJIS
 
 WEBHOOK_URL http://localhost:44303/webhook/en
 WEBHOOK_KEY testkey
+
+###### IP Reputation Checking
+# Enable/disable IP reputation checking (present/nonpresent)
+#IP_REPUTATION
+
+# Set the e-mail address problems can go to for IPR checks (e-mail address)
+IPR_EMAIL whatever@whatever.com
+
+# Above this value, reputation scores are considered 'bad' (number)
+IPR_BAD_SCORE 1
+
+# If you want the people disconnected. Otherwise it just logs. (present/nonpresent)
+IPR_BLOCK_BAD_IPS
+
+# If players of a certain length of playtime are allowed anyway (REQUIRES DATABASE) (present/nonpresent)
+IPR_ALLOW_EXISTING
+
+# And what that age is (number)
+IPR_MINIMUM_AGE 5
+
+# If provided, will look up additional IP reputation info from ipqualityscore.com
+#IPQUALITYSCORE_APIKEY ABC12345YOURKEYHERE
+
+###### Antiraid Settings
+# Enable/disable 'paranoia logging' (notifying admins of new byond accounts joining, and player first-time joins)
+#PARANOIA_LOGGING
+
+# Enable/disable 'panic bunker' (prevents new players from joining if they've never been seen before in the DB)
+#PANIC_BUNKER


### PR DESCRIPTION
Gifts from elsewhere.

I tested these a reasonable amount, but I'd suggest you test them too, since the testing would be more authentic if you use them with your real settings and real DB and such.

## Panic Bunker (config/verb)
When enabled, only players who have previously joined and been logged in the DB will be allowed to join. If they have not been logged in the DB, they will be kicked, and not logged in the DB (otherwise they could just rejoin and then they'd pass the test, you know?). Config option to enable it always (probably not a good idea), and R_ADMIN verb for toggling ingame.

## Paranoia Logging (config/verb)
When enabled, admins will be warned in two cases:
- A player joins who has never joined before
- A player joins with a very new byond account (0-2 days old)

Available as a config option to enable it forever, or an R_ADMIN verb ('New Player Logging').

## IP Reputation Checking (config/verb)
When enabled, connecting IPs will be queried through 1 or 2 (your option) IP reputation scoring services. The system will then take the worst score (normalized to 0.0 to 1.0, with higher being worse), and compare it to your config threshold for worst allowed score. It will then either alert admins, or kick them.

Additionally, you can configure a time period after which the player is effectively whitelisted and no longer checked (default is that their DB first seen time is 5 days ago). This cuts down on queries to the IP reputation services, and I'd recommend it, otherwise they may begin dropping your queries. This can be toggled via a verb ingame if there are issues, and ignores all admins with regards to testing their IPs.

## New configurations
```
###### IP Reputation Checking
# Enable/disable IP reputation checking (present/nonpresent)
#IP_REPUTATION

# Set the e-mail address problems can go to for IPR checks (e-mail address)
IPR_EMAIL whatever@whatever.com

# Above this value, reputation scores are considered 'bad' (number)
IPR_BAD_SCORE 1

# If you want the people disconnected. Otherwise it just logs. (present/nonpresent)
IPR_BLOCK_BAD_IPS

# If players of a certain length of playtime are allowed anyway (REQUIRES DATABASE) (present/nonpresent)
IPR_ALLOW_EXISTING

# And what that age is (number)
IPR_MINIMUM_AGE 5

# If provided, will look up additional IP reputation info from ipqualityscore.com
#IPQUALITYSCORE_APIKEY ABC12345YOURKEYHERE

###### Antiraid Settings
# Enable/disable 'paranoia logging' (notifying admins of new byond accounts joining, and player first-time joins)
#PARANOIA_LOGGING

# Enable/disable 'panic bunker' (prevents new players from joining if they've never been seen before in the DB)
#PANIC_BUNKER
```