### PR TITLE
Admins can bypass mouse respawn time

### DIFF
--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -434,7 +434,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 
 	if(!MayRespawn(1, ANIMAL))
-		return
+		if(!check_rights(0, 0) || alert("Normal players must wait at least [ANIMAL_SPAWN_DELAY / 600] minutes to spawn as mouse! Would you like to bypass it?","Warning", "No", "Yes") != "Yes")
+			return
 
 	var/turf/T = get_turf(src)
 	if(!T || !(T.z in GLOB.maps_data.station_levels))


### PR DESCRIPTION
## About The Pull Request
Admins can bypass mouse respawn time.

## Why It's Good For The Game
Closes #5096 

## Changelog
:cl:
admin: Admins can bypass mouse respawn time
/:cl: