### PR TITLE
Fix 2045

### DIFF
--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -75,8 +75,8 @@
 	if(QUALITY_WELDING in I.tool_qualities)
 		if(I.use_tool(user, src, WORKTIME_FAST, QUALITY_WELDING, FAILCHANCE_EASY, required_stat = STAT_MEC))
 			to_chat(user, "\blue Slicing lattice joints ...")
-			new /obj/item/stack/rods(src.loc)
-			new /obj/item/stack/rods(src.loc)
+			new /obj/item/stack/rods(get_turf(user))
+			new /obj/item/stack/rods(get_turf(user))
 			new /obj/structure/lattice/(src.loc)
 			qdel(src)
 	return

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -53,7 +53,7 @@
 	if(I.get_tool_type(user, list(QUALITY_WELDING), src))
 		if(I.use_tool(user, src, WORKTIME_FAST, QUALITY_WELDING, FAILCHANCE_EASY, required_stat = STAT_MEC))
 			to_chat(user, SPAN_NOTICE("Slicing lattice joints ..."))
-			new /obj/item/stack/rods(loc)
+			new /obj/item/stack/rods(get_turf(user))
 			qdel(src)
 	if (istype(I, /obj/item/stack/rods) || istype(I, /obj/item/stack/rods/cyborg))
 		var/obj/item/stack/rods/R = I

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -259,7 +259,7 @@
 			if(!anchored)
 				if(I.use_tool(user, src, WORKTIME_FAST, tool_type, FAILCHANCE_VERY_EASY, required_stat = STAT_MEC))
 					user.visible_message(SPAN_NOTICE("\The [user] dismantles \the [src]."), SPAN_NOTICE("You dismantle \the [src]."))
-					drop_materials(drop_location())
+					drop_materials(get_turf(user))
 					qdel(src)
 			return
 

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -68,6 +68,10 @@
 	if(opacity && isturf(loc))
 		var/turf/T = loc
 		T.reconsider_lights()
+	
+	if(istype(loc, /turf/simulated/open))
+		var/turf/simulated/open/open = loc
+		open.fallThrough(src)
 
 // If we have opacity, make sure to tell (potentially) affected light sources.
 /atom/movable/Destroy()

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -443,7 +443,7 @@
 	if(istype(target, /turf/simulated/open))
 		var/turf/simulated/open/T = target
 		if(T.isOpen())
-			return
+			return TRUE // halt powder pile/smears creation without wasting reagents
 
 	var/handled = TRUE
 	for(var/datum/reagent/current in reagent_list)
@@ -497,7 +497,6 @@
 /datum/reagents/proc/trans_to_turf(var/turf/target, var/amount = 1, var/multiplier = 1, var/copy = 0) // Turfs don't have any reagents (at least, for now). Just touch it.
 	if(!target || !target.simulated)
 		return
-
 
 	var/datum/reagents/R = new /datum/reagents(amount * multiplier)
 	. = trans_to_holder(R, amount, multiplier, copy)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #2045

Also, it removes powder/splash spawn from open space tiles and moves some items from struct deconstruction to mob's tile instead of leaving it floating around. 

## Why It's Good For The Game

bugfixes go brrrrr

## Changelog
:cl:
fix: No more powder piles and chem splashes in open space.
fix: Deconstruction of lattice, catwalk and railings would drop items under your feet.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
