### PR TITLE
Makes changelog actions suck a bit less

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -2,7 +2,7 @@ name: Compile changelogs
 
 on:
   schedule:
-    - cron: "*/15 * * * *"
+    - cron: "* */12 * * *"
 
 jobs:
   CompileCL:

--- a/tools/changelog/generate_cl.py
+++ b/tools/changelog/generate_cl.py
@@ -46,7 +46,7 @@ pr_list = commit.get_pulls()
 
 if not pr_list.totalCount:
     print("Direct commit detected")
-    exit(1) # Change to '0' if you do not want the action to fail when a direct commit is detected
+    exit(0) # Change to '0' if you do not want the action to fail when a direct commit is detected
 
 pr = pr_list[0]
 
@@ -60,7 +60,7 @@ try:
     cl_list = CL_SPLIT.findall(cl.group(2))
 except AttributeError:
     print("No CL found!")
-    exit(1) # Change to '0' if you do not want the action to fail when no CL is provided
+    exit(0) # Change to '0' if you do not want the action to fail when no CL is provided
 
 
 if cl.group(1) is not None:


### PR DESCRIPTION
* CL action would no longer :x: commits for not having a changelog entry.
* CL action would no longer :x: commits that were directly pushed to master.
* CL rebuild now fires every 12 hours, as opposed to 15 minutes. This should cut down on CL spam in commit log.

To :x: commits and people for pushing directly to master is a job for maintainers, not bots.