### PR TITLE
Fix runtime with perks in mob.dm

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1104,12 +1104,13 @@ mob/proc/yank_out_object()
 	"}
 	// Perks
 	var/list/Plist = list()
-	for(var/perk in stats.perks)
-		var/datum/perk/P = perk
-		var/filename = sanitizeFileName("[P.type].png")
-		var/asset = asset_cache.cache[filename] // this is definitely a hack, but getAtomCacheFilename accepts only atoms for no fucking reason whatsoever.
-		if(asset)
-			Plist += "<td valign='middle'><img src=[filename]></td><td><span style='text-align:center'>[P.name]<br>[P.desc]</span></td>"
+	if (stats) // Check if mob has stats. Otherwise we cannot read null.perks
+		for(var/perk in stats.perks)
+			var/datum/perk/P = perk
+			var/filename = sanitizeFileName("[P.type].png")
+			var/asset = asset_cache.cache[filename] // this is definitely a hack, but getAtomCacheFilename accepts only atoms for no fucking reason whatsoever.
+			if(asset)
+				Plist += "<td valign='middle'><img src=[filename]></td><td><span style='text-align:center'>[P.name]<br>[P.desc]</span></td>"
 	data += {"
 		<table width=80%>
 			<th colspan=2>Perks</th>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix a runtime issue when trying to read perks with the Show stats and perks verb.
It happens when the mob that uses this verb has no stats (ghost, mouse, borer for instance)

> [12:52:29] Runtime in mob.dm,1107: Cannot read null.perks
>    usr: The mouse (242) (zamoplay) (/mob/observer/ghost)
>   usr.loc: The open space (113,112,3) (/turf/simulated/open)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Runtimes are bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Hyperio
fix: Fixed a runtime when trying to read stats and perks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
