### PR TITLE
Things don't fall through catwalks on spawn

### DIFF
--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -71,7 +71,8 @@
 	
 	if(istype(loc, /turf/simulated/open))
 		var/turf/simulated/open/open = loc
-		open.fallThrough(src)
+		if(open.isOpen())
+			open.fallThrough(src)
 
 // If we have opacity, make sure to tell (potentially) affected light sources.
 /atom/movable/Destroy()


### PR DESCRIPTION
## About The Pull Request
Adds check to see if openspace is open or not, only then fall through it.

## Why It's Good For The Game
Things won't fall through catwalks on round start and when spawned.

## Changelog
:cl:
fix: Things won't fall through catwalks on round start.
/:cl: