### PR TITLE
Adjust the Techno-Tribalism Enforcer's quality requirements for mechanical stat

### DIFF
--- a/code/game/objects/items/devices/techno_tribalism.dm
+++ b/code/game/objects/items/devices/techno_tribalism.dm
@@ -26,10 +26,6 @@
 							oddity_stats[STAT_COG] += stat_cost
 							useful = TRUE
 
-						else if (quality == QUALITY_PULSING || quality == QUALITY_ADHESIVE || quality == QUALITY_SEALING)
-							oddity_stats[STAT_MEC] += stat_cost
-							useful = TRUE
-
 						else if (quality == QUALITY_PRYING || quality == QUALITY_HAMMERING || quality == QUALITY_DIGGING)
 							oddity_stats[STAT_ROB] += stat_cost
 							useful = TRUE
@@ -44,6 +40,12 @@
 
 						else if (quality == QUALITY_DRILLING || quality == QUALITY_SHOVELING || quality == QUALITY_EXCAVATION)
 							oddity_stats[STAT_TGH] += stat_cost
+							useful = TRUE
+
+					if(W.tool_qualities[quality] >= 30)
+						var/stat_cost = round(W.tool_qualities[quality] / 15)
+						if (quality == QUALITY_PULSING || quality == QUALITY_ADHESIVE || quality == QUALITY_SEALING)
+							oddity_stats[STAT_MEC] += stat_cost
 							useful = TRUE
 
 				if(!useful)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lowers the Techno-Tribalism Enforcer's tool quality requirement for pulsing, sealing, and adhesive qualities to 30 or greater, as opposed to the 35 required for the other qualities.  This allows multitools and duct tape to be used in the /k/ube for mechanical stats, instead of only fiber tape.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

There are not any tools with 35 or greater quality pulsing (multitool is the only pulsing tool with quality 30).  This change allows multitools to be used to add +2 mechanical oddity stats.

For the sealing and adhesive qualities, currently only fiber tape satisfies the >=35 quality condition - this change would allow duct tape to be used for +4 mechanical oddity stats.  Fiber tape is extremely rare maintenance item - it's commonplace for me to see none throughout the entire round.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Multitools and duct tape can be fed to the Techno-Tribalism Enforcer for mechanical oddity stats
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
