### PR TITLE
Better salvageables

### DIFF
--- a/code/game/objects/structures/salvageable.dm
+++ b/code/game/objects/structures/salvageable.dm
@@ -242,7 +242,7 @@ obj/structure/salvageable/personal/Initialize()
 		/obj/item/weapon/computer_hardware/processor_unit/adv = 60,
 		/obj/item/weapon/computer_hardware/hard_drive/cluster = 50,
 		/obj/item/weapon/computer_hardware/hard_drive/portable/advanced/shady = 50,
-		/obj/item/weapon/computer_hardware/hard_drive/portable/advanced/nuke = 50.
+		/obj/item/weapon/computer_hardware/hard_drive/portable/advanced/nuke = 50,
 		/obj/item/weapon/stock_parts/capacitor/excelsior = 20,
 		/obj/item/weapon/stock_parts/scanning_module/excelsior = 20,
 		/obj/item/weapon/stock_parts/manipulator/excelsior = 20,

--- a/code/game/objects/structures/salvageable.dm
+++ b/code/game/objects/structures/salvageable.dm
@@ -45,7 +45,11 @@
 		/obj/item/weapon/stock_parts/scanning_module/adv = 20,
 		/obj/item/weapon/stock_parts/manipulator/nano = 20,
 		/obj/item/weapon/stock_parts/micro_laser/high = 20,
-		/obj/item/weapon/stock_parts/matter_bin/adv = 20
+		/obj/item/weapon/stock_parts/matter_bin/adv = 20,
+		/obj/item/weapon/stock_parts/manipulator/pico = 5,
+		/obj/item/weapon/stock_parts/matter_bin/super = 5,
+		/obj/item/weapon/stock_parts/micro_laser/ultra = 5,
+		/obj/item/weapon/stock_parts/scanning_module/phasic = 5
 	)
 
 /obj/structure/salvageable/machine/Initialize()
@@ -70,7 +74,8 @@
 		/obj/item/weapon/computer_hardware/card_slot = 40,
 		/obj/item/weapon/computer_hardware/card_slot = 40,
 		/obj/item/weapon/stock_parts/capacitor/adv = 30,
-		/obj/item/weapon/computer_hardware/network_card/advanced = 20
+		/obj/item/weapon/computer_hardware/network_card/advanced = 20,
+		/obj/item/weapon/stock_parts/capacitor/super = 5
 	)
 obj/structure/salvageable/computer/Initialize()
 	. = ..()
@@ -99,13 +104,16 @@ obj/structure/salvageable/computer/Initialize()
 		/obj/item/weapon/stock_parts/micro_laser/high = 20,
 		/obj/item/weapon/stock_parts/matter_bin/adv = 20,
 		/obj/item/weapon/stock_parts/matter_bin/adv = 20,
+		/obj/item/weapon/circuitboard/autolathe = 5,
 		/obj/item/stack/material/steel{amount = 20} = 40,
 		/obj/item/stack/material/glass{amount = 20} = 40,
 		/obj/item/stack/material/plastic{amount = 20} = 40,
 		/obj/item/stack/material/plasteel{amount = 10} = 40,
 		/obj/item/stack/material/silver{amount = 10} = 20,
 		/obj/item/stack/material/gold{amount = 10} = 20,
-		/obj/item/stack/material/plasma{amount = 10} = 20
+		/obj/item/stack/material/plasma{amount = 10} = 20,
+		/obj/item/stack/material/uranium{amount = 3} = 5,
+		/obj/item/stack/material/diamond{amount = 1} = 1
 	)
 
 /obj/structure/salvageable/implant_container
@@ -234,7 +242,11 @@ obj/structure/salvageable/personal/Initialize()
 		/obj/item/weapon/computer_hardware/processor_unit/adv = 60,
 		/obj/item/weapon/computer_hardware/hard_drive/cluster = 50,
 		/obj/item/weapon/computer_hardware/hard_drive/portable/advanced/shady = 50,
-		/obj/item/weapon/computer_hardware/hard_drive/portable/advanced/nuke = 50
+		/obj/item/weapon/computer_hardware/hard_drive/portable/advanced/nuke = 50.
+		/obj/item/weapon/stock_parts/capacitor/excelsior = 20,
+		/obj/item/weapon/stock_parts/scanning_module/excelsior = 20,
+		/obj/item/weapon/stock_parts/manipulator/excelsior = 20,
+		/obj/item/weapon/stock_parts/micro_laser/excelsior = 20
 	)
 
 obj/structure/salvageable/bliss/Initialize()

--- a/code/game/objects/structures/salvageable.dm
+++ b/code/game/objects/structures/salvageable.dm
@@ -243,10 +243,10 @@ obj/structure/salvageable/personal/Initialize()
 		/obj/item/weapon/computer_hardware/hard_drive/cluster = 50,
 		/obj/item/weapon/computer_hardware/hard_drive/portable/advanced/shady = 50,
 		/obj/item/weapon/computer_hardware/hard_drive/portable/advanced/nuke = 50,
-		/obj/item/weapon/stock_parts/capacitor/excelsior = 20,
-		/obj/item/weapon/stock_parts/scanning_module/excelsior = 20,
-		/obj/item/weapon/stock_parts/manipulator/excelsior = 20,
-		/obj/item/weapon/stock_parts/micro_laser/excelsior = 20
+		/obj/item/weapon/stock_parts/capacitor/excelsior = 5,
+		/obj/item/weapon/stock_parts/scanning_module/excelsior = 5,
+		/obj/item/weapon/stock_parts/manipulator/excelsior = 5,
+		/obj/item/weapon/stock_parts/micro_laser/excelsior = 5
 	)
 
 obj/structure/salvageable/bliss/Initialize()


### PR DESCRIPTION
## About The Pull Request

Bliss console - Now can at 5% odds drop level 4 parts, *this is a legit 20% on a 2%*
Autolathe can now at 5% drop 3 uranium and a 1% to drop 1 diamond.
Autolathe have a 5% to drop a autolathe board 
broken machine now at 5%'s can drop t3 parts
broken computer now at 5%'s can drop t3 parts

## Why It's Good For The Game

These guys are much faster/easyer to over look as any role do to sci being able to cheaply outclass its parts rather fast - 10~ mins into a round - meaning if you ever want to get parts you just trade plastic and metal for them rather then look around maints and hope to get them.
Now rather then just throwing in the parts into all the things ever, that would be bad do to making them to common - See why you never need to print off crowbars basicly

Autolathes all be it wayyy more offten deconned are mostly for the mats rather then parts or anything inside. Well maybe miners and the cargo people are being a bit costly it can give the maints hunters some say/sway when it comes to competing prices for mats

## Changelog
:cl:
add: Bliss console - Now can at 5% odds drop level 4 parts, *this is a legit 20% on a 2%*
add: Autolathe can now at 5% drop 3 uranium and a 1% to drop 1 diamond.
add: Autolathe have a 5% to drop a autolathe board 
add: broken machine now at 5%'s can drop t3 parts
add: broken computer now at 5%'s can drop t3 parts
/:cl: