### PR TITLE
fix(frozen_star | designs & disk_name)

### DIFF
--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -795,14 +795,14 @@
 // SMGs
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_paco
-	disk_name = "Frozen Star - .35 Paco SMG"
+	disk_name = "Frozen Star - .35 Paco HG"
 	icon_state = "frozenstar"
 
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/paco = 3, // "FS HG .35 \"Paco\""
-		/datum/design/autolathe/ammo/smg/practice,
-		/datum/design/autolathe/ammo/smg/rubber,
+		/datum/design/autolathe/ammo/magazine_pistol/practice,
+		/datum/design/autolathe/ammo/magazine_pistol/rubber,
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_straylight


### PR DESCRIPTION
## About The Pull Request

Fix "Frozen Star - .35 Paco SMG" disk. Rename disk and replace ammo in designs.

## Why It's Good For The Game

Normal use "Frozen Star - .35 Paco HG" disk

## Changelog
:cl:
fix: Rename disk_name (Frozen Star - .35 Paco SMG -> Frozen Star - .35 Paco HG) and replace ammo in designs (smg -> magazine_pistol).
/:cl:
