### PR TITLE
Money fix

### DIFF
--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -80,11 +80,15 @@
 	var/amount = input(usr, "How many credits do you want to take? (0 to [src.worth])", "Take Money", 20) as num
 	amount = round(CLAMP(amount, 0, src.worth))
 	if(amount==0) return 0
+	else if (!Adjacent(usr))
+		to_chat(usr, SPAN_WARNING("You need to be in arm's reach for that!"))
+		return
 
 	src.worth -= amount
 	src.update_icon()
 	if(!worth)
 		usr.drop_from_inventory(src)
+		qdel(src)
 	if(amount in list(1000,500,200,100,50,20,1))
 		var/cashtype = text2path("/obj/item/weapon/spacecash/bundle/c[amount]")
 		var/obj/cash = new cashtype (usr.loc)
@@ -94,8 +98,6 @@
 		bundle.worth = amount
 		bundle.update_icon()
 		usr.put_in_hands(bundle)
-	if(!worth)
-		qdel(src)
 
 /obj/item/weapon/spacecash/bundle/Initialize()
 	. = ..()

--- a/code/modules/economy/price_list.dm
+++ b/code/modules/economy/price_list.dm
@@ -1076,7 +1076,7 @@
 /obj/structure/medical_stand/price_tag = 100
 /obj/item/weapon/virusdish/price_tag = 300
 
-/obj/item/weapon/reagent_containers/price_tag = 20
+/obj/item/weapon/reagent_containers/price_tag = 1
 /obj/item/weapon/reagent_containers/glass/beaker/bluespace/price_tag = 300
 /obj/item/weapon/reagent_containers/get_item_cost(export)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It was possible to dupe your money by splitting your money then again by throwing away the money after opening the dialog and enter the full number. More money will spawn in your hands. This PR fixes it

Blood reagents containers gives out too much money for what it is worth normally.

## Why It's Good For The Game

No more dupes

## Changelog
:cl:
tweak: Fixed the price of reagent containers for trading
fix: Money dupe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
