### PR TITLE
Booting with extools and VsCode part 2

### DIFF
--- a/code/modules/mechs/mech.dm
+++ b/code/modules/mechs/mech.dm
@@ -176,7 +176,7 @@
 		material ? to_chat(user, "Its frame is reinforced with [material].") : null
 
 /mob/living/exosuit/return_air()
-	if(src)
+	if(src && loc)
 		return (body && body.pilot_coverage >= 100 && hatch_closed) ? body.cockpit : loc.return_air()
 
 /mob/living/exosuit/GetIdCard()


### PR DESCRIPTION
Testing by loading it up multiple times on a loop there are instances where src exists here without loc on boot.

No idea what causes this but for me it seems to happen about once every 6 boots and sometimes multiple times in a row.

Works fine after this change.
Fingers crossed this is the last modification.