### PR TITLE
Glassification tweaks

### DIFF
--- a/code/datums/topic/admin.dm
+++ b/code/datums/topic/admin.dm
@@ -806,6 +806,29 @@
 	log_admin("[key_name(usr)] forced [key_name(M)] to say: [speech]")
 	message_admins("\blue [key_name_admin(usr)] forced [key_name_admin(M)] to say: [speech]")
 
+/datum/admin_topic/forcesanity
+	keyword = "forcesanity"
+	require_perms = list(R_FUN)
+
+/datum/admin_topic/forcesanity/Run(list/input)
+	var/mob/living/carbon/human/H = locate(input["forcesanity"])
+	if(!ishuman(H))
+		to_chat(usr, "This can only be used on instances of type /human.")
+		return
+
+	var/datum/breakdown/B = input("What breakdown will [key_name(H)] suffer from?", "Sanity Breakdown") as null | anything in subtypesof(/datum/breakdown)
+	if(!B)
+		return
+	B = new B(H.sanity)
+	if(!B.can_occur())
+		to_chat(usr, "[B] could not occur. [key_name(H)] did not meet the right conditions.")
+		qdel(B)
+		return
+	if(B.occur())
+		H.sanity.breakdowns += B
+		to_chat(usr, SPAN_NOTICE("[B] has occurred for [key_name(H)]."))
+		return
+
 
 /datum/admin_topic/revive
 	keyword = "revive"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -218,7 +218,8 @@ ADMIN_VERB_ADD(/datum/admins/proc/show_player_panel, null, TRUE)
 	body += {"<br><br>
 			<b>Other actions:</b>
 			<br>
-			<A href='?src=\ref[src];forcespeech=\ref[M]'>Forcesay</A>
+			<A href='?src=\ref[src];forcespeech=\ref[M]'>Forcesay</A> |
+			<A href='?src=\ref[src];forcesanity=\ref[M]'>Sanity Break</A>
 			"}
 	body += "<br><br><b>Languages:</b><br>"
 	var/f = 1

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1151,7 +1151,7 @@ var/list/rank_prefix = list(\
 	status_flags |= REBUILDING_ORGANS
 
 	var/obj/item/organ/internal/carrion/core = internal_organs_by_name[BP_SPCORE]
-	var/list/organs_to_readd = list() 
+	var/list/organs_to_readd = list()
 	if(core) //kinda wack, this whole proc should be remade
 		for(var/obj/item/organ/internal/carrion/C in internal_organs)
 			C.removed_mob()
@@ -1580,3 +1580,7 @@ var/list/rank_prefix = list(\
 		return TRUE
 	else
 		return FALSE
+
+/mob/living/carbon/human/proc/set_remoteview(var/atom/A)
+	remoteview_target = A
+	reset_view(A)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -63,7 +63,7 @@
 	var/xylophone = 0 //For the spoooooooky xylophone cooldown
 
 	var/mob/remoteview_target = null
-	var/remoteviewer = FALSE //for Glassification breakdown
+	var/remoteviewer = FALSE //Acts as an override for remoteview_target viewing, see human/life.dm: handle_vision()
 	var/hand_blood_color
 
 	var/gunshot_residue

--- a/code/modules/sanity/breakdowns.dm
+++ b/code/modules/sanity/breakdowns.dm
@@ -388,6 +388,8 @@
 /datum/breakdown/common/power_hungry/proc/check_shock()
 	finished = TRUE
 
+#define ACTVIEW_ONE TRUE
+#define ACTVIEW_BOTH 2
 
 /datum/breakdown/negative/glassification
 	name = "Glassification"
@@ -410,16 +412,8 @@
 /datum/breakdown/negative/glassification/update()
 	if(world.time < time)
 		return TRUE
-	if(active_view)
-		holder.owner.remoteviewer = FALSE
-		holder.owner.remoteview_target = null
-		holder.owner.reset_view(0)
-		target.remoteviewer = FALSE
-		target.remoteview_target = null
-		target.reset_view(0)
-		target = null
-		active_view = FALSE
-		time = world.time + cooldown
+	if(active_view) //Just in case the callback doesn't catch
+		reset_views()
 		return TRUE
 	. = ..()
 	if(!.)
@@ -428,16 +422,27 @@
 	if(targets.len)
 		target = pick(targets)
 		holder.owner.remoteviewer = TRUE
-		holder.owner.remoteview_target = target
-		holder.owner.reset_view(target)
+		holder.owner.set_remoteview(target)
 		to_chat(holder.owner, SPAN_WARNING("It seems as if you are looking through someone else's eyes."))
-		to_chat(target, SPAN_WARNING("It seems as if you are looking through someone else's eyes."))
-		target.remoteviewer = TRUE
-		target.remoteview_target = holder.owner
-		target.reset_view(holder.owner)
-		target.sanity.changeLevel(-rand(5,10))
-		active_view = TRUE
+		active_view = ACTVIEW_ONE
+		if(target.sanity.level < 50)
+			target.remoteviewer = TRUE
+			target.set_remoteview(holder.owner)
+			to_chat(target, SPAN_WARNING("It seems as if you are looking through someone else's eyes."))
+			active_view = ACTVIEW_BOTH
+		target.sanity.changeLevel(-rand(5,10)) //This phenomena will prove taxing on the viewed regardless
+		addtimer(CALLBACK(src, .proc/reset_views, TRUE), time_view)
 		time = world.time + time_view
+
+/datum/breakdown/negative/glassification/proc/reset_views()
+	holder.owner.set_remoteview()
+	holder.owner.remoteviewer = FALSE
+	if(active_view == ACTVIEW_BOTH)
+		target.set_remoteview()
+		target.remoteviewer = FALSE
+	target = null
+	active_view = FALSE
+	time = world.time + cooldown
 
 /datum/breakdown/common/herald
 	name = "Herald"


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Glassification breakdown now no longer hijacks both peoples views, unless the receiver is below a sanity threshold.

Glassification now only hijacks your view for precisely a second, rather than a second + mob tick offset

Adds some new debug tools for testing out sanity breakdowns through the player panel.

## Why It's Good For The Game
Having your eyesight hijacked during a firefight for 3~5 seconds because a vagabond stubbed his toe on a roach is not very fun.

## Changelog
:cl:
tweak: Glassification no longer hijacks the receiver's view, unless they are below a certain sanity threshold.
tweak: Glassification now only hijacks your view for a true second.
admin: Added a sanity debug function, to invoke a breakdown upon somebody.
/:cl:

