### PR TITLE
Remove prefixes for new RnD gun mods

### DIFF
--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -221,7 +221,6 @@
 	GUN_UPGRADE_RECOIL = 1.2,
 	GUN_UPGRADE_DAMAGE_MULT = 2,
 	GUN_UPGRADE_CHARGECOST = 3)
-	I.prefix = "shunted"
 	I.req_fuel_cell = REQ_CELL
 	I.gun_loc_tag = GUN_MECHANISM
 
@@ -239,7 +238,6 @@
 	GUN_UPGRADE_RECOIL = 1.2,
 	GUN_UPGRADE_DAMAGE_MULT = 0.20,
 	GUN_UPGRADE_FIRE_DELAY_MULT = 0.25)
-	I.prefix = "overdriven"
 	I.req_fuel_cell = REQ_CELL
 	I.gun_loc_tag = GUN_MECHANISM
 
@@ -255,7 +253,6 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
 	GUN_UPGRADE_HONK = TRUE)
-	I.prefix = "honking"
 	I.gun_loc_tag = GUN_TRIGGER
 
 // Add toxin damage to your weapon
@@ -270,7 +267,6 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
 	GUN_UPGRADE_DAMAGE_TOX = 5)
-	I.prefix = "toxin-coating"
 	I.req_gun_tags = list(GUN_PROJECTILE)
 	I.gun_loc_tag = GUN_BARREL
 
@@ -286,7 +282,6 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
 	GUN_UPGRADE_DAMAGE_RADIATION = 5)
-	I.prefix = "radiation-coating"
 	I.req_gun_tags = list(GUN_PROJECTILE)
 	I.gun_loc_tag = GUN_BARREL
 
@@ -302,6 +297,5 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
 	GUN_UPGRADE_DAMAGE_PSY = 0.4)
-	I.prefix = "psionic"
 	I.req_gun_tags = list(GUN_PROJECTILE)
 	I.gun_loc_tag = GUN_MECHANISM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Prefixes do not work for gun mods. I saw that it worked for tool mods but forgot to check for gun mods.

## Why It's Good For The Game

Cleaning the code of useless stuff.

## Changelog
:cl: Hyperio
code: Remove prefixes for new RnD gun mods
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
