### PR TITLE
Rebalances ESPO-830 disk

### DIFF
--- a/code/datums/autolathe/circuits.dm
+++ b/code/datums/autolathe/circuits.dm
@@ -4,6 +4,10 @@
 	name = "airlock electronics"
 	build_path = /obj/item/weapon/airlock_electronics
 
+/datum/design/autolathe/circuit/airlockmodule/secure
+	name = "secure airlock electronics"
+	build_path = /obj/item/weapon/airlock_electronics/secure
+
 /datum/design/autolathe/circuit/airalarm
 	name = "air alarm electronics"
 	build_path = /obj/item/weapon/airalarm_electronics

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -187,10 +187,10 @@
 
 	license = 10
 	designs = list(
-		/datum/design/autolathe/circuit/airlockmodule,
-		/datum/design/autolathe/circuit/airalarm,
-		/datum/design/autolathe/circuit/firealarm,
-		/datum/design/autolathe/circuit/powermodule,
+		/datum/design/autolathe/circuit/airlockmodule = 0,
+		/datum/design/autolathe/circuit/airalarm = 0,
+		/datum/design/autolathe/circuit/firealarm = 0,
+		/datum/design/autolathe/circuit/powermodule = 0,
 		/datum/design/autolathe/circuit/recharger,
 		/datum/design/research/circuit/autolathe,
 		/datum/design/autolathe/circuit/autolathe_disk_cloner,

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -188,6 +188,7 @@
 	license = 10
 	designs = list(
 		/datum/design/autolathe/circuit/airlockmodule = 0,
+		/datum/design/autolathe/circuit/airlockmodule/secure,
 		/datum/design/autolathe/circuit/airalarm = 0,
 		/datum/design/autolathe/circuit/firealarm = 0,
 		/datum/design/autolathe/circuit/powermodule = 0,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the licensing costs from: Airlock electronics, Air alarm electronics, Fire alarm electronics and Power control modules on the Technomancer disk: Technomancers ESPO-830 Circuits. In addition, adds the secure electronics and makes them available for technomancer use, seems like a thing that's up their alley.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Considering how easy it is to destroy these machines and how often they are - replacing them shouldn't be half the nuisance it is. I don't know where they're pulling the need for silicon from but this will at least make them 50% less of a PITA to rebuild.

The secure airlock electronics are for the paranoid Technomancers to make use of, who want to inconvenience outsiders transgressing into their domain.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The Technomancer Union's ESPO-830 now contains secure airlock electronics.
balance: APC/Airlock/Fire/Air alarm electronics no longer use license points on the ESPO-830 disk.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
