### PR TITLE
Adds Tricord to sleepers

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -7,7 +7,7 @@
 	anchored = TRUE
 	circuit = /obj/item/weapon/circuitboard/sleeper
 	var/mob/living/carbon/human/occupant = null
-	var/list/available_chemicals = list("inaprovaline" = "Inaprovaline", "stoxin" = "Soporific", "paracetamol" = "Paracetamol", "anti_toxin2" = "Synth-Dylovene", "dexalin" = "Dexalin", "tricordrazine" = "Tricordrazine")
+	var/list/available_chemicals = list("inaprovaline2" = "Synth-Inaprovaline", "stoxin" = "Soporific", "paracetamol" = "Paracetamol", "anti_toxin" = "Dylovene", "dexalin" = "Dexalin", "tricordrazine" = "Tricordrazine")
 	var/obj/item/weapon/reagent_containers/glass/beaker = null
 	var/filtering = 0
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -7,7 +7,7 @@
 	anchored = TRUE
 	circuit = /obj/item/weapon/circuitboard/sleeper
 	var/mob/living/carbon/human/occupant = null
-	var/list/available_chemicals = list("inaprovaline" = "Inaprovaline", "stoxin" = "Soporific", "paracetamol" = "Paracetamol", "anti_toxin" = "Dylovene", "dexalin" = "Dexalin")
+	var/list/available_chemicals = list("inaprovaline" = "Inaprovaline", "stoxin" = "Soporific", "paracetamol" = "Paracetamol", "anti_toxin2" = "Synth-Dylovene", "dexalin" = "Dexalin", "tricordrazine" = "Tricordrazine")
 	var/obj/item/weapon/reagent_containers/glass/beaker = null
 	var/filtering = 0
 

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -91,6 +91,10 @@
 	holder.remove_reagent("pararein", 0.2 )
 	holder.remove_reagent("blattedin", 0.2 )
 
+/datum/reagent/medicine/dylovene/sleeper
+	name = "Synth-Dylovene"
+	id = "anti_toxin2"
+
 /datum/reagent/medicine/dexalin
 	name = "Dexalin"
 	id = "dexalin"
@@ -347,7 +351,7 @@
 	taste_description = "acid"
 	reagent_state = SOLID
 	color = "#022000"
-	
+
 
 /datum/reagent/medicine/positive_ling
 	name = "Positive Paragenetic Marker"

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -18,6 +18,10 @@
 	M.add_chemical_effect(CE_PAINKILLER, 25 * effect_multiplier)
 	M.add_chemical_effect(CE_PULSE, 1)
 
+/datum/reagent/medicine/inaprovaline/sleeper
+	name = "Synth-Inaprovaline"
+	id = "inaprovaline2"
+
 /datum/reagent/medicine/bicaridine
 	name = "Bicaridine"
 	id = "bicaridine"
@@ -90,10 +94,6 @@
 	M.add_chemical_effect(CE_ANTITOX, 1)
 	holder.remove_reagent("pararein", 0.2 )
 	holder.remove_reagent("blattedin", 0.2 )
-
-/datum/reagent/medicine/dylovene/sleeper
-	name = "Synth-Dylovene"
-	id = "anti_toxin2"
 
 /datum/reagent/medicine/dexalin
 	name = "Dexalin"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds tricord to sleepers but removes the ability to mix them inside a sleeper.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Instead of adding an OD threshold or messing with tricord at all, it'll simply be added to a sleeper while removing the ability to spam it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Tricord to sleepers.
balance: Tricord can no longer be mixed in sleepers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
