### PR TITLE
Hidden events: Bluespace Rift

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -551,6 +551,7 @@
 #include "code\game\gamemodes\events\wallrot.dm"
 #include "code\game\gamemodes\events\weather.dm"
 #include "code\game\gamemodes\events\wormholes.dm"
+#include "code\game\gamemodes\events\hidden_events\bluespace_rift.dm"
 #include "code\game\gamemodes\events\hidden_events\kaiser.dm"
 #include "code\game\gamemodes\events\holidays\Christmas.dm"
 #include "code\game\gamemodes\events\holidays\Holidays.dm"

--- a/code/game/gamemodes/events/hidden_events/bluespace_rift.dm
+++ b/code/game/gamemodes/events/hidden_events/bluespace_rift.dm
@@ -38,7 +38,7 @@ They are unstable and be used only few times, and after that they die out on bot
 
 
 /datum/event/bluespace_rift/proc/prepare_event_areas(var/number)
-	var/area/list/candidates = all_areas.Copy()
+	var/list/candidates = all_areas.Copy()
 	var/area/candidate
 	for(candidate in candidates)
 		if(!candidate.is_maintenance)

--- a/code/game/gamemodes/events/hidden_events/bluespace_rift.dm
+++ b/code/game/gamemodes/events/hidden_events/bluespace_rift.dm
@@ -1,0 +1,47 @@
+/*
+Creates a number of two ways teleporters in maints.
+They are unstable and be used only few times, and after that they die out on both sides.
+*/
+
+/datum/storyevent/bluespace_rift
+	id = "bluespace_rift"
+	name = "bluespace_rift"
+
+	weight = 1
+
+	event_type = /datum/event/bluespace_rift
+	event_pools = list(
+		EVENT_LEVEL_MODERATE = POOL_THRESHOLD_MODERATE * 1.2
+	)
+	tags = list(TAG_POSITIVE)
+
+
+/datum/event/bluespace_rift
+	var/list/event_areas = list()
+	var/list/obj/effect/portal/rift/rifts = list()
+	var/pair_number
+	var/rift_number
+
+/datum/event/bluespace_rift/setup()
+	pair_number = rand(1, 5)
+	rift_number = pair_number * 2
+	prepare_event_areas(rift_number)
+
+/datum/event/bluespace_rift/start()
+	for(var/area/A in event_areas)
+		rifts.Add(new /obj/effect/portal/rift(A.random_space(), rand(3, 10)))
+	for(var/i=0, i<pair_number, i++)
+		var/obj/effect/portal/rift/enter = pick_n_take(rifts)
+		var/obj/effect/portal/rift/exit = pick_n_take(rifts)
+		enter.pair(exit)
+		log_and_message_admins("Bluespace rift created between [jumplink(enter)] and [jumplink(exit)] with [enter.usages_left] teleportations left.")
+
+
+/datum/event/bluespace_rift/proc/prepare_event_areas(var/number)
+	var/area/list/candidates = all_areas.Copy()
+	var/area/candidate
+	for(candidate in candidates)
+		if(!candidate.is_maintenance)
+			candidates -= candidate
+	for(var/i=0, i<number, i++)
+		event_areas.Add(pick_n_take(candidates))

--- a/code/game/gamemodes/events/hidden_events/bluespace_rift.dm
+++ b/code/game/gamemodes/events/hidden_events/bluespace_rift.dm
@@ -28,13 +28,10 @@ They are unstable and be used only few times, and after that they die out on bot
 	prepare_event_areas(rift_number)
 
 /datum/event/bluespace_rift/start()
-	for(var/area/A in event_areas)
-		rifts.Add(new /obj/effect/portal/rift(A.random_space(), rand(3, 10)))
 	for(var/i=0, i<pair_number, i++)
-		var/obj/effect/portal/rift/enter = pick_n_take(rifts)
-		var/obj/effect/portal/rift/exit = pick_n_take(rifts)
-		enter.pair(exit)
-		log_and_message_admins("Bluespace rift created between [jumplink(enter)] and [jumplink(exit)] with [enter.usages_left] teleportations left.")
+		var/area/enterence = pick_n_take(event_areas)
+		var/area/exit = pick_n_take(event_areas)
+		new /obj/effect/portal/wormhole/rift(enterence.random_space(), exit.random_space())
 
 
 /datum/event/bluespace_rift/proc/prepare_event_areas(var/number)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -185,11 +185,12 @@ var/list/portal_cache = list()
 	admin_announce_new = FALSE
 	var/teleportations_left
 
-/obj/effect/portal/wormhole/rift/New(loc, exit)
+/obj/effect/portal/wormhole/rift/New(loc, exit, msg_admins=TRUE)
 	teleportations_left = rand(3, 10)
 	..(loc, 0, exit)
 	deltimer(lifetime)
-	message_admins("Bluespace rift created between [jumplink(src)] and [jumplink(src.target)]")
+	if(msg_admins)
+		message_admins("Bluespace rift created between [jumplink(src)] and [jumplink(src.target)] with [teleportations_left] teleportations left")
 
 /obj/effect/portal/wormhole/rift/pair()
 	partner = null
@@ -200,7 +201,7 @@ var/list/portal_cache = list()
 	partner = (locate(/obj/effect/portal/wormhole/rift) in T)
 
 	if (!partner)
-		partner = new /obj/effect/portal/wormhole/rift(T, loc)
+		partner = new /obj/effect/portal/wormhole/rift(T, loc, FALSE)
 	var/obj/effect/portal/wormhole/rift/P = partner
 	P.teleportations_left = teleportations_left
 

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -170,3 +170,36 @@ var/list/portal_cache = list()
 		//Portals ignore armor when messing you up, it's logical
 		victim.apply_damage(20+rand(60), BRUTE, pick(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG))
 	do_teleport(M, get_destination(get_turf(M)), 1)
+
+
+
+/obj/effect/portal/rift
+	name = "bluespace rift"
+	failchance = 0
+	var/usages_left
+
+/obj/effect/portal/rift/New(loc, usages)
+	..()
+	deltimer(lifetime)
+	usages_left = usages
+
+/obj/effect/portal/rift/proc/pair(target_rift)
+	if(!istype(target_rift, /obj/effect/portal/rift))
+		return
+	var/obj/effect/portal/rift/T = target_rift
+	target = T
+	T.target = src
+	T.usages_left = usages_left
+
+/obj/effect/portal/rift/close()
+	if(usages_left <= 0)
+		qdel(src.target)
+		qdel(src)
+
+/obj/effect/portal/rift/teleport(atom/movable/M)
+	. = ..(M)
+	if(.)
+		var/obj/effect/portal/rift/T = target
+		usages_left -= 1
+		T.usages_left -= 1
+		close()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Event creates 1-5 pairs of two ways teleporters in maints
- Each pair can be used 3-10 times, when usage counter becomes 0 pair disappears
- Uses sprite and description of standard teleporter
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds diversity to possible random events.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added bluespace rift
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
