### PR TITLE
Lasblender damage adjustment

### DIFF
--- a/code/modules/projectiles/guns/energy/lasersmg.dm
+++ b/code/modules/projectiles/guns/energy/lasersmg.dm
@@ -16,7 +16,7 @@
 	slot_flags = SLOT_BELT
 	matter = list(MATERIAL_PLASTEEL = 11, MATERIAL_STEEL = 13, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 1, MATERIAL_GLASS = 2)
 	price_tag = 1000
-	damage_multiplier = 0.225 //makeshift laser
+	damage_multiplier = 0.275 //makeshift laser
 	recoil_buildup = 4
 	one_hand_penalty = 3 
 	projectile_type = /obj/item/projectile/beam

--- a/code/modules/projectiles/guns/energy/lasersmg.dm
+++ b/code/modules/projectiles/guns/energy/lasersmg.dm
@@ -1,4 +1,3 @@
-
 /obj/item/weapon/gun/energy/lasersmg
 	name = "Disco Vazer \"Lasblender\""
 	desc = "This conversion of the \"Atreides\" enables it to shoot lasers. Unlike in other laser weapons, the process of creating a laser is based on a chain reaction of localized micro-explosions.\
@@ -10,25 +9,24 @@
 	w_class = ITEM_SIZE_NORMAL
 	fire_sound = 'sound/weapons/Laser.ogg'
 	suitable_cell = /obj/item/weapon/cell/medium
-	can_dual = 1
+	can_dual = TRUE
 	projectile_type = /obj/item/projectile/beam
-	charge_meter = FALSE
+	charge_meter = FALSE //TODO: Rework overlays, check assets storage for charge states.
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	slot_flags = SLOT_BELT
 	matter = list(MATERIAL_PLASTEEL = 11, MATERIAL_STEEL = 13, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 1, MATERIAL_GLASS = 2)
 	price_tag = 1000
-	damage_multiplier = 0.9 //makeshift laser
+	damage_multiplier = 0.225 //makeshift laser
 	recoil_buildup = 4
 	one_hand_penalty = 3 
 	projectile_type = /obj/item/projectile/beam
-	init_offset = 7 // shit accuracy even on the first shot
+	init_offset = 7 // bad accuracy even on the first shot
 	suitable_cell = /obj/item/weapon/cell/medium
 	charge_cost = 50 // 2 bursts with a 800m cell
 
 	init_firemodes = list(
 		BURST_8_ROUND
 		)
-
 
 
 /obj/item/weapon/gun/energy/lasersmg/process_projectile(var/obj/item/projectile/P, mob/living/user, atom/target, var/target_zone, var/params=null)
@@ -46,7 +44,6 @@
 		iconstring += "_mag"
 		itemstring += "_mag"
 
-
 /obj/item/weapon/gun/energy/lasersmg/update_icon()
 	overlays.Cut()
 	..()
@@ -61,5 +58,3 @@
 
 	else if(istype(cell, /obj/item/weapon/cell/medium))
 		overlays += image(icon, "guild_cell")
-
-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This may actually just be too low, as we want players to specifically choose this thing, but with weapon attachments the damage output can be adjusted significantly. I was motivated to quickly make this after I noticed some other balance PRs coming up, and being closed. The lowered burst fire eliminates the core identity of the weapon, and this PR maintains that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Balances the weapon appropriately after doing dreaded math, and with actual knowledge of the values. Tested in-game as well to gauge its effectiveness somewhat.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Re-adjusted the Lasblender's damage values, remember to use weapon attachments to increase its power.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
