### PR TITLE
Mercenary shuttle travel time is now 3 minutes

### DIFF
--- a/maps/CEVEris/shuttles-eris.dm
+++ b/maps/CEVEris/shuttles-eris.dm
@@ -171,6 +171,7 @@
 /datum/shuttle/autodock/multi/antag/mercenary
 	name = "Mercenary"
 	warmup_time = 0
+	move_time = 180
 	cloaked = 0
 	destination_tags = list(
 		"nav_merc_northeast",


### PR DESCRIPTION
## About The Pull Request
Title.

## Changelog
:cl:
tweak: Adjusted the speed of Serbian shuttle travel time from 7 minutes to 3.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
