### PR TITLE
Cringe Filter

### DIFF
--- a/code/_global_vars/lists/names.dm
+++ b/code/_global_vars/lists/names.dm
@@ -10,5 +10,7 @@ GLOBAL_LIST_INIT(clown_names, file2list("config/names/clown.txt"))
 GLOBAL_LIST_INIT(verbs, file2list("config/names/verbs.txt"))
 GLOBAL_LIST_INIT(adjectives, file2list("config/names/adjectives.txt"))
 
+GLOBAL_LIST_EMPTY(in_character_filter)
+
 //loaded on startup because of "
 //would include in rsc if ' was used

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -225,6 +225,8 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 	var/webhook_url
 	var/webhook_key
 
+	var/static/regex/ic_filter_regex //For the cringe filter.
+
 /datum/configuration/New()
 	fill_storyevents_list()
 
@@ -761,6 +763,7 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")
+	LoadChatFilter()
 
 /datum/configuration/proc/loadsql(filename)  // -- TLE
 	var/list/Lines = file2list(filename)
@@ -827,3 +830,17 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 			config.python_path = "python"
 
 	world.name = station_name()
+
+
+/datum/configuration/proc/LoadChatFilter()
+	GLOB.in_character_filter = list()
+
+	for(var/line in world.file2list("config/in_character_filter.txt"))
+		if(!line)
+			continue
+		if(findtextEx(line,"#",1,2))
+			continue
+		GLOB.in_character_filter += line
+
+	if(!ic_filter_regex && GLOB.in_character_filter.len)
+		ic_filter_regex = regex("\\b([jointext(GLOB.in_character_filter, "|")])\\b", "i")

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -70,6 +70,9 @@ datum/preferences
 		if (!isnull(raw_first_name) && CanUseTopic(user))
 			var/new_fname = sanitize_name(raw_first_name, pref.species, 14)
 			if(new_fname)
+				if(GLOB.in_character_filter.len) //If you name yourself brazil, you're getting a random name.
+					if(findtext(new_fname, config.ic_filter_regex))
+						new_fname = random_first_name(pref.gender, pref.species)
 				pref.real_first_name = new_fname
 				pref.real_name = pref.real_first_name + " " + pref.real_last_name
 				return TOPIC_REFRESH
@@ -88,6 +91,9 @@ datum/preferences
 			else
 				var/new_lname = sanitize_name(raw_last_name, pref.species, last_name_max_length)
 				if(new_lname)
+					if(GLOB.in_character_filter.len) //Same here too. Naming yourself brazil isn't funny, please stop.
+						if(findtext(new_lname, config.ic_filter_regex))
+							new_lname = random_last_name(pref.gender, pref.species)
 					pref.real_last_name = new_lname
 					pref.real_name = pref.real_first_name + " " + pref.real_last_name
 					return TOPIC_REFRESH

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -165,11 +165,20 @@
 	// Sanitizing rather than saving as someone might still be editing when copy_to occurs.
 	player_setup.sanitize_setup()
 	character.set_species(species)
+	var/random_first = random_first_name(gender, species)
+	var/random_last = random_last_name(gender, species)
+	var/random_full = real_first_name + " " + real_last_name
 
 	if(be_random_name)
-		real_first_name = random_first_name(gender, species)
-		real_last_name = random_last_name(gender, species)
-		real_name = real_first_name + " " + real_last_name
+		real_first_name = random_first
+		real_last_name = random_last
+		real_name = random_full
+
+	if(GLOB.in_character_filter.len) //If you name yourself hitler you're getting a random name.
+		if(findtext(real_name, config.ic_filter_regex))
+			real_first_name = random_first
+			real_last_name = random_last
+			real_name = random_full
 
 	if(config.humans_need_surnames)
 		if(!real_last_name)	//we need a surname

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -174,7 +174,7 @@
 		real_last_name = random_last
 		real_name = random_full
 
-	if(GLOB.in_character_filter.len) //If you name yourself hitler you're getting a random name.
+	if(GLOB.in_character_filter.len) //If you name yourself brazil, you're getting a random name.
 		if(findtext(real_name, config.ic_filter_regex))
 			real_first_name = random_first
 			real_last_name = random_last

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -174,8 +174,8 @@
 		real_last_name = random_last
 		real_name = random_full
 
-	if(GLOB.in_character_filter.len) //If you name yourself brazil, you're getting a random name.
-		if(findtext(real_name, config.ic_filter_regex))
+	if(GLOB.in_character_filter.len) //This does not always work correctly but is here as a backup in case the first two attempts to catch bad names fail.
+		if(findtext(real_first_name, config.ic_filter_regex) || findtext(real_last_name, config.ic_filter_regex))
 			real_first_name = random_first
 			real_last_name = random_last
 			real_name = random_full

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -135,6 +135,25 @@ var/list/channel_to_radio_key = new
 			return say_dead(message)
 		return
 
+	if(GLOB.in_character_filter.len)
+		if(findtext(message, config.ic_filter_regex))
+			// let's try to be a bit more informative!
+			var/warning_message = "<span class='warning'>A splitting spike of headache prevents you from saying whatever vile words you planned to say! You think better of saying such nonsense again. The following terms break the atmosphere and are not allowed: &quot;"
+			var/list/words = splittext(message, " ")
+			var/cringe = ""
+			for (var/word in words)
+				if (findtext(word, config.ic_filter_regex))
+					warning_message = "[warning_message]<b>[word]</b> "
+					cringe += "/<b>[word]</b>"
+				else
+					warning_message = "[warning_message][word] "
+
+
+			warning_message = trim(warning_message)
+			to_chat(src, "[warning_message]&quot;</span>")
+			//log_and_message_admins("[src] just tried to say cringe: [cringe]", src) //Uncomment this if you want to keep tabs on who's saying cringe words.
+			return
+
 	if(HUSK in mutations)
 		return
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -356,7 +356,7 @@
 	if(SSticker.random_players)
 		new_character.gender = pick(MALE, FEMALE)
 		client.prefs.real_first_name = random_first_name(new_character.gender)
-		client.prefs.real_last_name = random_first_name(new_character.gender)
+		client.prefs.real_last_name = random_last_name(new_character.gender)
 		client.prefs.real_name = client.prefs.real_first_name + " " + client.prefs.real_last_name
 		client.prefs.randomize_appearance_and_body_for(new_character)
 	else

--- a/config/example/in_character_filter.txt
+++ b/config/example/in_character_filter.txt
@@ -1,0 +1,19 @@
+###############################################################################################
+# Words that will block in character chat messages from sending.                              #
+# Case is not important. Commented-out examples are listed below, just remove the "#".        #
+###############################################################################################
+lol
+kek
+omg
+tbh
+owo
+uwu
+idk
+cbt
+tfw
+mfw
+iirc
+lmao
+lmfao
+afaik
+afk


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds cringe filter to stop people from saying things IC or naming themselves things that break the atmosphere of the game. It is configurable in txt file. It will only match whole words, not parts of words so you don't need to worry about acronyms appearing in words setting it off.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This was requested by @GrayRachnid and Reere.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Added cringe filter to stop people from saying things that break the atmosphere.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
