### PR TITLE
fix sanity ui

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1016,12 +1016,12 @@ var/list/rank_prefix = list(\
 	data["style"] = get_total_style()
 	data["min_style"] = MIN_HUMAN_SYLE
 	data["max_style"] = MAX_HUMAN_STYLE
-	data["rest"] = sanity.resting
-	data["insight_rest"] = sanity.insight_rest
 	data["sanity"] = sanity.level
 	data["sanity_max_level"] = sanity.max_level
 	data["insight"] = sanity.insight
 	data["desires"] = sanity.desires
+	data["rest"] = sanity.resting
+	data["insight_rest"] = sanity.insight_rest
 	return data
 
 /mob/living/carbon/human/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, state = GLOB.default_state)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -2746,7 +2746,7 @@
 	nutriment_amt = 10
 	bitesize = 2
 	preloaded_reagents = list("protein" = 34, "tomatojuice" = 6)
-	taste_tag = list(MEAT_FOOD)
+	taste_tag = list(MEAT_FOOD, CHEESE_FOOD)
 
 /obj/item/weapon/reagent_containers/food/snacks/meatpizzaslice
 	name = "Meatpizza slice"
@@ -2757,7 +2757,7 @@
 	center_of_mass = list("x"=18, "y"=13)
 	preloaded_reagents = list("protein" = 7, "tomatojuice" = 1)
 	cooked = TRUE
-	taste_tag = list(MEAT_FOOD)
+	taste_tag = list(MEAT_FOOD, CHEESE_FOOD)
 
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/mushroompizza
 	name = "Mushroompizza"
@@ -2770,7 +2770,7 @@
 	nutriment_amt = 35
 	bitesize = 2
 	preloaded_reagents = list("protein" = 5)
-	taste_tag = list(CHEESE_FOOD)
+	taste_tag = list(CHEESE_FOOD, CHEESE_FOOD)
 
 /obj/item/weapon/reagent_containers/food/snacks/mushroompizzaslice
 	name = "Mushroompizza slice"
@@ -2781,7 +2781,7 @@
 	center_of_mass = list("x"=18, "y"=13)
 	preloaded_reagents = list("nutriment" = 5, "protein" = 1)
 	cooked = TRUE
-	taste_tag = list(CHEESE_FOOD)
+	taste_tag = list(CHEESE_FOOD, CHEESE_FOOD)
 
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/vegetablepizza
 	name = "Vegetable pizza"
@@ -2794,7 +2794,7 @@
 	nutriment_amt = 25
 	bitesize = 2
 	preloaded_reagents = list("protein" = 5, "tomatojuice" = 6, "imidazoline" = 12)
-	taste_tag = list(VEGETARIAN_FOOD)
+	taste_tag = list(VEGETARIAN_FOOD, CHEESE_FOOD)
 
 /obj/item/weapon/reagent_containers/food/snacks/vegetablepizzaslice
 	name = "Vegetable pizza slice"
@@ -2805,7 +2805,7 @@
 	center_of_mass = list("x"=18, "y"=13)
 	preloaded_reagents = list("nutriment" = 4, "protein" = 1, "tomatojuice" = 1, "imidazoline" = 2)
 	cooked = TRUE
-	taste_tag = list(VEGETARIAN_FOOD)
+	taste_tag = list(VEGETARIAN_FOOD, CHEESE_FOOD)
 
 /obj/item/pizzabox
 	name = "pizza box"

--- a/nano/templates/sanity.tmpl
+++ b/nano/templates/sanity.tmpl
@@ -131,7 +131,7 @@
 				</div>
 			</div>
 			<div class="itemContent"><br>
-				{{:helper.displayBar(data.insight_rest, 0, 100, data.insight_rest < 33 ? 'bad' : data.style > 66 ? 'good': 'average')}}
+				{{:helper.displayBar(data.insight_rest, 0, 100, data.insight_rest < 33 ? 'bad' : data.insight_rest > 66 ? 'good': 'average')}}
 				<br><br>
 			</div>
 		{{/if}}


### PR DESCRIPTION
## About The Pull Request
the sanity ui was not working well, this fixes it.

## Changelog
:cl:
fix: sanity ui.
tweak: add the label "cheese food" to various types of pizza.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
