### PR TITLE
Extinguisher Cabinants can be alt clicked to open/close

### DIFF
--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -65,7 +65,7 @@
 		update_icon()
 
 /obj/structure/extinguisher_cabinet/AltClick(mob/living/user)
-	src.toggle_open()
+	src.toggle_open(user)
 
 /obj/structure/extinguisher_cabinet/verb/toggle(mob/living/usr)
 	set name = "Open/Close"

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -51,7 +51,7 @@
 		opened = !opened
 	update_icon()
 
-/obj/structure/extinguisher_cabinet/AltClick(mob/user)
+/obj/structure/extinguisher_cabinet/proc/toggle_open(mob/user)
 	if(isrobot(user))
 		return
 	if(user.incapacitated())
@@ -63,6 +63,15 @@
 		playsound(src.loc, 'sound/machines/Custom_extin.ogg', 50, 0)
 		opened = !opened
 		update_icon()
+
+/obj/structure/extinguisher_cabinet/AltClick(mob/living/user)
+	src.toggle_open()
+
+/obj/structure/extinguisher_cabinet/verb/toggle(mob/living/usr)
+	set name = "Open/Close"
+	set category = "Object"
+	set src in oview(1)
+	src.toggle_open(usr)
 
 /obj/structure/extinguisher_cabinet/attack_tk(mob/user)
 	if(has_extinguisher)

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -51,6 +51,19 @@
 		opened = !opened
 	update_icon()
 
+/obj/structure/extinguisher_cabinet/AltClick(mob/user)
+	if(isrobot(user))
+		return
+	if(user.incapacitated())
+		to_chat(user, SPAN_WARNING("You can't do that right now!"))
+		return
+	if(!in_range(src, user))
+		return
+	else
+		playsound(src.loc, 'sound/machines/Custom_extin.ogg', 50, 0)
+		opened = !opened
+		update_icon()
+
 /obj/structure/extinguisher_cabinet/attack_tk(mob/user)
 	if(has_extinguisher)
 		has_extinguisher.loc = loc


### PR DESCRIPTION
![H8qXJseMs0](https://user-images.githubusercontent.com/24533979/90075163-64bb8b00-dcc2-11ea-9af1-42b5e551de81.gif)

**EDIT:**
Extinguisher Cabinants have a new verb. They can now be opened via the right-click menu.

![4U7g4XsKvO](https://user-images.githubusercontent.com/24533979/90078096-6dfc2600-dcc9-11ea-9898-c60cd578d24d.gif)


Added 
## Changelog
:cl: Hopek
add: Extinguisher Cabinants can be alt clicked to open/close
add: Extinguisher Cabinants have a new verb. They can now be opened via the right-click menu.
/:cl:

