### PR TITLE
Spider time to attach fixed for surgery

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
@@ -38,6 +38,10 @@
 				to_chat(owner_mob, SPAN_NOTICE("[src] infested [L]"))
 				break
 
+/obj/item/weapon/implant/carrion_spider/on_uninstall()
+	..()
+	last_stun_time = world.time
+
 /obj/item/weapon/implant/carrion_spider/attackby(obj/item/I, mob/living/user, params) //Overrides implanter behaviour
 	if(I.force >= WEAPON_FORCE_WEAK)
 		attack_animation(user)


### PR DESCRIPTION
## About The Pull Request

Spiders were not getting the 4 sec cooldown on attaching after surgery, should be fixed.

## Why It's Good For The Game
It's a pain to kill spiders with a small time window.

## Changelog
:cl: TheShown911
fix: spiders should take the same time to attach after surgery, as after movement.
/:cl:
