### PR TITLE
Money fix final fix

### DIFF
--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -42,6 +42,10 @@
 		to_chat(user, SPAN_NOTICE("You add [src.worth] credits worth of money to the bundles.<br>It holds [bundle.worth] credits now."))
 		qdel(src)
 
+/obj/item/weapon/spacecash/Destroy()
+	. = ..()
+	worth = 0		// Prevents money from be duplicated anytime.
+
 /obj/item/weapon/spacecash/bundle
 	name = "pile of credits"
 	icon_state = ""


### PR DESCRIPTION


## About The Pull Request

Catch-all fix for the money when it gets deleted but the user could retain the split dialog. This stops from being duped after being put in ATM.

## Changelog
:cl:
fix: Makes sure duping money method is extra dead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
