### PR TITLE
Fixes some uplink items only showing up for carrions

### DIFF
--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -173,7 +173,7 @@
 	name = "Mental Imprinter"
 	item_cost = 5
 	path = /obj/item/device/mental_imprinter
-	antag_roles = list(ROLES_UPLINK_BASE, ROLE_CARRION)
+	antag_roles = list(ROLE_TRAITOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 
 //********** Blitzshell unique uplink items **********//
 

--- a/code/datums/uplink/stealth and camouflage items.dm
+++ b/code/datums/uplink/stealth and camouflage items.dm
@@ -18,7 +18,7 @@
 	name = "Agent ID card"
 	item_cost = 3
 	path = /obj/item/weapon/card/id/syndicate
-	antag_roles = list(ROLES_UPLINK_BASE, ROLE_CARRION)
+	antag_roles = list(ROLE_TRAITOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 
 /datum/uplink_item/item/stealth_items/chameleon_kit
 	name = "Chameleon Kit"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes some uplink items only showing up for carrions

## Why It's Good For The Game
Fixes a bug.

## Changelog
:cl: TheShown911
fix: agent ID and mental imprinters should be aveliable for other antags except carrion
/:cl:
