### PR TITLE
Gun rebalance

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -1058,6 +1058,7 @@
 #include "code\game\objects\random\exosuit.dm"
 #include "code\game\objects\random\flora.dm"
 #include "code\game\objects\random\food.dm"
+#include "code\game\objects\random\gun_upgrade.dm"
 #include "code\game\objects\random\guns.dm"
 #include "code\game\objects\random\junk.dm"
 #include "code\game\objects\random\lathe_disks.dm"

--- a/code/datums/autolathe/guns.dm
+++ b/code/datums/autolathe/guns.dm
@@ -88,7 +88,7 @@
 // SMGs
 
 /datum/design/autolathe/gun/zoric
-	name = "FS SMG .35 \"Zoric\""
+	name = "FS SMG .40 \"Zoric\""
 	build_path = /obj/item/weapon/gun/projectile/automatic/zoric
 
 /datum/design/autolathe/gun/atreides

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1034,14 +1034,14 @@
 					/obj/item/weapon/storage/box/shotgunammo/flashshells = 300,
 					/obj/item/weapon/storage/box/shotgunammo/blanks = 50,
 					/obj/item/ammo_magazine/sllrifle = 400,
-					/obj/item/ammo_magazine/slpistol = 800,
+					/obj/item/ammo_magazine/slpistol = 500,
 					/obj/item/ammo_magazine/smg/rubber = 300,
 					/obj/item/ammo_magazine/smg = 400,
 					/obj/item/ammo_magazine/ammobox/pistol = 700,
 					/obj/item/weapon/storage/box/shotgunammo/slug = 900,
 					/obj/item/weapon/storage/box/shotgunammo/buckshot = 900,
 					/obj/item/weapon/tool/knife/tacknife = 600,
-					/obj/item/ammo_magazine/pistol = 400,)
+					/obj/item/ammo_magazine/pistol = 600,)
 
 //This one's from bay12
 /obj/machinery/vending/cart

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1014,28 +1014,16 @@
 					/obj/item/clothing/accessory/holster/armpit = 5,
 					/obj/item/clothing/accessory/holster/waist = 5,
 					/obj/item/clothing/accessory/holster/hip = 5,
-					/obj/item/weapon/gun_upgrade/mechanism/weintraub = 3)
-
-
-	contraband = list(
-					/obj/item/ammo_magazine/slpistol = 20,
-					/obj/item/ammo_magazine/pistol = 20,
+					/obj/item/ammo_magazine/slpistol = 5,
+					/obj/item/ammo_magazine/pistol = 5,
 					/obj/item/ammo_magazine/hpistol = 5,
-					/obj/item/ammo_magazine/smg = 15,
-					/obj/item/ammo_magazine/ammobox/pistol = 20,
-					/obj/item/weapon/storage/box/shotgunammo/slug = 10,
-					/obj/item/weapon/storage/box/shotgunammo/buckshot = 10,
-					/obj/item/weapon/tool/knife/tacknife = 6)
+					/obj/item/ammo_magazine/smg = 3,
+					/obj/item/ammo_magazine/ammobox/pistol = 5,
+					/obj/item/weapon/storage/box/shotgunammo/slug = 3,
+					/obj/item/weapon/storage/box/shotgunammo/buckshot = 3,
+					/obj/item/weapon/tool/knife/tacknife = 5)
+
 	prices = list(
-					/obj/item/device/flash = 600,
-					/obj/item/weapon/reagent_containers/spray/pepper = 800,
-					/obj/item/weapon/gun/projectile/olivaw = 1600,
-					/obj/item/weapon/gun/projectile/giskard = 1200,
-					/obj/item/weapon/gun/energy/gun/martin = 1500,
-					/obj/item/weapon/gun/projectile/revolver/havelock = 2500,
-					/obj/item/weapon/gun/projectile/automatic/atreides = 1500,
-					/obj/item/weapon/gun/projectile/shotgun/pump/gladstone = 3700,
-					/obj/item/weapon/gun/projectile/shotgun/pump = 2000,
 					/obj/item/ammo_magazine/ammobox/pistol/rubber = 400,
 					/obj/item/ammo_magazine/ammobox/pistol/rubber = 500,
 					/obj/item/ammo_magazine/slpistol/rubber = 300,
@@ -1045,16 +1033,15 @@
 					/obj/item/weapon/storage/box/shotgunammo/beanbags = 300,
 					/obj/item/weapon/storage/box/shotgunammo/flashshells = 300,
 					/obj/item/weapon/storage/box/shotgunammo/blanks = 50,
-					/obj/item/ammo_magazine/sllrifle = 200,
-					/obj/item/ammo_magazine/slpistol = 400,
-					/obj/item/ammo_magazine/smg/rubber = 400,
-					/obj/item/ammo_magazine/smg = 500,
-					/obj/item/ammo_magazine/ammobox/pistol = 200,
-					/obj/item/weapon/storage/box/shotgunammo/slug = 300,
-					/obj/item/weapon/storage/box/shotgunammo/buckshot = 300,
+					/obj/item/ammo_magazine/sllrifle = 400,
+					/obj/item/ammo_magazine/slpistol = 800,
+					/obj/item/ammo_magazine/smg/rubber = 300,
+					/obj/item/ammo_magazine/smg = 400,
+					/obj/item/ammo_magazine/ammobox/pistol = 700,
+					/obj/item/weapon/storage/box/shotgunammo/slug = 900,
+					/obj/item/weapon/storage/box/shotgunammo/buckshot = 900,
 					/obj/item/weapon/tool/knife/tacknife = 600,
-					/obj/item/ammo_magazine/pistol = 400,
-					/obj/item/weapon/gun_upgrade/mechanism/weintraub = 1000,)
+					/obj/item/ammo_magazine/pistol = 400,)
 
 //This one's from bay12
 /obj/machinery/vending/cart
@@ -1447,7 +1434,7 @@
 					/obj/item/weapon/storage/deferred/crate/uniform_black = 4,
 					/obj/item/weapon/storage/deferred/crate/uniform_flak  = 2,
 					/obj/item/weapon/storage/deferred/crate/uniform_light = 2,
-					/obj/item/weapon/gun/projectile/boltgun/serbian = 8,
+					/obj/item/weapon/gun/projectile/boltgun/serbian = 10,
 					/obj/item/ammo_magazine/ammobox/lrifle_small = 30,
 					/obj/item/weapon/storage/ration_pack = 10
 					)
@@ -1458,12 +1445,10 @@
 					/obj/item/weapon/storage/deferred/crate/uniform_black = 2000,
 					/obj/item/weapon/storage/deferred/crate/uniform_flak  = 2200,
 					/obj/item/weapon/storage/deferred/crate/uniform_light = 1800,
-					/obj/item/weapon/gun/projectile/boltgun/serbian = 1000,
-					/obj/item/ammo_magazine/ammobox/lrifle_small = 300,
+					/obj/item/ammo_magazine/ammobox/lrifle_small = 400,
 					/obj/item/weapon/storage/ration_pack = 800
 					)
 	idle_power_usage = 211
-	auto_price = FALSE
 	vendor_department = DEPARTMENT_CIVILIAN
 
 /obj/machinery/vending/custom

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -7,6 +7,7 @@
 	w_class = ITEM_SIZE_SMALL
 	throw_speed = 4
 	throw_range = 10
+	price_tag = 300
 	flags = CONDUCT
 	origin_tech = list(TECH_MAGNET = 2, TECH_COMBAT = 1)
 	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -484,10 +484,10 @@
 	license = 20
 	designs = list(
 		/datum/design/autolathe/ammo/pistol_ammobox,
-		/datum/design/autolathe/ammo/pistol_ammobox/practice,
+		/datum/design/autolathe/ammo/pistol_ammobox/practice = 0,
 		/datum/design/autolathe/ammo/pistol_ammobox/rubber,
 		/datum/design/autolathe/ammo/magnum_ammobox,
-		/datum/design/autolathe/ammo/magnum_ammobox/practice,
+		/datum/design/autolathe/ammo/magnum_ammobox/practice = 0,
 		/datum/design/autolathe/ammo/magnum_ammobox/rubber,
 	)
 
@@ -498,17 +498,17 @@
 	license = 20
 	designs = list(
 		/datum/design/autolathe/ammo/srifle_ammobox_small,
-		/datum/design/autolathe/ammo/srifle_ammobox_small/practice,
+		/datum/design/autolathe/ammo/srifle_ammobox_small/practice = 0,
 		/datum/design/autolathe/ammo/srifle_ammobox_small/rubber,
 		/datum/design/autolathe/ammo/srifle_ammobox,
 		/datum/design/autolathe/ammo/srifle_ammobox/rubber,
 		/datum/design/autolathe/ammo/clrifle_ammobox_small,
-		/datum/design/autolathe/ammo/clrifle_ammobox_small/practice,
+		/datum/design/autolathe/ammo/clrifle_ammobox_small/practice = 0,
 		/datum/design/autolathe/ammo/clrifle_ammobox_small/rubber,
 		/datum/design/autolathe/ammo/clrifle_ammobox,
 		/datum/design/autolathe/ammo/clrifle_ammobox/rubber,
 		/datum/design/autolathe/ammo/lrifle_ammobox_small,
-		/datum/design/autolathe/ammo/lrifle_ammobox_small/practice,
+		/datum/design/autolathe/ammo/lrifle_ammobox_small/practice = 0,
 		/datum/design/autolathe/ammo/lrifle_ammobox_small/rubber,
 		/datum/design/autolathe/ammo/lrifle_ammobox,
 	)
@@ -620,9 +620,10 @@
 		/datum/design/autolathe/gun/olivaw = 3,
 		/datum/design/autolathe/gun/clarissa = 3,
 		/datum/design/autolathe/gun/havelock = 3,
-		/datum/design/autolathe/ammo/magazine_pistol/practice,
+		/datum/design/autolathe/ammo/magazine_pistol,
+		/datum/design/autolathe/ammo/magazine_pistol/practice = 0,
 		/datum/design/autolathe/ammo/magazine_pistol/rubber,
-		/datum/design/autolathe/ammo/sl_pistol/practice,
+		/datum/design/autolathe/ammo/sl_pistol/practice = 0,
 		/datum/design/autolathe/ammo/sl_pistol/rubber,
 		)
 
@@ -634,7 +635,8 @@
 	designs = list(
 		/datum/design/autolathe/gun/mk58 = 3,
 		/datum/design/autolathe/gun/mk58_wood = 3,
-		/datum/design/autolathe/ammo/magazine_pistol/practice,
+		/datum/design/autolathe/ammo/magazine_pistol,
+		/datum/design/autolathe/ammo/magazine_pistol/practice = 0,
 		/datum/design/autolathe/ammo/magazine_pistol/rubber,
 	)
 
@@ -645,7 +647,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/colt = 3, //"FS HG .35 Auto \"Colt M1911\""
-		/datum/design/autolathe/ammo/magazine_pistol/practice,
+		/datum/design/autolathe/ammo/magazine_pistol,
+		/datum/design/autolathe/ammo/magazine_pistol/practice = 0,
 		/datum/design/autolathe/ammo/magazine_pistol/rubber,
 	)
 
@@ -656,7 +659,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/mandella = 3, // "FS HG .25 Caseless \"Mandella\""
-		/datum/design/autolathe/ammo/cspistol/practice,
+		/datum/design/autolathe/ammo/cspistol,
+		/datum/design/autolathe/ammo/cspistol/practice = 0,
 		/datum/design/autolathe/ammo/cspistol/rubber,
 	)
 
@@ -669,7 +673,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/revolver = 3, // "FS REV .40 \"Miller\""
-		/datum/design/autolathe/ammo/sl_magnum/practice,
+		/datum/design/autolathe/ammo/sl_magnum,
+		/datum/design/autolathe/ammo/sl_magnum/practice = 0,
 		/datum/design/autolathe/ammo/sl_magnum/rubber,
 		)
 
@@ -680,7 +685,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/revolver_consul = 3, // "FS REV .40 \"Consul\""
-		/datum/design/autolathe/ammo/sl_magnum/practice,
+		/datum/design/autolathe/ammo/sl_magnum,
+		/datum/design/autolathe/ammo/sl_magnum/practice = 0,
 		/datum/design/autolathe/ammo/sl_magnum/rubber,
 		)
 
@@ -691,7 +697,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/revolver_deckard = 3, // "FS REV .40 \"Deckard\""
-		/datum/design/autolathe/ammo/sl_magnum/practice,
+		/datum/design/autolathe/ammo/sl_magnum,
+		/datum/design/autolathe/ammo/sl_magnum/practice = 0,
 		/datum/design/autolathe/ammo/sl_magnum/rubber,
 		)
 
@@ -702,7 +709,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/revolver_mateba = 3, // "FS REV .40 Magnum \"Mateba\""
-		/datum/design/autolathe/ammo/sl_magnum/practice,
+		/datum/design/autolathe/ammo/sl_magnum,
+		/datum/design/autolathe/ammo/sl_magnum/practice = 0,
 		/datum/design/autolathe/ammo/sl_magnum/rubber,
 		)
 
@@ -715,7 +723,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/lamia = 3, // "FS HG .40 \"Lamia\""
-		/datum/design/autolathe/ammo/mg_magnum/practice,
+		/datum/design/autolathe/ammo/mg_magnum,
+		/datum/design/autolathe/ammo/mg_magnum/practice = 0,
 		/datum/design/autolathe/ammo/mg_magnum/rubber,
 		)
 
@@ -726,7 +735,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/avasarala = 3, // "FS HG .40 \"Avasarala\""
-		/datum/design/autolathe/ammo/mg_magnum/practice,
+		/datum/design/autolathe/ammo/mg_magnum,
+		/datum/design/autolathe/ammo/mg_magnum/practice = 0,
 		/datum/design/autolathe/ammo/mg_magnum/rubber,
 		)
 
@@ -739,6 +749,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/doublebarrel = 3, // "double-barreled shotgun"
+		/datum/design/autolathe/ammo/shotgun_pellet,
+		/datum/design/autolathe/ammo/shotgun,
 		/datum/design/autolathe/ammo/shotgun_beanbag,
 		/datum/design/autolathe/ammo/shotgun_blanks,
 		/datum/design/autolathe/ammo/shotgun_flash,
@@ -751,6 +763,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/pump_shotgun = 3, // "FS SG \"Kammerer\""
+		/datum/design/autolathe/ammo/shotgun_pellet,
+		/datum/design/autolathe/ammo/shotgun,
 		/datum/design/autolathe/ammo/shotgun_beanbag,
 		/datum/design/autolathe/ammo/shotgun_blanks,
 		/datum/design/autolathe/ammo/shotgun_flash,
@@ -763,6 +777,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/regulator = 3, // "NT SG \"Regulator 1000\""
+		/datum/design/autolathe/ammo/shotgun_pellet,
+		/datum/design/autolathe/ammo/shotgun,
 		/datum/design/autolathe/ammo/shotgun_beanbag,
 		/datum/design/autolathe/ammo/shotgun_blanks,
 		/datum/design/autolathe/ammo/shotgun_flash,
@@ -775,6 +791,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/gladstone = 3, // "FS SG \"Gladstone\""
+		/datum/design/autolathe/ammo/shotgun_pellet,
+		/datum/design/autolathe/ammo/shotgun,
 		/datum/design/autolathe/ammo/shotgun_beanbag,
 		/datum/design/autolathe/ammo/shotgun_blanks,
 		/datum/design/autolathe/ammo/shotgun_flash,
@@ -801,7 +819,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/paco = 3, // "FS HG .35 \"Paco\""
-		/datum/design/autolathe/ammo/magazine_pistol/practice,
+		/datum/design/autolathe/ammo/magazine_pistol,
+		/datum/design/autolathe/ammo/magazine_pistol/practice = 0,
 		/datum/design/autolathe/ammo/magazine_pistol/rubber,
 	)
 
@@ -812,7 +831,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/straylight = 3, // "FS SMG .35 \"Straylight\""
-		/datum/design/autolathe/ammo/smg/practice,
+		/datum/design/autolathe/ammo/smg,
+		/datum/design/autolathe/ammo/smg/practice = 0,
 		/datum/design/autolathe/ammo/smg/rubber,
 	)
 
@@ -823,7 +843,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/molly = 3, // "FS MP .35 \"Molly\""
-		/datum/design/autolathe/ammo/smg/practice,
+		/datum/design/autolathe/ammo/smg,
+		/datum/design/autolathe/ammo/smg/practice = 0,
 		/datum/design/autolathe/ammo/smg/rubber,
 	)
 
@@ -834,7 +855,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/zoric = 3, // "SA SMG .40 \"Zoric\""
-		/datum/design/autolathe/ammo/msmg/practice,
+		/datum/design/autolathe/ammo/msmg,
+		/datum/design/autolathe/ammo/msmg/practice = 0,
 		/datum/design/autolathe/ammo/msmg/rubber,
 	)
 
@@ -845,7 +867,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/atreides = 3, // "FS SMG .35 \"Atreides\""
-		/datum/design/autolathe/ammo/smg/practice,
+		/datum/design/autolathe/ammo/smg,
+		/datum/design/autolathe/ammo/smg/practice = 0,
 		/datum/design/autolathe/ammo/smg/rubber,
 	)
 
@@ -873,7 +896,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/z8 = 3, // "FS CAR .20 \"Z8 Bulldog\""
-		/datum/design/autolathe/ammo/srifle/practice,
+		/datum/design/autolathe/ammo/srifle,
+		/datum/design/autolathe/ammo/srifle/practice = 0,
 		/datum/design/autolathe/ammo/srifle/rubber,
 	)
 
@@ -884,7 +908,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/wintermute = 3, // "FS BR .20 \"Wintermute\""
-		/datum/design/autolathe/ammo/srifle/practice,
+		/datum/design/autolathe/ammo/srifle,
+		/datum/design/autolathe/ammo/srifle/practice = 0,
 		/datum/design/autolathe/ammo/srifle/rubber,
 	)
 
@@ -897,7 +922,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/sol = 3, // "FS CAR .25 caseless \"Sol\""
-		/datum/design/autolathe/ammo/ihclrifle/practice,
+		/datum/design/autolathe/ammo/ihclrifle,
+		/datum/design/autolathe/ammo/ihclrifle/practice = 0,
 		/datum/design/autolathe/ammo/ihclrifle/rubber,
 	)
 
@@ -931,7 +957,8 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/ak47_fs = 3, // "FS AR .30 \"Kalashnikov\""
-		/datum/design/autolathe/ammo/lrifle/practice,
+		/datum/design/autolathe/ammo/lrifle,
+		/datum/design/autolathe/ammo/lrifle/practice = 0,
 		/datum/design/autolathe/ammo/lrifle/rubber,
 	)
 

--- a/code/game/objects/random/gun_upgrade.dm
+++ b/code/game/objects/random/gun_upgrade.dm
@@ -1,0 +1,20 @@
+/obj/random/gun_upgrade
+	name = "random gun upgrade"
+	icon_state = "ammo-orange"
+
+/obj/random/gun_cheap/item_to_spawn()
+	return pickweight(list(/obj/item/weapon/gun_upgrade/trigger/dangerzone = 4,
+				/obj/item/weapon/gun_upgrade/trigger/cop_block = 4,
+				/obj/item/weapon/gun_upgrade/mechanism/overshooter = 2,
+				/obj/item/weapon/gun_upgrade/barrel/excruciator = 1,
+				/obj/item/weapon/gun_upgrade/barrel/mag_accel = 2,
+				/obj/item/weapon/gun_upgrade/barrel/overheat = 2,
+				/obj/item/weapon/gun_upgrade/barrel/silencer = 3,
+				/obj/item/weapon/gun_upgrade/mechanism/glass_widow = 1,
+				/obj/item/weapon/gun_upgrade/mechanism/weintraub = 2,
+				/obj/item/weapon/gun_upgrade/barrel/forged = 5))
+
+/obj/random/gun_cheap/low_chance
+	name = "low chance random gun upgrade"
+	icon_state = "ammo-orange-low"
+	spawn_nothing_percentage = 70

--- a/code/game/objects/random/guns.dm
+++ b/code/game/objects/random/guns.dm
@@ -14,8 +14,7 @@
 				/obj/item/weapon/gun/projectile/olivaw = 4,\
 				/obj/item/weapon/gun/energy/gun/martin = 2,\
 				/obj/item/weapon/gun/launcher/crossbow = 1,\
-				/obj/item/weapon/gun/projectile/boltgun/serbian = 1,\
-				/obj/item/weapon/gun_upgrade/barrel/forged = 2,))
+				/obj/item/weapon/gun/projectile/boltgun/serbian = 1))
 
 /obj/random/gun_cheap/low_chance
 	name = "low chance random cheap gun"
@@ -47,10 +46,7 @@
 				/obj/item/weapon/gun/projectile/automatic/straylight = 1,\
 				/obj/item/weapon/gun/energy/gun = 2,\
 				/obj/item/weapon/gun/energy/laser = 2,\
-				/obj/item/weapon/gun/energy/plasma/cassad = 2,
-				/obj/item/weapon/gun_upgrade/trigger/dangerzone = 1,
-				/obj/item/weapon/gun_upgrade/trigger/cop_block = 1,
-				/obj/item/weapon/gun_upgrade/mechanism/overshooter = 1))
+				/obj/item/weapon/gun/energy/plasma/cassad = 2))
 
 /obj/random/gun_normal/low_chance
 	name = "low chance random normal gun"
@@ -67,8 +63,7 @@
 /obj/random/gun_energy_cheap/item_to_spawn()
 	return pickweight(list(/obj/item/weapon/gun/energy/gun/martin = 2,\
 				/obj/item/weapon/gun/energy/gun = 2,\
-				/obj/item/weapon/gun/energy/retro = 1,
-				/obj/item/weapon/gun_upgrade/barrel/excruciator = 1))
+				/obj/item/weapon/gun/energy/retro = 1))
 
 /obj/random/gun_energy_cheap/low_chance
 	name = "low chance random cheap energy weapon"

--- a/code/game/objects/random/packs.dm
+++ b/code/game/objects/random/packs.dm
@@ -58,6 +58,7 @@ They generally give more random result and can provide more divercity in spawn.
 					/obj/random/tool_upgrade = 30,
 					/obj/random/toolbox = 5,
 					/obj/random/voidsuit = 3,
+					/obj/random/gun_upgrade = 2
 				))
 
 /obj/random/pack/tech_loot/low_chance
@@ -96,6 +97,7 @@ They generally give more random result and can provide more divercity in spawn.
 					/obj/random/ammo/shotgun = 15,
 					/obj/random/ammo_ihs = 15,
 					/obj/random/ammo_lowcost = 18,
+					/obj/random/gun_upgrade = 10,
 					/obj/random/cloth/holster = 8
 				))
 

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/energy/shrapnel
-	name = "Asters \"Shellshock\" energy shotgun"
-	desc = "Based on an SDF design, this mat-fab shotgun tends to burn through cells with use."
+	name = "OR SDF \"Shellshock\" energy shotgun"
+	desc = "An Oberth Republic Self Defence Force design, this mat-fab shotgun tends to burn through cells with use."
 	icon = 'icons/obj/guns/energy/shrapnel.dmi'
 	icon_state = "eshotgun"
 	item_charge_meter = TRUE

--- a/code/modules/projectiles/guns/projectile/automatic/dallas.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/dallas.dm
@@ -18,7 +18,7 @@
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/m41_reload.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/m41_cocked.ogg'
-	damage_multiplier = 1.3 //35.1 with lethal, 41.3 with hv
+	damage_multiplier = 1.35
 	penetration_multiplier = 1
 	recoil_buildup = 6
 	one_hand_penalty = 10 //heavy, but very advanced, so bullpup rifle level despite not being bullpup

--- a/code/modules/projectiles/guns/projectile/automatic/sol.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sol.dm
@@ -16,7 +16,7 @@
 	price_tag = 2300
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	recoil_buildup = 5
-	damage_multiplier = 1.3
+	damage_multiplier = 1.25
 	penetration_multiplier = 1.1
 	one_hand_penalty = 5 //bullpup rifle (this one is smaller and carbine, so it's 5)
 

--- a/code/modules/projectiles/guns/projectile/automatic/sol.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sol.dm
@@ -15,7 +15,9 @@
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 12)
 	price_tag = 2300
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
-	recoil_buildup = 8 
+	recoil_buildup = 5
+	damage_multiplier = 1.3
+	penetration_multiplier = 1.1
 	one_hand_penalty = 5 //bullpup rifle (this one is smaller and carbine, so it's 5)
 
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/automatic/sts35.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts35.dm
@@ -1,6 +1,8 @@
 /obj/item/weapon/gun/projectile/automatic/sts35
-	name = "STS-35"
-	desc = "The rugged STS-35 is a durable automatic weapon, popular on frontier worlds. Uses .30 Rifle rounds. This one is unmarked."
+	name = "OR SDF \"STS-35\""
+	desc = "The rugged STS-35 is a durable automatic weapon, made by Oberth Republic Self Defence Force. \
+			Extremely efficient rifle that was put in service right before collapse of the Republic, this weapon can be found almost anywhere in the galaxy by now. \
+			Uses .30 Rifle rounds."
 	icon = 'icons/obj/guns/projectile/sts.dmi'
 	icon_state = "sts"
 	item_state = "sts"
@@ -26,7 +28,6 @@
 	init_firemodes = list(
 		FULL_AUTO_400,
 		SEMI_AUTO_NODELAY,
-		BURST_3_ROUND,
 		BURST_5_ROUND
 		)
 

--- a/code/modules/projectiles/guns/projectile/automatic/sts35.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts35.dm
@@ -1,7 +1,7 @@
 /obj/item/weapon/gun/projectile/automatic/sts35
 	name = "OR SDF \"STS-35\""
 	desc = "The rugged STS-35 is a durable automatic weapon, made by Oberth Republic Self Defence Force. \
-			Extremely efficient rifle that was put in service right before collapse of the Republic, this weapon can be found almost anywhere in the galaxy by now. \
+			Extremely efficient rifle design that was put in service right before collapse of the Republic, this weapon can be found almost anywhere in the galaxy by now. \
 			Uses .30 Rifle rounds."
 	icon = 'icons/obj/guns/projectile/sts.dmi'
 	icon_state = "sts"

--- a/code/modules/projectiles/guns/projectile/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun.dm
@@ -21,7 +21,7 @@
 	fire_sound = 'sound/weapons/guns/fire/sniper_fire.ogg'
 	reload_sound = 'sound/weapons/guns/interact/rifle_load.ogg'
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_PLASTIC = 10)
-	price_tag = 2000
+	price_tag = 1600
 	one_hand_penalty = 20 //full sized rifle with bayonet is hard to keep on target
 	var/bolt_open = 0
 	var/item_suffix = ""

--- a/code/modules/projectiles/guns/projectile/pistol/giskard.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/giskard.dm
@@ -15,8 +15,8 @@
 	mag_well = MAG_WELL_PISTOL
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_WOOD = 4)
 	price_tag = 600
-	damage_multiplier = 0.75
-	penetration_multiplier = 0.9
+	damage_multiplier = 1.3
+	penetration_multiplier = 0.8
 	recoil_buildup = 2
 
 /obj/item/weapon/gun/projectile/giskard/update_icon()

--- a/code/modules/projectiles/guns/projectile/pistol/lamia.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/lamia.dm
@@ -18,8 +18,8 @@
 	unload_sound 	= 'sound/weapons/guns/interact/hpistol_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/hpistol_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/hpistol_cock.ogg'
-	damage_multiplier = 1.2
-	penetration_multiplier = 1.3
+	damage_multiplier = 1.4
+	penetration_multiplier = 1.4
 	recoil_buildup = 21
 
 /obj/item/weapon/gun/projectile/lamia/update_icon()

--- a/code/modules/projectiles/guns/projectile/pistol/mandella.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mandella.dm
@@ -2,7 +2,7 @@
 	name = "FS HG .25 CS \"Mandella\""
 	desc = "A rugged, robust operator handgun with inbuilt silencer. Chambered in rifle caseless ammunition, this time-tested handgun is \
 			your absolute choise if you need to take someone down silently, as it's deadly, produces no sound and leaves no traces. \
-			Build to enhance armor penetration abilities of ammo. \
+			Built to have enhanced armor penetration abilities. \
 			Uses .25 Caseless rounds."
 	icon = 'icons/obj/guns/projectile/mandella.dmi'
 	icon_state = "mandella"

--- a/code/modules/projectiles/guns/projectile/pistol/mandella.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mandella.dm
@@ -2,6 +2,7 @@
 	name = "FS HG .25 CS \"Mandella\""
 	desc = "A rugged, robust operator handgun with inbuilt silencer. Chambered in rifle caseless ammunition, this time-tested handgun is \
 			your absolute choise if you need to take someone down silently, as it's deadly, produces no sound and leaves no traces. \
+			Build to enhance armor penetration abilities of ammo. \
 			Uses .25 Caseless rounds."
 	icon = 'icons/obj/guns/projectile/mandella.dmi'
 	icon_state = "mandella"
@@ -16,8 +17,8 @@
 	price_tag = 1500
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_PISTOL
-	damage_multiplier = 1			//27 with lethal, 32 with hv
-	penetration_multiplier = 0.8	//12 with lethal, 16 with hv
+	damage_multiplier = 1.2
+	penetration_multiplier = 1.7
 	recoil_buildup = 19
 
 

--- a/code/modules/projectiles/guns/projectile/pistol/mk58.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mk58.dm
@@ -12,8 +12,8 @@
 	can_dual = 1
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_PISTOL
-	damage_multiplier = 0.9
-	penetration_multiplier = 0.9
+	damage_multiplier = 1.3
+	penetration_multiplier = 1.3
 	recoil_buildup = 3
 
 

--- a/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
@@ -12,8 +12,8 @@
 	mag_well = MAG_WELL_PISTOL|MAG_WELL_H_PISTOL
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
 	price_tag = 800
-	damage_multiplier = 1.1
-	penetration_multiplier = 1.1
+	damage_multiplier = 1.2
+	penetration_multiplier = 1.2
 	recoil_buildup = 6
 	init_firemodes = list(
 		list(mode_name="semiauto",       burst=1, fire_delay=1.2, move_delay=null, 				icon="semi"),

--- a/code/modules/projectiles/guns/projectile/pistol/paco.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/paco.dm
@@ -18,7 +18,8 @@
 	price_tag = 1500
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
-	damage_multiplier = 1.1
+	damage_multiplier = 1.35
+	penetration_multiplier = 0.8
 	recoil_buildup = 20
 	gun_tags = list(GUN_SILENCABLE)
 

--- a/code/modules/projectiles/guns/projectile/revolver/consul.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/consul.dm
@@ -11,6 +11,6 @@
 	ammo_type = /obj/item/ammo_casing/magnum/rubber
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 8)
 	price_tag = 1700
-	damage_multiplier = 1.3
+	damage_multiplier = 1.35
 	penetration_multiplier = 1.5
 	recoil_buildup = 35

--- a/code/modules/projectiles/guns/projectile/revolver/deckard.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/deckard.dm
@@ -9,6 +9,6 @@
 	ammo_type = /obj/item/ammo_casing/magnum/rubber
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
 	price_tag = 3100 //one of most robust revolvers here
-	damage_multiplier = 1.35
+	damage_multiplier = 1.45
 	penetration_multiplier = 1.65
 	recoil_buildup = 40

--- a/code/modules/projectiles/guns/projectile/revolver/havelock.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/havelock.dm
@@ -11,7 +11,7 @@
 	fire_sound = 'sound/weapons/Gunshot_light.ogg'
 	ammo_type = /obj/item/ammo_casing/pistol
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
-	price_tag = 800 //cheap civ peashooter revolver, something similar to olivav
-	damage_multiplier = 1.15 //because pistol round
-	penetration_multiplier = 1.2
+	price_tag = 900
+	damage_multiplier = 1.4 //because pistol round
+	penetration_multiplier = 1.4
 	recoil_buildup = 18

--- a/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
@@ -13,7 +13,7 @@
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_RIFLE
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 10)
-	price_tag = 5000
+	price_tag = 4000
 	fire_sound = 'sound/weapons/guns/fire/shotgunp_fire.ogg'
 	unload_sound = 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound = 'sound/weapons/guns/interact/ltrifle_magin.ogg'

--- a/code/modules/projectiles/guns/projectile/shotgun/bull.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/bull.dm
@@ -16,7 +16,7 @@
 	var/reload = 1
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 4)
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 6)
-	price_tag = 2800 //gives tactical advantage with beanbags, but consumes more ammo and hits less harder with lethal ammo, so Gladstone or Regulator would be better for lethal takedowns in general
+	price_tag = 2000 //gives tactical advantage with beanbags, but consumes more ammo and hits less harder with lethal ammo, so Gladstone or Regulator would be better for lethal takedowns in general
 	damage_multiplier = 0.75
 	penetration_multiplier = 0.75
 	one_hand_penalty = 10 //compact shotgun level

--- a/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
@@ -19,7 +19,7 @@
 	bulletinsert_sound 	= 'sound/weapons/guns/interact/shotgun_insert.ogg'
 	fire_sound = 'sound/weapons/guns/fire/shotgunp_fire.ogg'
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 10)
-	price_tag = 1500
+	price_tag = 1200
 	one_hand_penalty = 15 //full sized shotgun level
 	var/bolt_open = 0
 	burst_delay = 0

--- a/code/modules/projectiles/guns/projectile/shotgun/gladstone.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/gladstone.dm
@@ -9,6 +9,6 @@
 	damage_multiplier = 0.9 //slightly less damage
 	ammo_type = /obj/item/ammo_casing/shotgun
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 6)
-	price_tag = 3000
+	price_tag = 2000
 	recoil_buildup = 14
 	one_hand_penalty = 15 //full sized shotgun level

--- a/code/modules/projectiles/guns/projectile/shotgun/pump.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/pump.dm
@@ -17,7 +17,7 @@
 	fire_sound = 'sound/weapons/guns/fire/shotgunp_fire.ogg'
 	bulletinsert_sound 	= 'sound/weapons/guns/interact/shotgun_insert.ogg'
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 10)
-	price_tag = 2200
+	price_tag = 1000
 	recoil_buildup = 20
 	one_hand_penalty = 15 //full sized shotgun level
 

--- a/code/modules/projectiles/guns/projectile/shotgun/regulator.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/regulator.dm
@@ -9,7 +9,7 @@
 	max_shells = 7 //less ammo and regular recoil, decided not to give 1.2 because Gladstone would be anyhow better in this case
 	ammo_type = /obj/item/ammo_casing/shotgun
 	matter = list(MATERIAL_PLASTEEL = 25, MATERIAL_PLASTIC = 12)
-	price_tag = 2600
+	price_tag = 1500
 	damage_multiplier = 1.1
 	penetration_multiplier = 1
 	recoil_buildup = 16

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -58,7 +58,10 @@
 	var/knockback = 0
 
 	var/hitscan = FALSE		// whether the projectile should be hitscan
-	var/step_delay = 1	// the delay between iterations if not a hitscan projectile
+
+	var/step_delay = 0.8	// the delay between iterations if not a hitscan projectile
+							// This thing right here goes to sleep(). We should not send non decimal things to sleep(),
+							// but it was doing it for a while, it works, and this whole shit should be rewriten or ported from another codebase.
 
 	// effect types to be used
 	var/muzzle_type

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -11,13 +11,13 @@ There are important things regarding this file:
 */
 //Low-caliber pistols and SMGs .35
 /obj/item/projectile/bullet/pistol
-	damage_types = list(BRUTE = 24)
-	armor_penetration = 5
+	damage_types = list(BRUTE = 28)
+	armor_penetration = 10
 	can_ricochet = TRUE
 
 /obj/item/projectile/bullet/pistol/hv
-	damage_types = list(BRUTE = 28)
-	armor_penetration = 10
+	damage_types = list(BRUTE = 32)
+	armor_penetration = 20
 	penetrating = 1
 	step_delay = 0.75
 
@@ -33,7 +33,7 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/pistol/rubber
 	name = "rubber bullet"
 	damage_types = list(BRUTE = 3)
-	agony = 22
+	agony = 25
 	armor_penetration = 0
 	embed = FALSE
 	sharp = FALSE
@@ -141,7 +141,7 @@ There are important things regarding this file:
 
 //Revolvers and high-caliber pistols .40
 /obj/item/projectile/bullet/magnum
-	damage_types = list(BRUTE = 32)
+	damage_types = list(BRUTE = 34)
 	armor_penetration = 15
 	can_ricochet = TRUE
 
@@ -155,7 +155,7 @@ There are important things regarding this file:
 	can_ricochet = FALSE
 
 /obj/item/projectile/bullet/magnum/hv
-	damage_types = list(BRUTE = 35)
+	damage_types = list(BRUTE = 39)
 	armor_penetration = 20
 	penetrating = 1
 	step_delay = 0.75

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -116,6 +116,7 @@
 	icon_state = "pepperspray"
 	item_state = "pepperspray"
 	possible_transfer_amounts = null
+	price_tag = 300
 	volume = 40
 	var/safety = 1
 	preloaded_reagents = list("condensedcapsaicin" = 40)


### PR DESCRIPTION
## About The Pull Request

In the memory of Course.

Rebalance of most guns that were ignored by players to be something more decent.
Lowered price on all shotguns.
Gun mods should now appear much more often in loot.
Speed boost for all projectiles by 20%.

## Why It's Good For The Game

Making using some guns less of a meme and generally enhancing gunplay.

## Changelog
:cl:
balance: All projectiles are 20% faster.
balance: All shotguns now cost less.
balance: All gun discs now have lethal ammo. All shotgun ammo can be now found in gun discs. Practice ammo does not consume any license points.
balance: Vendor price for guns changed for real prices for guns. Contraband removed from FS vendor, and t's contents were moved to regular selection. There is less lethal ammo there, however.
balance: Caliber .35 received a buff, along with all non SMG guns that use it. They are now much more usable.
balance: Caliber .40 received minor buffs.
balance: Paco damage is buffed, armor penetration lowered.
balance: Lamia buffed.
balance: Mandela now have huge armor penetration capabilities so you can actually use it against protected targets.
balance: Sol is buffed substantially, lower recoil and higher damage.
balance: Decard is buffed a bit.
balance: All of the gun mods now can spawn in general technical loot. They will appear much more often.
balance: Blitzshell gun and STS are now German produced guns.
balance: STS no longer have 3 burst mode and only have 5 one, to lower the amount of mods you need to cycle though.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
