### PR TITLE
Pod undocking fix

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -731,6 +731,7 @@
 #include "code\game\machinery\embedded_controller\embedded_controller_base.dm"
 #include "code\game\machinery\embedded_controller\embedded_program_base.dm"
 #include "code\game\machinery\embedded_controller\simple_docking_controller.dm"
+#include "code\game\machinery\embedded_controller\~docking_program_undef.dm"
 #include "code\game\machinery\excelsior\autolathe.dm"
 #include "code\game\machinery\excelsior\boombox.dm"
 #include "code\game\machinery\excelsior\diesel.dm"

--- a/code/game/machinery/embedded_controller/docking_program.dm
+++ b/code/game/machinery/embedded_controller/docking_program.dm
@@ -287,11 +287,4 @@
 		if (STATE_DOCKED) return "docked"
 
 
-#undef STATE_UNDOCKED
-#undef STATE_DOCKING
-#undef STATE_UNDOCKING
-#undef STATE_DOCKED
 
-#undef MODE_NONE
-#undef MODE_SERVER
-#undef MODE_CLIENT

--- a/code/game/machinery/embedded_controller/simple_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/simple_docking_controller.dm
@@ -5,6 +5,7 @@
 	var/datum/computer/file/embedded_program/docking/simple/docking_program
 	var/progtype = /datum/computer/file/embedded_program/docking/simple/
 
+
 /obj/machinery/embedded_controller/radio/simple_docking_controller/Initialize()
 	. = ..()
 	docking_program = new progtype(src)
@@ -49,6 +50,8 @@
 //A docking controller program for a simple door based docking port
 /datum/computer/file/embedded_program/docking/simple
 	var/tag_door
+
+	var/undocking_attempts = 0 //Once an undocking request reaches 5 attempts, it force undocks, to prevent airlock deadlock.
 
 /datum/computer/file/embedded_program/docking/simple/New(var/obj/machinery/embedded_controller/M)
 	..(M)
@@ -131,7 +134,10 @@
 
 //are we ready for undocking?
 /datum/computer/file/embedded_program/docking/simple/ready_for_undocking()
-	return (memory["door_status"]["state"] == "closed" && memory["door_status"]["lock"] == "locked")
+	. = (control_mode == MODE_SERVER && undocking_attempts++ >= 5) || (memory["door_status"]["state"] == "closed" && memory["door_status"]["lock"] == "locked")
+	if(.)
+		undocking_attempts = 0
+	return .
 
 /*** DEBUG VERBS ***
 

--- a/code/game/machinery/embedded_controller/~docking_program_undef.dm
+++ b/code/game/machinery/embedded_controller/~docking_program_undef.dm
@@ -1,0 +1,8 @@
+#undef STATE_UNDOCKED
+#undef STATE_DOCKING
+#undef STATE_UNDOCKING
+#undef STATE_DOCKED
+
+#undef MODE_NONE
+#undef MODE_SERVER
+#undef MODE_CLIENT


### PR DESCRIPTION
## About The Pull Request

Adds a frustration limit to undocking, where a ship will auto-undock after 5 failed attempts for the server-side dock to respond correctly.

## Why It's Good For The Game
It makes sense that, if you fuck up a ships docking door, it won't be able to undock, but a ship should be able to undock if there is an issue with the port it is docked to (Emergency undocking)

## Changelog
:cl:
tweak: After 5 failed attempts to undock, a ship will auto undock regardless of the condition of the port it is docked to.
/:cl:

