### PR TITLE
Autolathe disk eject QoL

### DIFF
--- a/code/game/machinery/autolathe/autolathe.dm
+++ b/code/game/machinery/autolathe/autolathe.dm
@@ -460,6 +460,13 @@
 
 	disk = null
 
+/obj/machinery/autolathe/AltClick(mob/living/user)
+	if(user.incapacitated())
+		to_chat(user, SPAN_WARNING("You can't do that right now!"))
+		return
+	if(!in_range(src, user))
+		return
+	src.eject_disk(user)
 
 /obj/machinery/autolathe/proc/eat(mob/living/user, obj/item/eating)
 	if(!eating && istype(user))


### PR DESCRIPTION
You can now Alt-Click autolathes to eject the disks.

## Changelog
:cl: Hopek
add: Autolathe disk eject QoL. You can now Alt-Click on any autolathe to eject the design disk.
/:cl:

