### PR TITLE
Fix runtime in spiderbot.dm

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -200,8 +200,9 @@
 	if(camera)
 		camera.status = 0
 
-	held_item.loc = src.loc
-	held_item = null
+	if (held_item): // if the spiderbot is holding an item
+		held_item.loc = src.loc
+		held_item = null
 
 	gibs(loc, null, null, /obj/effect/gibspawner/robot) //TODO: use gib() or refactor spiderbots into synthetics.
 	qdel(src)

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -200,7 +200,7 @@
 	if(camera)
 		camera.status = 0
 
-	if (held_item): // if the spiderbot is holding an item
+	if (held_item) // if the spiderbot is holding an item
 		held_item.loc = src.loc
 		held_item = null
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix runtime in spiderbot.dm when trying to assign src.loc to held_item.loc with held_item being null.

> [19:27:19] Runtime in spiderbot.dm,203: Cannot modify null.loc.

## Why It's Good For The Game

Runtimes are bad.

## Changelog
:cl: Hyperio
fix: Fixed runtime in spiderbot.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
