### PR TITLE
Control spider fix and carrion attaching changes

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
@@ -29,16 +29,14 @@
 	..()
 
 /obj/item/weapon/implant/carrion_spider/Process()
-	
 	if(ready_to_attack && (last_stun_time <= world.time - 4 SECONDS))
 		for(var/mob/living/L in mobs_in_view(1, src))
-			var/mob/living/carbon/human/H = L
-			if(is_carrion(H))
-				continue
-
-			install(L)
-			to_chat(owner_mob, SPAN_NOTICE("[src] infested [L]"))
-			break
+			if(istype(L, /mob/living/simple_animal) || istype(L, /mob/living/carbon))
+				if(is_carrion(L))
+					continue
+				install(L)
+				to_chat(owner_mob, SPAN_NOTICE("[src] infested [L]"))
+				break
 
 /obj/item/weapon/implant/carrion_spider/attackby(obj/item/I, mob/living/user, params) //Overrides implanter behaviour
 	if(I.force >= WEAPON_FORCE_WEAK)
@@ -61,6 +59,9 @@
 	qdel(src)
 
 /obj/item/weapon/implant/carrion_spider/attack(mob/living/M, mob/living/user)
+	if(!(istype(M, /mob/living/simple_animal) || istype(M, /mob/living/carbon)))
+		to_chat(user, SPAN_WARNING("You can't implant spiders into robots."))
+		return
 	user.drop_item()
 	M.attack_hand(user)
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)

--- a/code/game/objects/items/weapons/implant/implants/carrion/control_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/control_spider.dm
@@ -2,8 +2,9 @@
 	name = "control spider"
 	icon_state = "spiderling_control"
 	spider_price = 40
-	var/mob/living/captive_brain/host_brain
 	var/active = FALSE
+	var/last_use = - 5 MINUTES
+	var/mob/living/captive_brain/host_brain
 	var/datum/mind/owner_mind_last
 	var/mob/living/wearer_last
 	var/list/start_damage = list()
@@ -18,13 +19,16 @@
 	if(wearer.stat == DEAD)
 		to_chat(owner_mob, SPAN_WARNING("[wearer] is dead"))
 		return
-	if(wearer.has_brain_worms())
-		to_chat(owner_mob, SPAN_WARNING("There is something more powerful than you in the host"))
-		return
 	if(wearer == owner_mob)
 		to_chat(owner_mob, SPAN_DANGER("You feel dumb"))
 		return
-
+	if(wearer.has_brain_worms() || is_carrion(wearer))
+		to_chat(owner_mob, SPAN_DANGER("A parasite inside this body prevents spider influence."))
+		return
+	if(last_use + 5 MINUTES > world.time)
+		to_chat(owner_mob, SPAN_WARNING("The mind control spider is spent, and needs 5 minutes to regenerate."))
+		return
+	
 	var/datum/mind/owner_mind = owner_mob.mind
 
 	to_chat(owner_mob, SPAN_NOTICE("You assume control of the host."))
@@ -42,6 +46,7 @@
 	wearer.mind?.transfer_to(host_brain)
 	owner_mind.transfer_to(wearer)
 	active = TRUE
+	last_use = world.time
 
 	addtimer(CALLBACK(src, .proc/return_mind), 1 MINUTES)
 


### PR DESCRIPTION
## About The Pull Request

Control spiders don't work on carrions anymore and have a 5 minute cooldown on each controled mob. Spiders can't attach to robots and silicons anymore.

## Why It's Good For The Game
Control spider is more balanced, and spiders in general make more sense.

## Changelog
:cl: TheShown911
tweak: carrion spiders can't attach to robots anymore
balance: control spider has a 5 minute cooldown on each mob controled
balance: control spiders can't control other carrions
fix: fixes #5250 
/:cl:

