### PR TITLE
paramedic no longer has melee/bullet/energy armor on his jumpsuit

### DIFF
--- a/code/modules/clothing/under/jobs/medsci.dm
+++ b/code/modules/clothing/under/jobs/medsci.dm
@@ -124,10 +124,10 @@
 	item_state = "paramedic"
 	permeability_coefficient = 0.50
 	armor = list(
-		melee = 10,
-		bullet = 5,
-		energy = 5,
+		melee = 0,
+		bullet = 0,
+		energy = 0,
 		bomb = 0,
-		bio = 30,
+		bio = 10,
 		rad = 0
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

removes melee/bullet/energy armor from paramedic jumpsuit and nerfs bio from 30 to 10

## Why It's Good For The Game

paramedics shouldnt have the best single jumpsuit from every crewman, sec jumpsuits and tactical turtlenecks dont even have any armor values, and their bio armor is stronger than anyone else's

## Changelog
:cl:
balance: removes melee/bullet/energy armor from paramedic jumpsuit and nerfs bio from 30 to 10
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
