### PR TITLE
buffin chems

### DIFF
--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -37,6 +37,7 @@
 	var/glass_center_of_mass = null
 	var/color = "#000000"
 	var/color_weight = 1
+	var/sanity_gain
 
 	var/chilling_point
 	var/chilling_message = "crackles and freezes!"

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -37,7 +37,7 @@
 	var/glass_center_of_mass = null
 	var/color = "#000000"
 	var/color_weight = 1
-	var/sanity_gain
+	var/sanity_gain = 0
 
 	var/chilling_point
 	var/chilling_message = "crackles and freezes!"

--- a/code/modules/reagents/reagents/drugs.dm
+++ b/code/modules/reagents/reagents/drugs.dm
@@ -2,8 +2,6 @@
 /datum/reagent/drug
 	reagent_type = "Drug"
 
-	var/sanity_gain
-
 /datum/reagent/drug/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(sanity_gain)
 		var/mob/living/carbon/human/H = M

--- a/code/modules/reagents/reagents/drugs.dm
+++ b/code/modules/reagents/reagents/drugs.dm
@@ -1,6 +1,7 @@
 /* Drugs */
 /datum/reagent/drug
 	reagent_type = "Drug"
+	sanity_gain = 0.5
 
 /datum/reagent/drug/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(sanity_gain)
@@ -215,6 +216,8 @@
 	withdrawal_threshold = 10
 	nerve_system_accumulations = 55
 	reagent_type = "Drug/Stimulator"
+	sanity_gain = 0
+
 
 /datum/reagent/drug/hyperzine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(prob(5))

--- a/code/modules/reagents/reagents/stims.dm
+++ b/code/modules/reagents/reagents/stims.dm
@@ -4,6 +4,8 @@
 	constant_metabolism = TRUE
 	reagent_type = "Stimulator"
 
+	var/sanity_gain
+
 /datum/reagent/stim/mbr
 	name = "Machine binding ritual"
 	id = "machine binding ritual"

--- a/code/modules/reagents/reagents/stims.dm
+++ b/code/modules/reagents/reagents/stims.dm
@@ -16,12 +16,14 @@
 	nerve_system_accumulations = 15
 
 /datum/reagent/stim/stim/mbr/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	M.stats.addTempStat(STAT_MEC, STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "mbr")
-	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "mbr")
+	M.stats.addTempStat(STAT_MEC, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "mbr")
+	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "mbr")
+	sanity_gain = 1
 
 /datum/reagent/stim/stim/mbr/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC, STIM_TIME, "mbr_w")
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "mbr_w")
+	sanity_gain = -1.5
 
 /datum/reagent/stim/mbr/overdose(var/mob/living/carbon/M, var/alien)
 	if(prob(5))
@@ -45,13 +47,15 @@
 	addiction_chance = 30
 
 /datum/reagent/stim/cherrydrops/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	M.stats.addTempStat(STAT_COG, STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "cherrydrops")
-	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "cherrydrops")
+	M.stats.addTempStat(STAT_COG, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "cherrydrops")
+	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "cherrydrops")
+	sanity_gain = 1
 
 /datum/reagent/stim/cherrydrops/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC, STIM_TIME, "cherrydrops_w")
 	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_BASIC, STIM_TIME, "cherrydrops_w")
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "cherrydrops_w")
+	sanity_gain = -1.5
 
 /datum/reagent/stim/cherrydrops/overdose(var/mob/living/carbon/M, var/alien)
 	M.apply_effect(3, STUTTER)
@@ -68,13 +72,15 @@
 	addiction_chance = 20
 
 /datum/reagent/stim/pro_surgeon/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	M.stats.addTempStat(STAT_BIO, STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "pro_surgeon")
-	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "pro_surgeon")
+	M.stats.addTempStat(STAT_BIO, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "pro_surgeon")
+	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "pro_surgeon")
+	sanity_gain = 1
 
 /datum/reagent/stim/pro_surgeon/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_BASIC, STIM_TIME, "proSurgeon_w")
 	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_BASIC, STIM_TIME, "proSurgeon_w")
 	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_BASIC, STIM_TIME, "proSurgeon_w")
+	sanity_gain = -1.5
 
 /datum/reagent/stim/pro_surgeon/overdose(var/mob/living/carbon/M, var/alien)
 	if(prob(5 - (5 * M.stats.getMult(STAT_TGH))))
@@ -96,14 +102,16 @@
 	addiction_chance = 30
 
 /datum/reagent/stim/violence/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	M.stats.addTempStat(STAT_ROB, STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "violence")
-	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "violence")
+	M.stats.addTempStat(STAT_ROB, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "violence")
+	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "violence")
 	M.add_chemical_effect(CE_PULSE, 1)
 	M.add_chemical_effect(CE_SPEECH_VOLUME, rand(3,4))
+	sanity_gain = 1
 
 /datum/reagent/stim/violence/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_BASIC, STIM_TIME, "violence_w")
 	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_BASIC, STIM_TIME, "violence_w")
+	sanity_gain = -1
 
 /datum/reagent/stim/violence/overdose(var/mob/living/carbon/M, var/alien)
 	M.adjustCloneLoss(5)
@@ -122,12 +130,14 @@
 	addiction_chance = 20
 
 /datum/reagent/stim/bouncer/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	M.stats.addTempStat(STAT_TGH, STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "bouncer")
-	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "bouncer")
+	M.stats.addTempStat(STAT_TGH, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "bouncer")
+	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "bouncer")
+	sanity_gain = 1
 
 /datum/reagent/stim/bouncer/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "bouncer_w")
 	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_BASIC, STIM_TIME, "bouncer_w")
+	sanity_gain = -1.5
 
 /datum/reagent/stim/bouncer/overdose(var/mob/living/carbon/M, var/alien)
 	if(prob(5 - (3 * M.stats.getMult(STAT_TGH))))
@@ -146,14 +156,16 @@
 	addiction_chance = 20
 
 /datum/reagent/stim/steady/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	M.stats.addTempStat(STAT_VIG, STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "steady")
-	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "steady")
+	M.stats.addTempStat(STAT_VIG, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "steady")
+	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "steady")
+	sanity_gain = 1
 
 /datum/reagent/stim/steady/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "steady_w")
 	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_BASIC, STIM_TIME, "steady_w")
 	if(prob(25 - (10 * M.stats.getMult(STAT_TGH))))
 		M.shake_animation(5)
+	sanity_gain = -1.5
 
 /datum/reagent/stim/steady/overdose(var/mob/living/carbon/M, var/alien)
 	if(prob(80 - (30 * M.stats.getMult(STAT_TGH))))
@@ -175,14 +187,16 @@
 	addiction_chance = 30
 
 /datum/reagent/stim/machine_spirit/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	M.stats.addTempStat(STAT_MEC, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "machine_spirit")
-	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "machine_spirit")
-	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "machine_spirit")
+	M.stats.addTempStat(STAT_MEC, STAT_LEVEL_EXPERT * effect_multiplier, STIM_TIME, "machine_spirit")
+	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "machine_spirit")
+	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "machine_spirit")
+	sanity_gain = 1.25
 
 /datum/reagent/stim/machine_spirit/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC, STIM_TIME, "machineSpirit_w")
 	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_BASIC, STIM_TIME, "machineSpirit_w")
 	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_BASIC, STIM_TIME, "machineSpirit_w")
+	sanity_gain = -1.75
 
 /datum/reagent/stim/machine_spirit/overdose(var/mob/living/carbon/M, var/alien)
 	if(prob(5))
@@ -206,15 +220,17 @@
 	addiction_chance = 40
 
 /datum/reagent/stim/grape_drops/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	M.stats.addTempStat(STAT_COG, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "grape_drops")
-	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "grape_drops")
-	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "grape_drops")
+	M.stats.addTempStat(STAT_COG, STAT_LEVEL_EXPERT * effect_multiplier, STIM_TIME, "grape_drops")
+	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "grape_drops")
+	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "grape_drops")
+	sanity_gain = 1.25
 
 /datum/reagent/stim/grape_drops/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC, STIM_TIME, "grapeDrops_w")
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "grapeDrops_w")
 	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_BASIC, STIM_TIME, "grapeDrops_w")
 	M.add_side_effect("Headache", 11)
+	sanity_gain = -1.75
 
 /datum/reagent/stim/grape_drops/overdose(var/mob/living/carbon/M, var/alien)
 	M.slurring = max(M.slurring, 30)
@@ -232,9 +248,10 @@
 	addiction_chance = 30
 
 /datum/reagent/stim/ultra_surgeon/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	M.stats.addTempStat(STAT_BIO, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "ultra_surgeon")
-	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "ultra_surgeon")
-	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "ultra_surgeon")
+	M.stats.addTempStat(STAT_BIO, STAT_LEVEL_EXPERT * effect_multiplier, STIM_TIME, "ultra_surgeon")
+	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "ultra_surgeon")
+	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "ultra_surgeon")
+	sanity_gain = 1.25
 
 /datum/reagent/stim/ultra_surgeon/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC, STIM_TIME, "ultraSurgeon_w")
@@ -242,6 +259,7 @@
 	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_BASIC, STIM_TIME, "ultraSurgeon_w")
 	if(prob(25 - (10 * M.stats.getMult(STAT_TGH))))
 		M.shake_animation(8)
+	sanity_gain = -1.75
 
 /datum/reagent/stim/ultra_surgeon/overdose(var/mob/living/carbon/M, var/alien)
 	if(prob(80 - (20 * M.stats.getMult(STAT_TGH))))
@@ -262,9 +280,10 @@
 	addiction_chance = 40
 
 /datum/reagent/stim/violence_ultra/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	M.stats.addTempStat(STAT_ROB, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "violence_ultra")
-	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "violence_ultra")
-	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "violence_ultra")
+	M.stats.addTempStat(STAT_ROB, STAT_LEVEL_EXPERT * effect_multiplier, STIM_TIME, "violence_ultra")
+	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "violence_ultra")
+	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "violence_ultra")
+	sanity_gain = 1.25
 
 /datum/reagent/stim/violence_ultra/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_BASIC, STIM_TIME, "violenceUltra_w")
@@ -273,6 +292,7 @@
 	if(prob(25 - (10 * M.stats.getMult(STAT_TGH))))
 		M.shake_animation(8)
 	M.adjustNutrition(-5)
+	sanity_gain = -1.75
 
 /datum/reagent/stim/violence_ultra/overdose(var/mob/living/carbon/M, var/alien)
 	M.adjustCloneLoss(5)
@@ -291,13 +311,15 @@
 	addiction_chance = 30
 
 /datum/reagent/stim/boxer/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	M.stats.addTempStat(STAT_TGH, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "boxer")
-	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "boxer")
-	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "boxer")
+	M.stats.addTempStat(STAT_TGH, STAT_LEVEL_EXPERT * effect_multiplier, STIM_TIME, "boxer")
+	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "boxer")
+	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "boxer")
+	sanity_gain = 1.25
 
 /datum/reagent/stim/boxer/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC, STIM_TIME, "boxer_w")
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "boxer_w")
+	sanity_gain = -1.75
 
 /datum/reagent/stim/boxer/overdose(var/mob/living/carbon/M, var/alien)
 	if(prob(8 - (3 * M.stats.getMult(STAT_TGH))))
@@ -316,15 +338,17 @@
 	addiction_chance = 40
 
 /datum/reagent/stim/turbo/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	M.stats.addTempStat(STAT_VIG, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "turbo")
-	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "turbo")
-	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "turbo")
+	M.stats.addTempStat(STAT_VIG, STAT_LEVEL_EXPERT * effect_multiplier, STIM_TIME, "turbo")
+	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "turbo")
+	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "turbo")
+	sanity_gain = 1.25
 
 /datum/reagent/stim/turbo/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC, STIM_TIME, "turbo_w")
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "turbo_w")
 	if(prob(25 - (5 * M.stats.getMult(STAT_TGH))))
 		M.shake_animation(8)
+	sanity_gain = -1.75
 
 /datum/reagent/stim/turbo/overdose(var/mob/living/carbon/M, var/alien)
 	if(prob(80 - (30 * M.stats.getMult(STAT_TGH))))
@@ -348,12 +372,13 @@
 	addiction_chance = 50
 
 /datum/reagent/stim/party_drops/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	M.stats.addTempStat(STAT_MEC, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "party_drops")
-	M.stats.addTempStat(STAT_BIO, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "party_drops")
-	M.stats.addTempStat(STAT_COG, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "party_drops")
-	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "party_drops")
-	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "party_drops")
-	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "party_drops")
+	M.stats.addTempStat(STAT_MEC, STAT_LEVEL_EXPERT * effect_multiplier, STIM_TIME, "party_drops")
+	M.stats.addTempStat(STAT_BIO, STAT_LEVEL_EXPERT * effect_multiplier, STIM_TIME, "party_drops")
+	M.stats.addTempStat(STAT_COG, STAT_LEVEL_EXPERT * effect_multiplier, STIM_TIME, "party_drops")
+	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "party_drops")
+	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "party_drops")
+	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "party_drops")
+	sanity_gain = 1
 
 /datum/reagent/stim/party_drops/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC, STIM_TIME, "partyDrops_w")
@@ -361,6 +386,7 @@
 	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_BASIC, STIM_TIME, "partyDrops_w")
 	if(prob(25 - (5 * M.stats.getMult(STAT_TGH))))
 		M.shake_animation(8)
+	sanity_gain = -2
 
 /datum/reagent/stim/party_drops/overdose(var/mob/living/carbon/M, var/alien)
 	M.adjustBrainLoss(2)
@@ -380,14 +406,15 @@
 	addiction_chance = 70
 
 /datum/reagent/stim/menace/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	M.stats.addTempStat(STAT_VIG, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "menace")
-	M.stats.addTempStat(STAT_TGH, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "menace")
-	M.stats.addTempStat(STAT_ROB, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "menace")
-	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "menace")
-	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "menace")
-	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_BASIC * effect_multiplier, STIM_TIME, "menace")
+	M.stats.addTempStat(STAT_VIG, STAT_LEVEL_EXPERT * effect_multiplier, STIM_TIME, "menace")
+	M.stats.addTempStat(STAT_TGH, STAT_LEVEL_EXPERT * effect_multiplier, STIM_TIME, "menace")
+	M.stats.addTempStat(STAT_ROB, STAT_LEVEL_EXPERT * effect_multiplier, STIM_TIME, "menace")
+	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "menace")
+	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "menace")
+	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "menace")
 	M.slurring = max(M.slurring, 30)
 	M.add_chemical_effect(CE_SPEECH_VOLUME, 4)
+	sanity_gain = 1
 
 /datum/reagent/stim/menace/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_ADEPT, STIM_TIME, "menace_w")
@@ -396,6 +423,7 @@
 	if(prob(25 - (5 * M.stats.getMult(STAT_TGH))))
 		M.shake_animation(8)
 	M.adjustNutrition(-7)
+	sanity_gain = -2
 
 /datum/reagent/stim/menace/overdose(var/mob/living/carbon/M, var/alien)
 	M.slurring = max(M.slurring, 50)

--- a/code/modules/reagents/reagents/stims.dm
+++ b/code/modules/reagents/reagents/stims.dm
@@ -1,6 +1,3 @@
-/datum/reagent
-	var/sanity_gain
-
 /datum/reagent/stim
 	scannable = 1
 	metabolism = REM/4

--- a/code/modules/reagents/reagents/stims.dm
+++ b/code/modules/reagents/reagents/stims.dm
@@ -1,10 +1,12 @@
+/datum/reagent
+	var/sanity_gain
+
 /datum/reagent/stim
 	scannable = 1
 	metabolism = REM/4
 	constant_metabolism = TRUE
 	reagent_type = "Stimulator"
 
-	var/sanity_gain
 
 /datum/reagent/stim/mbr
 	name = "Machine binding ritual"

--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -288,7 +288,7 @@
 /datum/chemical_reaction/nicotine
     result = "nicotine"
     required_reagents = list("toxin" = 1, "carbon" = 1, "capsaicin" = 1, "mercury" = 1)
-    result_amount = 4
+    result_amount = 8
 
 /datum/chemical_reaction/lube
 	result = "lube"

--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -1781,8 +1781,8 @@
 
 /datum/chemical_reaction/mbr
 	result = "machine binding ritual"
-	required_reagents = list("coffee" = 2, "diplopterum" = 1, "sugar" = 1, "ethanol" = 1)
-	result_amount = 5
+	required_reagents = list("coffee" = 1, "carbon" = 1, "sugar" = 1, "ethanol" = 1)
+	result_amount = 4
 	maximum_temperature = 343
 	minimum_temperature = 323
 
@@ -1796,20 +1796,19 @@
 /datum/chemical_reaction/party_drops
 	result = "party drops"
 	required_reagents = list("grape drops" = 1, "machine spirit" = 1, "ultrasurgeon" = 1)
-	catalysts = list("honey" = 1)
 	result_amount = 3
 
 /datum/chemical_reaction/cherry_drops
 	result = "cherry drops"
-	required_reagents = list("iron" = 1, "psilocybin" = 1, "plantbgone" = 1)
+	required_reagents = list("iron" = 1, "nicotine" = 1, "vodka" = 1)
 	result_amount = 3
 	maximum_temperature = 333
 	minimum_temperature = 303
 
 /datum/chemical_reaction/grape_drops
 	result = "grape drops"
-	required_reagents = list("honey" = 1, "cherry drops" = 2, "ethanol" = 2)
-	result_amount = 5
+	required_reagents = list("nanites" = 1, "cherry drops" = 1, "ethanol" = 1)
+	result_amount = 3
 	maximum_temperature = 343
 	minimum_temperature = 338
 
@@ -1827,47 +1826,47 @@
 
 /datum/chemical_reaction/noexcutite
 	result = "noexcutite"
-	required_reagents = list("oxycodone" = 1, "anti_toxin" = 1)
+	required_reagents = list("tramadol" = 1, "anti_toxin" = 1)
 	result_amount = 2
 
 /datum/chemical_reaction/violence
 	result = "violence"
-	required_reagents = list("blood" = 3, "ammonia" = 1, "gewaltine" = 1)
-	result_amount = 5
+	required_reagents = list("acetone" = 1, "ammonia" = 1, "vodka" = 1)
+	result_amount = 6
 	maximum_temperature = 423
 	minimum_temperature = 393
 
 /datum/chemical_reaction/violence_ultra
 	result = "violence ultra"
-	required_reagents = list("violence" = 1, "fuhrerole" = 1, "hyperzine" = 1)
+	required_reagents = list("violence" = 1, "gewaltine" = 1, "tramadol" = 1)
 	result_amount = 3
 	maximum_temperature = 258
 	minimum_temperature = 243
 
 /datum/chemical_reaction/bouncer
 	result = "bouncer"
-	required_reagents = list("violence" = 1, "fuhrerole" = 1, "hyperzine" = 1)
+	required_reagents = list("inaprovaline" = 1, "vodka" = 1, "tramadol" = 1)
 	result_amount = 3
 	maximum_temperature = 333
 	minimum_temperature = 303
 
 /datum/chemical_reaction/boxer
 	result = "boxer"
-	required_reagents = list("bouncer" = 2, "plasma" = 1, "amatoxin" = 2)
-	result_amount = 5
+	required_reagents = list("bouncer" = 1, "Starkellin" = 1, "toxin" = 1)
+	result_amount = 3
 	maximum_temperature = 328
 	minimum_temperature = 323
 
 /datum/chemical_reaction/steady
 	result = "steady"
-	required_reagents = list("pararein" = 1, "carpotoxin" = 1, "copper" = 1, "hydrazine" = 1)
+	required_reagents = list("nicotine" = 1, "copper" = 1, "tramadol" = 1)
 	result_amount = 4
 	maximum_temperature = 338
 	minimum_temperature = 323
 
 /datum/chemical_reaction/turbo
 	result = "turbo"
-	required_reagents = list("steady" = 1, "adrenaline" = 1, "synaptizine" = 1)
+	required_reagents = list("steady" = 1, "kelotane" = 1, "pararein" = 1)
 	result_amount = 3
 	maximum_temperature = 293
 	minimum_temperature = 288

--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -475,8 +475,9 @@
 
 /datum/chemical_reaction/mindwipe
 	result = "mindwipe"
-	required_reagents = list("mindbreaker" = 1, "psilocybin" = 1, "sanguinum" = 1 , "anti_toxin" = 1, "ethanol" = 1)
-	result_amount = 5
+	required_reagents = list("mindbreaker" = 1, "anti_toxin" = 1, "ethanol" = 1)
+	catalysts = list("whiskey" = 5)
+	result_amount = 1
 
 /datum/chemical_reaction/lipozine
 	result = "lipozine"

--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -1827,6 +1827,8 @@
 /datum/chemical_reaction/noexcutite
 	result = "noexcutite"
 	required_reagents = list("tramadol" = 1, "anti_toxin" = 1)
+	maximum_temperature = 120
+	minimum_temperature = 150
 	result_amount = 2
 
 /datum/chemical_reaction/violence


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

recipes are now WAY easier
1st tier you can USUALLY make without roaches
2nd tier usually you need at least one monster part
3rd tier. sum of stim

also buffs are now stronger with same debuff

BUT withdraws now take sanity away
## Why It's Good For The Game

well stims are underused and sanity was not in the game when they where added
and drugs should give some more reason to use em aside from RP and Sanguinium thats just not needed

## Changelog
:cl: Fernandos33 

tweak: Recipes for stat stimulators changed to be made easier
balance: Withdraws now get sanity debuff (sanity debuff from withdrawing>> than sanity gain using the drug) 
balance: Every stat drug will give a small sanity boost, except for hyperzine.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
