### PR TITLE
beanbags now actually properly check bullet armor, removes a dumb comment

### DIFF
--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -194,7 +194,7 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/shotgun/beanbag		//because beanbags are not bullets
 	name = "beanbag"
 	icon_state = "buckshot"
-	check_armour = ARMOR_MELEE
+	check_armour = ARMOR_BULLET //neverforget
 	damage_types = list(BRUTE = 10)
 	agony = 60
 	armor_penetration = 0

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -191,7 +191,7 @@ There are important things regarding this file:
 	knockback = 1
 	step_delay = 1.1
 
-/obj/item/projectile/bullet/shotgun/beanbag		//because beanbags are not bullets
+/obj/item/projectile/bullet/shotgun/beanbag
 	name = "beanbag"
 	icon_state = "buckshot"
 	check_armour = ARMOR_BULLET //neverforget


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/46353991/90165367-6a11e780-dd4d-11ea-9c6a-65df044c509e.png)
![image](https://user-images.githubusercontent.com/46353991/90165391-726a2280-dd4d-11ea-8177-1ed1cc488218.png)
![image](https://user-images.githubusercontent.com/46353991/90165415-77c76d00-dd4d-11ea-80d8-ea3b4bdb9836.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: beanbags finally. Check bullet armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
