### PR TITLE
In theory fixes the huge organ issue destroying the server

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -165,8 +165,8 @@ meteor_act
 		if(gear && istype(gear ,/obj/item/clothing))
 			var/obj/item/clothing/C = gear
 			if(istype(C) && C.body_parts_covered & def_zone.body_part)
-				if(C.armor.getRating(type) > protection)
-					protection = C.armor.getRating(type)
+				if(C.armor.vars[type] > protection)
+					protection = C.armor.vars[type]
 
 	return protection
 


### PR DESCRIPTION
Can't test this at the moment but this fix, in theory, will work.

Issue:
----
In human_defense.dm

After C is defined (as obj/item/clothing) it is calling a proc that doesn't exist inside of its scope twice ( getRating() ) .
getRating() exists in /datum/armor not obj/item/clothing
![image](https://user-images.githubusercontent.com/24533979/91664364-681d8780-eab4-11ea-986d-c39fee760538.png)


My fix:
-----

Mimics the function of getRating() in this place by just doing vars[] instead since getRating is basically just vars[]

## Changelog
:cl: Hopek
fix: In theory fixed the huge organ issue destroying the server
/:cl:
