### PR TITLE
Toxin spider and runtime fix

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/carrion/toxic_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/toxic_spider.dm
@@ -8,7 +8,7 @@
 /obj/item/weapon/implant/carrion_spider/toxicbomb/activate()
 	var/location = get_turf(src)
 	gas_storage = new /datum/reagents(100, src)
-	gas_storage.add_reagent("lexorinp", 100)
+	gas_storage.add_reagent("lexorin", 100)
 	var/datum/effect/effect/system/smoke_spread/chem/S = new
 	S.attach(location)
 	S.set_up(gas_storage, 10, 100, location)

--- a/code/modules/organs/external/stump.dm
+++ b/code/modules/organs/external/stump.dm
@@ -31,8 +31,9 @@
 
 /obj/item/organ/external/stump/removed()
 	..()
+	if(owner)
+		qdel(src)
 	owner = null //To stop infinate deletion loop.
-	qdel(src)
 
 /obj/item/organ/external/stump/is_usable()
 	return FALSE

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -275,14 +275,6 @@
 	if(M.losebreath < 15)
 		M.losebreath++
 
-/datum/reagent/toxin/lexorin/plus //Currently uncraftable, could be made with carrion parts.
-	name = "Lexorin plus"
-	id = "lexorinp"
-	description = "Advanced lexorin able to penetrate skin."
-
-/datum/reagent/toxin/lexorin/plus/affect_touch(mob/living/carbon/M, alien, effect_multiplier)
-	affect_blood(M, alien, effect_multiplier)
-
 /datum/reagent/toxin/mutagen
 	name = "Unstable mutagen"
 	id = "mutagen"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nerfs toxin spiders and fixes a runtime.

## Why It's Good For The Game
Toxin spiders were way too op and runtimes are bad.

## Changelog
:cl:
balance: toxin bomb spider uses normal lexorin instead of lexorin plus
fix: qdel loop in limbstumps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
