### PR TITLE
Medical rank prefixes

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -254,10 +254,10 @@ var/list/rank_prefix = list(\
 	"Moebius Doctor" = "Dr.",\
 	"Moebius Chemist" = "Dr.",\
 	"Moebius Psychiatrist" = "Dr.",\
-	"Moebius Biolab Officer" = "Prof.",\
+	"Moebius Biolab Officer" = "Professor",\
 	"Moebius Roboticist" = "Dr.",\
 	"Moebius Scientist" = "Dr.",\
-	"Moebius Expedition Overseer" = "Prof.",\
+	"Moebius Expedition Overseer" = "Professor",\
 	)
 
 /mob/living/carbon/human/proc/rank_prefix_name(name)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -251,6 +251,13 @@ var/list/rank_prefix = list(\
 	"Ironhammer Gunnery Sergeant" = "Sergeant",\
 	"Ironhammer Commander" = "Lieutenant",\
 	"Captain" = "Captain",\
+	"Moebius Doctor" = "Dr.",\
+	"Moebius Chemist" = "Dr.",\
+	"Moebius Psychiatrist" = "Dr.",\
+	"Moebius Biolab Officer" = "Prof.",\
+	"Moebius Roboticist" = "Dr.",\
+	"Moebius Scientist" = "Dr.",\
+	"Moebius Expedition Overseer" = "Prof.",\
 	)
 
 /mob/living/carbon/human/proc/rank_prefix_name(name)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Appropriate Moebius personnel will be given the title "Dr.", and the MBO and MEO will be given the title "Professor". These titles will replace the first name in exactly the same way as IH operatives.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Calling doctors as such will add to the overall atmosphere.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Moebius employees given appropriate titles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
