### PR TITLE
Fixes runtime in mob_helpers.dm

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -628,6 +628,8 @@ proc/is_blind(A)
 	embedded = list()
 
 /mob/proc/skill_to_evade_traps()
+	if(!stats)
+		return 0
 	var/prob_evade = 0
 	var/base_prob_evade = 30
 	if(MOVING_DELIBERATELY(src))


### PR DESCRIPTION
![fjQ5hySxMG](https://user-images.githubusercontent.com/24533979/93658023-713bad80-f9fd-11ea-885d-bf04448c2fb2.png)

This happens when something without stats sets off a trap
Returns no skill as intended.