### PR TITLE
Carrion balance changes and bugfixes

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/carrion/breeding_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/breeding_spider.dm
@@ -7,7 +7,7 @@
 
 /obj/item/weapon/implant/carrion_spider/breeding/Initialize()
 	..()
-	number_of_spiders = rand(10, 15)
+	number_of_spiders = rand(9, 12)
 
 /obj/item/weapon/implant/carrion_spider/breeding/activate()
 	..()

--- a/code/game/objects/items/weapons/implant/implants/carrion/infection_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/infection_spider.dm
@@ -20,6 +20,10 @@
 		to_chat(owner_mob, SPAN_WARNING("[wearer]'s cruciform prevents activation"))
 		return
 
+	if(is_carrion(wearer))
+		to_chat(owner_mob, SPAN_WARNING("Another core inside prevents activation"))
+		return
+
 	if(active)
 		to_chat(owner_mob, SPAN_WARNING("[src] is already active"))
 		return
@@ -28,12 +32,13 @@
 	to_chat(owner_mob, SPAN_NOTICE("\The [src] is active"))
 
 	spawn(3.5 MINUTES)
-		if(wearer && istype(wearer) && !(wearer.stat == DEAD) && !is_neotheology_disciple(wearer) && active)
+		if(wearer && istype(wearer) && !(wearer.stat == DEAD) && !is_neotheology_disciple(wearer) && active && !is_carrion(wearer))
 			to_chat(wearer, SPAN_DANGER("The transformation is complete, you are not human anymore, you are something more"))
 			to_chat(owner_mob, SPAN_NOTICE("\The [src] was succesfull"))
 			wearer.make_carrion()
 			die()
 		else
+			active = FALSE
 			to_chat(owner_mob, SPAN_WARNING("Conversion failed."))
 
 /obj/item/weapon/implant/carrion_spider/infection/Process()
@@ -49,7 +54,7 @@
 				"You feel like something is taking control of you!",
 				"You feel weak, like something is growing inside of your body!"
 			))
-			wearer.apply_effect(30, AGONY, armor_value = 0, check_protection = FALSE) //Flat 30 agony damage
+			wearer.apply_effect(20, AGONY, armor_value = 0, check_protection = FALSE) //Flat 20 agony damage
 			to_chat(wearer, "\red <font size=3><b>[pain_message]</b></font>")
 		if(prob(1)) //around one limb per transformation
 			var/obj/item/organ/external/E = wearer.get_organ(pick(list(BP_L_ARM, BP_L_LEG, BP_R_ARM, BP_R_LEG)))

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -155,6 +155,9 @@
 		to_chat(owner, SPAN_WARNING("We are regenerating our body!"))
 		return
 
+	if(alert("Are you sure you want to detach? You will lose your old body and half of your evolved abilities and gene points.",,"Yes","No") == "No")
+		return
+
 	gibs(owner.loc, null, /obj/effect/gibspawner/generic, "#666600", "#666600")
 	visible_message(SPAN_DANGER("Something bursts out of [owner]'s chest!"))
 	removed() //removed() does all of the work
@@ -256,6 +259,7 @@
 	icon_state = "carrion_maw"
 	organ_tag = BP_MAW
 	var/hunger = 0
+	var/last_call = -5 MINUTES
 
 	owner_verbs = list(
 		/obj/item/organ/internal/carrion/maw/proc/consume_flesh,
@@ -344,21 +348,26 @@
 
 /obj/item/organ/internal/carrion/maw/proc/spider_call()
 	set category = "Carrion"
-	set name = "Spider call (25)"
+	set name = "Spider call (30)"
 
-	if(owner.check_ability(25))
+	if(last_call + 5 MINUTES > world.time)
+		to_chat(owner, SPAN_WARNING("Your maw is tired, you can only call for help every 5 minutes."))
+		return
+
+	if(owner.check_ability(30))
 		playsound(src.loc, 'sound/voice/shriek1.ogg', 100, 1, 8, 8)
 		spawn(2)
 			playsound(src.loc, 'sound/voice/shriek1.ogg', 100, 1, 8, 8) //Same trick as with the fuhrer
 		visible_message(SPAN_DANGER("[owner] emits a frightening screech as you feel the ground tramble!"))
 		for (var/obj/structure/burrow/B in find_nearby_burrows())
-			for(var/i = 1, i <= 3 ,i++) //3 per burrow
+			for(var/i = 1, i <= 4 ,i++) //4 per burrow
 				var/obj/structure/burrow/origin = SSmigration.choose_burrow_target(null, TRUE, 100)
 				var/spider_to_spawn = pickweight(list(/mob/living/carbon/superior_animal/giant_spider = 4,\
 					/mob/living/carbon/superior_animal/giant_spider/nurse = 2,\
 					/mob/living/carbon/superior_animal/giant_spider/hunter = 2))
 				new spider_to_spawn(B)
 				origin.migrate_to(B, 3 SECONDS, 0)
+		last_call = world.time
 
 /obj/item/organ/internal/carrion/maw/proc/toxic_puddle()
 	set category = "Carrion"


### PR DESCRIPTION
## About The Pull Request
Few carrion balance changes and bugfixes, less spiders in general.

## Why It's Good For The Game
Making carrions a bit more fair, and some abilities more situational. Also bugs are bad.

## Changelog
:cl:
balance: Spider call now has a 5 minute cooldown, costs a bit more chem points, but makes more spiders.
balance: Infection spider does 33% less agony damage.
balance: Breeding spider creates a bit less spiders.
fix: Added a popup window to make sure that the player really want's to exit the body as a spider core.
fix: It should now be impossible to convert carrions to carrions.
fix: Infection spider should stop giving you pain if it failed.
/:cl: