### PR TITLE
anchor that mine.

### DIFF
--- a/code/game/objects/items/weapons/mine.dm
+++ b/code/game/objects/items/weapons/mine.dm
@@ -22,6 +22,8 @@
 	var/explosion_f_size = 15
 
 	var/armed = FALSE
+	var/deployed = FALSE
+	anchored = FALSE
 
 /obj/item/weapon/mine/ignite_act()
 	explode()
@@ -42,9 +44,48 @@
 
 /obj/item/weapon/mine/attack_self(mob/user)
 	armed = !armed
+	if(!deployed)
+		user.visible_message(
+			SPAN_DANGER("[user] starts to deploy \the [src]."),
+			SPAN_DANGER("You begin deploying \the [src]!"),
+			"You hear the slow creaking of a spring."
+			)
+
+		if (do_after(user, 25))
+			user.visible_message(
+				SPAN_DANGER("[user] has deployed \the [src]."),
+				SPAN_DANGER("You have deployed \the [src]!"),
+				"You hear a latch click loudly."
+				)
+
+			deployed = TRUE
+			user.drop_from_inventory(src)
+			anchored = TRUE
+			update_icon()
+		
 	if (armed)
 		playsound(loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
+	
 	update_icon()
+
+/obj/item/weapon/mine/attackby(obj/item/I, mob/user)
+	if(QUALITY_PULSING in I.tool_qualities)
+		
+		if (deployed)
+			user.visible_message(
+			SPAN_DANGER("[user] starts to carefully disarm \the [src]."),
+			SPAN_DANGER("You begin to carefully disarm \the [src].")
+			)
+		if(I.use_tool(user, src, WORKTIME_NORMAL, QUALITY_PULSING, FAILCHANCE_VERY_EASY,  required_stat = STAT_COG)) //disarming a mine with a multitool should be for smarties
+			user.visible_message(
+				SPAN_DANGER("[user] has disarmed \the [src]."),
+				SPAN_DANGER("You have disarmed \the [src]!")
+				)
+			deployed = FALSE
+			anchored = FALSE
+			update_icon()
+		return
+
 
 /obj/item/weapon/mine/Crossed(mob/AM)
 	if (armed)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
anchors mines when armed "can disarm with multitool"
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
mines now cannot be pulled and quickly taken out from groud
BUT
you can multitool (aka pulse) it disarmed
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Fernandos33
tweak: mines now anchor when deployed
tweak: deployed mines can now be disarmed with multitool
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
