### PR TITLE
Fixed typos for Damp Rag smothering actions

### DIFF
--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -114,6 +114,10 @@
 		else if(reagents.total_volume)
 			if(user.targeted_organ == BP_MOUTH && ishuman(target))
 				var/mob/living/carbon/human/H = target
+				user.visible_message(
+					"<span class='danger'>\The [user] starts smothering [H] with [src]!</span>",
+					"<span class='warning'>You start smothering [H] with [src]!</span>"
+					)
 				if(!H.check_mouth_coverage())
 					if(do_after(user, 20, H))
 						user.do_attack_animation(src)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -129,8 +129,8 @@
 
 				user.do_attack_animation(src)
 				user.visible_message(
-					"<span class='danger'>\The [user] try to smothers [H] with [src], but blocked!</span>",
-					"<span class='warning'>You try to smother [H] with [src]!</span>"
+					"<span class='danger'>\The [user] tries to smother [H] with [src], but fails!</span>",
+					"<span class='warning'>You try to smother [H] with [src], but the mouth is covered!</span>"
 					)
 			else
 				wipe_down(target, user)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -114,28 +114,17 @@
 		else if(reagents.total_volume)
 			if(user.targeted_organ == BP_MOUTH && ishuman(target))
 				var/mob/living/carbon/human/H = target
-				user.visible_message(
-					"<span class='danger'>\The [user] starts smothering [H] with [src]!</span>",
-					"<span class='warning'>You start smothering [H] with [src]!</span>"
-					)
+				user.visible_message(SPAN_DANGER("\The [user] starts smothering [H] with [src]!"), SPAN_DANGER("You start smothering [H] with [src]!"))
 				if(!H.check_mouth_coverage())
 					if(do_after(user, 20, H))
 						user.do_attack_animation(src)
-						user.visible_message(
-							"<span class='danger'>\The [user] smothers [H] with [src]!</span>",
-							"<span class='warning'>You smother [H] with [src]!</span>",
-							"You hear some struggling and muffled cries of surprise"
-							)
-
+						user.visible_message(SPAN_DANGER("\The [user] smothers [H] with [src]!"), SPAN_DANGER("You smother [H] with [src]!"))
 						reagents.trans_to_mob(H, amount_per_transfer_from_this, CHEM_BLOOD)
 						update_name()
 						return
 
 				user.do_attack_animation(src)
-				user.visible_message(
-					"<span class='danger'>\The [user] tries to smother [H] with [src], but fails!</span>",
-					"<span class='warning'>You try to smother [H] with [src], but the mouth is covered!</span>"
-					)
+				user.visible_message(SPAN_DANGER("\The [user] tries to smother [H] with [src], but fails because the mouth is covered!"), SPAN_DANGER("You try to smother [H] with [src], but their mouth is covered!"))
 			else
 				wipe_down(target, user)
 		return


### PR DESCRIPTION
## About The Pull Request

1) Typo fixes
"The [name] try to smothers [target] with the damp rag, but blocked!"
changed into
"The [name] tries to smother [target] with the damp rag, but fails!"

"You try to smother [target] with the damp rag!"
changed to
"You try to smother [target] with the damp rag, but the mouth is covered!"

2) When someone just STARTS smothering another person, a message about the action appears in the chat (like with forcefeeding).

## Why It's Good For The Game

Before the fix,
1) it was unclear if you are smothering someone or their mouth is blocked.
2) Also, incorrect grammar.
3) Also, there was only a progress bar above the smotherer's head without a message about what's actually going on.

## Changelog
:cl:
fix: fixed grammar/notification for rag smothering actions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
