### PR TITLE
Breeding spider bugfix

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/carrion/breeding_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/breeding_spider.dm
@@ -26,6 +26,11 @@
 		to_chat(owner_mob, SPAN_WARNING("[src] is already active!"))
 		return
 	
+	for(var/obj/item/weapon/implant/carrion_spider/breeding/BS in wearer)
+		if(BS.active)
+			to_chat(owner_mob, SPAN_WARNING("Another breeding spider is already active in [wearer]!"))
+			return
+
 	active = TRUE
 	spawn(1 MINUTES)
 		active = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a check so that you can't use multiple breeding spiders on a single corpse.

## Why It's Good For The Game

No more crashing the server from breeding spider spam.

## Changelog
:cl: TheShown
fix: Multiple breeding spiders can't be activated on the same body anymore.
/:cl:
