### PR TITLE
Fixed copying cloning stats

### DIFF
--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -55,6 +55,9 @@ var/list/disciples = list()
 	add_module(new CRUCIFORM_COMMON)
 	update_data()
 	disciples |= wearer
+	var/datum/core_module/cruciform/cloning/M = get_module(CRUCIFORM_CLONING)
+	if(M)
+		M.write_wearer(wearer) //writes all needed data to cloning module
 	return TRUE
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Added copying mob stats in cruciform on activation, so now cruciform can copy stats after cloning.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Because it makes cloning work as intended
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Vlad777
fix: Fixed copying stats after cloning
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
