### PR TITLE
Fixes cyborg guns spawning with infinite charge

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -110,12 +110,14 @@ var/global/list/robot_modules = list(
 	for (var/obj/item/weapon/tool/T in modules)
 		T.degradation = 0 //We don't want robot tools breaking
 
-
+	//A quick hack to stop robot modules running out of power
+	//Later they'll be wired to the robot's central battery once we code functionality for that
+	//Setting it to infinity causes errors, so just a high number is fine
 	for (var/obj/item/I in modules)
-		for (var/obj/item/weapon/cell/C in I)
-			C.charge = 999999999 //A quick hack to stop robot modules running out of power
-			//Later they'll be wired to the robot's central battery once we code functionality for that
-			//Setting it to infinity causes errors, so just a high number is fine
+		if(!istype(I, /obj/item/weapon/gun/energy)) // Guns have their own code for drawing charge from cyborg cell
+			for (var/obj/item/weapon/cell/C in I)
+				C.charge = 999999999
+	// I wanna make component cell holders soooo bad, but it's going to be a big refactor, and I don't have the time -- ACCount
 
 /obj/item/weapon/robot_module/proc/Reset(var/mob/living/silicon/robot/R)
 	remove_camera_networks(R)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -20,8 +20,8 @@
 	var/item_charge_meter = FALSE //same as above for item state
 
 	//self-recharging
-	var/self_recharge = 0	//if set, the weapon will recharge itself
-	var/use_external_power = 0 //if set, the weapon will look for an external power source to draw from, otherwise it recharges magically
+	var/self_recharge = FALSE		//if set, the weapon will recharge itself
+	var/use_external_power = FALSE	//if set, the weapon will look for an external power source to draw from, otherwise it recharges magically
 	var/recharge_time = 4
 	var/charge_tick = 0
 	var/overcharge_timer //Holds ref to the timer used for overcharging

--- a/code/modules/projectiles/guns/energy/egun.dm
+++ b/code/modules/projectiles/guns/energy/egun.dm
@@ -24,8 +24,8 @@
 
 /obj/item/weapon/gun/energy/gun/mounted
 	name = "mounted energy gun"
-	self_recharge = 1
-	use_external_power = 1
+	self_recharge = TRUE
+	use_external_power = TRUE
 	safety = FALSE
 	restrict_safety = TRUE
 

--- a/code/modules/projectiles/guns/energy/lasertag.dm
+++ b/code/modules/projectiles/guns/energy/lasertag.dm
@@ -3,7 +3,7 @@
 	item_state = "laser"
 	desc = "Standard-issue weapon of the Imperial Guard"
 	origin_tech = list(TECH_COMBAT = 1, TECH_MAGNET = 2)
-	self_recharge = 1
+	self_recharge = TRUE
 	matter = list(MATERIAL_PLASTIC = 6)
 	fire_sound = 'sound/weapons/Laser.ogg'
 	projectile_type = /obj/item/projectile/beam/lastertag/blue

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -7,7 +7,7 @@
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 5, TECH_POWER = 3)
 	slot_flags = SLOT_BELT
 	force = WEAPON_FORCE_PAINFUL //looks heavier than a pistol
-	self_recharge = 1
+	self_recharge = TRUE
 	modifystate = null
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_URANIUM = 10)
 	price_tag = 4000

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -42,8 +42,8 @@
 	name = "SDF SC \"Schrapnell\""
 	desc = "An energy-based shotgun, employing a matter fabricator to pull shotgun rounds from thin air and energy."
 	icon_state = "shrapnel"
-	self_recharge = 1
-	use_external_power = 1
+	self_recharge = TRUE
+	use_external_power = TRUE
 	safety = FALSE
 	restrict_safety = TRUE
 	consume_cell = FALSE

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -12,8 +12,8 @@
 
 /obj/item/weapon/gun/energy/taser/mounted
 	name = "mounted taser gun"
-	self_recharge = 1
-	use_external_power = 1
+	self_recharge = TRUE
+	use_external_power = TRUE
 	safety = FALSE
 	restrict_safety = TRUE
 


### PR DESCRIPTION
Also makes two gun vars use `TRUE` and `FALSE`.

## Changelog
:cl: ACCount
balance: Robot energy guns no longer have infinite charges - they now draw charge from robot's cell and take time to recharge
/:cl: