### PR TITLE
Advanced subsurface ore detector

### DIFF
--- a/code/modules/mining/drilling/scanner.dm
+++ b/code/modules/mining/drilling/scanner.dm
@@ -7,24 +7,29 @@
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_STEEL = 1, MATERIAL_GLASS = 1)
 
 	charge_per_use = 2
+	var/precision = FALSE
 
 /obj/item/device/scanner/mining/is_valid_scan_target(atom/O)
 	return istype(O, /turf/simulated)
 
 
 /obj/item/device/scanner/mining/scan(turf/T, mob/user)
-	scan_data = mining_scan_action(T, user)
+	scan_data = mining_scan_action(T, user, precision)
 	scan_title = "Subsurface ore scan - ([T.x], [T.y])"
 	show_results(user)
 
-/proc/mining_scan_action(turf/source, mob/user)
-	var/list/metals = list(
-		"surface minerals" = 0,
+/obj/item/device/scanner/mining/advanced
+	name = "advanced subsurface ore detector"
+	precision = TRUE
+
+/proc/mining_scan_action(turf/source, mob/user, precision)
+	if(precision)
+		return mining_scan_action_precise(source, user)
+	var/list/metals = list("surface minerals" = 0,
 		"precious metals" = 0,
 		"nuclear fuel" = 0,
 		"exotic matter" = 0
 		)
-
 	var/list/lines = list("Ore deposits found at [source.x], [source.y]:")
 
 	for(var/turf/simulated/T in trange(2, source))
@@ -46,6 +51,28 @@
 
 			if(ore_type)
 				metals[ore_type] += T.resources[metal]
+
+	for(var/ore_type in metals)
+		var/result = "no sign"
+
+		switch(metals[ore_type])
+			if(1 to 25) result = "trace amounts"
+			if(26 to 75) result = "significant amounts"
+			if(76 to INFINITY) result = "huge quantities"
+
+		lines += "- [result] of [ore_type]."
+
+	return jointext(lines, "<br>")
+
+/proc/mining_scan_action_precise(turf/source, mob/user)
+	var/list/lines = list("Ore deposits found at [source.x], [source.y]:")
+	var/list/metals = list()
+	for(var/turf/simulated/T in trange(2, source))
+		if(!T.has_resources)
+			continue
+
+		for(var/metal in T.resources)
+			metals[metal] += T.resources[metal]
 
 	for(var/ore_type in metals)
 		var/result = "no sign"

--- a/code/modules/research/designs/mining.dm
+++ b/code/modules/research/designs/mining.dm
@@ -12,3 +12,8 @@
 	build_path = /obj/item/weapon/tool/pickaxe/diamonddrill
 	sort_string = "KAAAC"
 	category = CAT_MINING
+
+/datum/design/research/item/weapon/mining/scanner
+	build_path = /obj/item/device/scanner/mining/advanced
+	sort_string = "KAAAD"
+	category = CAT_MINING

--- a/code/modules/research/nodes/engineering.dm
+++ b/code/modules/research/nodes/engineering.dm
@@ -194,7 +194,8 @@
 	unlocks_designs = list(	/datum/design/research/circuit/miningdrill,
 							/datum/design/research/circuit/miningdrillbrace,
 							/datum/design/research/item/weapon/mining/drill_diamond,
-							/datum/design/research/item/weapon/mining/jackhammer
+							/datum/design/research/item/weapon/mining/jackhammer,
+							/datum/design/research/item/weapon/mining/scanner
 							)
 
 /datum/technology/adv_tools


### PR DESCRIPTION
Adds an advanced mining scanner, to help with locating subsurface materials more precisely

I could not test this on local, as I was not robust enough to get the ship running to move it to a mining asteroid.

## About The Pull Request
After playing some rounds as a shaft miner, I found that, while surface minerals were plentiful, it was misleading and mostly carbon.


## Why It's Good For The Game
This gives something for moebius to give to miners besides atomic cells, and helps with optimizing subsurface mining.


## Changelog
:cl:
add: Adds the advanced subsurface ore detector
/:cl:
