### PR TITLE
processor pickup buff, plasma slag fix

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -142,14 +142,14 @@
 
 /obj/machinery/mineral/processing_unit/Process()
 
-	if (!output_dir || !input_dir) return
+	if(!output_dir || !input_dir)
+		return
 
 	var/list/tick_alloys = list()
 
 	//Grab some more ore to process this tick.
-	var/limit = sheets_per_tick
 	for(var/obj/item/weapon/ore/O in get_step(src, input_dir))
-		if(--limit <= 0)
+		if(!O)
 			break
 		if(!isnull(ores_stored[O.material]))
 			ores_stored[O.material]++

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -149,8 +149,6 @@
 
 	//Grab some more ore to process this tick.
 	for(var/obj/item/weapon/ore/O in get_step(src, input_dir))
-		if(!O)
-			break
 		if(!isnull(ores_stored[O.material]))
 			ores_stored[O.material]++
 		qdel(O)

--- a/code/modules/mining/ore_datum.dm
+++ b/code/modules/mining/ore_datum.dm
@@ -67,6 +67,7 @@ var/global/list/ore_data = list()
 	name = "plasma"
 	display_name = "plasma crystals"
 	compresses_to = "plasma"
+	alloy = 1
 	//smelts_to = something that explodes violently on the conveyor, huhuhuhu
 	result_amount = 8
 	spread_chance = 25


### PR DESCRIPTION
## About The Pull Request
plasteel no longer makes an extra piece of plasma ore into slag
the ore processor picks ore up off the ground faster
## Why It's Good For The Game
i do not enjoy having my perfectly good plasma turned into slag
also slow pickups are cringe and controllable ore processing speed would be nice but that's out of scope of this fix
## Changelog
:cl:
fix: Plasteel now alloys properly without extra conversion of plasma ore into slag.
tweak: The ore processor on the Hulk no longer has a limiter on how much ore it can pick up per tick.
/:cl: