### PR TITLE
Adds 2 roundstart disk spawns, NT biofabric and logistics for guild

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -58444,6 +58444,7 @@
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/misc,
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/devices,
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/tools,
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/conveyors,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/quartermaster/storage)
 "cAu" = (
@@ -105361,6 +105362,7 @@
 /area/space)
 "eBl" = (
 /obj/structure/table/standard,
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/nt_bioprinter_clothes,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/neotheology/bioreactor)
 "eBm" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
NT lost biofabrics in the disk change, this gives it to 'em on the desk next to the bioprinter.
I'd intended to add the logistics disk to the guild with my recycling PR but my mapmerge was fucking up - so I did that now while I was taking care of the NT disk too.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
NT needs to have their designs, since they're spawn-only and they've no other way of getting them.
Guild can get any disk from the vendor for free anyway, so let's give them logistics roundstart to encourage playing with conveyors and sorters.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The NT bioreactor room and Guild lathe now have a new disk spawn each - biofabrics for NT, and logistics for guild.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
