### PR TITLE
Custodian QOL changes proper

### DIFF
--- a/code/datums/outfits/jobs/church.dm
+++ b/code/datums/outfits/jobs/church.dm
@@ -36,3 +36,4 @@
 /decl/hierarchy/outfit/job/church/janitor
 	name = OUTFIT_JOB_NAME("Janitor")
 	uniform = /obj/item/clothing/under/rank/church
+	shoes = /obj/item/clothing/shoes/jackboots/neotheology

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -33,11 +33,11 @@
 	icon_state = "trashbag0"
 	item_state = "trashbag"
 
-	w_class = ITEM_SIZE_BULKY
+	w_class = ITEM_SIZE_NORMAL
 	max_w_class = ITEM_SIZE_SMALL
 	can_hold = list() // any
 	cant_hold = list(/obj/item/weapon/disk/nuclear)
-	max_storage_space = DEFAULT_BULKY_STORAGE
+	max_storage_space = DEFAULT_NORMAL_STORAGE
 
 /obj/item/weapon/storage/bag/trash/update_icon()
 	if(contents.len == 0)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -78,6 +78,8 @@
 	can_hold_extra = list(
 		/obj/item/weapon/book/ritual/cruciform,
 		/obj/item/weapon/implant/core_implant/cruciform
+		/obj/item/weapon/soap
+		/obj/item/weapon/reagent_containers/spray/cleaner
 	)
 
 /obj/item/weapon/storage/belt/medical

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -77,8 +77,8 @@
 	icon_state = "utility_neotheology"
 	can_hold_extra = list(
 		/obj/item/weapon/book/ritual/cruciform,
-		/obj/item/weapon/implant/core_implant/cruciform
-		/obj/item/weapon/soap
+		/obj/item/weapon/implant/core_implant/cruciform,
+		/obj/item/weapon/soap,
 		/obj/item/weapon/reagent_containers/spray/cleaner
 	)
 

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -20,6 +20,16 @@
 /obj/item/clothing/shoes/jackboots/ironhammer
 	icon_state = "jackboots_ironhammer"
 
+/obj/item/clothing/shoes/jackboots/neotheology
+	name = "custodian's jackboots"
+	desc = "Specially altered jackboots for NeoTheology custodians to prevent them from slipping."
+	icon_state = "jackboots"
+	item_state = "jackboots"
+	force = WEAPON_FORCE_HARMLESS
+	siemens_coefficient = 0.3
+	item_flags = NOSLIP
+	can_hold_knife = TRUE
+
 /obj/item/clothing/shoes/reinforced
 	name = "reinforced shoes"
 	desc = "Slightly reinforced shoes. Optimal for your journey into a wonderful world of maintenance."

--- a/code/modules/clothing/spacesuits/void/neotheology.dm
+++ b/code/modules/clothing/spacesuits/void/neotheology.dm
@@ -72,7 +72,7 @@
 	name = "Custodian armor"
 	desc = "Someone's gotta clean this mess."
 	icon_state = "custodian"
-	slowdown = 0.15
+	slowdown = 0.05
 	armor = list(
 		melee = 20,
 		bullet = 10,

--- a/code/modules/projectiles/guns/matter/launcher/nt_sprayer.dm
+++ b/code/modules/projectiles/guns/matter/launcher/nt_sprayer.dm
@@ -3,7 +3,7 @@
 	desc = "\"NeoTheology\" brand cleansing carbine. Uses solid biomass as ammo and dispense cleansing liquid on hit."
 	icon_state = "nt_sprayer"
 	icon = 'icons/obj/guns/matter/nt_sprayer.dmi'
-	slot_flags = SLOT_BACK
+	slot_flags = SLOT_BACK | SLOT_BELT
 	fire_sound = 'sound/weapons/Genhit.ogg'
 
 	matter_type = MATERIAL_BIOMATTER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Now fixed PR of Custian QOL changes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Custodian is a very menial and boring job, this aims to make the job at least more comfortable by having better space to utilize and appropiate boots that prevent the custodian from slipping. These boots are UNOBTAINABLE other than spawning as custodian as to prevent these boots to be used everywhere.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new custodian jackboots to prevent slipping
tweak: NeoTheo Utility belt now holds soap and space cleaner
tweak: Cleansing carbine now also is carriable in the belt slot
balance: Trash bag is smaller but holds less, it now fits properly into a bag to carry it with you
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
