### PR TITLE
clrifle rubbers (sol/caselesspistol) does more agony damage

### DIFF
--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -102,7 +102,7 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/clrifle/rubber
 	name = "rubber bullet"
 	damage_types = list(BRUTE = 3)
-	agony = 16
+	agony = 22
 	armor_penetration = 0
 	embed = FALSE
 	sharp = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes clrifle in general do more AGONY damage
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/46353991/87240357-b922d080-c3cd-11ea-88f5-6b231c4aa44e.png)
also lets traitors capture people more consistently, and with no evidence. ~~the Dallas isn't real, it can't hurt you.~~
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Crifle rubber ammo (ceaseless) does more agony damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
