### PR TITLE
Space heater - Cell size fix

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -55,14 +55,14 @@
 	..(severity)
 
 /obj/machinery/space_heater/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/weapon/cell/medium))
+	if(istype(I, /obj/item/weapon/cell/large))
 		if(panel_open)
 			if(cell)
 				to_chat(user, "There is already a power cell inside.")
 				return
 			else
 				// insert cell
-				var/obj/item/weapon/cell/medium/C = usr.get_active_hand()
+				var/obj/item/weapon/cell/large/C = usr.get_active_hand()
 				if(istype(C))
 					user.drop_item()
 					src.cell = C
@@ -145,7 +145,7 @@
 
 			if("cellinstall")
 				if(panel_open && !cell)
-					var/obj/item/weapon/cell/medium/C = usr.get_active_hand()
+					var/obj/item/weapon/cell/large/C = usr.get_active_hand()
 					if(istype(C))
 						usr.drop_item()
 						src.cell = C


### PR DESCRIPTION
## About The Pull Request

Space heaters start with large cells which cannot be inserted back, because the check is for medium cell. Corrected that.

## Why It's Good For The Game

Without the fix:
- You cannot reuse the cell the heater starts with.
- Since the heaters are designed to run for prolonged time (to maintain/change atmosphere temperature), it makes sense for them to be designed with long term cells.

## Changelog
:cl:
fix: Space heaters now properly accept large cells instead of medium ones.
/:cl: