### PR TITLE
fix lowborn and absolute grab perks

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -417,7 +417,9 @@ GLOBAL_LIST_INIT(click_catchers, create_click_catcher())
 
 	if(!T || !src || src.stat)
 		return
-	if(get_dist(get_turf(T), get_turf(src)) != 2)
+	if(get_dist(get_turf(T), get_turf(src)) < 2)
+		return
+	if(get_dist_euclidian(get_turf(T), get_turf(src)) >= 3)
 		return
 	if(last_special > world.time)
 		return

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -67,9 +67,11 @@
 			return
 
 	//PERK_ABSOLUTE_GRAB
-	if(ishuman(A) && stats.getPerk(PERK_ABSOLUTE_GRAB) && a_intent == I_GRAB)
-		absolute_grab(A) // moved into a proc below
-		return
+	
+	if(get_dist_euclidian(get_turf(A), get_turf(src)) < 3 && ishuman(A))
+		if(stats.getPerk(PERK_ABSOLUTE_GRAB) && a_intent == I_GRAB)
+			absolute_grab(A) // moved into a proc belowaa
+			return
 	if(!gloves && !mutations.len) return
 	var/obj/item/clothing/gloves/G = gloves
 	if((LASER in mutations) && a_intent == I_HURT)

--- a/code/datums/setup_option/backgrounds/fate.dm
+++ b/code/datums/setup_option/backgrounds/fate.dm
@@ -104,6 +104,7 @@
 			You never knew your parents and were lucky enough to learn how to read, and that, in time, landed you a position on this ship. \
 			Would you still choose to be part of this journey if you knew what it meant? Will you leave a mark or be forgotten forever? \
 			You cannot play command roles. Additionally, you have the ability to have a name without a last name and have an increased sanity pool."
-			
+
 	restricted_jobs = list(/datum/job/captain, /datum/job/chaplain, /datum/job/merchant, /datum/job/cmo, /datum/job/rd, /datum/job/ihc)
+	restricted_depts = IRONHAMMER | MEDICAL | SCIENCE
 	perks = list(PERK_LOWBORN)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
1. Lowborn perk makes you are blacklisted from all jobs in moebis and IH.

2. Absolute grab perk now acts on a circular radius of 2 tiles.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Lowborn perk makes you are blacklisted from all jobs in moebis and IH.
tweak: Absolute grab perk now acts on a circular radius of 2 tiles. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
