### PR TITLE
Fix runtime in mind.dm

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -90,12 +90,12 @@
 		current.mind = null
 
 		SSnano.user_transferred(current, new_character) // transfer active NanoUI instances to new user
-	if(new_character.mind)		//remove any mind currently in our new body's mind variable
-		new_character.mind.current = null
 
-	if (current) // check if current exists otherwise we cannot read current.client
 		if(current.client)
 			current.client.destroy_UI()
+
+	if(new_character.mind)		//remove any mind currently in our new body's mind variable
+		new_character.mind.current = null
 
 	current = new_character		//link ourself to our new body
 	new_character.mind = src	//and link our new body to ourself

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -93,8 +93,9 @@
 	if(new_character.mind)		//remove any mind currently in our new body's mind variable
 		new_character.mind.current = null
 
-	if(current.client)
-		current.client.destroy_UI()
+	if (current) // check if current exists otherwise we cannot read current.client
+		if(current.client)
+			current.client.destroy_UI()
 
 	current = new_character		//link ourself to our new body
 	new_character.mind = src	//and link our new body to ourself


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix runtime in mind.dm when trying to check `current.mind` with `current` being `null`.

Considering that at the beginning there is a check for 
```
if(current)	//remove ourself from our old body's mind variable
	if(changeling)
		[...]
```
the possibility that `current` could be `null` seems to be expected.
 
> [19:04:26] Runtime in mind.dm,96: Cannot read null.client
>    usr: Francis Fuchs (as Pablo Mand) (coolfoolftw) (/mob/living/carbon/human)
>   usr.loc: The floor (115,114,2) (/turf/simulated/floor/tiled/dark)

## Why It's Good For The Game

Runtimes are bad.

## Changelog
:cl: Hyperio
fix: Fixed runtime in mind.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
