### PR TITLE
You can now Alt-click on storage containers to look inside them

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -259,6 +259,15 @@
 /obj/item/weapon/storage/proc/close(var/mob/user)
 	hide_from(user)
 
+/obj/item/weapon/storage/AltClick(mob/user)
+	if(user.incapacitated())
+		to_chat(user, SPAN_WARNING("You can't do that right now!"))
+		return
+	if(!in_range(src, user))
+		return
+	else
+		src.open(user)
+
 /obj/item/weapon/storage/proc/close_all()
 	for (var/mob/M in is_seeing)
 		close(M)


### PR DESCRIPTION
I was surprised this feature wasn't here. 
The only way to do this at the moment that I could find was to drag the container to your body.
This functionality works really well in other codebases.

![7qwpFopDsM](https://user-images.githubusercontent.com/24533979/90076087-7aca4b00-dcc4-11ea-9804-4239ad90d44e.gif)


## Changelog
:cl: Hopek
add: You can now Alt-click on storage containers to look inside them
/:cl:

