### PR TITLE
#494 again

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -229,15 +229,15 @@
 			a = get_area(src.loc)
 
 	//done throwing, either because it hit something or it finished moving
+	src.throwing = 0
+	src.thrower = null
+	src.throw_source = null
+
 	var/turf/new_loc = get_turf(src)
 	if(new_loc)
 		if(isobj(src))
 			src.throw_impact(new_loc,speed)
 		new_loc.Entered(src)
-	src.throwing = 0
-	src.thrower = null
-	src.throw_source = null
-
 
 //Overlays
 /atom/movable/overlay


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#5186 wasn't good enough as previous call order was so bad so it called things to check before updating atom's state

## Why It's Good For The Game

Previous PR wasn't done properly so there is another one. _its done now trust me_

## Changelog
:cl:
fix: Mobs that got thrown at open space are falling down as expected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
