### PR TITLE
[Order] Fix large grenades not exploding

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -229,7 +229,6 @@
 					if(beakers.len)
 						for(var/obj/item/slime_extract/O in beakers)
 							O.forceMove(get_turf(src))
-	beakers = list()
 	..()
 
 

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -229,6 +229,7 @@
 					if(beakers.len)
 						for(var/obj/item/slime_extract/O in beakers)
 							O.forceMove(get_turf(src))
+						beakers = list()
 	..()
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

> Large Chem Grenades:
> They don't work, fix them. Nobody know why.

Explanation:
```
beakers = list()
..()
```
at the end of `chem_grenade/large/prime()`, meaning the beakers were deleted just before processing `chem_grenade/prime()`

## Why It's Good For The Game

You can now use large chem grenades.

## Changelog
:cl: Hyperio
fix: Fix large grenades not exploding
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
