### PR TITLE
priest and acolyte jacket should at least protect as much as a labcoat

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -94,7 +94,7 @@
 		bullet = 10,
 		energy = 10,
 		bomb = 0,
-		bio = 0,
+		bio = 50,  //same as labcoats at LEAST
 		rad = 0
 	)
 
@@ -109,7 +109,7 @@
 		bullet = 20,
 		energy = 20,
 		bomb = 0,
-		bio = 0,
+		bio = 50,  //same as labcoats at LEAST
 		rad = 0
 	)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
give the priest and acolyte jacket same bio protect as a lab coat. so he doesn't "insta die" from touching biomass
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
well if the chemist can resist a bit of bio why not the priest that works with it?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Priest and acolyte jacket should at least protect as much as a labcoat from bio damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
