### PR TITLE
Adds few designs to Circuits, IH, Computer parts and Devices disks

### DIFF
--- a/code/datums/autolathe/circuits.dm
+++ b/code/datums/autolathe/circuits.dm
@@ -56,6 +56,10 @@
 	name = "reagent grinder"
 	build_path = /obj/item/weapon/circuitboard/reagentgrinder
 
+/datum/design/autolathe/circuit/industrialgrinder
+	name = "industrial grinder"
+	build_path = /obj/item/weapon/circuitboard/industrial_grinder
+
 //Exelsior ciruits
 /datum/design/autolathe/circuit/shieldgen_excelsior
 	name = "excelsior shield wall generator"

--- a/code/datums/autolathe/computer_parts.dm
+++ b/code/datums/autolathe/computer_parts.dm
@@ -22,3 +22,11 @@
 /datum/design/autolathe/computer_part/scanner/atmos
 	name = "atmospheric scanner module"
 	build_path = /obj/item/weapon/computer_hardware/scanner/atmos
+
+/datum/design/autolathe/computer_part/scanner/reagent
+	name = "reagent scanner module"
+	build_path = /obj/item/weapon/computer_hardware/scanner/reagent
+
+/datum/design/autolathe/computer_part/scanner/medical
+	name = "medical scanner module"
+	build_path = /obj/item/weapon/computer_hardware/scanner/medical

--- a/code/datums/autolathe/security.dm
+++ b/code/datums/autolathe/security.dm
@@ -29,3 +29,7 @@
 /datum/design/autolathe/sec/silencer
 	name = "silencer"
 	build_path = /obj/item/weapon/gun_upgrade/barrel/silencer
+
+/datum/design/autolathe/sec/hailer
+	name = "hailer"
+	build_path = /obj/item/device/hailer

--- a/code/game/objects/items/devices/whistle.dm
+++ b/code/game/objects/items/devices/whistle.dm
@@ -4,6 +4,7 @@
 	icon_state = "voice0"
 	item_state = "flashbang"	//looks exactly like a flash (and nothing like a flashbang)
 	w_class = ITEM_SIZE_TINY
+	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1, MATERIAL_STEEL = 2)
 	flags = CONDUCT
 
 	var/use_message = "Halt! Security!"

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -114,6 +114,7 @@
 		/datum/design/autolathe/device/implanter,
 		/datum/design/autolathe/device/hand_labeler,
 		/datum/design/research/item/light_replacer
+		/datum/design/autolathe/sec/hailer	
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/robustcells
@@ -194,7 +195,7 @@
 		/datum/design/autolathe/circuit/powermodule = 0,
 		/datum/design/autolathe/circuit/recharger,
 		/datum/design/research/circuit/autolathe,
-		/datum/design/autolathe/circuit/autolathe_disk_cloner,
+		/datum/design/autolathe/circuit/autolathe_disk_cloner = 3,
 		/datum/design/autolathe/circuit/vending,
 		/datum/design/research/circuit/arcade_battle,
 		/datum/design/research/circuit/arcade_orion_trail,
@@ -205,6 +206,7 @@
 		/datum/design/autolathe/circuit/centrifuge,
 		/datum/design/autolathe/circuit/electrolyzer,
 		/datum/design/autolathe/circuit/reagentgrinder,
+		/datum/design/autolathe/circuit/industrialgrinder = 2,
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/conveyors
@@ -284,6 +286,8 @@
 		/datum/design/autolathe/computer_part/gps,
 		/datum/design/autolathe/computer_part/scanner/paper,
 		/datum/design/autolathe/computer_part/scanner/atmos,
+		/datum/design/autolathe/computer_part/scanner/reagent,
+		/datum/design/autolathe/computer_part/scanner/medical,
 	)
 
 
@@ -405,6 +409,7 @@
 		/datum/design/autolathe/tool/tacknife,
 		/datum/design/autolathe/sec/beartrap,
 		/datum/design/autolathe/sec/silencer,
+		/datum/design/autolathe/sec/hailer	
 	)
 
 // One Star

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -113,8 +113,8 @@
 		/datum/design/autolathe/device/export_scanner,
 		/datum/design/autolathe/device/implanter,
 		/datum/design/autolathe/device/hand_labeler,
-		/datum/design/research/item/light_replacer
-		/datum/design/autolathe/sec/hailer	
+		/datum/design/research/item/light_replacer,
+		/datum/design/autolathe/sec/hailer,
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/robustcells


### PR DESCRIPTION
## About The Pull Request

Adds a Hailer design for the Ironhammer misc pack and the Aester's device disks
Adds an Industrial Grinder board design to the Technomancer's circuit disk
Adds medical and reagent scanners modules for PDAs to the Moebius computer parts disk.
Tweaks the license cost of two boards in the circuit disk (3 license uses for a Disk Cloner board and 2 license uses for an Industrial Grinder board)
![tc](https://user-images.githubusercontent.com/38330373/91233006-b4f50d00-e706-11ea-93bf-63062ab9c39f.png)
(Yes, I am aware that the Hailer in that picture says "silencer", forgot to change the label when I compiled before testing it. It's properly labeled in this PR)

All tested.

## Why It's Good For The Game

1- Currently, it rather fucking impossible to craft loudmouth grenades since there's no viable way of getting hailers
2- Industrial grinders can benefit ghetto chem labs made by vagabonds and NT Agrolytes that want to get chems out of plant produce
3- Scanner modules are neat thing to have at hand, making said scanner modules more commonly available don't really impact the game's balance since you can already get actual medical and reagent scanners devices from the Aester's device disks.
4- Disk cloners and Industrial Grinders are rather usefull machines, they should cost more than the other circuit boards in the disk.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Hailers, Reagent and Medical scanner modules for PDAs and Industrial Grinder boards have been added to some disks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
