### PR TITLE
Cleaning a voidsuit now cleans the attached boots, helmet, and tank

### DIFF
--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -75,6 +75,13 @@
 
 	return ..()
 
+/obj/item/clothing/suit/space/void/decontaminate()
+	if(boots) boots.decontaminate()
+	if(helmet) helmet.decontaminate()
+	if(tank) tank.decontaminate()
+
+	return ..()
+
 /obj/item/clothing/suit/space/void/equipped(mob/M)
 	..()
 


### PR DESCRIPTION


## About The Pull Request

Now when you put a voidsuit in the washing machine, it'll clean the helmet, boots, and tank attached too.

## Why It's Good For The Game

You can't detach a voidsuit helmet (without decapitating somebody), so cleaning your voidsuit only to find that it irradiates you when you deploy the helmet with no way to clean it kinda sucks.

## Changelog
:cl:
add: Cleaning a voidsuit with a washing machine now cleans the attached components
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
