### PR TITLE
Removing sectional shutters and buttons from bridge

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -17564,12 +17564,6 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "ArrivalLockdown";
-	name = "Arrival Lockdown Control";
-	pixel_x = -38;
-	pixel_y = -8
-	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/command/bridge)
 "aPo" = (
@@ -34932,19 +34926,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/cryo)
-"bzQ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "ArrivalLockdown";
-	name = "Arrival Lockdown Control";
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/steel,
-/area/eris/hallway/side/cryo)
 "bzR" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -40905,11 +40886,6 @@
 /area/eris/maintenance/section4deck4port)
 "bMs" = (
 /obj/item/modular_computer/console/preset/security/camera,
-/obj/machinery/button/remote/blast_door{
-	id = "ArrivalLockdown";
-	name = "Arrival Lockdown Control";
-	pixel_y = 24
-	},
 /obj/machinery/camera,
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/security/lobby)
@@ -43664,15 +43640,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "ArrivalLockdown";
-	layer = 2.6;
-	name = "Arrival Lockdown";
-	opacity = 0
-	},
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/eris/crew_quarters/sleep/cryo)
 "bSj" = (
@@ -43771,15 +43738,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "ArrivalLockdown";
-	layer = 2.6;
-	name = "Arrival Lockdown";
-	opacity = 0
-	},
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/eris/crew_quarters/sleep/cryo)
 "bSt" = (
@@ -64360,26 +64318,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/breakroom)
-"cNF" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "ArrivalLockdown";
-	layer = 2.6;
-	name = "Arrival Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/steel/cargo,
-/area/eris/hallway/main/section4)
 "cNG" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/machinery/light/small,
@@ -64414,53 +64352,10 @@
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck2starboard)
-"cNK" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/metal,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "ArrivalLockdown";
-	layer = 2.6;
-	name = "Arrival Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/steel/cargo,
-/area/eris/hallway/main/section4)
 "cNL" = (
 /obj/random/pack/machine,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck2port)
-"cNM" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Escape Pod Bay"
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "ArrivalLockdown";
-	layer = 2.6;
-	name = "Arrival Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/steel/cargo,
-/area/eris/hallway/side/eschangara)
-"cNN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "ArrivalLockdown";
-	layer = 2.6;
-	name = "Arrival Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/steel/cargo,
-/area/eris/hallway/side/eschangara)
 "cNO" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "0,23"
@@ -209436,7 +209331,7 @@ aaa
 aaa
 aaa
 cVE
-bzQ
+bzS
 crI
 cso
 csF
@@ -210445,7 +210340,7 @@ cRN
 cRQ
 cRQ
 cSU
-cNK
+cIK
 cWA
 dzr
 cYj
@@ -210647,7 +210542,7 @@ cRP
 cSk
 cSk
 cSV
-cNF
+cLe
 cWB
 cXs
 cYk
@@ -211859,7 +211754,7 @@ aDf
 bLq
 aWp
 azN
-cNM
+aTE
 bzX
 bzX
 bzX
@@ -212061,7 +211956,7 @@ aDf
 bLq
 aWp
 bzE
-cNN
+aTs
 bzX
 bzX
 bzX

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -48258,15 +48258,6 @@
 /area/eris/neotheology/bioreactor)
 "ccC" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "FirstSectionLockdown";
-	layer = 2.6;
-	name = "First Section Lockdown";
-	opacity = 0
-	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/main/section1)
 "ccD" = (
@@ -48287,15 +48278,6 @@
 "ccF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/metal,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "FirstSectionLockdown";
-	layer = 2.6;
-	name = "First Section Lockdown";
-	opacity = 0
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/main/section1)
@@ -48608,32 +48590,10 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/hangarsupply)
-"cdn" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "SecondSectionLockdown";
-	layer = 2.6;
-	name = "Second Section Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/steel/cargo,
-/area/eris/hallway/main/section1)
 "cdo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/metal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "SecondSectionLockdown";
-	layer = 2.6;
-	name = "Second Section Lockdown";
-	opacity = 0
-	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/main/section1)
 "cdp" = (
@@ -53273,19 +53233,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/medbay)
-"cnS" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "SecondSectionLockdown";
-	layer = 2.6;
-	name = "Second Section Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/steel/cargo,
-/area/eris/hallway/main/section2)
 "cnT" = (
 /obj/machinery/power/supermatter{
 	layer = 4
@@ -53496,15 +53443,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/metal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "SecondSectionLockdown";
-	layer = 2.6;
-	name = "Second Section Lockdown";
-	opacity = 0
-	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/main/section2)
 "cow" = (
@@ -53964,19 +53902,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/eris/neotheology/chapel)
-"cpt" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "ThirdSectionLockdown";
-	layer = 2.6;
-	name = "Third Section Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/steel/cargo,
-/area/eris/hallway/main/section3)
 "cpu" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 8
@@ -53996,15 +53921,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/metal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "ThirdSectionLockdown";
-	layer = 2.6;
-	name = "Third Section Lockdown";
-	opacity = 0
-	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/main/section3)
 "cpy" = (
@@ -61484,15 +61400,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "ThirdSectionLockdown";
-	layer = 2.6;
-	name = "Third Section Lockdown";
-	opacity = 0
-	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/main/section3)
 "cGs" = (
@@ -61557,20 +61464,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
-"cGx" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/metal,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "ThirdSectionLockdown";
-	layer = 2.6;
-	name = "Third Section Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/steel/cargo,
-/area/eris/hallway/main/section3)
 "cGy" = (
 /obj/structure/bed/chair,
 /obj/structure/cable{
@@ -62015,15 +61908,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "FourthSectionLockdown";
-	layer = 2.6;
-	name = "Fourth Section Lockdown";
-	opacity = 0
-	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/main/section4)
 "cHC" = (
@@ -62447,15 +62331,6 @@
 "cIK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/metal,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "FourthSectionLockdown";
-	layer = 2.6;
-	name = "Fourth Section Lockdown";
-	opacity = 0
-	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/main/section4)
 "cIL" = (
@@ -63496,15 +63371,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "FourthSectionLockdown";
-	layer = 2.6;
-	name = "Fourth Section Lockdown";
-	opacity = 0
-	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/main/section4)
 "cLf" = (
@@ -210595,7 +210461,7 @@ cFr
 cAx
 cAx
 cCW
-cGx
+cFr
 cFc
 cxD
 cxD
@@ -210747,7 +210613,7 @@ bYh
 bYi
 bYi
 bYA
-cdn
+ccC
 bZj
 bZj
 caa
@@ -210767,12 +210633,12 @@ ccf
 ceh
 dup
 bZj
-cnS
+dxu
 dux
 cgs
 cgs
 dvc
-cpt
+cFk
 cAx
 cAx
 dGy

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -10538,22 +10538,6 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/storage)
 "ayf" = (
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for the engine control room blast doors.";
-	id = "EngineBlast";
-	name = "Engine Monitoring Room Blast Doors";
-	pixel_x = 24;
-	pixel_y = -6;
-	req_access = newlist()
-	},
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for the engine control room blast doors.";
-	id = "EngineEmitterPortWest";
-	name = "Engine Room Blast Doors";
-	pixel_x = 24;
-	pixel_y = 6;
-	req_access = list(11)
-	},
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
@@ -18962,25 +18946,6 @@
 /turf/simulated/floor/hull,
 /area/eris/maintenance/junk)
 "aSe" = (
-/obj/machinery/button/remote/blast_door{
-	id = "Incernator Vent";
-	name = "Incernator Vent";
-	pixel_x = 24;
-	pixel_y = 6
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 2;
-	id = "Skynet_launch";
-	name = "Mech Bay Door Control";
-	pixel_x = 24;
-	pixel_y = -6
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "Cargo1DeckHatch";
-	name = "Cargo Hatch";
-	pixel_x = 36;
-	pixel_y = 6
-	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/command/bridge)
 "aSf" = (
@@ -30877,30 +30842,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck3central)
 "bqS" = (
-/obj/machinery/button/remote/blast_door{
-	id = "CargoTotalLockdown";
-	name = "Cargo Total Lockdown Control";
-	pixel_x = -26;
-	pixel_y = 4
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "EngineeringTotalLockdown";
-	name = "Engineering Total Lockdown Control";
-	pixel_x = -26;
-	pixel_y = -8
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "MedbayTotalLockdown";
-	name = "Medbay Total Lockdown Control";
-	pixel_x = -38;
-	pixel_y = 4
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "ScienceTotalLockdown";
-	name = "Science Total Lockdown Control";
-	pixel_x = -38;
-	pixel_y = -8
-	},
 /obj/item/modular_computer/console/preset/security/records{
 	dir = 1
 	},
@@ -32718,18 +32659,6 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/command/teleporter)
 "bvg" = (
-/obj/machinery/button/remote/blast_door{
-	id = "toxinchamber2";
-	name = "Mixing Room Vent Control";
-	pixel_x = 24;
-	pixel_y = -6
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "toxinchamber1";
-	name = "Mixing Room Vent Control";
-	pixel_x = 24;
-	pixel_y = 6
-	},
 /obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/command/bridge)

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -17533,18 +17533,6 @@
 /turf/simulated/wall,
 /area/eris/maintenance/section1deck4central)
 "aPn" = (
-/obj/machinery/button/remote/blast_door{
-	id = "BrigExternalLobbyLockdown";
-	name = "Brig External Lobby Lockdown Control";
-	pixel_x = -26;
-	pixel_y = -8
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "BrigInternalLobbyLockdown";
-	name = "Brig Internal Lobby Lockdown Control";
-	pixel_x = -26;
-	pixel_y = 4
-	},
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -10415,6 +10415,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/eschangara)
+"axL" = (
+/obj/item/modular_computer/console/preset/security/camera,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/eris/command/bridge)
 "axM" = (
 /obj/structure/table/standard,
 /obj/item/weapon/packageWrap,
@@ -10539,6 +10543,28 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/storage)
+"ayf" = (
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine control room blast doors.";
+	id = "EngineBlast";
+	name = "Engine Monitoring Room Blast Doors";
+	pixel_x = 24;
+	pixel_y = -6;
+	req_access = newlist()
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine control room blast doors.";
+	id = "EngineEmitterPortWest";
+	name = "Engine Room Blast Doors";
+	pixel_x = 24;
+	pixel_y = 6;
+	req_access = list(11)
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/eris/command/bridge)
 "ayg" = (
 /turf/simulated/wall/r_wall,
 /area/eris/crew_quarters/library)
@@ -17528,6 +17554,30 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
 /area/eris/maintenance/section1deck4central)
+"aPn" = (
+/obj/machinery/button/remote/blast_door{
+	id = "BrigExternalLobbyLockdown";
+	name = "Brig External Lobby Lockdown Control";
+	pixel_x = -26;
+	pixel_y = -8
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "BrigInternalLobbyLockdown";
+	name = "Brig Internal Lobby Lockdown Control";
+	pixel_x = -26;
+	pixel_y = 4
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "ArrivalLockdown";
+	name = "Arrival Lockdown Control";
+	pixel_x = -38;
+	pixel_y = -8
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/eris/command/bridge)
 "aPo" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -30838,6 +30888,36 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck3central)
+"bqS" = (
+/obj/machinery/button/remote/blast_door{
+	id = "CargoTotalLockdown";
+	name = "Cargo Total Lockdown Control";
+	pixel_x = -26;
+	pixel_y = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "EngineeringTotalLockdown";
+	name = "Engineering Total Lockdown Control";
+	pixel_x = -26;
+	pixel_y = -8
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "MedbayTotalLockdown";
+	name = "Medbay Total Lockdown Control";
+	pixel_x = -38;
+	pixel_y = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "ScienceTotalLockdown";
+	name = "Science Total Lockdown Control";
+	pixel_x = -38;
+	pixel_y = -8
+	},
+/obj/item/modular_computer/console/preset/security/records{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/eris/command/bridge)
 "bqT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	tag = "icon-intact (SOUTHEAST)";
@@ -32649,6 +32729,22 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/command/teleporter)
+"bvg" = (
+/obj/machinery/button/remote/blast_door{
+	id = "toxinchamber2";
+	name = "Mixing Room Vent Control";
+	pixel_x = 24;
+	pixel_y = -6
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "toxinchamber1";
+	name = "Mixing Room Vent Control";
+	pixel_x = 24;
+	pixel_y = 6
+	},
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/eris/command/bridge)
 "bvi" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled/techmaint_cargo,
@@ -79616,34 +79712,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/eris/maintenance/section2deck2port)
-"dvJ" = (
-/obj/machinery/button/remote/blast_door{
-	id = "ThirdSectionLockdown";
-	name = "Third Section Lockdown Control";
-	pixel_x = -26;
-	pixel_y = -8
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "ArrivalLockdown";
-	name = "Arrival Lockdown Control";
-	pixel_x = -26;
-	pixel_y = 6
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "FirstSectionLockdown";
-	name = "First Section Lockdown Control";
-	pixel_x = -38;
-	pixel_y = 6
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "SecondSectionLockdown";
-	name = "Second Section Lockdown Control";
-	pixel_x = -38;
-	pixel_y = -8
-	},
-/obj/item/modular_computer/console/preset/security/camera,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/eris/command/bridge)
 "dvK" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -79722,28 +79790,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
-"dvQ" = (
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for the engine control room blast doors.";
-	id = "EngineBlast";
-	name = "Engine Monitoring Room Blast Doors";
-	pixel_x = 24;
-	pixel_y = -6;
-	req_access = newlist()
-	},
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for the engine control room blast doors.";
-	id = "EngineEmitterPortWest";
-	name = "Engine Room Blast Doors";
-	pixel_x = 24;
-	pixel_y = 6;
-	req_access = list(11)
-	},
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/eris/command/bridge)
 "dvR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -79926,30 +79972,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
-"dwi" = (
-/obj/machinery/button/remote/blast_door{
-	id = "BrigExternalLobbyLockdown";
-	name = "Brig External Lobby Lockdown Control";
-	pixel_x = -26;
-	pixel_y = -8
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "BrigInternalLobbyLockdown";
-	name = "Brig Internal Lobby Lockdown Control";
-	pixel_x = -26;
-	pixel_y = 4
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "FourthSectionLockdown";
-	name = "Fourth Section Lockdown Control";
-	pixel_x = -38;
-	pixel_y = 4
-	},
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/eris/command/bridge)
 "dwj" = (
 /obj/random/pack/machine,
 /obj/random/pack/tech_loot/low_chance,
@@ -80108,36 +80130,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
-"dwB" = (
-/obj/machinery/button/remote/blast_door{
-	id = "CargoTotalLockdown";
-	name = "Cargo Total Lockdown Control";
-	pixel_x = -26;
-	pixel_y = 4
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "EngineeringTotalLockdown";
-	name = "Engineering Total Lockdown Control";
-	pixel_x = -26;
-	pixel_y = -8
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "MedbayTotalLockdown";
-	name = "Medbay Total Lockdown Control";
-	pixel_x = -38;
-	pixel_y = 4
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "ScienceTotalLockdown";
-	name = "Science Total Lockdown Control";
-	pixel_x = -38;
-	pixel_y = -8
-	},
-/obj/item/modular_computer/console/preset/security/records{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/eris/command/bridge)
 "dwC" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
@@ -80185,22 +80177,6 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/medbay)
-"dwI" = (
-/obj/machinery/button/remote/blast_door{
-	id = "toxinchamber2";
-	name = "Mixing Room Vent Control";
-	pixel_x = 24;
-	pixel_y = -6
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "toxinchamber1";
-	name = "Mixing Room Vent Control";
-	pixel_x = 24;
-	pixel_y = 6
-	},
-/obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/eris/command/bridge)
 "dwJ" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -288718,9 +288694,9 @@ dVw
 dVw
 dVw
 dvG
-dvJ
-dwi
-dwB
+axL
+aPn
+bqS
 dwJ
 dVw
 dVw
@@ -291950,9 +291926,9 @@ dVw
 dXf
 dVw
 dvH
-dvQ
+ayf
 aSe
-dwI
+bvg
 dxa
 dVw
 dVw

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -3397,12 +3397,6 @@
 /area/eris/command/commander)
 "ahY" = (
 /obj/structure/table/woodentable,
-/obj/machinery/button/remote/blast_door{
-	id = "FirstSectionLockdown";
-	name = "First Section Lockdown Control";
-	pixel_x = 0;
-	pixel_y = 4
-	},
 /turf/simulated/floor/wood,
 /area/eris/command/commander)
 "ahZ" = (
@@ -40889,12 +40883,6 @@
 /area/eris/maintenance/section1deck3central)
 "bMq" = (
 /obj/machinery/button/remote/blast_door{
-	id = "FirstSectionLockdown";
-	name = "First Section Lockdown Control";
-	pixel_x = 6;
-	pixel_y = 24
-	},
-/obj/machinery/button/remote/blast_door{
 	id = "BrigInternalLobbyLockdown";
 	name = "Brig Internal Lobby Lockdown Control";
 	pixel_x = -6;
@@ -47333,12 +47321,6 @@
 "cau" = (
 /obj/structure/table/woodentable,
 /obj/item/device/lighting/toggleable/lamp/green,
-/obj/machinery/button/remote/blast_door{
-	id = "FirstSectionLockdown";
-	name = "First Section Lockdown Control";
-	pixel_x = 24;
-	pixel_y = -8
-	},
 /obj/item/weapon/tool/tape_roll,
 /turf/simulated/floor/wood,
 /area/eris/command/fo)
@@ -55683,12 +55665,6 @@
 	name = "Science Total Lockdown Control";
 	pixel_x = -24;
 	pixel_y = 5
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "SecondSectionLockdown";
-	name = "Second Section Lockdown Control";
-	pixel_x = -24;
-	pixel_y = -8
 	},
 /obj/item/modular_computer/console/preset/research/sysadmin,
 /turf/simulated/floor/carpet/purcarpet,
@@ -65466,12 +65442,6 @@
 	name = "Engineering Total Lockdown Control";
 	pixel_x = -24;
 	pixel_y = -5
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "FourthSectionLockdown";
-	name = "Fourth Section Lockdown Control";
-	pixel_x = -24;
-	pixel_y = 8
 	},
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/command/exultant)
@@ -81277,12 +81247,6 @@
 	name = "Medbay Total Lockdown Control";
 	pixel_x = -24;
 	pixel_y = 5
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "SecondSectionLockdown";
-	name = "Second Section Lockdown Control";
-	pixel_x = -24;
-	pixel_y = -8
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/command/mbo)


### PR DESCRIPTION
## About The Pull Request
Sectional shutters and buttons are gone. Remote buttons on bridge are removed.

## Changelog
:cl:
del: Sections shutters and buttons that activates them are no more as and all remote buttons on bridge.
/:cl: