### PR TITLE
You can now compile and run the codebase through VS code or extools without errors on start.

### DIFF
--- a/code/modules/mechs/mech.dm
+++ b/code/modules/mechs/mech.dm
@@ -176,7 +176,8 @@
 		material ? to_chat(user, "Its frame is reinforced with [material].") : null
 
 /mob/living/exosuit/return_air()
-	return (body && body.pilot_coverage >= 100 && hatch_closed) ? body.cockpit : loc.return_air()
+	if(src)
+		return (body && body.pilot_coverage >= 100 && hatch_closed) ? body.cockpit : loc.return_air()
 
 /mob/living/exosuit/GetIdCard()
 	return access_card

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -105,6 +105,8 @@
 
 
 /datum/gas_mixture/proc/equalize(datum/gas_mixture/sharer)
+	if(!sharer)
+		return
 	var/our_heatcap = heat_capacity()
 	var/share_heatcap = sharer.heat_capacity()
 


### PR DESCRIPTION
Works now if you're running through extools or VS code.
Only an issue because these runtimes pause the whole application on boot.

Also should in theory help memory usage if sharer doesn't exist in gas mixture which for some reason I encountered.

![Ba1bGUJfDh](https://user-images.githubusercontent.com/24533979/93507498-6987e600-f8e3-11ea-84bd-921ba576c9ad.png)
![ynUxFwMzr1](https://user-images.githubusercontent.com/24533979/93507510-6bea4000-f8e3-11ea-9a01-ef1ef6182f02.png)


## Changelog
:cl: Hopek
code: You can now compile and run the codebase through VS code or extools without errors on start.
/:cl:
