### PR TITLE
Fixes a mistake I did when datumizing admin topic

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -23,7 +23,7 @@
 		return
 
 	var/static/list/topic_handlers = AdminTopicHandlers()
-	var/datum/world_topic/handler
+	var/datum/admin_topic/handler
 
 	for(var/I in topic_handlers)
 		if(I in href_list)


### PR DESCRIPTION
Just noticed while porting https://github.com/discordia-space/CEV-Eris/pull/2977/files that I accidentally made this reference world_topic instead of admin_topic. Effectively it doesn't matter, but it's still the wrong type so you know