### PR TITLE
STS and Sol no longer have a damage bonus. STS now only bursts in rounds of 3

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic/sol.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sol.dm
@@ -17,6 +17,7 @@
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	recoil_buildup = 5
 	penetration_multiplier = 1.1
+	damage_multiplier = 1.15
 	one_hand_penalty = 8 //because otherwise you can shoot it one-handed in bursts and still be very accurate. One-handed recoil is now as much as it was back in the day when wielded.
 
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/automatic/sol.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sol.dm
@@ -16,7 +16,6 @@
 	price_tag = 2300
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	recoil_buildup = 5
-	damage_multiplier = 1.25
 	penetration_multiplier = 1.1
 	one_hand_penalty = 8 //because otherwise you can shoot it one-handed in bursts and still be very accurate. One-handed recoil is now as much as it was back in the day when wielded.
 

--- a/code/modules/projectiles/guns/projectile/automatic/sts35.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts35.dm
@@ -20,6 +20,7 @@
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/ltrifle_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
+	damage_multiplier = 1.2
 	recoil_buildup = 8
 	one_hand_penalty = 15 //automatic rifle level
 

--- a/code/modules/projectiles/guns/projectile/automatic/sts35.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts35.dm
@@ -20,7 +20,6 @@
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/ltrifle_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
-	damage_multiplier = 1.3
 	recoil_buildup = 8
 	one_hand_penalty = 15 //automatic rifle level
 
@@ -28,7 +27,7 @@
 	init_firemodes = list(
 		FULL_AUTO_400,
 		SEMI_AUTO_NODELAY,
-		BURST_5_ROUND
+		BURST_3_ROUND
 		)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Basically the title. The STS and sol literally do not need a damage bonus. If you want something that does a decent amount of damage as IH get a wintermute.
If you want more damage as a traitor buy HV ammo for your STS.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the sts not a literal death laser beam that fires enough damage to instantly kill everything in the game in 2 bursts and makes the sol not literally better than the wintermute in almost every way
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: sol and sts no longer have damage multipliers and now do 1x damage, or basically base damage for their calibers. STS can now only bursts in bursts of 3.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
