### PR TITLE
Fix runtime in priest.dm

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -277,8 +277,11 @@
 
 
 /datum/ritual/cruciform/priest/short_boost/proc/take_boost(mob/living/carbon/human/participant, stat, amount)
-	participant.stats.changeStat(stat, -amount)
-	to_chat(participant, SPAN_WARNING("Your knowledge of [get_stats_to_text()] feels lessened."))
+	// take_boost is automatically triggered by a callback function when the boost ends but the participant 
+	// may have been deleted during the duration of the boost
+	if (participant) // check if participant still exists otherwise we cannot read null.stats
+		participant.stats.changeStat(stat, -amount)
+		to_chat(participant, SPAN_WARNING("Your knowledge of [get_stats_to_text()] feels lessened."))
 
 /datum/ritual/cruciform/priest/short_boost/proc/get_stats_to_text()
 	if(stats_to_boost.len == 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix a runtime in priest.dm when removing a ritual boost from a participant when this participant no longer exists. It can happen if the participant is deleted between the moment the boost is received and the moment the boost ends (since the `take_boost` is an automatic callback).

> [19:28:16] Runtime in priest.dm,280: Cannot read null.stats

## Why It's Good For The Game

Runtimes are bad.

## Changelog
:cl: Hyperio
fix: Fixed runtime in priest.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
