### PR TITLE
Excelsior can dab

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -559,6 +559,12 @@
 					message = "makes a very loud noise."
 					m_type = 2
 			cloud_emote = "cloud-scream"
+		if("dab")
+			m_type = 1
+			if(is_excelsior(src))
+				message = "<span class='warning'>dabs!</span>"
+			else
+				message = "fumbles their arms in a confusing way."
 
 		if ("help")
 			to_chat(src, {"blink, blink_r, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough,


### PR DESCRIPTION
![image](https://i.imgur.com/ZlxcYRO.png)
Allows the Excelsior to dab, which gives an unique red message if they really are Excelsior, since only they know all the intricacies of dabbing to truly make a dab a dab.

:cl:
add: Excelsior can now dab using the *dab emote. Normal folks can do it too but they don't truly know how to do it like the Excelsior do.
/:cl:
