### PR TITLE
Change to prevent export abuse

### DIFF
--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -43,6 +43,7 @@
 	name = "Moebius \"Penetrator\" magnetic accelerator barrel"
 	desc = "Uses sympathetic magnetic coiling to increase exit velocity of a metal projectile."
 	icon_state = "Penetrator"
+	matter = list(MATERIAL_PLASTEEL = 10)
 
 /obj/item/weapon/gun_upgrade/barrel/mag_accel/New()
 	..()
@@ -60,6 +61,7 @@
 	name = "Moebius \"Caster\" magnetic overheat barrel"
 	desc = "Uses magnetic induction to heat the projectile of a weapon. Arguable combat effectiveness, but flashy nonetheless."
 	icon_state = "Caster"
+	matter = list(MATERIAL_PLASTEEL = 10)
 
 /obj/item/weapon/gun_upgrade/barrel/overheat/New()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This change gives a price of 10 units of plasteel to the mods for weapons that are created in science, in case of still wanting to build and export them they would give a benefit of 200 credits (much less compared to the 500 before), but above all it prevents that is being spammed in the protolathe of sciences so that cargo becomes rich effortlessly.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It helps to balance the economy so that it does not break so easily, giving more value to money by not providing an easy and effortless method of achieving it
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Changed the build values of the Penetrator and Caster mods from nothing to 10 units of plasteel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
