### PR TITLE
Tray shield crafting fix

### DIFF
--- a/code/datums/craft/recipes/weapon.dm
+++ b/code/datums/craft/recipes/weapon.dm
@@ -108,7 +108,7 @@
 	result = /obj/item/weapon/shield/riot/handmade/tray
 	steps = list(
 		list(/obj/item/weapon/tray, 1),
-		list(/obj/item/weapon/storage/belt, 2, "time" = 10)
+		list(/obj/item/weapon/storage/belt, 1, "time" = 10)
 	)
 
 /datum/craft_recipe/weapon/pistol


### PR DESCRIPTION
The recipe does not match what is written in the directions.
This will prevent confusion as there is no other way to know that it requires 2 whole belts when reading the instructions.

![viGvCIRs5O](https://user-images.githubusercontent.com/24533979/90966708-49f3ce00-e49b-11ea-9523-9bc5abed39c4.png)


## Changelog
:cl: Hopek
fix: The Tray shield is now crafted exactly as stated on the recipe with a single tool belt vs two.
/:cl:
