### PR TITLE
Parkour should no longer increase the time it takes to do parkour anymore

### DIFF
--- a/code/datums/perks/oddity.dm
+++ b/code/datums/perks/oddity.dm
@@ -66,7 +66,7 @@
 
 /datum/perk/oddity/parkour/assign(mob/living/carbon/human/H)
 	..()
-	holder.mod_climb_delay -= -0.5
+	holder.mod_climb_delay -= 0.5
 
 /datum/perk/oddity/parkour/remove()
 	holder.mod_climb_delay += 0.5


### PR DESCRIPTION
![great](https://i.imgur.com/BUXyuVz.jpg)

:cl:
fix: Parkour will no longer actually increase the delay before doing parkour.
/:cl: