### PR TITLE
Repair platform

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -641,6 +641,7 @@
 #include "code\game\machinery\portable_turret.dm"
 #include "code\game\machinery\recharger.dm"
 #include "code\game\machinery\rechargestation.dm"
+#include "code\game\machinery\repairstation.dm"
 #include "code\game\machinery\requests_console.dm"
 #include "code\game\machinery\seed_extractor.dm"
 #include "code\game\machinery\shower.dm"

--- a/code/game/machinery/repairstation.dm
+++ b/code/game/machinery/repairstation.dm
@@ -1,0 +1,119 @@
+#define REPAIR_HULL 1
+#define REPAIR_COMPONENTS 2
+
+/obj/machinery/repair_station
+	name = "cyborg auto-repair platform"
+	desc = "An automated repair system, designed to repair drones and cyborgs that stand on it."
+	//PLACEHOLDER
+	icon = 'icons/mechs/mech_bay.dmi'
+	icon_state = "recharge_floor"
+	///PLACEHOLDER
+	anchored = TRUE
+	density = FALSE
+	layer = TURF_LAYER + 0.1
+
+	use_power = IDLE_POWER_USE
+	idle_power_usage = 4
+	active_power_usage = 4000
+
+	var/mob/living/silicon/robot/repairing
+
+	var/repair_amount = 100 //How much we can heal something for.
+	var/repair_rate = 5 //How much HP we restore per second
+	var/repair_complexity = REPAIR_HULL //How complex we get regarding repairing things
+
+/obj/machinery/repair_station/examine(mob/user)
+	..()
+	to_chat(user, "It has [SPAN_NOTICE("[repair_amount]")] repair points remaining.")
+
+/obj/machinery/repair_station/Crossed(var/mob/living/silicon/robot/R)
+	. = ..()
+	if(istype(R) && repairing != R)
+		start_repairing(R)
+
+/obj/machinery/repair_station/Uncrossed(var/mob/living/silicon/R)
+	. = ..()
+	if(R == repairing)
+		stop_repairing()
+
+/obj/machinery/repair_station/RefreshParts()
+	..()
+	var/manip_level = 1
+	var/scan_level = 1
+	for(var/obj/item/weapon/stock_parts/P in component_parts)
+		if(istype(P, /obj/item/weapon/stock_parts/scanning_module))
+			scan_level += P.rating-1
+		if(istype(P, /obj/item/weapon/stock_parts/manipulator))
+			manip_level += P.rating-1
+
+	repair_rate = initial(repair_rate)+(manip_level*max(1, scan_level/2))
+	if(scan_level >= 3)
+		repair_complexity |= REPAIR_COMPONENTS
+	idle_power_usage *= manip_level*scan_level
+	active_power_usage *= manip_level*scan_level
+
+/obj/machinery/repair_station/Process()
+	..()
+	if(!repairing)
+		return
+
+	if(repairing.loc != loc)
+		stop_repairing()
+		return
+
+	if(!repair_amount)
+		visible_message("\The [src] buzzes \"Insufficient material remaining to continue repairs.\".")
+		stop_repairing()
+		return
+	var/repair_count = 0
+	if(repair_complexity & REPAIR_HULL && (repairing.getBruteLoss() || repairing.getFireLoss()))
+		var/amount_to_heal = min(repair_amount, repair_rate)
+		repairing.adjustBruteLoss(-amount_to_heal)
+		repairing.adjustFireLoss(-amount_to_heal)
+		repairing.updatehealth()
+		repair_amount = max(0, repair_amount-amount_to_heal)
+		repair_count += amount_to_heal
+
+	if(!repair_amount)
+		return
+
+	if(repair_complexity & REPAIR_COMPONENTS)
+		for(var/V in repairing.components)
+			var/datum/robot_component/C = repairing.components[V]
+			if(C.brute_damage || C.electronics_damage)
+				var/amount_to_heal = min(repair_amount, repair_rate)
+				C.heal_damage(amount_to_heal/2,amount_to_heal/2)
+				repair_amount = max(0, repair_amount-amount_to_heal)
+				repair_count += amount_to_heal
+				break
+
+	if(!repair_count)
+		to_chat(repairing, SPAN_NOTICE("Repairs complete. Shutting down."))
+		stop_repairing()
+
+/obj/machinery/repair_station/proc/start_repairing(var/mob/living/silicon/robot/R)
+	if(stat & (NOPOWER | BROKEN))
+		to_chat(R, SPAN_WARNING("Repair system not responding. Terminating."))
+		return
+
+	to_chat(R, SPAN_NOTICE("Commencing repairs. Please stand by."))
+	repairing = R
+	update_use_power(ACTIVE_POWER_USE)
+
+/obj/machinery/repair_station/proc/stop_repairing()
+	if(!repairing)
+		return
+
+	repairing = null
+	update_use_power(IDLE_POWER_USE)
+
+/obj/machinery/repair_station/attackby(var/obj/item/weapon/O, var/mob/user)
+	.=..()
+	if(istype(O,/obj/item/stack/material) && O.get_material_name() == MATERIAL_STEEL)
+		var/obj/item/stack/material/S = O
+		if(S.use(1))
+			to_chat(user, SPAN_NOTICE("You insert a sheet of \the [S]. \The [src] now has [repair_amount] repair points remaining."))
+			repair_amount += 25
+
+#undef REPAIR_HULL
+#undef REPAIR_COMPONENTS

--- a/code/game/objects/items/weapons/circuitboards/machinery/recharge_station.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/recharge_station.dm
@@ -9,3 +9,13 @@
 		/obj/item/weapon/stock_parts/manipulator = 2,
 		/obj/item/weapon/cell/large = 1
 	)
+
+/obj/item/weapon/circuitboard/repair_station
+	name = T_BOARD("cyborg auto-repair platform")
+	build_path = /obj/machinery/repair_station
+	board_type = "machine"
+	origin_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 4)
+	req_components = list(
+		/obj/item/weapon/stock_parts/manipulator = 3,
+		/obj/item/weapon/stock_parts/scanning_module = 1,
+	)

--- a/code/game/objects/random/circuitboards.dm
+++ b/code/game/objects/random/circuitboards.dm
@@ -39,6 +39,7 @@
 				/obj/item/weapon/circuitboard/rdserver = 2,
 				/obj/item/weapon/circuitboard/rdservercontrol = 2,
 				/obj/item/weapon/circuitboard/recharge_station = 2,
+				/obj/item/weapon/circuitboard/repair_station = 2,
 				/obj/item/weapon/circuitboard/robotics = 1,
 				/obj/item/weapon/circuitboard/smes = 2,
 				/obj/item/weapon/circuitboard/solar_control = 1,

--- a/code/modules/research/designs/circuits.dm
+++ b/code/modules/research/designs/circuits.dm
@@ -203,6 +203,12 @@
 	sort_string = "HACAC"
 	category = CAT_MACHINE
 
+/datum/design/research/circuit/repair_station
+	name = "cyborg auto-repair platform"
+	build_path = /obj/item/weapon/circuitboard/repair_station
+	sort_string = "HACAE"
+	category = CAT_MACHINE
+
 /datum/design/research/circuit/recharger
 	name = "recharger"
 	build_path = /obj/item/weapon/circuitboard/recharger

--- a/code/modules/research/nodes/robotics.dm
+++ b/code/modules/research/nodes/robotics.dm
@@ -377,7 +377,8 @@
 						/datum/design/research/item/mechfab/robot/component/jetpack,
 						/datum/design/research/item/robot_upgrade/vtec,
 						/datum/design/research/item/robot_upgrade/tasercooler,
-						/datum/design/research/item/robot_upgrade/rcd
+						/datum/design/research/item/robot_upgrade/rcd,
+						/datum/design/research/circuit/repair_station,
 						)
 
 

--- a/maps/submaps/deepmaint_rooms/normal/mechbay.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/mechbay.dmm
@@ -10,7 +10,7 @@
 "j" = (/obj/structure/table/standard{name = "plastic table frame"},/obj/random/powercell,/obj/random/powercell,/obj/random/powercell,/turf/simulated/floor/tiled/steel/gray_platform,/area/deepmaint)
 "k" = (/obj/structure/reagent_dispensers/fueltank,/turf/simulated/floor/tiled/steel/gray_platform,/area/deepmaint)
 "l" = (/obj/structure/table/standard{name = "plastic table frame"},/obj/random/pack/rare/low_chance,/turf/simulated/floor/tiled/steel/gray_platform,/area/deepmaint)
-"m" = (/obj/random/cluster/roaches/low_chance,/turf/simulated/floor/tiled/steel/gray_platform,/area/deepmaint)
+"m" = (/obj/random/cluster/roaches/low_chance,/obj/machinery/repair_station,/turf/simulated/floor/tiled/steel/gray_platform,/area/deepmaint)
 "n" = (/obj/machinery/recharge_station,/turf/simulated/floor/tiled/steel/gray_platform,/area/deepmaint)
 "o" = (/obj/structure/table/standard{name = "plastic table frame"},/obj/item/weapon/storage/toolbox/mechanical,/turf/simulated/floor/tiled/steel/gray_platform,/area/deepmaint)
 "p" = (/obj/structure/reagent_dispensers/fueltank,/obj/machinery/light/small{dir = 1},/turf/simulated/floor/tiled/steel/gray_platform,/area/deepmaint)


### PR DESCRIPTION
## About The Pull Request
Adds an automated repair platform, to fix cyborgs up that stand on it

## Why It's Good For The Game
Another ingame request. I'm aware that the cyborg recharger can perform skin-level repairs, but as a drone you apparently have to suffer human interaction to repair yourself, worse so if its internal components that are broken.

## Changelog
:cl:
add: Adds the cyborg auto repair platform. Repairs cyborgs that stand on top of them.
/:cl:
