### PR TITLE
Fixes runtime in organ damage code

### DIFF
--- a/code/modules/organs/external/damage.dm
+++ b/code/modules/organs/external/damage.dm
@@ -26,7 +26,7 @@
 		fracture()
 
 	if(status & ORGAN_BROKEN && prob(40) && brute)
-		if (!(owner.species && (owner.species.flags & NO_PAIN)))
+		if (owner && !(owner.species && (owner.species.flags & NO_PAIN)))
 			owner.emote("scream")	//getting hit on broken hand hurts
 	if(used_weapon)
 		add_autopsy_data("[used_weapon]", brute + burn)


### PR DESCRIPTION
Not sure why this isn't here since it checks for "owner" later in the file as well.

Runtime:
![image](https://user-images.githubusercontent.com/24533979/91682538-87013580-eb17-11ea-89d7-72ce793c0f89.png)
