### PR TITLE
large syringe price change. and typo in tastes, amd Emt plus medical belt changes

### DIFF
--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -79,7 +79,6 @@
 		/datum/design/autolathe/container/bucket,
 		/datum/design/autolathe/container/jar,
 		/datum/design/autolathe/container/syringe,
-		/datum/design/autolathe/container/syringe/large,
 		/datum/design/autolathe/container/vial,
 		/datum/design/autolathe/container/beaker,
 		/datum/design/autolathe/container/beaker_large,
@@ -250,6 +249,7 @@
 		/datum/design/autolathe/container/freezer_medical,
 		/datum/design/autolathe/device/implanter,
 		/datum/design/autolathe/container/syringegun_ammo,
+		/datum/design/autolathe/container/syringe/large,
 
 	)
 

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -122,7 +122,10 @@
 		/obj/item/weapon/tool/hemostat,
 		/obj/item/weapon/reagent_containers/pill,
 		/obj/item/weapon/storage/pill_bottle,
-		/obj/item/bodybag/cryobag
+		/obj/item/bodybag/cryobag,
+		/obj/item/clothing/gloves,
+		/obj/item/clothing/glasses,
+		/obj/item/weapon/reagent_containers/blood
 	)
 
 /obj/item/weapon/storage/belt/medical/emt
@@ -131,9 +134,48 @@
 	icon_state = "emsbelt"
 	item_state = "emsbelt"
 	can_hold = list(
+		/obj/item/device/scanner/health,
+		/obj/item/weapon/dnainjector,
+		/obj/item/device/radio/headset,
+		/obj/item/weapon/reagent_containers/dropper,
+		/obj/item/weapon/reagent_containers/glass/beaker,
+		/obj/item/weapon/reagent_containers/glass/bottle,
+		/obj/item/weapon/reagent_containers/pill,
+		/obj/item/weapon/reagent_containers/syringe,
+		/obj/item/weapon/flame/lighter,
+		/obj/item/weapon/cell/small,
+		/obj/item/weapon/storage/fancy/cigarettes,
+		/obj/item/weapon/storage/pill_bottle,
+		/obj/item/stack/medical,
+		/obj/item/clothing/mask/surgical,
+		/obj/item/clothing/head/surgery,
+		/obj/item/clothing/gloves,
+		/obj/item/weapon/reagent_containers/hypospray,
+		/obj/item/clothing/glasses,
+		/obj/item/weapon/tool/crowbar,
+		/obj/item/device/lighting/toggleable/flashlight,
+		/obj/item/weapon/extinguisher/mini,
+		/obj/item/stack/nanopaste,
+		/obj/item/bodybag,
+		/obj/item/weapon/tool/bonesetter,
+		/obj/item/weapon/tool/scalpel,
+		/obj/item/weapon/tool/scalpel/advanced,
+		/obj/item/weapon/tool/scalpel/laser,
+		/obj/item/weapon/tool/surgicaldrill,
+		/obj/item/weapon/tool/cautery,
+		/obj/item/weapon/tool/retractor,
+		/obj/item/weapon/tool/saw/circular,
+		/obj/item/weapon/tool/hemostat,
+		/obj/item/weapon/reagent_containers/pill,
+		/obj/item/weapon/storage/pill_bottle,
+		/obj/item/bodybag/cryobag,
 		/obj/item/weapon/inflatable_dispenser,
 		/obj/item/device/radio/off,
-		/obj/item/taperoll/medical
+		/obj/item/taperoll/medical,
+		/obj/item/weapon/tool/crowbar,
+		/obj/item/weapon/extinguisher/mini,
+		/obj/item/clothing/gloves,
+		/obj/item/clothing/glasses
 
 	)
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -207,7 +207,7 @@
 	if(junk_food)
 		to_chat(user, SPAN_WARNING("\The [src] its a junk food!"))
 	else if(taste_tag.len)
-		to_chat(user, SPAN_NOTICE("\The [src] this tastes like [english_list(taste_tag)]"))
+		to_chat(user, SPAN_NOTICE("\The [src] tastes like [english_list(taste_tag)]"))
 	if (bitecount==0)
 		return
 	else if (bitecount==1)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -329,7 +329,7 @@
 	..()
 
 /obj/item/weapon/reagent_containers/syringe/large
-	name = "Large syringe"
+	name = "large syringe"
 	desc = "A large syringe for those patients who needs a little more"
 	icon = 'icons/obj/large_syringe.dmi'
 	item_state = "large_syringe"

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -334,7 +334,7 @@
 	icon = 'icons/obj/large_syringe.dmi'
 	item_state = "large_syringe"
 	icon_state = "0"
-	matter = list(MATERIAL_GLASS = 1, MATERIAL_STEEL = 1)
+	matter = list(MATERIAL_GLASS = 1, MATERIAL_STEEL = 1,MATERIAL_SILVER = 1)
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = list(5,10)
 	volume = 30


### PR DESCRIPTION
large syringe now uses 1 silver. and is in Moebius Medical Designs" (20 liscense points)

typo in the "taste like"

EMT now can hold everything that regular medical belt does, except for the blood bag plus:
crowbar
mini extinguisher
and flashlight,

that medical belt can now hold bloodbags

and both are able to hold glasses and gloves to make surgery swaps easier, if you wanna go for that

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
large syringe now uses 1 silver. and in Moebius Medical Designs" (20 liscense points)

typo in the "taste like"

gives medical belts and EMT belts some more unique stuff
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixes

picking up one belt or the other should be more of a choice now
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Fernandos33
balance: large syringe now uses 1 silver. and is in Moebius Medical Designs" (20 liscense points)
fix: typo in the "THIS taste like"
add: EMT now holds, crowbar, mini extinguisherand, flashlight.
add: medical belt can now hold bloodbags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
