### PR TITLE
Fixes intentional wire splicing

### DIFF
--- a/code/game/objects/structures/wire_splicing.dm
+++ b/code/game/objects/structures/wire_splicing.dm
@@ -113,6 +113,10 @@
 				qdel(src)
 
 	if(istype(I, /obj/item/stack/cable_coil) && user.a_intent == I_HURT)
+		if(used_now)
+			to_chat(user, "The [src.name] is already being manipulated!") //so people with low stats can't spam their way past the failure chance
+			return
+		used_now = TRUE
 		if(messiness >= 10)
 			messiness = 10
 			to_chat(user, SPAN_WARNING("Enough."))
@@ -122,14 +126,17 @@
 		if(coil.get_amount() >= 1)
 			to_chat(user, SPAN_NOTICE("You started to wire to this pile of wires..."))
 			if(shock(user)) //check if he got his insulation gloves
+				used_now = FALSE
 				return 		//he didn't
-			if(do_after(src, 20))
+			if(do_after(user, 20))
 				if(shock(user)) //check if he got his insulation gloves. Again.
+					used_now = FALSE
 					return
 				var/fail_chance = FAILCHANCE_HARD - user.stats.getStat(STAT_MEC) // 72 for assistant
 				if(prob(fail_chance))
 					if(!shock(user, FALSE)) //why not
 						to_chat(user, SPAN_WARNING("You failed to finish your task with [src.name]! There was a [fail_chance]% chance to screw this up."))
+					used_now = FALSE
 					return
 				if(messiness >= 10)
 					messiness = 10
@@ -138,3 +145,5 @@
 				messiness += 1
 				icon_state = "wire_splicing[messiness]"
 				to_chat(user, SPAN_NOTICE("You added one more wire."))
+				used_now = FALSE
+

--- a/code/game/objects/structures/wire_splicing.dm
+++ b/code/game/objects/structures/wire_splicing.dm
@@ -128,7 +128,7 @@
 			if(shock(user)) //check if he got his insulation gloves
 				used_now = FALSE
 				return 		//he didn't
-			if(do_after(user, 20))
+			if(do_after(user, 20, src))
 				if(shock(user)) //check if he got his insulation gloves. Again.
 					used_now = FALSE
 					return

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -165,23 +165,31 @@ var/list/possible_cable_coil_colours = list(
 			to_chat(user, "Not enough cable")
 			return
 		if(user.a_intent == I_HURT)
+			if(used_now)
+				to_chat(user, SPAN_WARNING("You are already splicing the [src.name]!")) //don't want people stacking splices on one turf
+				return
+			used_now = TRUE
 			if(locate(/obj/structure/wire_splicing) in T)
 				to_chat(user, SPAN_WARNING("There is splicing already!"))
+				used_now = FALSE
 				return
 			to_chat(user, SPAN_NOTICE("You started messsing with wires..."))
 			if(shock(user, 100)) //check if he got his insulation gloves
+				used_now = FALSE
 				return 		//he didn't
 			if(do_after(user, 20))
 				var/fail_chance = FAILCHANCE_HARD - user.stats.getStat(STAT_MEC) // 72 for assistant
 				if(prob(fail_chance))
 					if(!shock(user, 100)) //why not
 						to_chat(user, SPAN_WARNING("You failed to finish your task with [src.name]! There was a [fail_chance]% chance to screw this up."))
+					used_now = FALSE
 					return
 
 				//all clear, update things
 				coil.use(1)
 				spawnSplicing()
 				to_chat(user, SPAN_NOTICE("You have created such a mess. Shame."))
+				used_now = FALSE
 		else
 			coil.cable_join(src, user)
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -177,7 +177,7 @@ var/list/possible_cable_coil_colours = list(
 			if(shock(user, 100)) //check if he got his insulation gloves
 				used_now = FALSE
 				return 		//he didn't
-			if(do_after(user, 20))
+			if(do_after(user, 20, src))
 				var/fail_chance = FAILCHANCE_HARD - user.stats.getStat(STAT_MEC) // 72 for assistant
 				if(prob(fail_chance))
 					if(!shock(user, 100)) //why not


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
It's possible to create wire splicings on existing cables, but there is some jank, and this PR addresses it. You'll actually be able to make splicings larger now. It adds in some spam protection to stop people from bypassing the skill check and prevents people from being able to create multiple splices on a single turf.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Because it fixes some intended functionality and includes a couple of safeguards to prevent ~~hilarity~~ abuse.
## Changelog
:cl:
tweak: it should no longer be possible to spam player-made wire splices
fix: making splices bigger is now properly functional
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
