### PR TITLE
You can now spawn with duct tape

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -61,7 +61,7 @@
 	path = /obj/item/modular_computer/laptop/preset/custom_loadout/advanced/golden
 	cost = 5
 
-/datum/gear/utility/cheaplaptop
+/datum/gear/utility/ducttape
 	display_name = "duct tape"
 	path = /obj/item/weapon/tool/tape_roll
 	cost = 3

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -61,4 +61,7 @@
 	path = /obj/item/modular_computer/laptop/preset/custom_loadout/advanced/golden
 	cost = 5
 
-
+/datum/gear/utility/cheaplaptop
+	display_name = "duct tape"
+	path = /obj/item/weapon/tool/tape_roll
+	cost = 3


### PR DESCRIPTION
**Why:**
At the moment in order to get started with improvised tools you need adhesive.

You cannot get adhesive unless you go to the public autolathe or get really lucky meaning that you cannot start making improvised tools without leaving maintenance if you spawn as a vagabond.

The point of improvised tools is to be able to make them without relying on the autolathe to start out.

Yes; I know you can make the spider web tape but the recipe for it is not accessible to someone without tools or weapons (probably needs a separate PR to change that)

## Changelog
:cl: Hopek
add: You can now spawn with duct tape for 3 loadout points because at the moment you cannot get adhesive unless you go to the public autolathe or get really lucky defeating the point of current improvised tools.
/:cl:

