### PR TITLE
Stops changelog generator from Xing PRs with no changelog

### DIFF
--- a/tools/changelog/generate_cl.py
+++ b/tools/changelog/generate_cl.py
@@ -60,7 +60,7 @@ try:
     cl_list = CL_SPLIT.findall(cl.group(2))
 except AttributeError:
     print("No CL found!")
-    exit(1) # Change to '0' if you do not want the action to fail when no CL is provided
+    exit(0) # Change to '0' if you do not want the action to fail when no CL is provided
 
 
 if cl.group(1) is not None:


### PR DESCRIPTION
Commits shouldn't be flagged with a big scary :x: just because they had no changelog on them.

Reasons to have a PR with no changelog entries:

* Straight up refactor PRs.
* Tooling-related PRs, like this one.
* PRs with changes too small or too technical to bother the players with, like grammar or runtime error fixes.

I should also redo the changelog generator thing one day, so that it wouldn't add two commits for every PR with a changelog in it. But that's a fight for another day.