### PR TITLE
changes air alarm mode to cycle instead of off if there's a fire

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -145,7 +145,7 @@
 
 	if (old_pressurelevel != pressure_dangerlevel)
 		if (breach_detected())
-			apply_mode(AALARM_MODE_OFF)
+			apply_mode(AALARM_MODE_CYCLE)
 
 	if (mode==AALARM_MODE_CYCLE && environment.return_pressure()<ONE_ATMOSPHERE*0.05)
 		apply_mode(AALARM_MODE_FILL)


### PR DESCRIPTION


## About The Pull Request

One line change. Previously, if a red air alarm went off in a room, the vents and scrubbers would just switch themselves off. Now, the air alarm sends all the room to waste while keeping distro shut, then refills it through distro.
If the plasmaflood is achieved through distro pipes, this gives leeway for people to escape it with their internals tank (low pressure isn't a problem in a fire), then will unfortunately refill it with the bad stuff.
If the plasmaflood is achieved by literally dropping 1u of plasma reagent on the floor with welding fuel (yes this can cause an entire room to be set on fire) or through other methods such as shooting in toxins storage then this has the possibility to stop it in its tracks.

## Why It's Good For The Game

Nerfs plasmafloods

## Changelog
:cl:
tweak: Air alarms no longer shut off in case of a big emergency but instead drain the room then refill it, allowing to slow/halt a plasmaflood.
/:cl:

