### PR TITLE
Makes trashcarts better at being usefull

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -108,6 +108,8 @@
 	name = "trash cart"
 	desc = "A heavy, metal trashcart with wheels."
 	icon_state = "trashcart"
+	storage_capacity = 6 * MOB_MEDIUM //3x Storage
+	max_mob_size = 4 //2 more mobs then normal. Makes clearing mobs faster
 
 /*these aren't needed anymore
 /obj/structure/closet/crate/hat


### PR DESCRIPTION

## About The Pull Request

Simply buffs trash carts to hold 3x more items and 2 more mobs

## Why It's Good For The Game

Trash carts atm are just lesser lockers as they seem to hold the same amount but cant walk past when open, making clearing things like the becone or halls of ~~bodys~~ roaches and spiders harder for no reason, and makes clearing things like maints up a lot harder to use the cart that WOULD BE USE FOR IT. >:|

## Changelog
:cl:
tweak: Trash Carts now hold 3x more items and 2 more bodies inside them
/:cl: