### PR TITLE
fixes beartraps and mines being able to be placed on ladder tiles

### DIFF
--- a/code/game/objects/items/weapons/mine.dm
+++ b/code/game/objects/items/weapons/mine.dm
@@ -42,6 +42,9 @@
 		overlays.Add(image(icon,"mine_light"))
 
 /obj/item/weapon/mine/attack_self(mob/user)
+	if(locate(/obj/structure/multiz/ladder) in get_turf(user))
+		to_chat(user, SPAN_NOTICE("You cannot place \the [src] here, there is a ladder."))
+		return
 	if(!armed)
 		user.visible_message(
 			SPAN_DANGER("[user] starts to deploy \the [src]."),

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -198,6 +198,9 @@ Freeing yourself is much harder than freeing someone else. Calling for help is a
 
 /obj/item/weapon/beartrap/attack_self(mob/user as mob)
 	..()
+	if(locate(/obj/structure/multiz/ladder) in get_turf(user))
+		to_chat(user, SPAN_NOTICE("You cannot place \the [src] here, there is a ladder."))
+		return
 	if(!deployed && can_use(user))
 		user.visible_message(
 			SPAN_DANGER("[user] starts to deploy \the [src]."),


### PR DESCRIPTION
## About The Pull Request

This PR fixes bear traps and mines being able to be placed onto ladder turfs

## Why It's Good For The Game

Gamey combat exploits are dumb and this is an order from gray

## Changelog
:cl:
fix: fixed bear traps and mines being able to be placed onto ladder turfs
/:cl:

