### PR TITLE
fix(autolathe.eject): zero stack amount

### DIFF
--- a/code/game/machinery/autolathe/autolathe.dm
+++ b/code/game/machinery/autolathe/autolathe.dm
@@ -767,23 +767,28 @@
 	var/whole_amount = round(amount)
 	var/remainder = amount - whole_amount
 
-
 	if (whole_amount)
 		var/obj/item/stack/material/S = new M.stack_type(drop_location())
 
 		//Accounting for the possibility of too much to fit in one stack
 		if (whole_amount <= S.max_amount)
 			S.amount = whole_amount
+			S.update_strings()
+			S.update_icon()
 		else
 			//There's too much, how many stacks do we need
 			var/fullstacks = round(whole_amount / S.max_amount)
 			//And how many sheets leftover for this stack
 			S.amount = whole_amount % S.max_amount
 
+			if (!S.amount)
+				qdel(S)
+
 			for(var/i = 0; i < fullstacks; i++)
 				var/obj/item/stack/material/MS = new M.stack_type(drop_location())
 				MS.amount = MS.max_amount
-
+				MS.update_strings()
+				MS.update_icon()
 
 	//And if there's any remainder, we eject that as a shard
 	if (remainder)


### PR DESCRIPTION
## About The Pull Request

Add `update_strings` and `update_icon` after eject a material and validate NOT zero amount an material stack

## Why It's Good For The Game

Normal use autolathe

## Changelog
:cl:
fix: Fixed an error when the autholate eject zero stack, and bug with ejected icon.
/:cl:
