### PR TITLE
Bandaid-fixes robots from spawning in maintenance

### DIFF
--- a/code/game/objects/landmarks/join.dm
+++ b/code/game/objects/landmarks/join.dm
@@ -61,6 +61,7 @@ GLOBAL_LIST_EMPTY(spawntypes)
 	icon_state = "synth-cyan"
 	join_tag = "late_cyborg"
 	message = "has been activated from storage"
+	spawn_datum_type = /datum/spawnpoint/nosearch
 	restrict_job = list("Robot")
 
 /obj/landmark/join/observer

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -150,6 +150,8 @@
 		M.buckled.set_dir(M.dir)
 	return TRUE
 
+/datum/spawnpoint/nosearch //for when we want people to start on the exact tile of the spawn landmark
+	search_range = 0
 
 /**********************
 	Cryostorage Spawning


### PR DESCRIPTION
Robot latejoin now uses a nosearch spawnpoint datum, which'll only take into account the turf the spawn landmark is on.

Issue was spawnpoints add all turfs in view, which doesn't take into account obstacles between the initial landmark and the found turf, causing robots to spawn in the maintenance section close by. (See fig 1)
![fig 1](https://user-images.githubusercontent.com/30557196/84929066-39079480-b0c7-11ea-8778-01e0c98e4053.png)

:cl:
 fix: Fixes latejoin robots from spawning in the maintenance near to the robot storage units.
/:cl:
