### PR TITLE
Makes the Energy Armblade Implant stop deleting itself

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -192,6 +192,7 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	var/mob/living/creator
 	var/datum/effect/effect/system/spark_spread/spark_system
+	var/cleanup = TRUE	// Should the blade despawn moments after being discarded by the summoner?
 
 /obj/item/weapon/melee/energy/blade/New()
 
@@ -207,10 +208,12 @@
 
 /obj/item/weapon/melee/energy/blade/attack_self(mob/user as mob)
 	user.drop_from_inventory(src)
-	spawn(1) if(src) qdel(src)
+	if(cleanup)
+		spawn(1) if(src) qdel(src)
 
 /obj/item/weapon/melee/energy/blade/dropped()
-	spawn(1) if(src) qdel(src)
+	if(cleanup)
+		spawn(1) if(src) qdel(src)
 
 /obj/item/weapon/melee/energy/blade/Process()
 	if(!creator || loc != creator || (creator.l_hand != src && creator.r_hand != src))
@@ -225,9 +228,11 @@
 			host.pinned -= src
 			host.embedded -= src
 			host.drop_from_inventory(src)
-		spawn(1) if(src) qdel(src)
+		if(cleanup)
+			spawn(1) if(src) qdel(src)
 
 /obj/item/weapon/melee/energy/blade/organ_module //just to make sure that blade doesnt delet itself
+	cleanup = FALSE
 
 /obj/item/weapon/melee/energy/blade/organ_module/New()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Energy Armblade Implant that can be gotten from uplinks has a critical flaw: It stops working 1 minute after you first use it. This is because it uses the hardsuit energy blade projector's blades, which would normally instantly despawn after being dropped. I have no idea why the implant takes a full minute to delete itself instead of instantly, but it just does.

This PR will fix that, without allowing the hardsuit energy blade projector to infinitely spam more and more blades onto the floor.

## Changelog
:cl: Toriate
fix: Energy Armblade implant should no longer delete itself a minute after being used for the first time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
