### PR TITLE
fixes rad storms affecting encounter maps

### DIFF
--- a/code/game/gamemodes/events/weather/rad_storm.dm
+++ b/code/game/gamemodes/events/weather/rad_storm.dm
@@ -17,7 +17,7 @@
 	end_message = "<span class='notice'>The air seems to be cooling off again.</span>"
 
 	area_type = /area
-	protected_areas = list(/area/asteroid/rogue, /area/shuttle/mining, /area/deepmaint, /area/shuttle/escape, /area/shuttle/escape_pod1, /area/shuttle/escape_pod2, /area/shuttle/escape_pod3, \
+	protected_areas = list(/area/outpost/abandoned_fortress, /area/outpost/abandoned, /area/mine/unexplored, /area/mine/explored, /area/eris/crew_quarters/sleep, area/asteroid/rogue, /area/shuttle/mining, /area/deepmaint, /area/shuttle/escape, /area/shuttle/escape_pod1, /area/shuttle/escape_pod2, /area/shuttle/escape_pod3, \
 	/area/shuttle/escape_pod5, /area/shuttle/specops/centcom, /area/shuttle/mercenary, /area/shuttle/administration, /area/eris/maintenance, \
 	/area/eris/crew_quarters/sleep/cryo, /area/eris/security/disposal, /area/eris/security/maintpost, /area/eris/rnd/anomalisolone, \
 	/area/eris/rnd/anomalisoltwo, /area/eris/rnd/anomalisolthree, /area/eris/rnd/server)

--- a/code/game/gamemodes/events/weather/rad_storm.dm
+++ b/code/game/gamemodes/events/weather/rad_storm.dm
@@ -17,7 +17,7 @@
 	end_message = "<span class='notice'>The air seems to be cooling off again.</span>"
 
 	area_type = /area
-	protected_areas = list(/area/outpost/abandoned_fortress, /area/outpost/abandoned, /area/mine/unexplored, /area/mine/explored, /area/eris/crew_quarters/sleep, area/asteroid/rogue, /area/shuttle/mining, /area/deepmaint, /area/shuttle/escape, /area/shuttle/escape_pod1, /area/shuttle/escape_pod2, /area/shuttle/escape_pod3, \
+	protected_areas = list(/area/outpost/abandoned_fortress, /area/outpost/abandoned, /area/mine/unexplored, /area/mine/explored, /area/eris/crew_quarters/sleep, /area/asteroid/rogue, /area/shuttle/mining, /area/deepmaint, /area/shuttle/escape, /area/shuttle/escape_pod1, /area/shuttle/escape_pod2, /area/shuttle/escape_pod3, \
 	/area/shuttle/escape_pod5, /area/shuttle/specops/centcom, /area/shuttle/mercenary, /area/shuttle/administration, /area/eris/maintenance, \
 	/area/eris/crew_quarters/sleep/cryo, /area/eris/security/disposal, /area/eris/security/maintpost, /area/eris/rnd/anomalisolone, \
 	/area/eris/rnd/anomalisoltwo, /area/eris/rnd/anomalisolthree, /area/eris/rnd/server)


### PR DESCRIPTION

## About The Pull Request

this PR fixes radstorms affecting areas of limited to no coverage against rad storms, which prolonged exposure will almost certainly lead to death.

## Why It's Good For The Game

fixes good, this was ordered by Gray

## Changelog
:cl:

fix: fixed radstorms affecting encounter maps, like the mine, asteroid belt, space fortress

/:cl:

