### PR TITLE
botany fix and more

### DIFF
--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -249,6 +249,13 @@
 /datum/reagent/toxin/plantbgone/touch_obj(var/obj/O, var/volume)
 	if(istype(O, /obj/effect/plant))
 		qdel(O)
+	if(istype(O, /obj/machinery/portable_atmospherics/hydroponics))
+		var/obj/machinery/portable_atmospherics/hydroponics/T = O
+		T.seed = null
+		T.weedlevel = 0
+		T.pestlevel = 0
+		T.update_icon()
+		return
 
 /datum/reagent/acid/polyacid
 	name = "Polytrinic acid"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
-you can know sample FROM TRAYS with wirecutters and knife (just be sure to use the "WIREcutting skill that it got" not the CUTTING

PLANT B GONE now kills everything on the tray
-plant
-pests
-and weeds

**ALSO:** 
you can now sample 3 times before killing the plant (no more RNG) and 4th will kill it and sample one last seed


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixes 2 bugs with botany

deletes the RNG around sampling from trays. AND allows for botanists to experiment more around splices
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Fernandos33
tweak: you can now sample 3 times before killing the plant (no more RNG) and 4th will kill it and sample one last seed
fix: wire cutters can be used to sample from tray now
fix: plant b gone now kills everything in Hydroponic trays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
