### PR TITLE
Made teleporter fully (dis)assembleable

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -8,6 +8,33 @@
 	var/id = null
 	var/one_time_use = 0 //Used for one-time-use teleport cards (such as clown planet coordinates.)
 						 //Setting this to 1 will set src.locked to null after a player enters the portal and will not allow hand-teles to open portals to that location.
+	var/obj/machinery/teleport/station/mstation
+	var/obj/machinery/teleport/hub/mhub
+
+/obj/machinery/teleport/hub
+	name = "Teleporter Hub"
+	desc = "It's the hub of a teleporting machine."
+	icon_state = "tele0"
+	var/accurate = 0
+	use_power = 1
+	idle_power_usage = 10
+	active_power_usage = 2000
+	circuit = /obj/item/weapon/circuitboard/teleporterhub
+	var/obj/machinery/computer/teleporter/mconsole
+	var/obj/machinery/teleport/station/mstation
+
+/obj/machinery/teleport/station
+	name = "Teleporter Station"
+	desc = "It's the teleporter engagement/testfire station." 
+	icon_state = "controller"
+	var/active = 0
+	var/engaged = 0
+	use_power = 1
+	idle_power_usage = 10
+	active_power_usage = 2000
+	circuit = /obj/item/weapon/circuitboard/teleporterstation
+	var/obj/machinery/teleport/hub/mhub
+	var/obj/machinery/computer/teleporter/mconsole
 
 /obj/machinery/computer/teleporter/New()
 	src.id = "[rand(1000, 9999)]"
@@ -16,8 +43,7 @@
 	underlays += image('icons/obj/stationobjs.dmi', icon_state = "telecomp-wires")
 	return
 
-/obj/machinery/computer/teleporter/Initialize()
-	. = ..()
+/obj/machinery/computer/teleporter/proc/LinkTogether()
 	var/obj/machinery/teleport/station/station
 	for(var/dir in list(NORTH,EAST,SOUTH,WEST))
 		station = locate(/obj/machinery/teleport/station, get_step(src, dir))
@@ -29,13 +55,93 @@
 			hub = locate(/obj/machinery/teleport/hub, get_step(station, dir))
 			if(!isnull(hub))
 				break
+	if(hub)
+		src.mhub=hub
+	if(station)
+		src.mstation=station
 
 	if(istype(station))
-		station.com = hub
-
-
+		station.mconsole = src
+		if(hub)
+			station.mhub = hub
 	if(istype(hub))
-		hub.com = src
+		hub.mconsole = src
+		if(station)
+			hub.mstation=station
+
+/obj/machinery/teleport/station/proc/LinkUpwards()
+	var/obj/machinery/computer/teleporter/teleporter
+	for(var/dir in list(NORTH,EAST,SOUTH,WEST))
+		teleporter = locate(/obj/machinery/computer/teleporter, get_step(src, dir))
+		if(!isnull(teleporter))
+			break
+	if(istype(teleporter))
+		teleporter.LinkTogether()
+
+/obj/machinery/teleport/hub/proc/LinkUpwards()
+	var/obj/machinery/teleport/station/station
+	for(var/dir in list(NORTH,EAST,SOUTH,WEST))
+		station = locate(/obj/machinery/teleport/station, get_step(src, dir))
+		if(!isnull(station))
+			break
+	if(istype(station))
+		station.LinkUpwards()
+
+/obj/machinery/computer/teleporter/Initialize()
+	. = ..()
+	src.LinkTogether()
+
+/obj/machinery/teleport/hub/Initialize()
+	. = ..()
+	src.LinkUpwards()
+
+/obj/machinery/teleport/station/Initialize()
+	. = ..()
+	src.LinkUpwards()
+
+
+/obj/machinery/teleport/hub/on_deconstruction()
+	if(mstation)
+		if(mstation.engaged)
+			mstation.disengage()
+		mstation.mhub = null
+	if(mconsole)
+		mconsole.mhub = null
+	underlays.Cut()
+	. = ..()
+	
+
+/obj/machinery/teleport/station/on_deconstruction()
+	if(engaged)
+		disengage()
+	if(mhub)
+		mhub.mstation = null
+	if(mconsole)
+		mconsole.mstation = null
+	. = ..()
+
+/obj/machinery/computer/teleporter/on_deconstruction()
+	if(mstation)
+		if(mstation.engaged)
+			mstation.disengage()
+		mstation.mconsole = null
+	if(mhub)
+		mhub.mconsole = null
+	. = ..()
+		
+
+/obj/machinery/teleport/hub/attackby(obj/item/I, mob/user, params)
+	if(default_deconstruction(I, user))
+		return
+	if(default_part_replacement(I, user))
+		return
+
+/obj/machinery/teleport/station/attackby(obj/item/I, mob/user, params)
+	if(default_deconstruction(I, user))
+		return
+	if(default_part_replacement(I, user))
+		return
+	src.attack_hand()
 
 
 /obj/machinery/computer/teleporter/attackby(I as obj, mob/living/user as mob)
@@ -167,15 +273,7 @@
 	var/lockeddown = 0
 
 
-/obj/machinery/teleport/hub
-	name = "teleporter hub"
-	desc = "It's the hub of a teleporting machine."
-	icon_state = "tele0"
-	var/accurate = 0
-	use_power = 1
-	idle_power_usage = 10
-	active_power_usage = 2000
-	var/obj/machinery/computer/teleporter/com
+
 
 
 /obj/machinery/teleport/hub/New()
@@ -191,9 +289,9 @@
 	return
 
 /obj/machinery/teleport/hub/proc/teleport(atom/movable/M as mob|obj)
-	if (!com)
+	if (!mconsole)
 		return
-	if (!com.locked)
+	if (!mconsole.locked)
 		for(var/mob/O in hearers(src, null))
 			O.show_message(SPAN_WARNING("Failure: Cannot authenticate locked on coordinates. Please reinstate coordinate matrix."))
 		return
@@ -201,19 +299,19 @@
 		if(prob(5) && !accurate) //oh dear a problem, put em in deep space
 			do_teleport(M, locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), 3), 2)
 		else
-			do_teleport(M, com.locked) //dead-on precision
+			do_teleport(M, mconsole.locked) //dead-on precision
 
-		if(com.one_time_use) //Make one-time-use cards only usable one time!
-			com.one_time_use = 0
-			com.locked = null
+		if(mconsole.one_time_use) //Make one-time-use cards only usable one time!
+			mconsole.one_time_use = 0
+			mconsole.locked = null
 	else
 		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 		s.set_up(5, 1, src)
 		s.start()
 		accurate = 1
-		spawn(3000)	accurate = 0 //Accurate teleporting for 5 minutes
 		for(var/mob/B in hearers(src, null))
 			B.show_message(SPAN_NOTICE("Test fire completed."))
+		spawn(3000) if(src) accurate = 0 //Accurate teleporting for 5 minutes
 	return
 /*
 /proc/do_teleport(atom/movable/M as mob|obj, atom/destination, precision)
@@ -302,24 +400,19 @@
 	return
 */
 
-/obj/machinery/teleport/station
-	name = "station"
-	desc = "It's the station thingy of a teleport thingy." //seriously, wtf.
-	icon_state = "controller"
-	var/active = 0
-	var/engaged = 0
-	use_power = 1
-	idle_power_usage = 10
-	active_power_usage = 2000
-	var/obj/machinery/teleport/hub/com
+
 
 /obj/machinery/teleport/station/New()
 	..()
 	overlays.Cut()
 	overlays += "controller-wires"
 
-/obj/machinery/teleport/station/attackby(var/obj/item/weapon/W)
-	src.attack_hand()
+/*
+/obj/machinery/teleport/station/default_deconstruction(obj/item/I, mob/user)
+	if(engaged)
+		src.disengage()
+	. = ..()*/
+	
 
 /obj/machinery/teleport/station/attack_ai()
 	src.attack_hand()
@@ -333,31 +426,32 @@
 /obj/machinery/teleport/station/proc/engage()
 	if(stat & (BROKEN|NOPOWER))
 		return
-
-	if (com)
-		com.icon_state = "tele1"
+	if (mhub)
+		src.engaged = 1
+		mhub.icon_state = "tele1"
 		use_power(5000)
 		update_use_power(2)
-		com.update_use_power(2)
+		mhub.update_use_power(2)
 		for(var/mob/O in hearers(src, null))
 			O.show_message(SPAN_NOTICE("Teleporter engaged!"), 2)
 	src.add_fingerprint(usr)
-	src.engaged = 1
+	
 	return
 
 /obj/machinery/teleport/station/proc/disengage()
 	if(stat & (BROKEN|NOPOWER))
 		return
 
-	if (com)
-		com.icon_state = "tele0"
-		com.accurate = 0
-		com.update_use_power(1)
+	if (mhub)
+		src.engaged = 0
+		mhub.icon_state = "tele0"
+		mhub.accurate = 0
+		mhub.update_use_power(1)
 		update_use_power(1)
 		for(var/mob/O in hearers(src, null))
 			O.show_message(SPAN_NOTICE("Teleporter disengaged!"), 2)
 	src.add_fingerprint(usr)
-	src.engaged = 0
+	
 	return
 
 /obj/machinery/teleport/station/verb/testfire()
@@ -368,11 +462,11 @@
 	if(stat & (BROKEN|NOPOWER) || !isliving(usr))
 		return
 
-	if (com && !active)
+	if (mhub && !active)
 		active = 1
 		for(var/mob/O in hearers(src, null))
 			O.show_message(SPAN_NOTICE("Test firing!"), 2)
-		com.teleport()
+		mhub.teleport()
 		use_power(5000)
 
 		spawn(30)
@@ -386,8 +480,8 @@
 	if(stat & NOPOWER)
 		icon_state = "controller-p"
 
-		if(com)
-			com.icon_state = "tele0"
+		if(mhub)
+			mhub.icon_state = "tele0"
 	else
 		icon_state = "controller"
 

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -407,13 +407,6 @@
 	overlays.Cut()
 	overlays += "controller-wires"
 
-/*
-/obj/machinery/teleport/station/default_deconstruction(obj/item/I, mob/user)
-	if(engaged)
-		src.disengage()
-	. = ..()*/
-	
-
 /obj/machinery/teleport/station/attack_ai()
 	src.attack_hand()
 

--- a/code/game/objects/items/weapons/circuitboards/machinery/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/research.dm
@@ -73,6 +73,27 @@
 		/obj/item/weapon/stock_parts/console_screen = 1
 	)
 
+/obj/item/weapon/circuitboard/teleporterstation
+	name = "Circuit board (Teleporter station board)"
+	build_path = /obj/machinery/teleport/station
+	board_type = "machine"
+	origin_tech = list(TECH_DATA = 2, TECH_BLUESPACE = 2)
+	req_components = list(
+		/obj/item/bluespace_crystal/artificial = 3,
+		/obj/item/stack/cable_coil = 1,
+		/obj/item/weapon/stock_parts/subspace/filter = 1
+	)
+
+/obj/item/weapon/circuitboard/teleporterhub
+	name = "Circuit board (Teleporter hub board)"
+	build_path = /obj/machinery/teleport/hub
+	board_type = "machine"
+	origin_tech = list(TECH_DATA = 2, TECH_BLUESPACE = 2)
+	req_components = list(
+		/obj/item/bluespace_crystal/artificial = 2,
+		/obj/item/weapon/stock_parts/capacitor = 1
+	)
+
 obj/item/weapon/circuitboard/ntnet_relay
 	name = "Circuit board (NTNet Quantum Relay)"
 	build_path = /obj/machinery/ntnet_relay

--- a/code/modules/research/designs/circuits.dm
+++ b/code/modules/research/designs/circuits.dm
@@ -425,6 +425,18 @@
 	sort_string = "VAAAG"
 	category = CAT_BLUE
 
+/datum/design/research/circuit/teleporter/station
+	name = "Teleporter Station"
+	build_path = /obj/item/weapon/circuitboard/teleporterstation
+	sort_string = "VAAAO"
+	category = CAT_BLUE
+
+/datum/design/research/circuit/teleporter/hub
+	name = "Teleporter Hub"
+	build_path = /obj/item/weapon/circuitboard/teleporterhub
+	sort_string = "VAAAP"
+	category = CAT_BLUE
+
 //Experimental devices
 /datum/design/research/circuit/mindswapper
 	name = "experimental mind swapper"

--- a/code/modules/research/nodes/bluespace.dm
+++ b/code/modules/research/nodes/bluespace.dm
@@ -157,7 +157,9 @@
 							/datum/design/research/item/part/artificialbscrystal,
 							/datum/design/research/circuit/bssilk/hub,
 							/datum/design/research/circuit/bssilk/console,
-							/datum/design/research/item/bs_snare
+							/datum/design/research/item/bs_snare,
+							/datum/design/research/circuit/teleporter/station,
+							/datum/design/research/circuit/teleporter/hub
 							)
 
 /datum/technology/bluespace_tools


### PR DESCRIPTION
## About the pull request
Spent a day revamping old gutted teleporter code to make it fully (dis)assemblable. 
Now you can assemble teleporter anywhere. Or disassemble one from MEO's office to go play telescientist early ingame. Up to you really. Demo [https://youtu.be/9itPC5xVsPI](url)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: changed and refactored /code/game/machinery/teleporter.dm 
code: added circuitboards to /code/game/objects/items/weapons/circuitboards/machinery/research.dm component pricing is equal to NSV13
code: added design definitions to /code/modules/research/designs/circuits.dm 
tweak: /code/modules/research/nodes/bluespace.dm added both station and hub to research tree
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
