### PR TITLE
Adds More Protection to TM Helmet, Patches TE Rig Cape Icon

### DIFF
--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -67,6 +67,9 @@
 	name = "technomancer helmet"
 	desc = "A piece of armor used in hostile work conditions to protect the head. Comes with a built-in flashlight."
 	icon_state = "technohelmet"
+	body_parts_covered = HEAD|EARS|EYES|FACE
+	item_flags = THICKMATERIAL
+	flags_inv = BLOCKHEADHAIR|HIDEEARS|HIDEEYES|HIDEFACE
 	action_button_name = "Toggle Headlamp"
 	brightness_on = 4
 	armor = list(
@@ -77,6 +80,8 @@
 		bio = 15,
 		rad = 30
 	)//Mix between hardhat.dm armor values, helmet armor values in armor.dm, and armor values for TM void helmet in station.dm.
+	flash_protection = FLASH_PROTECTION_MAJOR
+	price_tag = 500
 
 /obj/item/clothing/head/armor/helmet/handmade
 	name = "handmade combat helmet"

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -44,6 +44,7 @@
 	var/suit_overlay_active             // If set, drawn over icon and mob when effect is active.
 	var/suit_overlay_inactive           // As above, inactive.
 	var/suit_overlay_used               // As above, when engaged.
+	var/suit_overlay_mob_only           // Set to 1 for overlay to only display on mob and not on icon
 
 	//Display fluff
 	var/interface_name = "hardsuit upgrade"

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -450,8 +450,15 @@
 	name = "cape"
 	desc = "A cape designed to be attached to hardsuits."
 
+	interface_name = "Hardsuit Cape"
+	interface_desc = "A generic cape for a hardsuit."
+
 /obj/item/rig_module/cape/te
 	name = "technomancer cape"
 	desc = "A tough regal cape, imprinted with the emblem of the Technomancer League."
 	suit_overlay_active = "cape_te"
 	suit_overlay_inactive = "cape_te"
+	suit_overlay_mob_only = 1
+
+	interface_name = "Technomancer Cape"
+	interface_desc = "A grand yet hardy cape."

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -521,7 +521,7 @@
 /obj/item/weapon/rig/update_icon(var/update_mob_icon)
 	if(installed_modules.len)
 		for(var/obj/item/rig_module/module in installed_modules)
-			if(module.suit_overlay)
+			if(module.suit_overlay && !module.suit_overlay_mob_only)
 				chest.overlays += image("icon" = 'icons/mob/rig_modules.dmi', "icon_state" = module.suit_overlay, "dir" = SOUTH)
 
 /obj/item/weapon/rig/proc/check_suit_access(var/mob/living/carbon/human/user)


### PR DESCRIPTION
## About The Pull Request

Adds flash protection, a price tag, hair, ear, eye and face blocking to the TM helmet. Also adds a interface name and interface description to the TE cape, and makes it so the TE cape doesn't appear over inventory icons by adding an option in rig.dm to toggle whether a rig module appears overlayed on the inventory of the wearer.

## Why It's Good For The Game

Adds value and practicality to the TM helmet and makes it so hair stays under the helmet, the description can help with knowing what's installed in the rig, and the cape icon doesn't fit the icon of the chest rig in the inventory far as I know. 

## Changelog
:cl:
add: TE cape now has interface name and description
tweak: TM helmet now blocks flashes, hair, and facial features and has a price tag
tweak: TE cape no longer appears overlayed in inventory
refactor: rig modules now have an option for whether or not their overlay only appears on the mob
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
