### PR TITLE
Adds more guild crates

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1288,11 +1288,11 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	group = "Miscellaneous"
 
 /datum/supply_pack/discs
-	contains = list(/obj/item/weapon/computer_hardware/hard_drive/portable/design
-					/obj/item/weapon/computer_hardware/hard_drive/portable/design
-					/obj/item/weapon/computer_hardware/hard_drive/portable/design
-					/obj/item/weapon/computer_hardware/hard_drive/portable/design
-					/obj/item/weapon/computer_hardware/hard_drive/portable/design
+	contains = list(/obj/item/weapon/computer_hardware/hard_drive/portable/design,
+					/obj/item/weapon/computer_hardware/hard_drive/portable/design,
+					/obj/item/weapon/computer_hardware/hard_drive/portable/design,
+					/obj/item/weapon/computer_hardware/hard_drive/portable/design,
+					/obj/item/weapon/computer_hardware/hard_drive/portable/design,
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design)
 	name = "Empty Design Disk Crate"
 	cost = 1000

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -326,13 +326,6 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 //-----------------HOSPITALITY------------------
 //----------------------------------------------
 /*
-/datum/supply_pack/vending_bar
-	name = "Bartending supply crate"
-	contains = list(/obj/item/weapon/vending_refill/boozeomat)
-	cost = 1000
-	containertype = /obj/structure/closet/crate/freezer
-	crate_name = "bartending supply crate"
-	group = "Hospitality"
 
 /datum/supply_pack/vending_coffee
 	name = "Hotdrinks supply crate"
@@ -374,6 +367,27 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	crate_name = "cigarette supply crate"
 	group = "Hospitality"
 */
+
+/datum/supply_pack/bardrinks
+	name = "Bartending resupply crate"
+	contains = list(/obj/item/weapon/reagent_containers/food/drinks/bottle/gin = 2,/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey = 2,
+					/obj/item/weapon/reagent_containers/food/drinks/bottle/tequilla = 2,/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka = 2,
+					/obj/item/weapon/reagent_containers/food/drinks/bottle/vermouth = 2,/obj/item/weapon/reagent_containers/food/drinks/bottle/rum = 2,
+					/obj/item/weapon/reagent_containers/food/drinks/bottle/wine = 3,/obj/item/weapon/reagent_containers/food/drinks/bottle/cognac = 2,
+					/obj/item/weapon/reagent_containers/food/drinks/bottle/kahlua = 3,/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer = 6,
+					/obj/item/weapon/reagent_containers/food/drinks/bottle/small/ale = 6,/obj/item/weapon/reagent_containers/food/drinks/bottle/orangejuice = 2,
+					/obj/item/weapon/reagent_containers/food/drinks/bottle/tomatojuice = 2,/obj/item/weapon/reagent_containers/food/drinks/bottle/limejuice = 2,
+					/obj/item/weapon/reagent_containers/food/drinks/bottle/cream = 2,/obj/item/weapon/reagent_containers/food/drinks/cans/tonic = 6,
+					/obj/item/weapon/reagent_containers/food/drinks/bottle/cola = 5,/obj/item/weapon/reagent_containers/food/drinks/bottle/space_up = 5,
+					/obj/item/weapon/reagent_containers/food/drinks/bottle/space_mountain_wind = 5,/obj/item/weapon/reagent_containers/food/drinks/cans/sodawater = 15,
+					/obj/item/weapon/reagent_containers/food/drinks/flask/barflask = 2,/obj/item/weapon/reagent_containers/food/drinks/bottle/bluecuracao = 2,
+					/obj/item/weapon/reagent_containers/food/drinks/drinkingglass = 30,/obj/item/weapon/reagent_containers/food/drinks/bottle/grenadine = 5,
+					/obj/item/weapon/reagent_containers/food/drinks/bottle/melonliquor = 2,/obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe = 1)
+	cost = 2000
+	containertype = /obj/structure/closet/crate/freezer
+	crate_name = "bartending resupply crate"
+	group = "Hospitality"
+
 /datum/supply_pack/party
 	name = "Party equipment"
 	contains = list(/obj/item/weapon/storage/box/drinkingglasses,
@@ -392,6 +406,20 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	cost = 1200
 	containertype = /obj/structure/closet/crate
 	crate_name = "Party equipment"
+	group = "Hospitality"
+
+/datum/supply_pack/cakes
+	name = "Party Cakes"
+	contains = list(/obj/item/weapon/reagent_containers/food/snacks/sliceable/carrotcake,
+					/obj/item/weapon/reagent_containers/food/snacks/sliceable/cheesecake,
+					/obj/item/weapon/reagent_containers/food/snacks/sliceable/plaincake,
+					/obj/item/weapon/reagent_containers/food/snacks/sliceable/orangecake,
+					/obj/item/weapon/reagent_containers/food/snacks/sliceable/limecake,
+					/obj/item/weapon/reagent_containers/food/snacks/sliceable/lemoncake,
+					/obj/item/weapon/reagent_containers/food/snacks/sliceable/chocolatecake,)
+	cost = 2000
+	containertype = /obj/structure/closet/crate
+	crate_name = "Party Cake Box"
 	group = "Hospitality"
 
 //----------------------------------------------
@@ -573,9 +601,12 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 					/obj/random/tool_upgrade,
 					/obj/random/tool_upgrade,
 					/obj/random/tool_upgrade,
+					/obj/random/tool_upgrade,
+					/obj/random/tool_upgrade,
+					/obj/random/tool_upgrade,
 					/obj/random/tool_upgrade)
 	name = "Unsorted Tool Upgrades"
-	cost = 1500
+	cost = 2000
 	containertype = /obj/structure/closet/crate
 	crate_name = "Tool upgrade Crate"
 	group = "Engineering"
@@ -787,7 +818,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 //----------------------------------------------
 
 /datum/supply_pack/medical
-	name = "Medical crate"
+	name = "Medical kits crate"
 	contains = list(/obj/item/weapon/storage/firstaid/regular,
 					/obj/item/weapon/storage/firstaid/fire,
 					/obj/item/weapon/storage/firstaid/toxin,
@@ -800,7 +831,24 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 					/obj/item/weapon/storage/box/autoinjectors)
 	cost = 1000
 	containertype = /obj/structure/closet/crate/medical
-	crate_name = "Medical crate"
+	crate_name = "Medical kits crate"
+	group = "Medical / Science"
+
+/datum/supply_pack/medical
+	name = "Medical supply crate"
+	contains = list(/obj/item/stack/medical/bruise_pack,
+					/obj/item/stack/medical/bruise_pack,
+					/obj/item/stack/medical/bruise_pack,
+					/obj/item/stack/medical/bruise_pack,
+					/obj/item/stack/medical/bruise_pack,
+					/obj/item/stack/medical/ointment,
+					/obj/item/stack/medical/ointment,
+					/obj/item/stack/medical/ointment,
+					/obj/item/stack/medical/ointment,
+					/obj/item/stack/medical/ointment)
+	cost = 1000
+	containertype = /obj/structure/closet/crate/medical
+	crate_name = "Medical supply crate"
 	group = "Medical / Science"
 
 /datum/supply_pack/virus
@@ -813,6 +861,16 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	containertype = /obj/structure/closet/crate/secure
 	crate_name = "Virus sample crate"
 	access = access_cmo
+	group = "Medical / Science"
+
+/datum/supply_pack/research
+	name = "Research Data crate"
+	contains = list(/obj/item/weapon/computer_hardware/hard_drive/portable/research_points,
+					/obj/item/weapon/computer_hardware/hard_drive/portable/research_points)
+	cost = 5000
+	containertype = /obj/structure/closet/crate/secure
+	crate_name = "Research data crate"
+	access = access_moebius
 	group = "Medical / Science"
 
 /datum/supply_pack/coolanttank
@@ -1227,6 +1285,18 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	name = "EFTPOS scanner"
 	cost = 700
 	crate_name = "EFTPOS crate"
+	group = "Miscellaneous"
+
+/datum/supply_pack/discs
+	contains = list(/obj/item/weapon/computer_hardware/hard_drive/portable/design
+					/obj/item/weapon/computer_hardware/hard_drive/portable/design
+					/obj/item/weapon/computer_hardware/hard_drive/portable/design
+					/obj/item/weapon/computer_hardware/hard_drive/portable/design
+					/obj/item/weapon/computer_hardware/hard_drive/portable/design
+					/obj/item/weapon/computer_hardware/hard_drive/portable/design)
+	name = "Empty Design Disk Crate"
+	cost = 1000
+	crate_name ="Empty disks crate"
 	group = "Miscellaneous"
 
 //----------------------------------------------

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -383,7 +383,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 					/obj/item/weapon/reagent_containers/food/drinks/flask/barflask = 2,/obj/item/weapon/reagent_containers/food/drinks/bottle/bluecuracao = 2,
 					/obj/item/weapon/reagent_containers/food/drinks/drinkingglass = 30,/obj/item/weapon/reagent_containers/food/drinks/bottle/grenadine = 5,
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/melonliquor = 2,/obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe = 1)
-	cost = 2000
+	cost = 3000
 	containertype = /obj/structure/closet/crate/freezer
 	crate_name = "bartending resupply crate"
 	group = "Hospitality"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ok so this adds more crates to the guild.

Bar resupply:  Almost everything that is in the booze-o-mat in reduced quantity , 2000 credits
Cake crate: one of each possible cake sans brain cake, 2000 credits
Research data crate: 2 research data discs, 5000 credits
Medical resupply crate: bruise packs and ointments, 1000 credits
Medical Kit crate: renamed
changed tool crate: 2 more toolmods, 2000 credits
empty disks crate: 5 empty autolathe design disks, 1000 credits


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Guild is in dire need of more crates that have an actual use.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Bar resupply crate:  Almost everything that is in the booze-o-mat in reduced quantity , 2000 credits
add: Cake crate: one of each possible cake sans brain cake, 2000 credits
add: Research data crate: 2 research data discs, 5000 credits
add: Medical resupply crate: bruise packs and ointments, 1000 credits
add: empty disks crate: 5 empty autolathe design disks, 1000 credits
tweak: medical kit crate renamed
balance: toolmod crate now costs 2000 credits and has 2 more toolmods
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
