### PR TITLE
Vagabond spawn with weak adhesive

### DIFF
--- a/code/datums/outfits/jobs/civilian.dm
+++ b/code/datums/outfits/jobs/civilian.dm
@@ -3,6 +3,7 @@
 	suit = /obj/item/clothing/suit/storage/ass_jacket
 	uniform = /obj/item/clothing/under/rank/assistant
 	r_pocket = /obj/item/weapon/spacecash/bundle/vagabond
+	l_pocket = /obj/item/weapon/tool/tape_roll/web
 
 /decl/hierarchy/outfit/job/service
 	l_ear = /obj/item/device/radio/headset/headset_service


### PR DESCRIPTION
**Please;** see --> #5467 to understand the full reasoning behind this change.
------
This PR addressed Vagabonds while #5467 addresses non-Vagabond crew's ability to make improvised tools at the cost of loadout points.

**Why:**
At the moment in order to get started with improvised tools you need adhesive.

Vagabonds spawn in maintenance.

**You cannot get adhesive unless you go to the public autolathe or get really lucky meaning that you cannot start making improvised tools without leaving maintenance if you spawn as a vagabond.**

This PR gives them the weakest tape (the web tape) on spawn so that they may start making their improvised tools without leeching off the station. 

**With this change Vagabond is more like being a hitchhiker vs being completely reliant on using the public autolathe round-start.**

Yes; I know you can make the spider web tape but the recipe for it is not accessible to someone without tools or weapons (probably needs a separate PR to change that)

## Changelog
:cl: Hopek
add: Vagabond now spawn with a weak adhesive. With this change Vagabond can be more like being a hitchhiker vs being completely reliant on leeching from the public autolathe round-start.
/:cl: