### PR TITLE
Fixes the cryopod not following logic when occupant is afk

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -423,6 +423,10 @@
 	set name = "Eject Pod"
 	set category = "Object"
 	set src in oview(1)
+	if(!usr) // when called from preferences_spawnpoints.dm there is no usr since it is called indirectly. If there is no occupant and usr something really bad has happened here so just keep them in the pod - Hopek
+		if(!occupant)
+			return
+		usr = occupant
 	if(usr.stat != 0)
 		return
 

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -200,7 +200,7 @@
 		//You can get yourself out of the cryopod, or it will auto-eject after one minute
 		spawn(600)
 			if (C && C.occupant == M)
-				C.go_out()
+				C.eject() 
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
Who knew some typo merged 2 years ago would come back to haunt me!
(That or an attempt at a lazy workaround since usr isn't defined when eject() is called indirectly)

**Cause:**
When you go afk in a cryopod when spawning in; go_out() is called.

When go_out()  is called instead of eject()  it bypasses all the logic in eject() meaning that the cryopod eats the items and doesn't give them back.
This is bad because we need the cryopod to give the items back to people spawning in.


![image](https://user-images.githubusercontent.com/24533979/93657077-fe2e3900-f9f4-11ea-8334-700e2a8efc02.png)


## Changelog
:cl: Hopek
fix: fixed cryopods ignoring logic and not giving items back when the occupant went afk on spawn for longer than a minute.
/:cl:

