### PR TITLE
Toolmods no longer erase the noble family name.

### DIFF
--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -137,7 +137,7 @@
 				/obj/item/weapon/gun/projectile/revolver = 0.4))
 	holder.sanity.valid_inspirations += W
 	W = new W(T)
-	W.desc += " Has inscribed \"[holder.last_name]\" family."
+	W.desc += " It has been inscribed with the \"[holder.last_name]\" family name."
 	var/oddities = rand(2,4)
 	var/list/stats = ALL_STATS
 	var/list/final_oddity = list()

--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -124,10 +124,10 @@
 
 /datum/perk/noble/assign(mob/living/carbon/human/H)
 	..()
-	if(!holder.last_name)
-		qdel(src)
-		return
 	holder.sanity.environment_cap_coeff -= 1
+	if(!holder.last_name)
+		holder.stats.removePerk(src.type)
+		return
 	var/turf/T = get_turf(holder)
 	var/obj/item/W = pickweight(list(
 				/obj/item/weapon/tool/knife/ritual = 0.5,
@@ -137,7 +137,7 @@
 				/obj/item/weapon/gun/projectile/revolver = 0.4))
 	holder.sanity.valid_inspirations += W
 	W = new W(T)
-	W.name = "[holder.last_name] family [W.name]"
+	W.desc += " Has inscribed \"[holder.last_name]\" family."
 	var/oddities = rand(2,4)
 	var/list/stats = ALL_STATS
 	var/list/final_oddity = list()


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/49106866/89326374-2d146980-d658-11ea-8e74-9ec47b817738.png)


The name of the noble family is now found in the description of the weapon and not in the name of the weapon.


## Changelog
:cl:
fix: Toolmods no longer erase the noble family name.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
