### PR TITLE
Add the PSY damage type and the possibility for guns to do PSY damage

### DIFF
--- a/code/__DEFINES/damage_organs.dm
+++ b/code/__DEFINES/damage_organs.dm
@@ -7,6 +7,7 @@
 #define CLONE     "clone"
 #define HALLOSS   "halloss"
 #define BLAST	  "blast"
+#define PSY       "psy"
 
 #define CUT       "cut"
 #define BRUISE    "bruise"

--- a/code/__DEFINES/items.dm
+++ b/code/__DEFINES/items.dm
@@ -55,6 +55,7 @@
 #define GUN_UPGRADE_DAMAGE_CLONE "clone_damage"
 #define GUN_UPGRADE_DAMAGE_HALLOSS "hallucination_damage"
 #define GUN_UPGRADE_DAMAGE_RADIATION "radiation_damage"
+#define GUN_UPGRADE_DAMAGE_PSY "psy_damage"
 
 #define GUN_UPGRADE_OFFSET "offset" //Constant offset, in degrees
 

--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -263,6 +263,8 @@
 		G.proj_damage_adjust[HALLOSS] += weapon_upgrades[GUN_UPGRADE_DAMAGE_HALLOSS]
 	if(weapon_upgrades[GUN_UPGRADE_DAMAGE_RADIATION])
 		G.proj_damage_adjust[IRRADIATE] += weapon_upgrades[GUN_UPGRADE_DAMAGE_RADIATION]
+	if(weapon_upgrades[GUN_UPGRADE_DAMAGE_PSY])
+		G.proj_damage_adjust[PSY] += weapon_upgrades[GUN_UPGRADE_DAMAGE_PSY]
 	if(weapon_upgrades[GUN_UPGRADE_HONK])
 		G.fire_sound = 'sound/items/bikehorn.ogg'
 	if(weapon_upgrades[GUN_UPGRADE_RIGGED])
@@ -401,6 +403,9 @@
 
 		if(weapon_upgrades[GUN_UPGRADE_DAMAGE_RADIATION])
 			to_chat(user, SPAN_NOTICE("Modifies projectile radiation damage by [weapon_upgrades[GUN_UPGRADE_DAMAGE_RADIATION]] damage points"))
+
+		if(weapon_upgrades[GUN_UPGRADE_DAMAGE_PSY])
+			to_chat(user, SPAN_NOTICE("Modifies projectile psy damage by [weapon_upgrades[GUN_UPGRADE_DAMAGE_PSY]] damage points"))
 
 		if(weapon_upgrades[GUN_UPGRADE_RECOIL])
 			var/amount = weapon_upgrades[GUN_UPGRADE_RECOIL]

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -358,6 +358,11 @@ This function restores all organs.
 
 	//visible_message("Hit debug. [damage] | [damagetype] | [def_zone] | [blocked] | [sharp] | [used_weapon]")
 
+	//Handle PSY damage
+	if(damagetype == PSY)
+		sanity.onPsyDamage(damage)
+		return 1
+
 	//Handle other types of damage
 	if(damagetype != BRUTE && damagetype != BURN)
 		if(damagetype == HALLOSS && !(species && (species.flags & NO_PAIN)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Add the `PSY` damage type with a `GUN_UPGRADE_DAMAGE_PSY` keyword to add PSY damage to guns.

* This type of damage is handled like the others so it is reduced by armor when you are hit by a bullet

* Damage is applied to sanity through `sanity.onPsyDamage(damage)` with for instance mindfryer doing 2 damage and mindboil spider doing 1 damage. So for projectiles psy damage will have to stay quite low or else the target will go into breakdown really quickly if they are hit several times.

## Why It's Good For The Game

There is now a way for guns to shoot projectiles that directly impact the sanity level.

## Changelog
:cl: Hyperio
add: Added psy damage type to guns and projectiles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
