### PR TITLE
Random trash tweaks

### DIFF
--- a/code/game/objects/random/guns.dm
+++ b/code/game/objects/random/guns.dm
@@ -29,25 +29,26 @@
 	icon_state = "gun-green"
 
 /obj/random/gun_normal/item_to_spawn()
-	return pickweight(list(/obj/item/weapon/gun/projectile/lamia = 2,\
-				/obj/item/weapon/gun/projectile/automatic/zoric = 1,\
-				/obj/item/weapon/gun/projectile/automatic/atreides = 1,\
-				/obj/item/weapon/gun/projectile/avasarala = 2,\
-				/obj/item/weapon/gun/projectile/shotgun/pump/gladstone = 2,\
-				/obj/item/weapon/gun/projectile/colt = 3,\
-				/obj/item/weapon/gun/projectile/revolver/consul = 3,\
-				/obj/item/weapon/gun/projectile/revolver = 3,\
-				/obj/item/weapon/gun/projectile/revolver/deckard = 2,\
-				/obj/item/weapon/gun/projectile/automatic/wintermute = 1,\
-				/obj/item/weapon/gun/projectile/automatic/sol = 1,\
-				/obj/item/weapon/gun/projectile/automatic/ak47/fs = 1,\
-				/obj/item/weapon/gun/projectile/automatic/molly = 2,\
-				/obj/item/weapon/gun/projectile/automatic/straylight = 1,\
-				/obj/item/weapon/gun/projectile/automatic/c20r = 1,\
-				/obj/item/weapon/gun/energy/gun = 2,\
-				/obj/item/weapon/gun/energy/laser = 2,\
-				/obj/item/weapon/gun/energy/plasma/cassad = 2,
-				/obj/item/weapon/gun/energy/ionrifle))
+	return pickweight(list(/obj/item/weapon/gun/projectile/lamia = 6,\
+				/obj/item/weapon/gun/projectile/automatic/zoric = 3,\
+				/obj/item/weapon/gun/projectile/automatic/atreides = 5,\
+				/obj/item/weapon/gun/projectile/avasarala = 7,\
+				/obj/item/weapon/gun/projectile/shotgun/pump/gladstone = 9,\
+				/obj/item/weapon/gun/projectile/colt = 12,\
+				/obj/item/weapon/gun/projectile/revolver/consul = 12,\
+				/obj/item/weapon/gun/projectile/revolver = 10,\
+				/obj/item/weapon/gun/projectile/revolver/deckard = 8,\
+				/obj/item/weapon/gun/projectile/automatic/wintermute = 2,\
+				/obj/item/weapon/gun/projectile/automatic/sol = 4,\
+				/obj/item/weapon/gun/projectile/automatic/ak47/fs = 5,\
+				/obj/item/weapon/gun/projectile/automatic/molly = 6,\
+				/obj/item/weapon/gun/projectile/automatic/straylight = 8,\
+				/obj/item/weapon/gun/projectile/automatic/c20r = 5,\
+				/obj/item/weapon/gun/projectile/automatic/sts35 = 1,\
+				/obj/item/weapon/gun/energy/gun = 6,\
+				/obj/item/weapon/gun/energy/laser = 8,\
+				/obj/item/weapon/gun/energy/plasma/cassad = 8,
+				/obj/item/weapon/gun/energy/ionrifle = 4))
 
 /obj/random/gun_normal/low_chance
 	name = "low chance random normal gun"

--- a/code/game/objects/random/guns.dm
+++ b/code/game/objects/random/guns.dm
@@ -35,18 +35,19 @@
 				/obj/item/weapon/gun/projectile/avasarala = 2,\
 				/obj/item/weapon/gun/projectile/shotgun/pump/gladstone = 2,\
 				/obj/item/weapon/gun/projectile/colt = 3,\
-				/obj/item/weapon/gun/projectile/avasarala = 1,\
 				/obj/item/weapon/gun/projectile/revolver/consul = 3,\
 				/obj/item/weapon/gun/projectile/revolver = 3,\
 				/obj/item/weapon/gun/projectile/revolver/deckard = 2,\
 				/obj/item/weapon/gun/projectile/automatic/wintermute = 1,\
 				/obj/item/weapon/gun/projectile/automatic/sol = 1,\
-				/obj/item/weapon/gun/projectile/automatic/sts35 = 1,\
+				/obj/item/weapon/gun/projectile/automatic/ak/fs = 1,\
 				/obj/item/weapon/gun/projectile/automatic/molly = 2,\
 				/obj/item/weapon/gun/projectile/automatic/straylight = 1,\
+				/obj/item/weapon/gun/projectile/automatic/c20r = 1,\
 				/obj/item/weapon/gun/energy/gun = 2,\
 				/obj/item/weapon/gun/energy/laser = 2,\
-				/obj/item/weapon/gun/energy/plasma/cassad = 2))
+				/obj/item/weapon/gun/energy/plasma/cassad = 2,
+				/obj/item/weapon/gun/energy/plasma/ionrifle))
 
 /obj/random/gun_normal/low_chance
 	name = "low chance random normal gun"

--- a/code/game/objects/random/guns.dm
+++ b/code/game/objects/random/guns.dm
@@ -40,14 +40,14 @@
 				/obj/item/weapon/gun/projectile/revolver/deckard = 2,\
 				/obj/item/weapon/gun/projectile/automatic/wintermute = 1,\
 				/obj/item/weapon/gun/projectile/automatic/sol = 1,\
-				/obj/item/weapon/gun/projectile/automatic/ak/fs = 1,\
+				/obj/item/weapon/gun/projectile/automatic/ak47/fs = 1,\
 				/obj/item/weapon/gun/projectile/automatic/molly = 2,\
 				/obj/item/weapon/gun/projectile/automatic/straylight = 1,\
 				/obj/item/weapon/gun/projectile/automatic/c20r = 1,\
 				/obj/item/weapon/gun/energy/gun = 2,\
 				/obj/item/weapon/gun/energy/laser = 2,\
 				/obj/item/weapon/gun/energy/plasma/cassad = 2,
-				/obj/item/weapon/gun/energy/plasma/ionrifle))
+				/obj/item/weapon/gun/energy/ionrifle))
 
 /obj/random/gun_normal/low_chance
 	name = "low chance random normal gun"

--- a/code/game/objects/random/packs.dm
+++ b/code/game/objects/random/packs.dm
@@ -25,7 +25,8 @@ They generally give more random result and can provide more divercity in spawn.
 					/obj/random/cloth/shoes = 6,
 					/obj/random/cloth/backpack = 4,
 					/obj/random/cloth/belt = 4,
-					/obj/random/cloth/holster = 4
+					/obj/random/cloth/holster = 4,
+					/obj/random/pouch = 4
 				))
 
 /obj/random/pack/cloth/low_chance

--- a/code/game/objects/random/voidsuit.dm
+++ b/code/game/objects/random/voidsuit.dm
@@ -12,7 +12,7 @@
 		/obj/item/clothing/suit/space/void/mining = 2,
 		/obj/item/clothing/suit/space/void/medical = 2.3,
 		/obj/item/clothing/suit/space/void/atmos = 1.5,
-		/obj/item/clothing/suit/space/void/merc = 0.5))
+		/obj/item/clothing/suit/space/void/merc = 0.2))
 
 /obj/random/voidsuit/low_chance
 	name = "low chance random voidsuit"

--- a/code/modules/scrap/scrap.dm
+++ b/code/modules/scrap/scrap.dm
@@ -367,8 +367,7 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 	desc = "Pile of thrown away food. Someone sure have lots of spare food while children on Mars are starving."
 	parts_icon = 'icons/obj/structures/scrap/food_trash.dmi'
 	loot_list = list(
-		/obj/random/junkfood/rotten = 5,
-		/obj/random/junkfood,
+		/obj/random/junkfood = 5,
 		/obj/random/booze,
 		/obj/item/stack/rods/random,
 		/obj/item/weapon/material/shard,

--- a/code/modules/scrap/scrap.dm
+++ b/code/modules/scrap/scrap.dm
@@ -367,7 +367,7 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 	desc = "Pile of thrown away food. Someone sure have lots of spare food while children on Mars are starving."
 	parts_icon = 'icons/obj/structures/scrap/food_trash.dmi'
 	loot_list = list(
-		/obj/random/junkfood = 5,
+		/obj/random/junkfood/rotten = 5,
 		/obj/random/junkfood,
 		/obj/random/booze,
 		/obj/item/stack/rods/random,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1)Replaced STS with FS AK because it fits much more, sts is a gun desired by basically everyone
2)Also added c20r smg and ion rifle, it isn't a real gamechanger
3)Added pouches to cloth piles because why not?
4)Lowered chance of drop for red voidsuit
5)Food trash piles now have mostly rotten food inside for obvious reasons

## Why It's Good For The Game

Currently, STS is a top tier gun, why simply putting it to junk pile for everyone to dig? Same goes for blood red voidsuit, though I didn't remove it entirely. But I noticed that pouches were even more rare than guns and there were no spoiled food in food junk, that's ridiculous.

## Changelog
:cl:
tweak: "Tweaked trash piles, much less chance to find STS and blood-red voidsuit in trash, but more for some other guns and pouches"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->