### PR TITLE
Corrects Wallets Holding Combo-Drills

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -4,6 +4,9 @@
 	storage_slots = 7
 	icon_state = "wallet"
 	w_class = ITEM_SIZE_SMALL
+	cant_hold = list(
+		/obj/item/weapon/tool/screwdriver/combi_driver,
+		/obj/item/weapon/tool/screwdriver/combi_driver/onestar) //We can not hold these do to being bigger then the wallet itself
 	can_hold = list(
 		/obj/item/weapon/spacecash,
 		/obj/item/weapon/card,


### PR DESCRIPTION

## About The Pull Request

Like on all codebases with wallets that hold screwdriver I have tested to see if the would hold larger one, the combo drill does infact do to how wallet storage works fit into the wallet.
This is not intended for many reasons
 - Its to big
 - Its meant to be harder to carry around
 - Its a more power weapon that you can just hide inside your wallet???
 - It has a built in wrench, and we cant store wrenches in are wallets can we?

## Why It's Good For The Game

Issue correction

## Changelog
:cl:
fix: Wallets have relised that the combo drill is not as small as a screwdriver normally.
/:cl:
