### PR TITLE
Breakdown admin log fix

### DIFF
--- a/code/modules/sanity/breakdown.dm
+++ b/code/modules/sanity/breakdown.dm
@@ -39,7 +39,7 @@
 	flick(icon_state, img)
 	holder.owner.playsound_local(get_turf(holder.owner), breakdown_sound, 100)
 	if(start_messages)
-		log_and_message_admins("[holder.owner] is affected by breakdown [name] with duration [duration]")
+		log_and_message_admins("[holder.owner] is affected by breakdown [name] with duration [duration/10] seconds.")
 		to_chat(holder.owner, span(start_message_span, pick(start_messages)))
 	if(restore_sanity_pre)
 		holder.restoreLevel(restore_sanity_pre)


### PR DESCRIPTION
Fixes the admin log showing the raw duration, now it shows it as seconds. This was giving cause for alarm, making people think that a duration of 900 was 15 minutes, not 1.5 minutes.

![image](https://user-images.githubusercontent.com/30557196/85130082-28246380-b22c-11ea-9a13-bd50ba32cba6.png)
