### PR TITLE
Change the evac vote to a bluespace jump vote

### DIFF
--- a/code/controllers/evacuation/evacuation_pods.dm
+++ b/code/controllers/evacuation/evacuation_pods.dm
@@ -40,6 +40,8 @@
 				pod.launch(src)
 
 		priority_announcement.Announce(replacetext(replacetext(GLOB.maps_data.emergency_shuttle_leaving_dock, "%dock_name%", "[dock_name]"),  "%ETA%", "[round(get_eta()/60,1)] minute\s"))
+	else
+		priority_announcement.Announce(replacetext(replacetext(GLOB.maps_data.shuttle_leaving_dock, "%dock_name%", "[dock_name]"),  "%ETA%", "[round(get_eta()/60,1)] minute\s"))
 
 /datum/evacuation_controller/starship/finish_evacuation()
 	..()

--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -223,13 +223,13 @@
 #undef MINIMUM_VOTE_LIFETIME
 
 /datum/vote_choice/evac
-	text = "Abandon ship!"
+	text = "Initiate a bluespace jump!"
 
 /datum/vote_choice/evac/on_win()
 	evacuation_controller.call_evacuation(null, FALSE, TRUE, FALSE, TRUE)
 
 /datum/vote_choice/noevac
-	text = "Stay aboard"
+	text = "No need to depart yet!"
 
 
 

--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -226,7 +226,7 @@
 	text = "Abandon ship!"
 
 /datum/vote_choice/evac/on_win()
-	evacuation_controller.call_evacuation(null, TRUE, TRUE, FALSE, TRUE)
+	evacuation_controller.call_evacuation(null, FALSE, TRUE, FALSE, TRUE)
 
 /datum/vote_choice/noevac
 	text = "Stay aboard"

--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -155,8 +155,8 @@
 	Evacuate Ship
 **********************/
 /datum/poll/evac
-	name = "Evacuate Ship"
-	question = "Do you want to call evacuation and restart the round?"
+	name = "Initiate Bluespace Jump"
+	question = "Do you want to initiate a bluespace jump and restart the round?"
 	time = 120
 	minimum_win_percentage = 0.6
 	cooldown = 20 MINUTES


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Order on the discord: "Change the evac vote to a bluespace jump vote that initiated the 20 minute evac jump if passed".

Need a confirmation that it works on live server since on a local server the end of round does not trigger (even with a normal evac).

## Why It's Good For The Game

Lore-wise there is no reason to abandon the ship if it is not critically damaged so it's more realist to just launch a bluespace jump to another star system.

## Changelog
:cl: Hyperio
tweak: Change the evac vote to a bluespace jump vote
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
