### PR TITLE
tweak noise_coeff and traps logic

### DIFF
--- a/code/game/objects/items/weapons/mine.dm
+++ b/code/game/objects/items/weapons/mine.dm
@@ -49,9 +49,8 @@
 /obj/item/weapon/mine/Crossed(mob/AM)
 	if (armed)
 		if (isliving(AM))
-			prob_explode = initial(prob_explode)
-			prob_explode -= AM.skill_to_evade_traps(prob_explode)
-			if(prob(prob_explode) && !is_excelsior(AM))
+			var/true_prob_explode = prob_explode - AM.skill_to_evade_traps()
+			if(prob(true_prob_explode) && !is_excelsior(AM))
 				explode()
 				return
 	.=..()

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -318,9 +318,8 @@ Very rarely it might escape
 		var/mob/living/L = AM
 		if(("\ref[L]" in aware_mobs) && MOVING_DELIBERATELY(L))
 			return ..()
-		prob_catch = initial(prob_catch)
-		prob_catch -= L.skill_to_evade_traps(prob_catch)
-		if(!prob(prob_catch))
+		var/true_prob_catch = prob_catch - L.skill_to_evade_traps()
+		if(!prob(true_prob_catch))
 			return ..()
 		L.visible_message(
 			SPAN_DANGER("[L] steps on \the [src]."),

--- a/code/game/objects/structures/wire_splicing.dm
+++ b/code/game/objects/structures/wire_splicing.dm
@@ -80,7 +80,7 @@
 		var/mob/living/L = AM
 		var/turf/T = get_turf(src)
 		var/chance_to_shock = messiness * 10
-		chance_to_shock -= L.skill_to_evade_traps(chance_to_shock)
+		chance_to_shock -= L.skill_to_evade_traps()
 		if(locate(/obj/structure/catwalk) in T)
 			chance_to_shock -= 20
 		if(prob(chance_to_shock))

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -92,9 +92,8 @@
 			triggered(AM)
 		else if(istype(AM, /mob/living))
 			var/mob/living/L = AM
-			prob_catch = initial(prob_catch)
-			prob_catch -= L.skill_to_evade_traps(prob_catch)
-			if(!prob(prob_catch))
+			var/true_prob_catch = prob_catch - L.skill_to_evade_traps()
+			if(!prob(true_prob_catch))
 				return ..()
 			triggered(L)
 			L.visible_message("<span class='warning'>[L] accidentally steps on [src].</span>", \

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -363,7 +363,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 
 /mob/living/carbon/human/get_max_w_class()
 	var/get_max_w_class = 0
-	for(var/obj/item/clothing/C in get_equipped_items())
+	for(var/obj/item/clothing/C in get_equipped_items(TRUE))
 		if(C)
 			if(C.w_class > ITEM_SIZE_TINY)
 				get_max_w_class = C.w_class

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -631,10 +631,10 @@ proc/is_blind(A)
 	var/prob_evade = 0
 	if(MOVING_DELIBERATELY(src))
 		var/base_prob_evade = 20
+		prob_evade += base_prob_evade
 		prob_evade += base_prob_evade * (stats.getStat(STAT_VIG)/STAT_LEVEL_GODLIKE - get_max_w_class()/ITEM_SIZE_COLOSSAL)
 		if(stats.getPerk(PERK_SURE_STEP))
 			prob_evade += base_prob_evade*30/STAT_LEVEL_GODLIKE
-		prob_evade += base_prob_evade
 		if(stats.getPerk(PERK_RAT))
 			prob_evade += base_prob_evade
 	return prob_evade

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -627,20 +627,20 @@ proc/is_blind(A)
 			A.tumble()
 	embedded = list()
 
-/mob/proc/skill_to_evade_traps(prob_catch)
+/mob/proc/skill_to_evade_traps()
 	var/prob_evade = 0
 	if(MOVING_DELIBERATELY(src))
 		prob_evade = 25
-		prob_evade += prob_evade/stats.getMult(STAT_VIG, STAT_LEVEL_GODLIKE) - prob_evade*get_max_w_class()/ITEM_SIZE_TITANIC
+		prob_evade += prob_evade * (stats.getStat(STAT_VIG)/STAT_LEVEL_GODLIKE - get_max_w_class()/ITEM_SIZE_COLOSSAL)
 		if(stats.getPerk(PERK_SURE_STEP))
-			prob_evade += prob_evade*30/STAT_LEVEL_GODLIKE
+			prob_evade += 25*30/STAT_LEVEL_GODLIKE
 		if(stats.getPerk(PERK_RAT))
-			prob_evade *= 2
+			prob_evade *= 25
 	return prob_evade
 
 /mob/proc/mob_playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, is_global, frequency, is_ambiance = 0,  ignore_walls = TRUE, zrange = 2, override_env, envdry, envwet, use_pressure = TRUE)
 	if(isliving(src))
 		var/mob/living/L = src
-		vol *= L.noise_coeff
-		extrarange *= L.noise_coeff
+		vol *= L.noise_coeff + get_max_w_class()/(ITEM_SIZE_COLOSSAL)
+		extrarange *= L.noise_coeff + get_max_w_class()/(ITEM_SIZE_COLOSSAL)
 	playsound(source, soundin, vol, vary, extrarange, falloff, is_global, frequency, is_ambiance,  ignore_walls, zrange, override_env, envdry, envwet, use_pressure)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -630,12 +630,13 @@ proc/is_blind(A)
 /mob/proc/skill_to_evade_traps()
 	var/prob_evade = 0
 	if(MOVING_DELIBERATELY(src))
-		prob_evade = 25
-		prob_evade += prob_evade * (stats.getStat(STAT_VIG)/STAT_LEVEL_GODLIKE - get_max_w_class()/ITEM_SIZE_COLOSSAL)
+		var/base_prob_evade = 20
+		prob_evade += base_prob_evade * (stats.getStat(STAT_VIG)/STAT_LEVEL_GODLIKE - get_max_w_class()/ITEM_SIZE_COLOSSAL)
 		if(stats.getPerk(PERK_SURE_STEP))
-			prob_evade += 25*30/STAT_LEVEL_GODLIKE
+			prob_evade += base_prob_evade*30/STAT_LEVEL_GODLIKE
+		prob_evade += base_prob_evade
 		if(stats.getPerk(PERK_RAT))
-			prob_evade *= 25
+			prob_evade += base_prob_evade
 	return prob_evade
 
 /mob/proc/mob_playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, is_global, frequency, is_ambiance = 0,  ignore_walls = TRUE, zrange = 2, override_env, envdry, envwet, use_pressure = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Player stats were giving too much ability to evade traps even with low stats in VIG.

The noise coefficient was not working as designed.

Both modifiers are now not only affected by the weight of what you are wearing but also by what you carry with you.

## Changelog
:cl:
tweak: traps are now a little more effective.
tweak: The noise coefficient is now affected by the objects you carry with you.
/:cl:
