### PR TITLE
Items left inside the cryopod will come back to occupant on eject.

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -426,7 +426,7 @@
 	if(usr.stat != 0)
 		return
 
-	//Eject any items that aren't meant to be in the pod.
+	//Eject any items that aren't meant to be in the pod. Attempts to put the items back on the occupant otherwise drops them.
 	var/list/items = src.contents
 	if(occupant)
 		if(usr != occupant && !occupant.client && occupant.stat != DEAD)
@@ -438,6 +438,7 @@
 
 	for(var/obj/item/W in items)
 		W.forceMove(get_turf(src))
+		occupant.equip_to_appropriate_slot(W) // Items are now ejected. Tries to put them items on the occupant so they don't leave them behind
 
 	src.go_out()
 	add_fingerprint(usr)


### PR DESCRIPTION
Bug: 
When clothes get changed inside of the Cryopod (a custom clothing loadout for example), the items get dumped on the ground. Since the cryopod is closed during this, this means that the contents are now inside the cryopod. The re-equipping code doesn't check for the contents of objects so it didn't put those back on the occupant.

This also happens to be a feature as well!
It is more efficient to do this check here vs where the initial re-equipping loadout uniform happens since doing it here means that other instances of items being left in the pod will be addressed instead of just on clothing changes.


## Changelog
:cl: Hopek
add: The cryopod will now attempt to give your items back on eject if you leave items inside of the pod.
fix: fixed a re-equipping bug where it left your items (Such as the PDA) on the floor if you equip a custom loadout.
/:cl:
