### PR TITLE
Tweaks some cells

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -66,12 +66,12 @@
 	maxcharge = 13000
 
 /obj/item/weapon/cell/large/excelsior
-	name = "Excelsior \"Zarya 11000L\""
+	name = "Excelsior \"Zarya 15000L\""
 	desc = "Commie rechargeable L-standardized power cell. Power to the people!"
 	icon_state = "exs_l"
-	origin_tech = list(TECH_POWER = 3)
+	origin_tech = list(TECH_POWER = 4)
 	matter = list(MATERIAL_STEEL = 6, MATERIAL_PLASTIC = 3)
-	maxcharge = 11000
+	maxcharge = 15000
 
 //Meme cells - for fun and cancer
 
@@ -169,7 +169,7 @@
 	name = "Excelsior \"Zarya 1000M\""
 	desc = "Commie rechargeable M-standardized power cell. Power to the people!"
 	icon_state = "exs_m"
-	origin_tech = list(TECH_POWER = 3)
+	origin_tech = list(TECH_POWER = 4)
 	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLASTIC = 2)
 	maxcharge = 1000
 
@@ -249,7 +249,8 @@
 	desc = "Moebius Laboratories branded S-standardized microreactor cell. Recharges itself over time."
 	icon_state = "meb_pda"
 	origin_tech = list(TECH_POWER = 4)
-	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_URANIUM = 1)
+	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1)
+	matter_reagents = list("radium" = 5, "uranium" = 1)
 	maxcharge = 50
 	// Autorecharge rate is calculated for PDA power consumption: enough to offset it, unless PDA light is on.
 	autorecharging = TRUE
@@ -260,6 +261,6 @@
 	name = "Excelsior \"Zarya 300S\""
 	desc = "Commie rechargeable S-standardized power cell. Power to the people!"
 	icon_state = "exs_s"
-	origin_tech = list(TECH_POWER = 3)
+	origin_tech = list(TECH_POWER = 4)
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 1)
 	maxcharge = 300


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

PDA cells no longer have Uranium material, they use a small amount of radioactive reagents instead. Increased tech level on Excelsior cells by one, and makes the large Excelsior cell equivalent to a Super cell.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Stops dumb meta-rushing of the FO's Office every round which doesn't make sense besides the fact this is a game.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Uranium has been removed from PDA Cells, replaced by radioactive reagents.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
