### PR TITLE
Removes a mob spawner from one of the One Star dungeon rooms

### DIFF
--- a/maps/submaps/dungeon_rooms/rooms/armory_secure.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/armory_secure.dmm
@@ -11,7 +11,7 @@
 /turf/simulated/floor/plating/under,
 /area/crawler)
 "d" = (
-/obj/machinery/porta_turret/stationary,
+/obj/machinery/porta_turret/One_star,
 /turf/simulated/floor/plating/under,
 /area/crawler)
 "e" = (
@@ -24,6 +24,7 @@
 /area/crawler)
 "g" = (
 /obj/random/contraband,
+/obj/random/mob/roomba,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/crawler)
 "h" = (

--- a/maps/submaps/dungeon_rooms/rooms/armory_secure.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/armory_secure.dmm
@@ -23,7 +23,6 @@
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "g" = (
-/obj/random/mob/roomba,
 /obj/random/contraband,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/crawler)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This thing has been causing log spam for the past year. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stops admin logs from being spammed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: fixed admin issue regarding log spam
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
