### PR TITLE
Buffs bombsuits melee/bullet/energy resist to be 40

### DIFF
--- a/code/modules/clothing/spacesuits/bomb.dm
+++ b/code/modules/clothing/spacesuits/bomb.dm
@@ -6,9 +6,9 @@
 	desc = "Use in case of bomb."
 	icon_state = "bombsuit"
 	armor = list(
-		melee = 30,
-		bullet = 30,
-		energy = 30,
+		melee = 40,
+		bullet = 40,
+		energy = 40,
 		bomb = 100,
 		bio = 100,
 		rad = 90
@@ -26,9 +26,9 @@
 	permeability_coefficient = 0.01
 	slowdown = 2
 	armor = list(
-		melee = 50,
-		bullet = 50,
-		energy = 50,
+		melee = 40,
+		bullet = 40,
+		energy = 40,
 		bomb = 100,
 		bio = 100,
 		rad = 90

--- a/code/modules/clothing/spacesuits/bomb.dm
+++ b/code/modules/clothing/spacesuits/bomb.dm
@@ -19,16 +19,16 @@
 
 /obj/item/clothing/suit/space/bomb
 	name = "bomb suit"
-	desc = "A space suit designed for safety when handling explosives."
+	desc = "A heavy armored space suit designed for safety when handling explosives."
 	icon_state = "bombsuit"
 	item_state = "bombsuit"
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
 	slowdown = 2
 	armor = list(
-		melee = 30,
-		bullet = 30,
-		energy = 30,
+		melee = 50,
+		bullet = 50,
+		energy = 50,
 		bomb = 100,
 		bio = 100,
 		rad = 90


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Basically the title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This thing isn't even useful for bomb disposal, and I think that it protecting more is fine for the game personally. It gives it a niche as an incredibly slow and situational armor.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: bomb suits now have 40 bullet/melee/energy resist.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
