### PR TITLE
update(sleeper): add eject_occupant_verb

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -221,3 +221,14 @@
 			to_chat(user, "The subject has too many chemicals.")
 	else
 		to_chat(user, "There's no suitable occupant in \the [src].")
+
+/obj/machinery/sleeper/verb/eject_occupant_verb()
+	set name = "Eject Occupant"
+	set desc = "Force eject occupant."
+	set category = "Object"
+	set src in view(1)
+
+	if (usr.incapacitated() || occupant == usr)
+		return
+
+	go_out()


### PR DESCRIPTION
## About The Pull Request

add `eject_occupant_verb` to sleeper

## Why It's Good For The Game

Force eject occupation from sleeper without console

## Changelog
:cl:
add: Abble to eject sleeper occupation, when there's no electricity.
/:cl: