### PR TITLE
Fix Counselor disk

### DIFF
--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -1016,7 +1016,7 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/taser = 3, // "NT SP \"Counselor\""
-		/datum/design/autolathe/cell/small/high,
+		/datum/design/autolathe/cell/medium/high,
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_spiderrose


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently counselor autolathe disk has small power cell while counselor is powered by medium power cell. This PR fixes that, replacing small high-capacity power cell with medium high-capacity power cell.

## Why It's Good For The Game

grug print ammo without walking away good

## Changelog
:cl:
fix: Counselor autolathe disk now contains medium battery design instead of small one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
