### PR TITLE
Fixes infinite loop in cash bundle inspiration

### DIFF
--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -107,7 +107,7 @@
 	var/points = min(worth/CASH_PER_STAT, 10) // capped at 10 points per bundle, costs 50k
 	var/list/stats = list()
 	// Distribute points evenly with random statistics. Just skips the loop if there's not enough money in the bundle, resulting in an empty list.
-	while(points)
+	while(points > 0)
 		stats[pick(ALL_STATS)] += 1 // Picks a random stat, if not present it adds it with a value of 1, else it increases the value by 1
 		points--
 	worth -= points*CASH_PER_STAT


### PR DESCRIPTION
Byond took the MC out back and shot it in the head when cash bundle decided to get stuck on fraction points

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: drexample
fix: fixes using cash bundle as oddity crashing the server
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
