### PR TITLE
Adds Light Tile to the Floor crafting tab

### DIFF
--- a/code/datums/craft/recipes/floor.dm
+++ b/code/datums/craft/recipes/floor.dm
@@ -319,6 +319,17 @@
 	result = /obj/item/stack/tile/floor/dark/monofloor
 	variation_type = CRAFT_VARIATION
 
+/datum/craft_recipe/floor/lighttile
+	name = "light tile"
+	result = /obj/machinery/floor_light
+	steps = list(
+		list(CRAFT_MATERIAL, 3, MATERIAL_GLASS, "time" = 30),
+		list(CRAFT_MATERIAL, 2, MATERIAL_STEEL, "time" = 10),
+		list(QUALITY_SCREW_DRIVING, 10, 80),
+		list(/obj/item/stack/cable_coil, 5, "time" = 20),
+		list(QUALITY_PULSING, 30, 80)
+	)
+
 /datum/craft_recipe/floor/grille
 	name = "regular grille"
 	result = /obj/structure/grille


### PR DESCRIPTION

## About The Pull Request

I decided to make a crafting recipe for light tiles because:

1- Currently, you can only make them from autolathes
2- They can't be picked up, you have to drag them to where you want to put the lights at which is trouble some if that places happens to be maint where you would have to drag it from the autolathe you just made it.
3- It's easier to just carry steel, glass and cable coil than drag the fucking thing to maint.
4- This would make it easier for maint bar/baazar enthusiasts for enhancing their own autism projects
5- It's not something that affects the balance of the game at all.

## Why It's Good For The Game

People will start making maint look prettier (Hopefully)

## Changelog
:cl:
add: There is a light tile recipe in the Floor tab of the crafting menu.

