### PR TITLE
Admin Chem Dispenser update and touchup

### DIFF
--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -223,9 +223,10 @@
 			to_chat(user, "You re-enable the 'cheap bastards' lock, disabling hidden and very expensive boozes.")
 			dispensable_reagents -= hacked_reagents
 
-/obj/machinery/chemical_dispenser/meds
-	name = "chem dispenser magic"
-	ui_title = "Chem Dispenser 9000"
+/obj/machinery/chemical_dispenser/admin
+	name = "debug chem dispenser"
+	desc = "A mysterious chemical dispenser that can produce all sorts of highly advanced medicines at the press of a button."
+	ui_title = "Cheat Synthesizer 1337"
 	dispensable_reagents = list(
 		"inaprovaline","ryetalyn","paracetamol",
 		"tramadol","oxycodone","sterilizine",
@@ -233,10 +234,13 @@
 		"dexalin","dexalinp","tricordrazine",
 		"anti_toxin","synaptizine","hyronalin",
 		"arithrazine","alkysine","imidazoline",
-		"peridaxon","bicaridine","hyperzine",
+		"peridaxon","bicaridine","meralyne","hyperzine",
 		"rezadone","spaceacillin","ethylredoxrazine",
 		"stoxin","chloralhydrate","cryoxadone",
-		"clonexadone"
+		"clonexadone","ossisine","noexcutite","kyphotorin",
+		"detox","polystem","purger","addictol","aminazine",
+		"vomitol","haloperidol","paroxetine","citalopram",
+		"methylphenidate"
 	)
 
 /obj/machinery/chemical_dispenser/industrial


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Saw that there was a admin chem dispenser, yet it lacked a couple medicines that a cheat dispenser really should have. Had a couple extra minutes on my hands, so I figured I'd update it. Also gave it a more descriptive atompath, name, and description.

Obviously incredibly unbalanced, but also unobtainable unless an admin spawns it. Mostly used for testing or for the admins to make Moebious Medical obsolete at the press of a button.

## Why It's Good For The Game

Consistency for the admin dispenser, mostly. It's nice for testing out chems on localhost, this makes it a bit easier to do that.

Let me know if I missed any medicines - I intentionally chose to leave out QuickClot, since internal bleeding doesn't exist. At least, according to the wiki. If QuickClot is actually useful, lemme know and I'll throw that in too.

## Changelog
:cl:
admin: Admin chem dispenser now has a more exhaustive list of medicines, a new name, a new atompath, and new description. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
