### PR TITLE
utf-8 two-byte russian chars hotfix

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -130,3 +130,10 @@
 /obj/item/device/encryptionkey/entertainment
 	name = "entertainment radio key"
 	channels = list("Entertainment" = 1)
+
+//addition to /obj/item/weapon/card/id/all_access
+/obj/item/device/encryptionkey/heads/admin
+	name = "Admin encryption key"
+	desc = "Full powers encryption key"
+	icon_state = "cap_cypherkey"
+	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "NT Voice" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "AI Private" = 1, "Mercenary" = 1)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -1,20 +1,36 @@
 var/list/department_radio_keys = list(
-	"r" = "right ear",
-	"l" = "left ear",
-	"i" = "intercom",
-	"h" = "department",
+	"r" = "right ear",   "R" = "right ear",
+	"l" = "left ear",    "L" = "left ear",
+	"i" = "intercom",    "I" = "intercom",
+	"h" = "department",  "H" = "department",
 	"+" = "special",	 //activate radio-specific special functions
-	"c" = "Command",
-	"n" = "Science",
-	"m" = "Medical",
-	"e" = "Engineering",
-	"s" = "Security",
-	"w" = "whisper",
-	"y" = "Mercenary",
-	"u" = "Supply",
-	"v" = "Service",
-	"p" = "AI Private",
-	"t" = "NT Voice",
+	"c" = "Command",     "C" = "Command",
+	"n" = "Science",     "N" = "Science",
+	"m" = "Medical",     "M" = "Medical",
+	"e" = "Engineering", "E" = "Engineering",
+	"s" = "Security",    "S" = "Security",
+	"w" = "whisper",     "W" = "whisper",
+	"y" = "Mercenary",   "Y" = "Mercenary",
+	"u" = "Supply",      "U" = "Supply",
+	"v" = "Service",     "V" = "Service",
+	"p" = "AI Private",  "P" = "AI Private",
+	"t" = "NT Voice",    "T" = "NT Voice",
+
+	"к" = "right ear",   "К" = "right ear",
+	"д" = "left ear",    "Д" = "left ear",
+	"ш" = "intercom",    "Ш" = "intercom",
+	"р" = "department",  "Р" = "department",
+	"с" = "Command",     "С" = "Command",
+	"т" = "Science",     "Т" = "Science",
+	"ь" = "Medical",     "Ь" = "Medical",
+	"у" = "Engineering", "У" = "Engineering",
+	"ы" = "Security",    "Ы" = "Security",
+	"ц" = "whisper",     "Ц" = "whisper",
+	"н" = "Mercenary",   "Н" = "Mercenary",
+	"г" = "Supply",      "Г" = "Supply",
+	"м" = "Service",     "М" = "Service",
+	"з" = "AI Private",  "З" = "AI Private",
+	"е" = "NT Voice",    "Е" = "NT Voice",
 )
 
 
@@ -135,11 +151,10 @@ var/list/channel_to_radio_key = new
 	//parse the radio code and consume it
 	var/message_mode = parse_message_mode(message, "headset")
 	if (message_mode)
-		//it would be really nice if the parse procs could do this for us.
 		if (message_mode == "headset")
-			message = copytext(message,2)
+			message = copytext(message,2)//parse ;
 		else
-			message = copytext(message,3)
+			message = copytext_char(message,3)//parse :s 
 
 	message = trim_left(message)
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -150,19 +150,19 @@
 //returns the message mode string or null for no message mode.
 //standard mode is the mode returned for the special ';' radio code.
 /mob/proc/parse_message_mode(var/message, var/standard_mode = "headset")
-	if(length(message) >= 1 && lowertext(copytext(message,1,2)) == get_prefix_key(/decl/prefix/radio_main_channel))
+	if(length(message) >= 1 && copytext(message,1,2) == get_prefix_key(/decl/prefix/radio_main_channel))
 		return standard_mode
 
-	if(length(message) >= 2 && lowertext(copytext(message,1,2)) == get_prefix_key(/decl/prefix/radio_channel_selection))
-		var/channel_prefix = lowertext(copytext(message, 2, 3))
+	if(length(message) >= 2 && copytext(message,1,2) == get_prefix_key(/decl/prefix/radio_channel_selection))
+		var/channel_prefix = copytext_char(message, 2, 3)//copytext_char due to 2-bytes rusky symbols
 		return department_radio_keys[channel_prefix]
-
 	return null
 
 //parses the language code (e.g. :j) from text, such as that supplied to say.
 //returns the language object only if the code corresponds to a language that src can speak, otherwise null.
 /mob/proc/parse_language(var/message)
 	var/prefix = copytext(message, 1, 2)
+	
 	if(length(message) >= 1 && prefix == get_prefix_key(/decl/prefix/audible_emote))
 		return all_languages["Noise"]
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Convenience of chatting for russians.

## Why It's Good For The Game

Becouse now you should not waste your time switching from languange to languange, to get right radio key.
In my case with 3 or 4 languages it is a problem.

## Changelog
:cl:
add: Russiano radio keys are now available. `:ы` `:ь` `:р` `:з` `:н`
/:cl:
