### PR TITLE
fix chemmaster bug (not being able to make pills with a beaker that have more than 60u)

### DIFF
--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -173,7 +173,7 @@
 					if("By volume")
 						amount_per_pill = input("Select the volume that single pill should contain.", "Max [R.total_volume]", 5) as num
 						amount_per_pill = CLAMP(amount_per_pill, 1, reagents.total_volume)
-						if (reagents.total_volume > max_pill_vol)
+						if (amount_per_pill > max_pill_vol)
 							alert("Maximum volume supported in pills is [max_pill_vol]","Error.","Ok")
 							return
 						if ((reagents.total_volume / amount_per_pill) > max_pill_count)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
due to a confusion/overlook i created a bug
 "I tried making 10 u pills with 120 medicine, it said the maximum was 60u of volume per pill"
it is now fixed with one var change
fix for chemmaster bug ((not being able to make pills with a beaker that have more than 60u))
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix for chemmaster bug
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Fernandos33
fix: you can again make pills with a beaker filled with more than 60u (pills themselves cannot have more than 60 tho)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
