### PR TITLE
Lowers slowdown on Captain Armor to default voidsuit value

### DIFF
--- a/code/modules/clothing/spacesuits/captain.dm
+++ b/code/modules/clothing/spacesuits/captain.dm
@@ -19,7 +19,7 @@
 	desc = "A bulky, heavy-duty piece of exclusive corporate armor. YOU are in charge!"
 	icon_state = "caparmor"
 	item_state = "capspacesuit"
-	slowdown = 1
+	slowdown = 0.3
 	armor = list(
 		melee = 50,
 		bullet = 40,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Captain armor slowdown changed from 1 to 0.3. That's it.

## Why It's Good For The Game

Context: stats are now identical to traitor/junk bloodred voidsuit, still worse than Excelsior armor (which is faster and more armored) and Serbian SCAF (which is far more armored). Now has same speed as IH/Techno voidsuit and NT armor, but with better protection (because Captain).
Captain armor is currently a joke deathtrap that nobody uses unless they happen to be inside of Captain's bedroom when the bridge is hit by a meteor and there is literally no other option, because for some reason it was more or less left behind when all voidsuits were buffed from being based around default 1 slowdown to the current default of 0.3. Captain armor at 0.3 slowdown may be a bit too fast (hard to judge without live gameplay), but 1 is comically slow to the point of unusability.

## Changelog
:cl:
balance: Captain's unique armor now has default voidsuit slowdown instead of a very high slowdown value
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
