### PR TITLE
Mining airlock assembly sprite fix (door_assembly.dm, 201)

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -198,7 +198,7 @@
 	airlock_type = "/engineering"
 
 /obj/structure/door_assembly/door_assembly_min
-	base_icon_state = "min"
+	base_icon_state = "ming"
 	base_name = "Mining Airlock"
 	glass_type = "/glass_mining"
 	airlock_type = "/mining"


### PR DESCRIPTION
## About The Pull Request

Fixes mining airlock assembly sprite.

## Why It's Good For The Game

Typo fix.

## Changelog
:cl:
fix: Fixed the mining airlock assembly sprite, it's no longer invisible.
/:cl: