### PR TITLE
Gun changes

### DIFF
--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -47,23 +47,21 @@
 #define STRUCTURE_DAMAGE_BORING 		3
 
 //Quick defines for fire modes
-#define FULL_AUTO_300		list(mode_name="full auto",  mode_type = /datum/firemode/automatic, fire_delay=2  , icon="auto")
-#define FULL_AUTO_400		list(mode_name="full auto",  mode_type = /datum/firemode/automatic, fire_delay=1.5, icon="auto")
-#define FULL_AUTO_600		list(mode_name="full auto",  mode_type = /datum/firemode/automatic, fire_delay=1  , icon="auto")
-#define FULL_AUTO_800		list(mode_name="full auto",  mode_type = /datum/firemode/automatic, fire_delay=0.8, icon="auto")
+#define FULL_AUTO_300		list(mode_name = "full auto",  mode_type = /datum/firemode/automatic, fire_delay = 2  , icon="auto", damage_mult_add = -0.1)
+#define FULL_AUTO_400		list(mode_name = "full auto",  mode_type = /datum/firemode/automatic, fire_delay = 1.5, icon="auto", damage_mult_add = -0.1)
+#define FULL_AUTO_600		list(mode_name = "full auto",  mode_type = /datum/firemode/automatic, fire_delay = 1  , icon="auto", damage_mult_add = -0.1)
+#define FULL_AUTO_800		list(mode_name = "full auto",  mode_type = /datum/firemode/automatic, fire_delay = 0.8, icon="auto", damage_mult_add = -0.1)
 
 #define SEMI_AUTO_NODELAY	list(mode_name="semiauto", burst=1, fire_delay=0, move_delay=null, icon="semi")
 
-#define BURST_3_ROUND		list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=4, icon="burst")
-#define BURST_5_ROUND		list(mode_name="5-round bursts", burst=5, fire_delay=null, move_delay=6, icon="burst")
-#define BURST_8_ROUND		list(mode_name="8-round bursts", burst=8, fire_delay=null, move_delay=8, icon="burst")
+#define BURST_3_ROUND		list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=4, icon="burst", damage_mult_add = -0.1)
+#define BURST_5_ROUND		list(mode_name="5-round bursts", burst=5, fire_delay=null, move_delay=6, icon="burst", damage_mult_add = -0.1)
+#define BURST_8_ROUND		list(mode_name="8-round bursts", burst=8, fire_delay=null, move_delay=8, icon="burst", damage_mult_add = -0.1)
 
 #define WEAPON_NORMAL		list(mode_name="standard", icon="semi")
 #define WEAPON_CHARGE		list(mode_name="charge mode", mode_type = /datum/firemode/charge, icon="charge")
 
-#define BASE_ACCURACY_REGEN 0.75 //Recoil reduction per ds with 0 VIG
-#define VIG_ACCURACY_REGEN  0.015 //Recoil reduction per ds per VIG
-#define MIN_ACCURACY_REGEN  0.4 //How low can we get with negative VIG
-#define MAX_ACCURACY_OFFSET  75 //It's both how big gun recoil can build up, and how hard you can miss
+#define MAX_ACCURACY_OFFSET  30 //It's both how big gun recoil can build up, and how hard you can miss
+#define RECOIL_REDUCTION_TIME 1 SECOND
 
 #define VIG_OVERCHARGE_GEN 0.05

--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -61,7 +61,7 @@
 #define WEAPON_NORMAL		list(mode_name="standard", icon="semi")
 #define WEAPON_CHARGE		list(mode_name="charge mode", mode_type = /datum/firemode/charge, icon="charge")
 
-#define MAX_ACCURACY_OFFSET  30 //It's both how big gun recoil can build up, and how hard you can miss
+#define MAX_ACCURACY_OFFSET  45 //It's both how big gun recoil can build up, and how hard you can miss
 #define RECOIL_REDUCTION_TIME 1 SECOND
 
 #define VIG_OVERCHARGE_GEN 0.05

--- a/code/datums/datum_click_handlers.dm
+++ b/code/datums/datum_click_handlers.dm
@@ -76,23 +76,14 @@
 *****************************/
 /datum/click_handler/fullauto
 	var/atom/target = null
-	var/firing = FALSE
 	var/obj/item/weapon/gun/reciever //The thing we send firing signals to.
 	//Todo: Make this work with callbacks
 
 /datum/click_handler/fullauto/Click()
 	return TRUE //Doesn't work with normal clicks
 
-/datum/click_handler/fullauto/proc/start_firing()
-	firing = TRUE
-	while (firing && target)
-		do_fire()
-		sleep(0.5) //Keep spamming events every frame as long as the button is held
-	stop_firing()
-
 //Next loop will notice these vars and stop shooting
 /datum/click_handler/fullauto/proc/stop_firing()
-	firing = FALSE
 	target = null
 	if(reciever)
 		reciever.cursor_check()
@@ -100,42 +91,33 @@
 /datum/click_handler/fullauto/proc/do_fire()
 	reciever.afterattack(target, owner.mob, FALSE)
 
-/datum/click_handler/fullauto/MouseDown(object,location,control,params)
+/datum/click_handler/fullauto/MouseDown(object, location, control, params)
 	if(!isturf(owner.mob.loc)) // This stops from firing full auto weapons inside closets or in /obj/effect/dummy/chameleon chameleon projector
 		return FALSE
-	
+
 	object = resolve_world_target(object)
-	if (object)
+	if(object)
 		target = object
-		owner.mob.face_atom(target)
-		spawn()
-			start_firing()
-		return FALSE
+		while(target)
+			owner.mob.face_atom(target)
+			do_fire()
+			sleep(reciever.burst_delay)		
 	return TRUE
 
-/datum/click_handler/fullauto/MouseDrag(over_object,src_location,over_location,src_control,over_control,params)
+/datum/click_handler/fullauto/MouseDrag(over_object, src_location, over_location, src_control, over_control, params)
 	src_location = resolve_world_target(src_location)
-	if (src_location && firing)
-		target = src_location //This var contains the thing the user is hovering over, oddly
-		owner.mob.face_atom(target)
+	if(src_location)
+		target = src_location
 		return FALSE
 	return TRUE
 
-/datum/click_handler/fullauto/MouseUp(object,location,control,params)
+/datum/click_handler/fullauto/MouseUp(object, location, control, params)
 	stop_firing()
 	return TRUE
 
 /datum/click_handler/fullauto/Destroy()
-	stop_firing()//Without this it keeps firing in an infinite loop when deleted
+	stop_firing() //Without this it keeps firing in an infinite loop when deleted
 	.=..()
-
-
-
-
-
-
-
-
 
 /datum/click_handler/human/mob_check(mob/living/carbon/human/user)
 	if(ishuman(user))

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -68,8 +68,7 @@
 
 	//Used in living/recoil.dm
 	var/recoil = 0 //What our current recoil level is
-	var/last_recoil_update = 0 //When our last recoil update was
-	var/recoil_timer //Holds the timer ID
+	var/recoil_reduction_timer
 	var/falls_mod = 1
 	var/mob_bomb_defense = 0	// protection from explosives
 	var/mod_climb_delay = 1 // delay for climb

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -286,7 +286,7 @@
 
 		projectile.multiply_projectile_damage(damage_multiplier)
 
-		projectile.multiply_projectile_penetration(penetration_multiplier)
+		projectile.multiply_projectile_penetration(penetration_multiplier + user.stats.getStat(STAT_VIG) * 0.2)
 
 		projectile.multiply_pierce_penetration(pierce_multiplier)
 
@@ -418,7 +418,7 @@
 	if(params)
 		P.set_clickpoint(params)
 	var/offset = init_offset
-	if(user.calc_recoil())
+	if(user.recoil)
 		offset += user.recoil
 	offset = min(offset, MAX_ACCURACY_OFFSET)
 	offset = rand(-offset, offset)
@@ -555,6 +555,7 @@
 	return set_firemode(sel_mode)
 
 /obj/item/weapon/gun/proc/set_firemode(index)
+	refresh_upgrades()
 	if(index > firemodes.len)
 		index = 1
 	var/datum/firemode/new_mode = firemodes[sel_mode]

--- a/code/modules/projectiles/gun_firemode.dm
+++ b/code/modules/projectiles/gun_firemode.dm
@@ -49,6 +49,8 @@
 					var/datum/component/item_upgrade/IU = I.GetComponent(/datum/component/item_upgrade)
 					if(IU.weapon_upgrades[GUN_UPGRADE_FIRE_DELAY_MULT])
 						gun.vars["fire_delay"] *= IU.weapon_upgrades[GUN_UPGRADE_FIRE_DELAY_MULT]
+		else if(propname == "damage_mult_add")
+			gun.damage_multiplier += settings[propname]
 
 //Called whenever the firemode is switched to, or the gun is picked up while its active
 /datum/firemode/proc/update()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -30,7 +30,7 @@
 	var/overcharge_timer //Holds ref to the timer used for overcharging
 	var/overcharge_rate = 1 //Base overcharge additive rate for the gun
 	var/overcharge_level = 0 //What our current overcharge level is. Peaks at overcharge_max
-	var/overcharge_max = 10
+	var/overcharge_max = 5
 
 	bad_type = /obj/item/weapon/gun/energy
 

--- a/code/modules/projectiles/guns/energy/crossbow.dm
+++ b/code/modules/projectiles/guns/energy/crossbow.dm
@@ -16,6 +16,7 @@
 	charge_meter = 0
 	charge_cost = 200
 	price_tag = 2500
+	damage_multiplier = 2.2
 
 /obj/item/weapon/gun/energy/crossbow/ninja
 	name = "energy dart thrower"
@@ -31,3 +32,4 @@
 	matter = list(MATERIAL_PLASTEEL = 35, MATERIAL_PLASTIC = 20, MATERIAL_SILVER = 9, MATERIAL_URANIUM = 9)
 	projectile_type = /obj/item/projectile/energy/bolt/large
 	price_tag = 4000
+	damage_multiplier = 1.7

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -12,7 +12,7 @@
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 8, MATERIAL_SILVER = 5)
 	zoom_factor = 0.5
-	damage_multiplier = 1.3
+	damage_multiplier = 0.9
 	charge_cost = 50
 	price_tag = 2500
 	rarity_value = 12
@@ -66,7 +66,7 @@
 	projectile_type = /obj/item/projectile/beam
 	fire_delay = 10 //old technology
 	zoom_factor = 0
-	damage_multiplier = 1
+	damage_multiplier = 1.1
 	charge_cost = 100
 	price_tag = 2000
 	rarity_value = 10

--- a/code/modules/projectiles/guns/energy/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma.dm
@@ -18,6 +18,7 @@
 	recoil_buildup = 1 //pulse weapons have a bit more recoil
 	one_hand_penalty = 10
 	twohanded = TRUE
+	damage_multiplier = 1.3
 
 	init_firemodes = list(
 		list(mode_name="burn", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/Taser.ogg', fire_delay=8, charge_cost=20, icon="stun", projectile_color = "#0000FF"),

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -27,6 +27,7 @@
 	price_tag = 2500
 	rarity_value = 20
 	spawn_tags = SPAWN_TAG_GUN_SHOTGUN_ENERGY
+	damage_multiplier = 1.15
 
 /obj/item/weapon/gun/energy/shrapnel/consume_next_projectile()
 	.=..()

--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -24,6 +24,7 @@
 	cocked_sound 	= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
 	recoil_buildup = 10
 	one_hand_penalty = 15 //automatic rifle level
+	damage_multiplier = 3
 
 	init_firemodes = list(
 		FULL_AUTO_400,
@@ -64,6 +65,7 @@
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 10)
 	price_tag = 3000
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
+	damage_multiplier = 1.6
 	init_firemodes = list(
 	SEMI_AUTO_NODELAY,
 	BURST_3_ROUND,

--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -22,7 +22,7 @@
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/ltrifle_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
-	recoil_buildup = 10
+	recoil_buildup = 1.8
 	one_hand_penalty = 15 //automatic rifle level
 	damage_multiplier = 3
 

--- a/code/modules/projectiles/guns/projectile/automatic/atreides.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/atreides.dm
@@ -19,7 +19,7 @@
 	price_tag = 1200
 	rarity_value = 19.2
 	damage_multiplier = 1.2
-	recoil_buildup = 4
+	recoil_buildup = 1.2
 	one_hand_penalty = 5 //smg level
 	gun_tags = list(GUN_SILENCABLE)
 

--- a/code/modules/projectiles/guns/projectile/automatic/atreides.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/atreides.dm
@@ -18,7 +18,7 @@
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 13, MATERIAL_PLASTIC = 2)
 	price_tag = 1200
 	rarity_value = 19.2
-	damage_multiplier = 0.8
+	damage_multiplier = 1.2
 	recoil_buildup = 4
 	one_hand_penalty = 5 //smg level
 	gun_tags = list(GUN_SILENCABLE)

--- a/code/modules/projectiles/guns/projectile/automatic/c20r.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/c20r.dm
@@ -25,7 +25,7 @@
 	damage_multiplier = 1.2
 	penetration_multiplier = 1.5 //7.5 with regular lethal ammo, 15 with HV, seems legit
 	zoom_factor = 0.4
-	recoil_buildup = 3
+	recoil_buildup = 1.2
 	one_hand_penalty = 5 //smg level
 	rarity_value = 19.2
 

--- a/code/modules/projectiles/guns/projectile/automatic/c20r.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/c20r.dm
@@ -22,7 +22,7 @@
 	unload_sound 	= 'sound/weapons/guns/interact/sfrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/sfrifle_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/sfrifle_cock.ogg'
-	damage_multiplier = 1
+	damage_multiplier = 1.2
 	penetration_multiplier = 1.5 //7.5 with regular lethal ammo, 15 with HV, seems legit
 	zoom_factor = 0.4
 	recoil_buildup = 3

--- a/code/modules/projectiles/guns/projectile/automatic/dallas.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/dallas.dm
@@ -19,7 +19,7 @@
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/m41_reload.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/m41_cocked.ogg'
-	damage_multiplier = 1.35
+	damage_multiplier = 1.55
 	penetration_multiplier = 1
 	recoil_buildup = 6
 	one_hand_penalty = 10 //heavy, but very advanced, so bullpup rifle level despite not being bullpup

--- a/code/modules/projectiles/guns/projectile/automatic/dallas.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/dallas.dm
@@ -21,7 +21,7 @@
 	cocked_sound 	= 'sound/weapons/guns/interact/m41_cocked.ogg'
 	damage_multiplier = 1.55
 	penetration_multiplier = 1
-	recoil_buildup = 6
+	recoil_buildup = 1.3
 	one_hand_penalty = 10 //heavy, but very advanced, so bullpup rifle level despite not being bullpup
 
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/automatic/drozd.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/drozd.dm
@@ -17,7 +17,7 @@
 	price_tag = 2200
 	damage_multiplier = 0.8 	 //25,6 lethal, 28 HV //damage
 	penetration_multiplier = 1.5 //22.5 lethal, 30 HV //AP
-	recoil_buildup = 6
+	recoil_buildup = 1.2
 
 	twohanded = FALSE
 	one_hand_penalty = 5 //smg level

--- a/code/modules/projectiles/guns/projectile/automatic/lmg.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/lmg.dm
@@ -22,7 +22,7 @@
 	reload_sound 	= 'sound/weapons/guns/interact/lmg_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/lmg_cock.ogg'
 	fire_sound = 'sound/weapons/guns/fire/lmg_fire.ogg'
-	recoil_buildup = 3.5
+	recoil_buildup = 1.9
 	one_hand_penalty = 30 //you're not Stallone. LMG level.
 
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/automatic/molly.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/molly.dm
@@ -23,7 +23,7 @@
 
 	damage_multiplier = 0.7 //good for rubber takedowns or self-defence, not so good to kill someone, you might want to use better smg
 	gun_tags = list(GUN_SILENCABLE)
-	recoil_buildup = 3
+	recoil_buildup = 1
 	one_hand_penalty = 5 //despine it being handgun, it's better to hold in two hands while shooting. SMG level.
 
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/automatic/sol.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sol.dm
@@ -24,7 +24,7 @@
 
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY,
-		BURST_3_ROUND
+		list(mode_name="3-round bursts", burst=3, fire_delay = 3, move_delay=4, icon="burst", damage_multiplier = 0.05)
 		)
 
 /obj/item/weapon/gun/projectile/automatic/sol/proc/update_charge()

--- a/code/modules/projectiles/guns/projectile/automatic/sol.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sol.dm
@@ -17,7 +17,7 @@
 	price_tag = 2300
 	rarity_value = 24
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
-	recoil_buildup = 5
+	recoil_buildup = 2
 	penetration_multiplier = 1.1
 	damage_multiplier = 1.15
 	one_hand_penalty = 8 //because otherwise you can shoot it one-handed in bursts and still be very accurate. One-handed recoil is now as much as it was back in the day when wielded.

--- a/code/modules/projectiles/guns/projectile/automatic/straylight.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/straylight.dm
@@ -20,7 +20,7 @@
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	damage_multiplier = 0.75	 //made with rubber rounds in mind. For lethality refer to Wintermute. Still quite lethal if you manage to land most shots.
 	penetration_multiplier = 0.5 //practically no AP, 2.5 with regular rounds and 5 with HV. Still deadly to unarmored targets.
-	recoil_buildup = 3
+	recoil_buildup = 1
 	one_hand_penalty = 5 //smg level
 	gun_tags = list(GUN_SILENCABLE)
 

--- a/code/modules/projectiles/guns/projectile/automatic/straylight.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/straylight.dm
@@ -18,7 +18,7 @@
 	price_tag = 1400
 	rarity_value = 12
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
-	damage_multiplier = 0.65	 //made with rubber rounds in mind. For lethality refer to Wintermute. Still quite lethal if you manage to land most shots.
+	damage_multiplier = 0.75	 //made with rubber rounds in mind. For lethality refer to Wintermute. Still quite lethal if you manage to land most shots.
 	penetration_multiplier = 0.5 //practically no AP, 2.5 with regular rounds and 5 with HV. Still deadly to unarmored targets.
 	recoil_buildup = 3
 	one_hand_penalty = 5 //smg level

--- a/code/modules/projectiles/guns/projectile/automatic/sts35.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts35.dm
@@ -21,7 +21,7 @@
 	reload_sound 	= 'sound/weapons/guns/interact/ltrifle_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
 	damage_multiplier = 1.2
-	recoil_buildup = 8
+	recoil_buildup = 2
 	one_hand_penalty = 15 //automatic rifle level
 	rarity_value = 96
 

--- a/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
@@ -18,7 +18,7 @@
 	zoom_factor = 0.8 // double as IH_heavy
 	penetration_multiplier = 1.2
 	damage_multiplier = 1.9
-	recoil_buildup = 8
+	recoil_buildup = 1.3
 	one_hand_penalty = 15 //automatic rifle level
 	silenced = TRUE
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
@@ -17,7 +17,7 @@
 	price_tag = 4000
 	zoom_factor = 0.8 // double as IH_heavy
 	penetration_multiplier = 1.2
-	damage_multiplier = 1.2
+	damage_multiplier = 1.9
 	recoil_buildup = 8
 	one_hand_penalty = 15 //automatic rifle level
 	silenced = TRUE

--- a/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
@@ -24,11 +24,12 @@
 	zoom_factor = 0.4
 	recoil_buildup = 7
 	one_hand_penalty = 15 //automatic rifle level
+	damage_multiplier = 1.5
 
 	init_firemodes = list(
 		FULL_AUTO_400,
 		SEMI_AUTO_NODELAY,
-		BURST_3_ROUND
+		list(mode_name="3-round bursts", burst=3, fire_delay = 3, move_delay=4, icon="burst", damage_multiplier = -1.2)
 		)
 
 /obj/item/weapon/gun/projectile/automatic/wintermute/update_icon()

--- a/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
@@ -22,7 +22,7 @@
 	reload_sound 	= 'sound/weapons/guns/interact/ltrifle_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
 	zoom_factor = 0.4
-	recoil_buildup = 7
+	recoil_buildup = 2
 	one_hand_penalty = 15 //automatic rifle level
 	damage_multiplier = 1.5
 

--- a/code/modules/projectiles/guns/projectile/automatic/z8.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/z8.dm
@@ -19,7 +19,7 @@
 	unload_sound 	= 'sound/weapons/guns/interact/batrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/batrifle_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/batrifle_cock.ogg'
-	recoil_buildup = 6
+	recoil_buildup = 1
 	penetration_multiplier = 1.1
 	damage_multiplier = 1.45
 	zoom_factor = 0.2

--- a/code/modules/projectiles/guns/projectile/automatic/z8.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/z8.dm
@@ -21,7 +21,7 @@
 	cocked_sound 	= 'sound/weapons/guns/interact/batrifle_cock.ogg'
 	recoil_buildup = 6
 	penetration_multiplier = 1.1
-	damage_multiplier = 1.1
+	damage_multiplier = 1.45
 	zoom_factor = 0.2
 	one_hand_penalty = 10 //bullpup rifle level
 

--- a/code/modules/projectiles/guns/projectile/automatic/zoric.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/zoric.dm
@@ -18,7 +18,7 @@
 	price_tag = 2000
 	damage_multiplier = 0.6
 	penetration_multiplier = 0.5 // 7.5 lethal
-	recoil_buildup = 7
+	recoil_buildup = 0.7
 	twohanded = FALSE
 	one_hand_penalty = 5 //smg level
 	rarity_value = 32

--- a/code/modules/projectiles/guns/projectile/automatic/zoric.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/zoric.dm
@@ -16,7 +16,7 @@
 	magazine_type = /obj/item/ammo_magazine/msmg
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_STEEL = 6, MATERIAL_PLASTIC = 4)
 	price_tag = 2000
-	damage_multiplier = 1	 // 34 lethal
+	damage_multiplier = 0.6
 	penetration_multiplier = 0.5 // 7.5 lethal
 	recoil_buildup = 7
 	twohanded = FALSE

--- a/code/modules/projectiles/guns/projectile/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun.dm
@@ -11,7 +11,7 @@
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	caliber = CAL_LRIFLE
 	fire_delay = 12 // double the standart
-	damage_multiplier = 1.4
+	damage_multiplier = 2.4
 	penetration_multiplier  = 1.5
 	recoil_buildup = 40 //same as AMR
 	handle_casings = HOLD_CASINGS

--- a/code/modules/projectiles/guns/projectile/pistol/avasarala.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/avasarala.dm
@@ -13,7 +13,7 @@
 	price_tag = 1600
 	rarity_value = 13.74
 	can_dual = 1
-	damage_multiplier = 1.45
+	damage_multiplier = 1.95
 	penetration_multiplier = 1.35
 	recoil_buildup = 33
 	fire_sound = 'sound/weapons/guns/fire/hpistol_fire.ogg'

--- a/code/modules/projectiles/guns/projectile/pistol/clarissa.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/clarissa.dm
@@ -50,7 +50,7 @@
 	desc = "Old-designed pistol of space communists. Small and easily concealable. Uses .35 Auto rounds."
 	icon = 'icons/obj/guns/projectile/makarov.dmi'
 	icon_state = "makarov"
-	damage_multiplier = 1.2
+	damage_multiplier = 1.8
 	recoil_buildup = 21
 	price_tag = 1400
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2, TECH_COVERT = 3)

--- a/code/modules/projectiles/guns/projectile/pistol/lamia.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/lamia.dm
@@ -20,7 +20,7 @@
 	unload_sound 	= 'sound/weapons/guns/interact/hpistol_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/hpistol_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/hpistol_cock.ogg'
-	damage_multiplier = 1.4
+	damage_multiplier = 1.1
 	penetration_multiplier = 1.4
 	recoil_buildup = 21
 

--- a/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
@@ -14,7 +14,7 @@
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
 	price_tag = 800
 	rarity_value = 12
-	damage_multiplier = 1.2
+	damage_multiplier = 1.6
 	penetration_multiplier = 1.2
 	recoil_buildup = 6
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/pistol/paco.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/paco.dm
@@ -19,7 +19,7 @@
 	rarity_value = 24
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
-	damage_multiplier = 1.5
+	damage_multiplier = 1.8
 	penetration_multiplier = 0.9
 	recoil_buildup = 10
 	gun_tags = list(GUN_SILENCABLE)

--- a/code/modules/projectiles/guns/projectile/revolver/consul.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/consul.dm
@@ -11,7 +11,7 @@
 	ammo_type = /obj/item/ammo_casing/magnum/rubber
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 8)
 	price_tag = 1700
-	damage_multiplier = 1.35
+	damage_multiplier = 1.5
 	penetration_multiplier = 1.5
 	recoil_buildup = 35
 	rarity_value = 8

--- a/code/modules/projectiles/guns/projectile/revolver/deckard.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/deckard.dm
@@ -9,7 +9,7 @@
 	ammo_type = /obj/item/ammo_casing/magnum/rubber
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
 	price_tag = 3100 //one of most robust revolvers here
-	damage_multiplier = 1.45
+	damage_multiplier = 1.65
 	penetration_multiplier = 1.65
 	recoil_buildup = 40
 	rarity_value = 12

--- a/code/modules/projectiles/guns/projectile/revolver/sky_driver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/sky_driver.dm
@@ -11,7 +11,7 @@
 	ammo_type = /obj/item/ammo_casing/pistol
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
 	price_tag = 20000
-	damage_multiplier = 1.1 //because pistol round
+	damage_multiplier = 1.5
 	penetration_multiplier = 20
 	pierce_multiplier =  5
 	recoil_buildup = 50

--- a/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
@@ -19,7 +19,7 @@
 	unload_sound = 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound = 'sound/weapons/guns/interact/ltrifle_magin.ogg'
 	cocked_sound = 'sound/weapons/guns/interact/ltrifle_cock.ogg'
-	damage_multiplier = 0.8
+	damage_multiplier = 1
 	penetration_multiplier = 1.4 // this is not babies first gun. It's a Serb-level weapon.
 	recoil_buildup = 15 // at least somewhat controllable
 	one_hand_penalty = 20 //automatic shotgun level

--- a/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
@@ -21,7 +21,7 @@
 	cocked_sound = 'sound/weapons/guns/interact/ltrifle_cock.ogg'
 	damage_multiplier = 1
 	penetration_multiplier = 1.4 // this is not babies first gun. It's a Serb-level weapon.
-	recoil_buildup = 15 // at least somewhat controllable
+	recoil_buildup = 7.4 // at least somewhat controllable
 	one_hand_penalty = 20 //automatic shotgun level
 
 				   //while also preserving ability to shoot as fast as you can click and maintain recoil good enough

--- a/code/modules/projectiles/guns/projectile/shotgun/bull.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/bull.dm
@@ -19,6 +19,7 @@
 	price_tag = 2000 //gives tactical advantage with beanbags, but consumes more ammo and hits less harder with lethal ammo, so Gladstone or Regulator would be better for lethal takedowns in general
 	damage_multiplier = 0.75
 	penetration_multiplier = 0.75
+	recoil_buildup = 7
 	one_hand_penalty = 10 //compact shotgun level
 	burst_delay = null
 	fire_delay = null

--- a/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
@@ -14,6 +14,7 @@
 	flags =  CONDUCT
 	slot_flags = SLOT_BACK
 	caliber = CAL_SHOTGUN
+	recoil_buildup = 7
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 1)
 	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
 	bulletinsert_sound 	= 'sound/weapons/guns/interact/shotgun_insert.ogg'

--- a/code/modules/projectiles/guns/projectile/shotgun/gladstone.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/gladstone.dm
@@ -11,6 +11,6 @@
 	ammo_type = /obj/item/ammo_casing/shotgun
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 6)
 	price_tag = 2000
-	recoil_buildup = 14
+	recoil_buildup = 10
 	one_hand_penalty = 15 //full sized shotgun level
 	rarity_value = 20

--- a/code/modules/projectiles/guns/projectile/shotgun/pump.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/pump.dm
@@ -19,7 +19,7 @@
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 10)
 	price_tag = 1000
 	rarity_value = 16
-	recoil_buildup = 20
+	recoil_buildup = 12
 	one_hand_penalty = 15 //full sized shotgun level
 
 /obj/item/weapon/gun/projectile/shotgun/pump/consume_next_projectile()

--- a/code/modules/projectiles/guns/projectile/shotgun/regulator.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/regulator.dm
@@ -10,7 +10,7 @@
 	ammo_type = /obj/item/ammo_casing/shotgun
 	matter = list(MATERIAL_PLASTEEL = 25, MATERIAL_PLASTIC = 12)
 	price_tag = 1500
-	damage_multiplier = 1.15
+	damage_multiplier = 0.6
 	penetration_multiplier = 0.9
 	recoil_buildup = 16
 	one_hand_penalty = 15 //full sized shotgun level

--- a/code/modules/projectiles/guns/projectile/shotgun/regulator.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/regulator.dm
@@ -12,6 +12,6 @@
 	price_tag = 1500
 	damage_multiplier = 0.6
 	penetration_multiplier = 0.9
-	recoil_buildup = 16
+	recoil_buildup = 10
 	one_hand_penalty = 15 //full sized shotgun level
 	rarity_value = 20

--- a/code/modules/projectiles/guns/projectile/shotgun/sawnoff.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/sawnoff.dm
@@ -11,6 +11,6 @@
 	w_class = ITEM_SIZE_NORMAL
 	force = WEAPON_FORCE_PAINFUL
 	damage_multiplier = 0.8 //slightly weaker due to sawn-off barrels
-	recoil_buildup = 1.2 //gonna have solid grip on those, point-blank shots adviced
+	recoil_buildup = 15 //gonna have solid grip on those, point-blank shots adviced
 	one_hand_penalty = 10 //compact shotgun level
 	rarity_value = 24

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -23,6 +23,7 @@
 	var/item_suffix = ""
 	zoom_factor = 2
 	twohanded = TRUE
+	damage_multiplier = 2
 
 /obj/item/weapon/gun/projectile/heavysniper/update_icon()
 	..()

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -68,7 +68,7 @@
 /obj/item/projectile/beam/xray
 	name = "xray beam"
 	icon_state = "xray"
-	damage_types = list(BURN = 25)
+	damage_types = list(BURN = 20)
 	armor_penetration = 40
 
 	muzzle_type = /obj/effect/projectile/xray/muzzle


### PR DESCRIPTION
## About The Pull Request
Recoil will decrease after second from last shot, so single fire is not pinpoint death laser.
Full auto and bursts have slightly less damage than single fire.
Maximum recoil offset is 90 degrees.
Some click handler optimization to reduce lags when firing continuously.
Projectile penetration is increased based on vig stat.
Maximum overcharge of energy weapons splitted in half.
All weapons got damage and recoil tweaks.

## Why It's Good For The Game
Reere requested changes

## Changelog
:cl:
:balance: Recoil will decrease after second from last shot, so single fire is not pinpoint death laser. Also maximum recoil offset is 90 degrees now.
:balance: Full auto and bursts have slightly less damage than single fire. All guns got damage and recoil changes. Projectiles got more penetration the more vig stat you have. Maximum overcharge cutted in half.
/:cl: