### PR TITLE
The Sol carbine no longer has insane recoil

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic/sol.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sol.dm
@@ -15,7 +15,7 @@
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 12)
 	price_tag = 2300
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
-	recoil_buildup = 13
+	recoil_buildup = 8 
 	one_hand_penalty = 5 //bullpup rifle (this one is smaller and carbine, so it's 5)
 
 	init_firemodes = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Sols recoil has been reduced from 13 (reere why) to a more manageable 8. This gun was literally basically worse than a pistol (paco) past point blank because of the recoil, and the kit still makes you have more recoil than a wintermute so I feel this is fine.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the Sol no longer worse than your handgun.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Sol has 38ish% less recoil overrall.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
