### PR TITLE
Snacks remade (also punpun and bones return) and tweaks to moebius

### DIFF
--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -1,6 +1,6 @@
 //Not to be confused with /obj/item/weapon/reagent_containers/food/drinks/bottle
 
-./obj/item/weapon/reagent_containers/glass/bottle
+/obj/item/weapon/reagent_containers/glass/bottle
 	name = "bottle"
 	desc = "A small bottle."
 	icon = 'icons/obj/chemical.dmi'

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -1,6 +1,6 @@
 //Not to be confused with /obj/item/weapon/reagent_containers/food/drinks/bottle
 
-/obj/item/weapon/reagent_containers/glass/bottle
+./obj/item/weapon/reagent_containers/glass/bottle
 	name = "bottle"
 	desc = "A small bottle."
 	icon = 'icons/obj/chemical.dmi'

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -108810,10 +108810,6 @@
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/eris/command/meo)
-"pgL" = (
-/mob/living/simple_animal/cat/fluff/bones,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/eris/command/mbo)
 "pkU" = (
 /obj/machinery/light/small,
 /obj/machinery/portable_atmospherics/canister/plasma,
@@ -108944,6 +108940,10 @@
 	},
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
+"rXZ" = (
+/mob/living/simple_animal/cat/fluff/bones,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/command/mbo)
 "rYg" = (
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/breakroom)
@@ -249012,7 +249012,7 @@ chl
 chl
 dEP
 dzD
-pgL
+rXZ
 dzT
 dzX
 eBA

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -74187,8 +74187,6 @@
 	dir = 4
 	},
 /obj/item/weapon/gun/projectile/handmade_pistol{
-	step_x = 0;
-	step_y = 0
 	},
 /obj/item/ammo_magazine/ammobox/pistol/rubber,
 /turf/simulated/floor/tiled/white/brown_perforated,

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -5177,7 +5177,9 @@
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/security/exerooms)
 "alK" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/assist{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
 "alL" = (
@@ -8183,9 +8185,11 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5starboard)
 "ash" = (
-/obj/machinery/vending/snack,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/vending/printomat{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/hallway/side/eschangarb)
@@ -28773,6 +28777,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/rnd/lab)
 "bmi" = (
@@ -46909,11 +46919,11 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/bioreactor)
 "bZF" = (
-/obj/machinery/vending/snack,
 /obj/item/device/radio/intercom{
 	dir = 2;
 	pixel_y = 24
 	},
+/obj/machinery/vending/powermat,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/hallway/main/section2)
 "bZG" = (
@@ -50052,6 +50062,7 @@
 /obj/machinery/alarm{
 	pixel_y = 26
 	},
+/obj/item/weapon/tool/screwdriver,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/surgery)
 "cgG" = (
@@ -50693,7 +50704,7 @@
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
 "cin" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/sovietsoda,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
 "cio" = (
@@ -51923,6 +51934,7 @@
 /area/eris/storage/tech)
 "cll" = (
 /obj/structure/table/glass,
+/obj/item/weapon/tool/screwdriver,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/surgery)
 "clm" = (
@@ -53087,6 +53099,12 @@
 "cnR" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/medbay)
@@ -54693,7 +54711,6 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/medical/reception)
 "crE" = (
-/obj/machinery/vending/snack,
 /obj/machinery/status_display{
 	density = 0;
 	pixel_x = 0;
@@ -58003,10 +58020,12 @@
 /turf/simulated/floor/tiled/white/violetcorener,
 /area/eris/rnd/research)
 "czy" = (
-/obj/machinery/vending/snack,
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 22
+	},
+/obj/machinery/vending/powermat{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/command/meeting_room)
@@ -62240,7 +62259,9 @@
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/miningdock)
 "cIR" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/printomat{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
 "cIS" = (
@@ -70139,7 +70160,7 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/rnd/research)
 "dbH" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/powermat,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/rnd/research)
 "dbI" = (
@@ -74165,6 +74186,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/weapon/gun/projectile/handmade_pistol{
+	step_x = 0;
+	step_y = 0
+	},
+/obj/item/ammo_magazine/ammobox/pistol/rubber,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/rnd/xenobiology)
 "dkf" = (
@@ -78571,9 +78597,11 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/security/checkpoint/supply)
 "dtQ" = (
-/obj/machinery/vending/snack,
 /obj/machinery/firealarm{
 	pixel_y = 28
+	},
+/obj/machinery/vending/powermat{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/medbreak)
@@ -89277,6 +89305,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/mob/living/carbon/human/monkey/punpun,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/barbackroom)
 "dRT" = (
@@ -94520,7 +94549,6 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/quartermaster/misc)
 "edM" = (
-/obj/machinery/vending/snack,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -94535,6 +94563,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/vending/cigarette{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/quartermaster/misc)
@@ -96652,7 +96683,7 @@
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/eris/maintenance/section3deck2port)
 "eiM" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending,
 /turf/simulated/floor/carpet/turcarpet,
 /area/eris/crew_quarters/clothingstorage)
 "eiN" = (
@@ -108779,6 +108810,10 @@
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/eris/command/meo)
+"pgL" = (
+/mob/living/simple_animal/cat/fluff/bones,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/command/mbo)
 "pkU" = (
 /obj/machinery/light/small,
 /obj/machinery/portable_atmospherics/canister/plasma,
@@ -248977,7 +249012,7 @@ chl
 chl
 dEP
 dzD
-dzC
+pgL
 dzT
 dzX
 eBA


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
well as suggested from the #feedback channel in discord.
replaces snack vendors all around the ship. that and

medbay got 2 extra sinks

RnD now have 1

bones. and punpun are back at their houses

added a handmade pistol and some bullets to xenobio. maybe this i'll give em a better chance against slimes roundstart

added screwdrivers to fix synth organs in surgery

https://gyazo.com/collections/01819e163794e3fc0d80cce71f9188ea
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
to make bar and garden more meaningfull. since the sanity on itself didn't brought it to eris needs

also
adds sinks to medbay and robotics surger. for surgeons. to clean their paws
adds pets. cause cmon you gotta love em (and incentive to pick MBO and Bar manager)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
🆑 Fernandos33
add: 2 sinks to moebius
add: handmade pistol and ammo to xenobio
add: 2 screwdrivers to surgery
del: snack vendors
tweak: seed servitor are in the same level as garden now. no more cardio needed
balance: some vendors got replaced with battery. cigarette and a soviet machine even.
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
