### PR TITLE
Atmos and chemisty investrigation

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -138,8 +138,10 @@
 
 	if("power" in signal.data)
 		unlocked = text2num(signal.data["power"])
+		investigate_log("was [unlocked ? "enabled" : "disabled"] by a remote signal", "atmos")
 
 	if("power_toggle" in signal.data)
+		investigate_log("was [unlocked ? "disabled" : "enabled"] by a remote signal", "atmos")
 		unlocked = !unlocked
 
 	if("set_target_pressure" in signal.data)
@@ -148,6 +150,7 @@
 			text2num(signal.data["set_target_pressure"]),
 			max_pressure_setting
 		)
+		investigate_log("had it's pressure changed to [target_pressure] by a remote signal", "atmos")
 
 	if("set_regulate_mode" in signal.data)
 		regulate_mode = text2num(signal.data["set_regulate_mode"])
@@ -209,6 +212,7 @@
 	if(..()) return 1
 
 	if(href_list["toggle_valve"])
+		investigate_log("was [unlocked ? "disabled" : "enabled"] by [key_name(usr)]", "atmos")
 		unlocked = !unlocked
 
 	if(href_list["regulate_mode"])
@@ -225,6 +229,8 @@
 		if ("set")
 			var/new_pressure = input(usr, "Enter new output pressure (0-[max_pressure_setting]kPa)", "Pressure Control", src.target_pressure) as num
 			src.target_pressure = between(0, new_pressure, max_pressure_setting)
+	if(href_list["set_press"])
+		investigate_log("had it's pressure changed to [target_pressure] by [key_name(usr)]", "atmos")
 
 	switch(href_list["set_flow_rate"])
 		if ("min")
@@ -259,6 +265,7 @@
 			SPAN_NOTICE("\The [user] unfastens \the [src]."), \
 			SPAN_NOTICE("You have unfastened \the [src]."), \
 			"You hear ratchet.")
+		investigate_log("was unfastened by [key_name(user)]", "atmos")
 		new /obj/item/pipe(loc, make_from=src)
 		qdel(src)
 

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -157,8 +157,10 @@ Thus, the two variables affect pump operation are set in New():
 			use_power = IDLE_POWER_USE
 		else
 			use_power = NO_POWER_USE
+		investigate_log("was [use_power ? "enabled" : "disabled"] by a remote signal", "atmos")
 
 	if("power_toggle" in signal.data)
+		investigate_log("was [use_power ? "disabled" : "enabled"] by a remote signal", "atmos")
 		use_power = !use_power
 
 	if(signal.data["set_output_pressure"])
@@ -167,6 +169,7 @@ Thus, the two variables affect pump operation are set in New():
 			text2num(signal.data["set_output_pressure"]),
 			ONE_ATMOSPHERE*50
 		)
+		investigate_log("had it's pressure changed to [target_pressure] by a remote signal", "atmos")
 
 	if(signal.data["status"])
 		spawn(2)
@@ -193,6 +196,7 @@ Thus, the two variables affect pump operation are set in New():
 	if(..()) return 1
 
 	if(href_list["power"])
+		investigate_log("was [use_power ? "disabled" : "enabled"] by a [key_name(usr)]", "atmos")
 		use_power = !use_power
 
 	switch(href_list["set_press"])
@@ -203,6 +207,8 @@ Thus, the two variables affect pump operation are set in New():
 		if ("set")
 			var/new_pressure = input(usr, "Enter new output pressure (0-[max_pressure_setting]kPa)", "Pressure control", src.target_pressure) as num
 			src.target_pressure = between(0, new_pressure, max_pressure_setting)
+	if(href_list["set_press"])
+		investigate_log("had it's pressure changed to [target_pressure] by [key_name(usr)]", "atmos")
 
 	playsound(loc, 'sound/machines/machine_switch.ogg', 100, 1)
 	usr.set_machine(src)
@@ -234,5 +240,6 @@ Thus, the two variables affect pump operation are set in New():
 			SPAN_NOTICE("\The [user] unfastens \the [src]."), \
 			SPAN_NOTICE("You have unfastened \the [src]."), \
 			"You hear ratchet.")
+		investigate_log("was unfastened by [key_name(user)]", "atmos")
 		new /obj/item/pipe(loc, make_from=src)
 		qdel(src)

--- a/code/ATMOSPHERICS/components/omni_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/filter.dm
@@ -160,6 +160,7 @@
 				use_power = !use_power
 			else
 				use_power = NO_POWER_USE
+			investigate_log("was [use_power ? "enabled" : "disabled"] by [key_name(usr)]", "atmos")
 		if("configure")
 			configuring = !configuring
 			if(configuring)
@@ -176,6 +177,8 @@
 			if("switch_filter")
 				var/new_filter = input(usr, "Select filter mode:", "Change filter", href_list["mode"]) in list("None", "Oxygen", "Nitrogen", "Carbon Dioxide", "Plasma", "Nitrous Oxide")
 				switch_filter(dir_flag(href_list["dir"]), mode_return_switch(new_filter))
+		if(href_list["command"])
+			investigate_log("had it's settings modified by [key_name(usr)]", "atmos")
 
 	update_icon()
 	SSnano.update_uis(src)

--- a/code/ATMOSPHERICS/components/omni_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/mixer.dm
@@ -180,6 +180,7 @@
 				use_power = !use_power
 			else
 				use_power = NO_POWER_USE
+			investigate_log("was [use_power ? "enabled" : "disabled"] by [key_name(usr)]", "atmos")
 		if("configure")
 			configuring = !configuring
 			if(configuring)
@@ -197,6 +198,8 @@
 				change_concentration(dir_flag(href_list["dir"]))
 			if("switch_conlock")
 				con_lock(dir_flag(href_list["dir"]))
+		if((href_list["command"]))
+			investigate_log("had it's settings modified by [key_name(usr)]", "atmos")
 
 	playsound(loc, 'sound/machines/machine_switch.ogg', 100, 1)
 	update_icon()

--- a/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
@@ -96,6 +96,7 @@
 			SPAN_NOTICE("\The [user] unfastens \the [src]."), \
 			SPAN_NOTICE("You have unfastened \the [src]."), \
 			"You hear a ratchet.")
+		investigate_log("was unfastened by [key_name(user)]", "atmos")
 		new /obj/item/pipe(loc, make_from=src)
 		qdel(src)
 

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -97,6 +97,7 @@
 				SPAN_NOTICE("\The [user] unfastens \the [src]."), \
 				SPAN_NOTICE("You have unfastened \the [src]."), \
 				"You hear a ratchet.")
+			investigate_log("was unfastened by [key_name(user)]", "atmos")
 			new /obj/item/pipe(loc, make_from=src)
 			for (var/obj/machinery/meter/meter in T)
 				if (meter.target == src)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -650,6 +650,8 @@
 				to_chat(usr, "Temperature must be between [min_temperature]C and [max_temperature]C")
 			else
 				target_temperature = input_temperature + T0C
+			investigate_log("had it's target temperature changed by [key_name(usr)]", "atmos")
+
 		playsound(loc, 'sound/machines/button.ogg', 100, 1)
 		return 1
 
@@ -688,6 +690,7 @@
 					"scrubbing")
 					playsound(loc, 'sound/machines/machine_switch.ogg', 100, 1)
 					send_signal(device_id, list(href_list["command"] = text2num(href_list["val"]) ) )
+					investigate_log("had it's settings changed by [key_name(usr)]", "atmos")
 					return 1
 
 				if("set_threshold")
@@ -739,6 +742,7 @@
 						if(selected[3] > selected[4])
 							selected[3] = selected[4]
 
+					investigate_log("had it's tresholds changed by [key_name(usr)]", "atmos")
 					apply_mode()
 					return 1
 
@@ -766,6 +770,7 @@
 		if(href_list["atmos_reset"])
 			playsound(loc, 'sound/machines/machine_switch.ogg', 100, 1)
 			forceClearAlarm()
+			investigate_log("had it's alarms cleared by [key_name(usr)]", "atmos")
 			return 1
 
 		if(href_list["mode"])

--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -28,12 +28,12 @@
 //ADMINVERBS
 ADMIN_VERB_ADD(/client/proc/investigate_show, R_ADMIN, TRUE)
 //various admintools for investigation. Such as a singulo grief-log
-/client/proc/investigate_show( subject in list("hrefs","notes","singulo","telesci") )
+/client/proc/investigate_show( subject in list("hrefs","notes","singulo","telesci","atmos","chemistry") )
 	set name = "Investigate"
 	set category = "Admin"
 	if(!holder)	return
 	switch(subject)
-		if("singulo", "telesci")			//general one-round-only stuff
+		if("singulo", "telesci", "atmos", "chemistry")			//general one-round-only stuff
 			var/F = investigate_subject2file(subject)
 			if(!F)
 				to_chat(src, "<font color='red'>Error: admin_investigate: [INVESTIGATE_DIR][subject] is an invalid path or cannot be accessed.</font>")

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -132,6 +132,7 @@
 			var/added_amount = min(amount, cell.charge / chemical_dispenser_ENERGY_COST, space)
 			R.add_reagent(href_list["dispense"], added_amount)
 			cell.use(added_amount * chemical_dispenser_ENERGY_COST)
+			investigate_log("dispensed [href_list["dispense"]] into [B], while being operated by [usr]", "chemistry")
 
 	if(href_list["ejectBeaker"])
 		src.detach()

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -132,7 +132,7 @@
 			var/added_amount = min(amount, cell.charge / chemical_dispenser_ENERGY_COST, space)
 			R.add_reagent(href_list["dispense"], added_amount)
 			cell.use(added_amount * chemical_dispenser_ENERGY_COST)
-			investigate_log("dispensed [href_list["dispense"]] into [B], while being operated by [usr]", "chemistry")
+			investigate_log("dispensed [href_list["dispense"]] into [B], while being operated by [key_name(usr)]", "chemistry")
 
 	if(href_list["ejectBeaker"])
 		src.detach()

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -195,7 +195,7 @@
 	var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
 	playsound(src,'sound/effects/Liquid_transfer_mono.ogg',50,1)
 	to_chat(user, SPAN_NOTICE("You transfer [trans] units of the solution to [target]."))
-	investigate_log("had [trans] units of it's reagents transfered to [target] by [key_name(user)]", "chemistry")
+	user.investigate_log("transfered [trans] units from [src]([reagents.log_list()]) to [target]([target.reagents.log_list()])", "chemistry")
 	return TRUE
 
 // if amount_per_reagent is null or zero it will transfer all

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -195,6 +195,7 @@
 	var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
 	playsound(src,'sound/effects/Liquid_transfer_mono.ogg',50,1)
 	to_chat(user, SPAN_NOTICE("You transfer [trans] units of the solution to [target]."))
+	investigate_log("had [trans] units of it's reagents transfered to [target] by [key_name(user)]", "chemistry")
 	return TRUE
 
 // if amount_per_reagent is null or zero it will transfer all

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -90,6 +90,7 @@
 
 /obj/item/weapon/reagent_containers/glass/pre_attack(atom/A, mob/user, params)
 	if(user.a_intent == I_HURT)
+		investigate_log("had it's contents splashed onto [A] by [key_name(user)] while containing [reagents.log_list()]", "chemistry")
 		if(standard_splash_mob(user, A))
 			return TRUE
 		if(is_drainable() && reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -90,7 +90,7 @@
 
 /obj/item/weapon/reagent_containers/glass/pre_attack(atom/A, mob/user, params)
 	if(user.a_intent == I_HURT)
-		investigate_log("had it's contents splashed onto [A] by [key_name(user)] while containing [reagents.log_list()]", "chemistry")
+		user.investigate_log("splashed [src] filled with [reagents.log_list()] onto [A]", "chemistry")
 		if(standard_splash_mob(user, A))
 			return TRUE
 		if(is_drainable() && reagents.total_volume)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds 2 new tabs to the investigation admin verb, based on /tg/ investigations.
![PR!](https://user-images.githubusercontent.com/61743710/92995138-ec362d00-f500-11ea-8e7d-b3b870151957.png)
![PR!!](https://user-images.githubusercontent.com/61743710/92995923-fa3b7c00-f507-11ea-9d9c-d2b3f423a9d6.png)

## Why It's Good For The Game

Admins should be able to track grief easier, while not clogging up the logs.

## Changelog
:cl:
admin: expands investigations to include atmos and chemistry information.
/:cl:
