### PR TITLE
Give technomancer loadout a proper helmet

### DIFF
--- a/code/datums/outfits/jobs/engineering.dm
+++ b/code/datums/outfits/jobs/engineering.dm
@@ -24,10 +24,10 @@
 
 /decl/hierarchy/outfit/job/engineering/engineer
 	name = OUTFIT_JOB_NAME("Technomancer")
-	head = /obj/item/clothing/head/hardhat
+	head = /obj/item/clothing/head/armor/helmet/technomancer
 	uniform = /obj/item/clothing/under/rank/engineer
 	suit = /obj/item/clothing/suit/storage/vest/insulated
-	head = /obj/item/clothing/head/hardhat
+	head = /obj/item/clothing/head/armor/helmet/technomancer
 	id_type = /obj/item/weapon/card/id/engie
 	pda_type = /obj/item/modular_computer/pda/engineering
 


### PR DESCRIPTION
## About The Pull Request

Changes hard hat in pre-spawn loadout for technomancer to proper one.

## Why It's Good For The Game

So you don't waste those 2 seconds changing your awful preset helmet that does not fits your palette onto cool technomancer one. Exultant keeps his white helmet.


## Changelog
:cl:
fix: Technomancers spawn with proper helmet now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
