### PR TITLE
Fixed some AI's text that called the CV Eris "station"

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -274,7 +274,7 @@
 	. = ..()
 
 /obj/item/projectile/beam/drone
-	damage_types = list(BRUTE = 15)
+	damage_types = list(BURN = 15)
 
 /obj/item/projectile/beam/pulse/drone
-	damage_types = list(BRUTE = 10)
+	damage_types = list(BURN = 10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Some descripcion text of the AI's used "station" (job description at the start of a round, Ai annoncements's text), so I changed it to "spaceship" or "ship"
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This way, the AI's text uses the correct nomination for the CV Eris. Used both "spaceship" and "ship" to avoid repetition, making a bit "cooler" to read. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
"You are the station's AI" is now "You are the spaceship's AI"
"Make station annoncement" is now "Make spaceship annoncement"
"Station's crew" is now "ship's crew"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
