### PR TITLE
More simple weapon tools

### DIFF
--- a/code/datums/craft/recipes/weapon.dm
+++ b/code/datums/craft/recipes/weapon.dm
@@ -88,7 +88,7 @@
 
 /datum/craft_recipe/weapon/nailed_bat
 	name = "nailed bat"
-	result = /obj/item/weapon/melee/nailstick
+	result = /obj/item/weapon/tool/nailstick
 	steps = list(
 		list(CRAFT_MATERIAL, 6, MATERIAL_WOOD),
 		list(/obj/item/stack/rods, 3, "time" = 50)

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -1,17 +1,3 @@
-/obj/item/weapon/melee/chainofcommand
-	name = "chain of command"
-	desc = "A tool used by great men to placate the frothing masses."
-	icon_state = "chain"
-	item_state = "chain"
-	flags = CONDUCT
-	slot_flags = SLOT_BELT
-	force = WEAPON_FORCE_DANGEROUS
-	throwforce = WEAPON_FORCE_DANGEROUS
-	w_class = ITEM_SIZE_NORMAL
-	origin_tech = list(TECH_COMBAT = 4)
-	attack_verb = list("flogged", "whipped", "lashed", "disciplined")
-
-
 /obj/item/weapon/melee/toolbox_maul
 	name = "toolmop the maul"
 	desc = "Toolbox tied to mop. A weapon of choice."
@@ -97,16 +83,3 @@
 		break_apart(user)
 		playsound(src.loc, 'sound/effects/bang.ogg', 45, 1)
 		user.visible_message(SPAN_WARNING("[src] breaks in hands of [user]!"))
-
-
-/obj/item/weapon/melee/nailstick
-	name = "nailed stick"
-	desc = "Stick with some nails in it. Looks sharp enough."
-	icon_state = "hm_spikeclub"
-	item_state = "hm_spikeclub"
-	force = WEAPON_FORCE_PAINFUL
-	throwforce = WEAPON_FORCE_PAINFUL
-	w_class = ITEM_SIZE_NORMAL
-	origin_tech = list(TECH_COMBAT = 2)
-	attack_verb = list("beaten", "slammed", "smacked", "struck", "battered")
-	structure_damage_factor = STRUCTURE_DAMAGE_HEAVY

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -17,6 +17,21 @@
 	tool_qualities = list(QUALITY_CUTTING = 10)
 	var/icon/broken_outline = icon('icons/obj/drinks.dmi', "broken")
 
+/obj/item/weapon/tool/nailstick
+	name = "nailed stick"
+	desc = "Stick with some nails in it. Looks sharp enough."
+	icon = 'icons/obj/weapons.dmi'
+	icon_state = "hm_spikeclub"
+	item_state = "hm_spikeclub"
+	force = WEAPON_FORCE_PAINFUL
+	throwforce = WEAPON_FORCE_PAINFUL
+	w_class = ITEM_SIZE_NORMAL
+	origin_tech = list(TECH_COMBAT = 2)
+	attack_verb = list("beaten", "slammed", "smacked", "struck", "battered")
+	structure_damage_factor = STRUCTURE_DAMAGE_HEAVY
+	max_upgrades = 5
+	tool_qualities = list(QUALITY_HAMMERING = 10)
+
 /obj/item/weapon/tool/hatchet
 	name = "hatchet"
 	desc = "A very sharp axe blade upon a short fibremetal handle. It has a long history of chopping things, but now it is used for chopping wood."
@@ -91,7 +106,6 @@
 	tool_qualities = list(QUALITY_CUTTING = 15)
 
 //Swords
-
 /obj/item/weapon/tool/sword
 	name = "claymore"
 	desc = "What are you standing around staring at this for? Get to killing!"
@@ -157,3 +171,20 @@
 		overlays += "[icon_state]_power_on"
 	else
 		overlays += "[icon_state]_power_off"
+
+//Flails
+/obj/item/weapon/tool/chainofcommand
+	name = "chain of command"
+	desc = "A tool used by great men to placate the frothing masses."
+	icon = 'icons/obj/weapons.dmi'
+	icon_state = "chain"
+	item_state = "chain"
+	flags = CONDUCT
+	slot_flags = SLOT_BELT
+	force = WEAPON_FORCE_DANGEROUS
+	throwforce = WEAPON_FORCE_DANGEROUS
+	w_class = ITEM_SIZE_NORMAL
+	origin_tech = list(TECH_COMBAT = 4)
+	attack_verb = list("flogged", "whipped", "lashed", "disciplined")
+	max_upgrades = 2
+	tool_qualities = list(QUALITY_HAMMERING = 5)

--- a/code/modules/stashes/stash_types/captain.dm
+++ b/code/modules/stashes/stash_types/captain.dm
@@ -11,7 +11,7 @@
 	contents_list_random = list(/obj/item/clothing/head/space/capspace = 70,
 	/obj/item/clothing/suit/space/captain = 70,
 	/obj/item/weapon/tank/jetpack/oxygen = 55,
-	/obj/item/weapon/melee/chainofcommand = 65,
+	/obj/item/weapon/tool/chainofcommand = 65,
 	/obj/item/weapon/reagent_containers/food/drinks/flask = 50,
 	/obj/item/weapon/gun/energy/captain = 65,
 	/obj/item/weapon/card/id/captains_spare = 10,

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -72507,7 +72507,7 @@
 	pixel_x = -6;
 	pixel_y = 5
 	},
-/obj/item/weapon/melee/chainofcommand,
+/obj/item/weapon/tool/chainofcommand,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -23


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Captain's Chain of Command, and the Nailstick are now tools which can be upgraded.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Just like broken bottles, you can augment your weapons with "stuff" now.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The Chain of Command and the "Nailstick" are now both tools, and accept tool mods.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
