### PR TITLE
Makes the cargo code less shitty

### DIFF
--- a/code/modules/economy/price_list.dm
+++ b/code/modules/economy/price_list.dm
@@ -2,7 +2,7 @@
 // all these will be defined here and sorted in different sections.
 
 // The item price in credits. atom/movable so we can also assign a price to animals and other things.
-/atom/movable/var/price_tag = null
+/atom/movable/var/price_tag
 
 // The proc that is called when the price is being asked for. Use this to refer to another object if necessary.
 /atom/movable/proc/get_item_cost(export)
@@ -13,7 +13,7 @@
 //---Beverages---//
 //***************//
 
-/datum/reagent/var/price_tag = null
+/datum/reagent/var/price_tag
 
 
 // Juices, soda and similar //
@@ -1046,13 +1046,6 @@
 /obj/item/stack/get_item_cost(export)
 	return amount * ..()
 
-/obj/item/weapon/reagent_containers/blood
-	price_tag = 50
-
-/obj/item/weapon/reagent_containers/blood/get_item_cost(export)
-	. = ..()
-	. += (. / 25 * reagents?.total_volume)
-
 /obj/item/ammo_magazine/price_tag = 60
 /obj/item/ammo_magazine/ammobox/price_tag = 40
 
@@ -1076,11 +1069,14 @@
 /obj/structure/medical_stand/price_tag = 100
 /obj/item/weapon/virusdish/price_tag = 300
 
-/obj/item/weapon/reagent_containers/price_tag = 1
+/obj/item/weapon/reagent_containers/price_tag = 20
 /obj/item/weapon/reagent_containers/glass/beaker/bluespace/price_tag = 300
 /obj/item/weapon/reagent_containers/get_item_cost(export)
 	. = ..()
-	. += reagents.total_volume * .
+	. += reagents?.get_price() //TODO assign an apprpriate price_per_unit
+
+/obj/item/weapon/reagent_containers/blood
+	price_tag = 50
 
 /obj/item/clothing/price_tag = 30
 /obj/item/solar_assembly/price_tag = 100

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -36,24 +36,24 @@ proc/isdeaf(A)
 		return (M.sdisabilities & DEAF) || M.ear_deaf
 	return 0
 
-proc/hasorgans(A) // Fucking really??
+/proc/hasorgans(A) // Fucking really??
 	return ishuman(A)
 
-proc/iscuffed(A)
+/proc/iscuffed(A)
 	if(iscarbon(A))
 		var/mob/living/carbon/C = A
 		if(C.handcuffed)
 			return 1
 	return 0
 
-proc/hassensorlevel(A, var/level)
+/proc/hassensorlevel(A, var/level)
 	var/mob/living/carbon/human/H = A
 	if(istype(H) && istype(H.w_uniform, /obj/item/clothing/under))
 		var/obj/item/clothing/under/U = H.w_uniform
 		return U.sensor_mode >= level
 	return 0
 
-proc/getsensorlevel(A)
+/proc/getsensorlevel(A)
 	var/mob/living/carbon/human/H = A
 	if(istype(H) && istype(H.w_uniform, /obj/item/clothing/under))
 		var/obj/item/clothing/under/U = H.w_uniform
@@ -196,7 +196,7 @@ var/list/global/organ_rel_size = list(
 	if(re_encode)
 		. = html_encode(.)
 
-proc/slur(phrase)
+/proc/slur(phrase)
 	phrase = html_decode(phrase)
 	var/leng=length(phrase)
 	var/counter=length(phrase)
@@ -241,7 +241,7 @@ proc/slur(phrase)
 		p++//for each letter p is increased to find where the next letter will be.
 	return sanitize(jointext(t, null))
 
-proc/Gibberish(t, p)//t is the inputted message, and any value higher than 70 for p will cause letters to be replaced instead of added
+/proc/Gibberish(t, p)//t is the inputted message, and any value higher than 70 for p will cause letters to be replaced instead of added
 	/* Turn text into complete gibberish! */
 	var/returntext = ""
 	for(var/i = 1, i <= length(t), i++)
@@ -628,12 +628,12 @@ proc/is_blind(A)
 	embedded = list()
 
 /mob/proc/skill_to_evade_traps()
-	if(!stats)
-		return 0
 	var/prob_evade = 0
 	var/base_prob_evade = 30
 	if(MOVING_DELIBERATELY(src))
 		prob_evade += base_prob_evade
+	if(!stats)
+		return prob_evade
 	prob_evade += base_prob_evade * (stats.getStat(STAT_VIG)/STAT_LEVEL_GODLIKE - weight_coeff())
 	if(stats.getPerk(PERK_SURE_STEP))
 		prob_evade += base_prob_evade*30/STAT_LEVEL_GODLIKE

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -25,6 +25,12 @@
 				continue
 			GLOB.chemical_reagents_list[D.id] = D
 
+/datum/reagents/proc/get_price()
+	var/price = 0
+	for(var/datum/reagent/R in reagent_list)
+		price += R.volume * R.price_per_unit
+	return price
+
 /datum/reagents/proc/get_average_reagents_state()
 	var/solid = 0
 	var/liquid = 0
@@ -66,7 +72,7 @@
 	return maximum_volume - total_volume
 
 /datum/reagents/proc/get_master_reagent() // Returns reference to the reagent with the biggest volume.
-	var/the_reagent = null
+	var/the_reagent
 	var/the_volume = 0
 
 	for(var/datum/reagent/A in reagent_list)
@@ -77,7 +83,7 @@
 	return the_reagent
 
 /datum/reagents/proc/get_master_reagent_name() // Returns the name of the reagent with the biggest volume.
-	var/the_name = null
+	var/the_name
 	var/the_volume = 0
 	for(var/datum/reagent/A in reagent_list)
 		if(A.volume > the_volume)
@@ -87,7 +93,7 @@
 	return the_name
 
 /datum/reagents/proc/get_master_reagent_id() // Returns the id of the reagent with the biggest volume.
-	var/the_id = null
+	var/the_id
 	var/the_volume = 0
 	for(var/datum/reagent/A in reagent_list)
 		if(A.volume > the_volume)

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -58,6 +58,7 @@
 	// Catalog stuff
 	var/appear_in_default_catalog = TRUE
 	var/reagent_type = "FIX DAT SHIT IMIDIATLY"
+	var/price_per_unit = 1 //por cargo rework
 
 /datum/reagent/proc/remove_self(amount) // Shortcut
 	holder.remove_reagent(id, amount)


### PR DESCRIPTION
Also fix the logic of the proc "skill_to_evade_traps" that someone has broken trying to fix.

## Changelog
:cl:
fix: skill_to_evade_traps logic
fix: reagent containers no longer have the same value as the entire multiverse.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
