### PR TITLE
Carrion regen change and control spider timer randomisation.

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/carrion/control_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/control_spider.dm
@@ -48,7 +48,7 @@
 	active = TRUE
 	last_use = world.time
 
-	addtimer(CALLBACK(src, .proc/return_mind), 1 MINUTES)
+	addtimer(CALLBACK(src, .proc/return_mind), rand(45 SECONDS, 70 SECONDS))
 
 /obj/item/weapon/implant/carrion_spider/control/on_uninstall()
 	..()

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -246,12 +246,20 @@
 	owner.tod = stationtime2text()
 	var/last_owner = owner
 
-	spawn(rand(800,2000))
+	spawn(rand(1 MINUTES, 3 MINUTES))
 		if(last_owner == owner)
-			owner.revive()
+			owner.rejuvenate()
+			for(var/limb_tag in owner.species.has_limbs)
+				var/obj/item/organ/external/E = owner.get_organ(limb_tag)
+				if(E.is_stump())
+					qdel(E)
+					var/datum/organ_description/OD = owner.species.has_limbs[limb_tag]
+					OD.create_organ(owner)
+
 			owner.status_flags &= ~(FAKEDEATH)
 			owner.update_lying_buckled_and_verb_status()
-			to_chat(owner, SPAN_NOTICE("We have regenerated."))
+			owner.update_icons()
+			to_chat(owner, SPAN_NOTICE("You have regenerated."))
 
 /obj/item/organ/internal/carrion/maw
 	name = "carrion maw"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the carrion healing proc from aheal to rejuvinate with extra changes for missing limbs, to hopefuly fix some bugs and randomizes control spider duration.

## Why It's Good For The Game

Bugs are bad, and some strange stuff can be done with perfectly timed control spiders.

## Changelog
:cl: TheShown
balance: control spider duration is no longer exactly 1 minute, but randomized from 45 to 70 seconds.
code: revive() proc from carrion regen stasis changed to rejuvinate().
/:cl:
