### PR TITLE
Fixed damage type of the combat drone's laser. 

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -274,7 +274,7 @@
 	. = ..()
 
 /obj/item/projectile/beam/drone
-	damage_types = list(BRUTE = 15)
+	damage_types = list(BURN = 15)
 
 /obj/item/projectile/beam/pulse/drone
-	damage_types = list(BRUTE = 10)
+	damage_types = list(BURN = 10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Combat drone's laser used to do brute damage, changed it to laser. I hope this is the right pull request
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lasers that make brute damage feel too "early Neal Stephenson-ish" kind of cyberpunk, so I think burn damage makes it more grounded.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
Combat drone's laser went from "BRUTE" to "BURN"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
