### PR TITLE
Rebalances chainsaws and hypersaws to be huge.

### DIFF
--- a/code/game/objects/items/weapons/tools/saws.dm
+++ b/code/game/objects/items/weapons/tools/saws.dm
@@ -58,6 +58,7 @@
 	armor_penetration = ARMOR_PEN_SHALLOW
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 2)
 	tool_qualities = list(QUALITY_SAWING = 60, QUALITY_CUTTING = 50, QUALITY_WIRE_CUTTING = 20) //not the best choice to cut wires
+	w_class = ITEM_SIZE_HUGE
 	max_upgrades = 4
 	use_fuel_cost = 0.1
 	max_fuel = 80
@@ -72,6 +73,7 @@
 	armor_penetration = ARMOR_PEN_SHALLOW
 	matter = list(MATERIAL_SILVER = 2, MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 3)
 	tool_qualities = list(QUALITY_SAWING = 60, QUALITY_CUTTING = 50, QUALITY_WIRE_CUTTING = 20)
+	w_class = ITEM_SIZE_HUGE
 	max_upgrades = 4
 	degradation = 0.7
 	use_power_cost = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title says it mostly
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
For balance reasons, you shouldn't be able to just put huge items like chainsaws and hypersaws in your belt.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Changed the size of hypersaws and chainsaws so they can't fit in belts anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
