### PR TITLE
Get rid of IHS equipment and rigged cells

### DIFF
--- a/code/game/objects/random/rig.dm
+++ b/code/game/objects/random/rig.dm
@@ -21,12 +21,10 @@
 
 	//Heavy armor
 	/obj/item/weapon/rig/combat = 10,
-	/obj/item/weapon/rig/combat/ironhammer = 10,
 	/obj/item/weapon/rig/hazard = 10,
 
 	//The ones below here come with built in weapons
 	/obj/item/weapon/rig/combat/equipped = 4,
-	/obj/item/weapon/rig/combat/ironhammer/equipped = 4,
 	/obj/item/weapon/rig/hazard/equipped = 4,
 	))
 
@@ -50,7 +48,7 @@
 		var/cnd = rand(40,80)
 		module.lose_modules(cnd)
 		module.misconfigure(cnd)
-		module.sabotage_cell()
+		//module.sabotage_cell()
 		module.sabotage_tank()
 
 /obj/random/rig/damaged/low_chance


### PR DESCRIPTION

## About The Pull Request

IHS equipment is taken away according to the loot doctrine and rigged cells are just painful without any counters.

## Why It's Good For The Game

## Changelog
:cl:
del: Removed IHS suits from random suits;
del: Removed rigged cells from the possible damage dealt to suits;
/:cl:
