### PR TITLE
Nerfs the damage of most guns in the game.

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic/atreides.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/atreides.dm
@@ -18,7 +18,7 @@
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 13, MATERIAL_PLASTIC = 2)
 	price_tag = 1200
 	damage_multiplier = 0.8
-	recoil_buildup = 4
+	recoil_buildup = 6
 	one_hand_penalty = 5 //smg level
 	gun_tags = list(GUN_SILENCABLE)
 

--- a/code/modules/projectiles/guns/projectile/automatic/dallas.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/dallas.dm
@@ -18,7 +18,7 @@
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/m41_reload.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/m41_cocked.ogg'
-	damage_multiplier = 1.35
+	damage_multiplier = 1.3
 	penetration_multiplier = 1
 	recoil_buildup = 6
 	one_hand_penalty = 10 //heavy, but very advanced, so bullpup rifle level despite not being bullpup

--- a/code/modules/projectiles/guns/projectile/automatic/molly.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/molly.dm
@@ -22,7 +22,7 @@
 
 	damage_multiplier = 0.7 //good for rubber takedowns or self-defence, not so good to kill someone, you might want to use better smg
 	gun_tags = list(GUN_SILENCABLE)
-	recoil_buildup = 3
+	recoil_buildup = 9 //Its a machinepistol. Good luck.
 	one_hand_penalty = 5 //despine it being handgun, it's better to hold in two hands while shooting. SMG level.
 
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/automatic/sol.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sol.dm
@@ -17,7 +17,6 @@
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	recoil_buildup = 5
 	penetration_multiplier = 1.1
-	damage_multiplier = 1.15
 	one_hand_penalty = 8 //because otherwise you can shoot it one-handed in bursts and still be very accurate. One-handed recoil is now as much as it was back in the day when wielded.
 
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/automatic/straylight.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/straylight.dm
@@ -24,7 +24,7 @@
 	gun_tags = list(GUN_SILENCABLE)
 
 	init_firemodes = list(
-		FULL_AUTO_500,
+		FULL_AUTO_600,
 		SEMI_AUTO_NODELAY
 		)
 

--- a/code/modules/projectiles/guns/projectile/automatic/straylight.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/straylight.dm
@@ -19,12 +19,12 @@
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	damage_multiplier = 0.65	 //made with rubber rounds in mind. For lethality refer to Wintermute. Still quite lethal if you manage to land most shots.
 	penetration_multiplier = 0.5 //practically no AP, 2.5 with regular rounds and 5 with HV. Still deadly to unarmored targets.
-	recoil_buildup = 6 //Becomes unsustaniable after a while.
+	recoil_buildup = 6
 	one_hand_penalty = 5 //smg level
 	gun_tags = list(GUN_SILENCABLE)
 
 	init_firemodes = list(
-		FULL_AUTO_600,
+		FULL_AUTO_500,
 		SEMI_AUTO_NODELAY
 		)
 

--- a/code/modules/projectiles/guns/projectile/automatic/straylight.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/straylight.dm
@@ -19,7 +19,7 @@
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	damage_multiplier = 0.65	 //made with rubber rounds in mind. For lethality refer to Wintermute. Still quite lethal if you manage to land most shots.
 	penetration_multiplier = 0.5 //practically no AP, 2.5 with regular rounds and 5 with HV. Still deadly to unarmored targets.
-	recoil_buildup = 3
+	recoil_buildup = 6 //Becomes unsustaniable after a while.
 	one_hand_penalty = 5 //smg level
 	gun_tags = list(GUN_SILENCABLE)
 

--- a/code/modules/projectiles/guns/projectile/automatic/sts35.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts35.dm
@@ -20,7 +20,7 @@
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/ltrifle_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
-	damage_multiplier = 1.2
+	damage_multiplier = 1.15
 	recoil_buildup = 8
 	one_hand_penalty = 15 //automatic rifle level
 

--- a/code/modules/projectiles/guns/projectile/pistol/avasarala.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/avasarala.dm
@@ -11,7 +11,7 @@
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 8)
 	price_tag = 1600
 	can_dual = 1
-	damage_multiplier = 1.45
+	damage_multiplier = 1
 	penetration_multiplier = 1.35
 	recoil_buildup = 33
 	fire_sound = 'sound/weapons/guns/fire/hpistol_fire.ogg'

--- a/code/modules/projectiles/guns/projectile/pistol/colt.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/colt.dm
@@ -11,7 +11,7 @@
 	can_dual = 1
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_PISTOL
-	damage_multiplier = 1.5
+	damage_multiplier = 1.35
 	recoil_buildup = 17
 
 

--- a/code/modules/projectiles/guns/projectile/pistol/giskard.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/giskard.dm
@@ -15,7 +15,7 @@
 	mag_well = MAG_WELL_PISTOL
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_WOOD = 4)
 	price_tag = 600
-	damage_multiplier = 1.3
+	damage_multiplier = 1
 	penetration_multiplier = 0.8
 	recoil_buildup = 2
 

--- a/code/modules/projectiles/guns/projectile/pistol/mk58.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mk58.dm
@@ -12,7 +12,7 @@
 	can_dual = 1
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_PISTOL
-	damage_multiplier = 1.3
+	damage_multiplier = 1.15
 	penetration_multiplier = 1.3
 	recoil_buildup = 3
 

--- a/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
@@ -12,7 +12,7 @@
 	mag_well = MAG_WELL_PISTOL|MAG_WELL_H_PISTOL
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
 	price_tag = 800
-	damage_multiplier = 1.2
+	damage_multiplier = 1
 	penetration_multiplier = 1.2
 	recoil_buildup = 6
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/pistol/paco.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/paco.dm
@@ -18,7 +18,7 @@
 	price_tag = 1500
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
-	damage_multiplier = 1.5
+	damage_multiplier = 1.1
 	penetration_multiplier = 0.9
 	recoil_buildup = 10
 	gun_tags = list(GUN_SILENCABLE)

--- a/code/modules/projectiles/guns/projectile/revolver/consul.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/consul.dm
@@ -11,6 +11,6 @@
 	ammo_type = /obj/item/ammo_casing/magnum/rubber
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 8)
 	price_tag = 1700
-	damage_multiplier = 1.35
+	damage_multiplier = 1.3
 	penetration_multiplier = 1.5
 	recoil_buildup = 35

--- a/code/modules/projectiles/guns/projectile/revolver/deckard.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/deckard.dm
@@ -9,6 +9,6 @@
 	ammo_type = /obj/item/ammo_casing/magnum/rubber
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
 	price_tag = 3100 //one of most robust revolvers here
-	damage_multiplier = 1.45
+	damage_multiplier = 1.3
 	penetration_multiplier = 1.65
 	recoil_buildup = 40

--- a/code/modules/projectiles/guns/projectile/revolver/havelock.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/havelock.dm
@@ -12,6 +12,6 @@
 	ammo_type = /obj/item/ammo_casing/pistol
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
 	price_tag = 900
-	damage_multiplier = 1.4 //because pistol round
+	damage_multiplier = 1.2 //Slightly more damage than most pistols.
 	penetration_multiplier = 1.4
 	recoil_buildup = 18

--- a/code/modules/projectiles/guns/projectile/revolver/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/revolver.dm
@@ -21,7 +21,7 @@
 	var/chamber_offset = 0 //how many empty chambers in the cylinder until you hit a round
 	fire_delay = 3 //all revolvers can fire faster, but have huge recoil
 	damage_multiplier = 1.75
-	armor_penetration = 0.65 // Insanely powerful handcannon, but worthless against heavy armor
+	armor_penetration = 0.4 // Insanely powerful handcannon, but worthless against heavy armor
 	recoil_buildup = 50
 
 /obj/item/weapon/gun/projectile/revolver/verb/spin_cylinder()

--- a/code/modules/projectiles/guns/projectile/shotgun/sawnoff.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/sawnoff.dm
@@ -10,6 +10,6 @@
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 10)
 	w_class = ITEM_SIZE_NORMAL
 	force = WEAPON_FORCE_PAINFUL
-	damage_multiplier = 0.8 //slightly weaker due to sawn-off barrels
+	damage_multiplier = 0.7 //weaker due to sawn-off barrels
 	recoil_buildup = 1.2 //gonna have solid grip on those, point-blank shots adviced
 	one_hand_penalty = 10 //compact shotgun level


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Eris has a severe problem with damage in general and everyone dies in literally 100ms ttk from powercreep overtime, pistols deal literally too much damage on paper and dual wielding them in general makes them horrifically overpowered.

AUTOMATICS
Automatics have too high of a TTK. Though I didn't nerf them as hard as I think I should've.

Atreides: Got nerfed to 6 recoil buildup so it actually has some minor recoil buildup.
Dallas: Got nerfed to 35.1 damage per click.
Molly: Nerfed to 9 recoil buildup so it has actual recoil.
Sol: Had its damage multiplier entirely removed, it's not supposed to be better than the wintermute with lethals.
Straylight: recoil buildup increased to 6 so it has actual recoil, it still kills incredibly fast with rubbers.
STS nerfed to 1.15 multiplier to make it deal 32.15 damage, HV still does 34.15.

Pistol memes (lmao what were they thinking)
Pistols specifically can be dual wielded with ease, and so they should not deal literally 40+ damage on their own.

Avarshala: Handgun uses Magnum ammo, and thus it should not have a damage multiplier, otherwise its better than every other magnum.
Lamia: Unchanged.
Colt: Reduced to 1.35 damage multiplier. 37.8 from 42.
Giskard: No damage multiplier, I don't get why this ever got one.
MK58: 1.15 from 1.3.
Olivaw: Got its damage multiplier entirely removed, because like. It shoots in a burst of 2. When dual wielded these deal hilarious amounts of damage. Just why?
Paco: Whoever did the value for this thing is dumb. 1.1 damage mult. It no longer literally does 42 damage per click, is acquireable roundstart 100% of the time so its not even rng like the colt, and isn't literally a death machine dual wielded.

REVOLVERS
Changed the damage on most of them to be less like the pistols, they deal too much damage overall and kill people in 3 clicks.

Consul reduced to 1.3 damage multiplier. It now deals 44.3 damage.
Deckard reduced to 1.3 damage multiplier. It now deals 44.3 damage, it has higher penetration than the consul.
Havelock: Should do more damage than most pistols at 1.2 and 1.4 multipliers. I'll increase it if I got the math wrong though to 1.3.
Miller: The gimmick of this revolver is to be a handcannon with high damage but low armor penetration. 0.65 does not accomplish this. 0.4 does better.

OTHER GUNS

Sawn offs got nerfed to 0.7.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lowers the overall ttk minorly until the fabled erismed pr happens in 5 years.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Rebalanced the damage of most firearms entirely. Pistols do overall less damage, Revolvers as well. Sol lost its damage multiplier, straylight fires has more recoil buildup, the molly has more recoil, Dallas nerfed minorly, STS nerfed to 1.15 damage multiplier as it should just be balanced around having HV ammo 99% times.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
