### PR TITLE
Fix blitzshell blood extraction and ancient teleporter restriction.

### DIFF
--- a/code/game/objects/items/weapons/storage/bsdm.dm
+++ b/code/game/objects/items/weapons/storage/bsdm.dm
@@ -75,3 +75,17 @@
 
 /obj/item/weapon/storage/bsdm/permanent
 	del_on_send = FALSE
+
+/obj/item/weapon/storage/bsdm/permanent/attackby(obj/item/W as obj, mob/user as mob)
+	..()
+
+	if(istype(W, /obj/item/weapon/reagent_containers/syringe/blitzshell))
+		var/obj/item/weapon/reagent_containers/syringe/blitzshell/syringe_blitzshell = W
+		if(syringe_blitzshell.reagents.total_volume)
+			var/trans
+			var/obj/item/weapon/reagent_containers/glass/beaker/vial/vial_blitzshell = new /obj/item/weapon/reagent_containers/glass/beaker/vial(src)
+			trans = syringe_blitzshell.reagents.trans_to(vial_blitzshell, syringe_blitzshell.reagents.total_volume)
+			to_chat(user ,SPAN_NOTICE("You transfer [trans] units of the solution from [syringe_blitzshell] to [src]"))
+			return handle_item_insertion(vial_blitzshell)
+
+	return handle_item_insertion(W)

--- a/code/modules/dungeons/teleporter.dm
+++ b/code/modules/dungeons/teleporter.dm
@@ -112,6 +112,9 @@
 	for(var/mob/living/silicon/robot/R in range(8, src))//Borgs too
 		victims_to_teleport += R
 
+	for(var/mob/living/exosuit/E in range(8, src))//And exosuits too
+		victims_to_teleport += E
+
 	for(var/mob/living/M in victims_to_teleport)
 		M.forceMove(get_turf(target))
 

--- a/code/modules/mob/living/silicon/robot/drone/blitzshell.dm
+++ b/code/modules/mob/living/silicon/robot/drone/blitzshell.dm
@@ -52,7 +52,7 @@
 	//Objective stuff
 	modules += new /obj/item/weapon/storage/bsdm/permanent(src) //for sending off item contracts
 	modules += new /obj/item/weapon/gripper/antag(src) //For picking up item contracts
-	modules += new /obj/item/weapon/reagent_containers/syringe(src) //Blood extraction
+	modules += new /obj/item/weapon/reagent_containers/syringe/blitzshell(src) //Blood extraction
 	modules += new /obj/item/device/drone_uplink(src)
 	//Misc equipment
 	modules += new /obj/item/weapon/card/id/syndicate(src) //This is our access. Scan cards to get better access

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -21,6 +21,7 @@
 	unacidable = 1 //glass
 	reagent_flags = TRANSPARENT
 	var/mode = SYRINGE_DRAW
+	var/breakable = TRUE
 	var/image/filling //holds a reference to the current filling overlay
 	var/visible_name = "a syringe"
 	var/time = 30
@@ -291,6 +292,9 @@
 	break_syringe(target, user)
 
 /obj/item/weapon/reagent_containers/syringe/proc/break_syringe(mob/living/carbon/target, mob/living/carbon/user)
+	if(!breakable)
+		return
+
 	desc += " It is broken."
 	mode = SYRINGE_BROKEN
 	if(target)
@@ -298,6 +302,11 @@
 	if(user)
 		add_fingerprint(user)
 	update_icon()
+
+/obj/item/weapon/reagent_containers/syringe/blitzshell
+	name = "blitzshell syringe"
+	desc = "A blitzshell syringe."
+	breakable = FALSE
 
 /obj/item/weapon/reagent_containers/syringe/ld50_syringe
 	name = "lethal injection syringe"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Blitzshell drone can now do blood extraction contracts, with unbreakable syringe.
Exosuits can now also be teleported by Ancient teleporter.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Blitzshell drone can now do blood extraction contracts.
Exosuits can now also be teleported by Ancient teleporter.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: DarkLevel
fix: Blitzshell drone can now do blood extraction contracts.
fix: Ancient teleporter will teleport exosuits as well.
/:cl: DarkLevel

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
