### PR TITLE
Climbing down onto the tables from another z-level.

### DIFF
--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -48,7 +48,7 @@ see multiz/movement.dm for some info.
 	// A lazy list to contain a list of mobs who are currently scaling
 	// up this turf. Used in human/can_fall.
 
-	var/tmp/list/climbers
+	var/tmp/list/climbers = list()
 
 /turf/simulated/open/New()
 	icon_state = "transparentclickable"
@@ -240,3 +240,49 @@ see multiz/movement.dm for some info.
 	else
 		return null
 
+/turf/simulated/open/MouseDrop_T(mob/target, mob/user)
+	var/mob/living/H = user
+	var/obj/structure/S = locate(/obj/structure) in GetBelow(src)
+	if(istype(H) && can_descent(H, S) && target == user)
+		do_descent(target, S)
+	else
+		return ..()
+
+/turf/simulated/open/proc/can_descent(var/mob/living/user, var/obj/structure/structure, post_descent_check = 0)
+	if(!structure || !structure.climbable || (!post_descent_check && (user in climbers)))
+		return
+
+	if(!user.Adjacent(src))
+		to_chat(user, SPAN_DANGER("You can't descent there, the way is blocked."))
+		return
+
+	var/obj/occupied = structure.turf_is_crowded()
+	if(occupied)
+		to_chat(user, SPAN_DANGER("There's \a [occupied] in the way."))
+		return
+
+	return 1
+
+/turf/simulated/open/proc/do_descent(var/mob/living/user, var/obj/structure/structure)
+	if(!can_descent(user, structure))
+		return
+
+	usr.visible_message(SPAN_WARNING("[user] starts descenting onto [structure]!"))
+	structure.visible_message(SPAN_WARNING("Someone starts descenting onto [structure]!"))
+	climbers |= user
+
+	var/delay = (issmall(user) ? 32 : 60) * user.mod_climb_delay
+	var/duration = max(delay * user.stats.getMult(STAT_VIG, STAT_LEVEL_EXPERT), delay * 0.66)
+	if(!do_after(user, duration, src))
+		climbers -= user
+		return
+
+	if(!can_descent(user, structure, post_descent_check = 1))
+		climbers -= user
+		return
+
+	usr.forceMove(GetBelow(src))
+
+	if(get_turf(user) == GetBelow(src))
+		usr.visible_message(SPAN_WARNING("[user] descents onto [structure]!"))
+	climbers -= user

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -253,7 +253,7 @@ see multiz/movement.dm for some info.
 		return
 
 	if(!user.Adjacent(src))
-		to_chat(user, SPAN_DANGER("You can't descent there, the way is blocked."))
+		to_chat(user, SPAN_DANGER("You can't descend there, the way is blocked."))
 		return
 
 	var/obj/occupied = structure.turf_is_crowded()
@@ -267,8 +267,8 @@ see multiz/movement.dm for some info.
 	if(!can_descent(user, structure))
 		return
 
-	usr.visible_message(SPAN_WARNING("[user] starts descenting onto [structure]!"))
-	structure.visible_message(SPAN_WARNING("Someone starts descenting onto [structure]!"))
+	user.visible_message(SPAN_WARNING("[user] starts descending onto [structure]!"))
+	structure.visible_message(SPAN_WARNING("Someone starts descending onto [structure]!"))
 	climbers |= user
 
 	var/delay = (issmall(user) ? 32 : 60) * user.mod_climb_delay
@@ -281,8 +281,8 @@ see multiz/movement.dm for some info.
 		climbers -= user
 		return
 
-	usr.forceMove(GetBelow(src))
+	user.forceMove(GetBelow(src))
 
 	if(get_turf(user) == GetBelow(src))
-		usr.visible_message(SPAN_WARNING("[user] descents onto [structure]!"))
+		user.visible_message(SPAN_WARNING("[user] descends onto [structure]!"))
 	climbers -= user

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -242,13 +242,13 @@ see multiz/movement.dm for some info.
 
 /turf/simulated/open/MouseDrop_T(mob/target, mob/user)
 	var/mob/living/H = user
-	var/obj/structure/S = locate(/obj/structure) in GetBelow(src)
-	if(istype(H) && can_descent(H, S) && target == user)
-		do_descent(target, S)
-	else
-		return ..()
+	for(var/obj/structure/S in GetBelow(src))
+		if(istype(H) && can_descend(H, S) && target == user)
+			do_descend(target, S)
+			return
+	return ..()
 
-/turf/simulated/open/proc/can_descent(var/mob/living/user, var/obj/structure/structure, post_descent_check = 0)
+/turf/simulated/open/proc/can_descend(var/mob/living/user, var/obj/structure/structure, post_descent_check = 0)
 	if(!structure || !structure.climbable || (!post_descent_check && (user in climbers)))
 		return
 
@@ -263,8 +263,8 @@ see multiz/movement.dm for some info.
 
 	return 1
 
-/turf/simulated/open/proc/do_descent(var/mob/living/user, var/obj/structure/structure)
-	if(!can_descent(user, structure))
+/turf/simulated/open/proc/do_descend(var/mob/living/user, var/obj/structure/structure)
+	if(!can_descend(user, structure))
 		return
 
 	user.visible_message(SPAN_WARNING("[user] starts descending onto [structure]!"))
@@ -273,11 +273,7 @@ see multiz/movement.dm for some info.
 
 	var/delay = (issmall(user) ? 32 : 60) * user.mod_climb_delay
 	var/duration = max(delay * user.stats.getMult(STAT_VIG, STAT_LEVEL_EXPERT), delay * 0.66)
-	if(!do_after(user, duration, src))
-		climbers -= user
-		return
-
-	if(!can_descent(user, structure, post_descent_check = 1))
+	if(!do_after(user, duration, src) || !can_descend(user, structure, post_descent_check = 1))
 		climbers -= user
 		return
 


### PR DESCRIPTION
## About The Pull Request
You can descend onto tables.
![mOed0I7Da6](https://user-images.githubusercontent.com/32336957/90420221-586b6f80-e0c0-11ea-8561-65d24fcb0376.gif)

## Why It's Good For The Game
You can climb up, and now you can climb down without breaking bones.

## Changelog
:cl:
add: Now you can climb down onto tables from z-level above by dragging yourself onto openspace.
/:cl: