### PR TITLE
Command stash directions change

### DIFF
--- a/code/modules/stashes/stash_types/captain.dm
+++ b/code/modules/stashes/stash_types/captain.dm
@@ -5,6 +5,7 @@
 /datum/stash/command
 	base_type = /datum/stash/command
 	loot_type = "Command"
+	directions = DIRECTION_LANDMARK
 	contents_list_base = list(/obj/item/clothing/under/rank/captain = 1,
 	/obj/item/clothing/gloves/captain = 1)
 	contents_list_extra = list()


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Command stash directions changed to only use landmark, no coordinates.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes the command stash more search-intensive to find.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Command stashes will only give personalized landmark directions to their loot now, and won't ever provide exact coordinates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
