### PR TITLE
Saw-off sawing fix

### DIFF
--- a/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
@@ -84,16 +84,20 @@
 
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel/attackby(var/obj/item/A as obj, mob/user as mob)
 	if(QUALITY_SAWING in A.tool_qualities)
-		to_chat(user, SPAN_NOTICE("You begin to shorten the barrel of \the [src]."))
-		if(loaded.len)
-			for(var/i in 1 to max_shells)
-				afterattack(user, user)	//will this work? //it will. we call it twice, for twice the FUN
-				playsound(user, fire_sound, 50, 1)
-			user.visible_message(SPAN_DANGER("The shotgun goes off!"), SPAN_DANGER("The shotgun goes off in your face!"))
-			return
-		if(A.use_tool(user, src, WORKTIME_FAST, QUALITY_SAWING, FAILCHANCE_NORMAL, required_stat = STAT_COG))
-			qdel(src)
-			new /obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawn(usr.loc)
-			to_chat(user, SPAN_WARNING("You shorten the barrel of \the [src]!"))
+		if (src.name != "sawn-off shotgun")
+			to_chat(user, SPAN_NOTICE("You begin to shorten the barrel of \the [src]."))
+			if(loaded.len)
+				for(var/i in 1 to max_shells)
+					afterattack(user, user)	//will this work? //it will. we call it twice, for twice the FUN
+					playsound(user, fire_sound, 50, 1)
+				user.visible_message(SPAN_DANGER("The shotgun goes off!"), SPAN_DANGER("The shotgun goes off in your face!"))
+				return
+			if(A.use_tool(user, src, WORKTIME_FAST, QUALITY_SAWING, FAILCHANCE_NORMAL, required_stat = STAT_COG))
+				qdel(src)
+				new /obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawn(usr.loc)
+				to_chat(user, SPAN_WARNING("You shorten the barrel of \the [src]!"))
+		else
+			to_chat(user, SPAN_WARNING("You cannot shorten \the [src] any further!"))
+				
 	else
 		..()

--- a/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
@@ -84,7 +84,10 @@
 
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel/attackby(var/obj/item/A as obj, mob/user as mob)
 	if(QUALITY_SAWING in A.tool_qualities)
-		if (src.name != "sawn-off shotgun")
+		if (!istype(src, /obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawn))
+			if (src.item_upgrades.len)
+				if("No" == input(user, "There are attachments present. Would you like to destroy them?") in list("Yes", "No"))
+					return
 			to_chat(user, SPAN_NOTICE("You begin to shorten the barrel of \the [src]."))
 			if(loaded.len)
 				for(var/i in 1 to max_shells)
@@ -98,6 +101,5 @@
 				to_chat(user, SPAN_WARNING("You shorten the barrel of \the [src]!"))
 		else
 			to_chat(user, SPAN_WARNING("You cannot shorten \the [src] any further!"))
-				
 	else
 		..()


### PR DESCRIPTION
## About The Pull Request

An attempt to saw a sawn-off shotgun now gives a message "You cannot shorten \the [src] any further!"
If you have attachments, you will be asked if you want to proceed.

## Why It's Good For The Game

It was an oversight. This is a fix.

## Changelog
:cl:
fix: You can no longer endlessly shorten the sawn-off shotgun.
fix: If the shotgun has attachments, you will be given a chance to cancel (yes/no) to avoid destroying them.
/:cl: