### PR TITLE
Fix runtime in who.dm

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -28,6 +28,8 @@
 								entry += " - <font color='black'><b>DEAD</b></font>"
 						else
 							entry += " - <font color='black'><b>DEAD</b></font>"
+			else
+				entry += " - <font color='gray'>In Lobby</font>"
 
 			if(is_special_character(C.mob))
 				entry += " - <b><font color='red'>Antagonist</font></b>"

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -15,7 +15,7 @@
 				entry += " - Ready as [C.prefs.real_name]"
 			else
 				entry += " - Playing as [C.mob.real_name]"
-			if (C.mob) // check if the client has a mob component otherwise we cannot read null.stat
+			if (!istype(C.mob, /mob/new_player)) // /mob/new_player has no stat (happens if client is a new player)
 				switch(C.mob.stat)
 					if(UNCONSCIOUS)
 						entry += " - <font color='darkgray'><b>Unconscious</b></font>"

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -15,18 +15,19 @@
 				entry += " - Ready as [C.prefs.real_name]"
 			else
 				entry += " - Playing as [C.mob.real_name]"
-			switch(C.mob.stat)
-				if(UNCONSCIOUS)
-					entry += " - <font color='darkgray'><b>Unconscious</b></font>"
-				if(DEAD)
-					if(isghost(C.mob))
-						var/mob/observer/ghost/O = C.mob
-						if(O.started_as_observer)
-							entry += " - <font color='gray'>Observing</font>"
+			if (C.mob) // check if the client has a mob component otherwise we cannot read null.stat
+				switch(C.mob.stat)
+					if(UNCONSCIOUS)
+						entry += " - <font color='darkgray'><b>Unconscious</b></font>"
+					if(DEAD)
+						if(isghost(C.mob))
+							var/mob/observer/ghost/O = C.mob
+							if(O.started_as_observer)
+								entry += " - <font color='gray'>Observing</font>"
+							else
+								entry += " - <font color='black'><b>DEAD</b></font>"
 						else
 							entry += " - <font color='black'><b>DEAD</b></font>"
-					else
-						entry += " - <font color='black'><b>DEAD</b></font>"
 
 			if(is_special_character(C.mob))
 				entry += " - <b><font color='red'>Antagonist</font></b>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix runtime in who.dm when trying to read `C.mob.stat` when `C.mob` is `null`.

Added a check for the existence of `C.mob`

> [19:42:54] Runtime in who.dm,18: Cannot read null.stat
>    proc name: Who (/client/verb/who)
>   usr: Fisk06 (fisk06) (/mob/new_player)
>   src: Fisk06 (/client)
>   call stack:
>   Fisk06 (/client): Who()

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Runtimes are bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Hyperio
fix: Fixed runtime in who.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
