### PR TITLE
The NeoTheology Cahors barrel holds less volume to give NT a chance to use the extra barrels downstairs.

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -269,7 +269,7 @@
 	name = "NeoTheology Cahors barrel"
 	desc = "Barrel a day - keeps liver away."
 	icon_state = "barrel"
-	volume = 1000
+	volume = 400
 	starting_reagent = "ntcahors"
 	price_tag = 50
 	contents_cost = 950


### PR DESCRIPTION
Why:
NT has 3 more barrels downstairs but because of the massive size of the barrels they never run out of wine in the first barrel inside of the altar room.

At the moment there is almost no point in having extra barrels downstairs if it holds 1000 units unless the barrels downstairs are meant to be stolen and not used by NT.

## Changelog
:cl: Hopek
tweak: The NeoTheology Cahors barrel holds less volume to give NT a chance to use the extra barrels downstairs.
/:cl:

