### PR TITLE
Radstorm fix: Expansion of protected areas

### DIFF
--- a/code/game/gamemodes/events/weather/rad_storm.dm
+++ b/code/game/gamemodes/events/weather/rad_storm.dm
@@ -17,7 +17,7 @@
 	end_message = "<span class='notice'>The air seems to be cooling off again.</span>"
 
 	area_type = /area
-	protected_areas = list(/area/shuttle/escape, /area/shuttle/escape_pod1, /area/shuttle/escape_pod2, /area/shuttle/escape_pod3, \
+	protected_areas = list(/area/asteroid/rogue, /area/shuttle/mining, /area/deepmaint, /area/shuttle/escape, /area/shuttle/escape_pod1, /area/shuttle/escape_pod2, /area/shuttle/escape_pod3, \
 	/area/shuttle/escape_pod5, /area/shuttle/specops/centcom, /area/shuttle/mercenary, /area/shuttle/administration, /area/eris/maintenance, \
 	/area/eris/crew_quarters/sleep/cryo, /area/eris/security/disposal, /area/eris/security/maintpost, /area/eris/rnd/anomalisolone, \
 	/area/eris/rnd/anomalisoltwo, /area/eris/rnd/anomalisolthree, /area/eris/rnd/server)


### PR DESCRIPTION
## About The Pull Request

Right now the way weathers work, they are created everywhere besides "protected areas".
For radstorm, there is an extra check on actual radiate() function if it's a station Z level or not.

As the result, the radstorm appears in deep maintenance/on mining level, but it does not do damage.
Also mining shuttle is the only shuttle that is not currently shielded from it.

My fix adds "mining shuttle", "asteroid" and "deep maintenance" to the list of protected areas.
What it does in reality: it simply removes the green overlay where it was not already damaging players/had no effect.

## Why It's Good For The Game

Right now the listed areas show overlay but do not damage, negating the purpose of the overlay.
This fixes it.

## Changelog
:cl:
fix: radstorm no longer displays its overlay in deep maintenance/asteroid belt (it did not damage before, but showed green overlay).
fix: radstorm has no effect on mining shuttle
/:cl: