### PR TITLE
[ORDERS] Implements random starting areas for the CEV Eris. One of 3 default l…

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -167,6 +167,8 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 	var/use_lib_nudge = 0 //Use the C library nudge instead of the python nudge.
 	var/use_overmap = 0
 
+	var/start_location = "asteroid" // Start location defaults to asteroid.
+
 	// Event settings
 	var/expected_round_length = 3 * 60 * 60 * 10 // 3 hours
 	// If the first delay has a custom start time
@@ -726,8 +728,27 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 
 				if("webhook_url")
 					config.webhook_url = value
+				
+		
+				if("random_start")
+					var/list/startlist = list(
+						"asteroid", 
+						"abandoned fortress", 
+						"space ruins") 
+					var/pick = rand(1, startlist.len)
+					config.start_location = startlist[pick]
+
+				if("asteroid_start")
+					config.start_location = "asteroid"
+
+				if("fortress_start")
+					config.start_location = "abandoned fortress"
+
+				if("ruins_start")
+					config.start_location = "space ruins"
 				else
 					log_misc("Unknown setting in configuration: '[name]'")
+
 
 		else if(type == "game_options")
 			if(!value)

--- a/code/global.dm
+++ b/code/global.dm
@@ -8,8 +8,9 @@ var/global/datum/datacore/data_core = null
 var/global/datum/DB_search/db_search = new()
 var/global/list/all_areas                = list()
 var/global/list/ship_areas               = list()
-var/global/list/obj/effect/overmap/ship/ships 					 = list()
 
+
+var/global/list/obj/effect/overmap/ship/ships 	= list() // List of ships in the game.
 
 //var/global/list/machines                 = list()		//Removed
 //var/global/list/processing_objects       = list()		//Removed

--- a/code/global.dm
+++ b/code/global.dm
@@ -8,7 +8,7 @@ var/global/datum/datacore/data_core = null
 var/global/datum/DB_search/db_search = new()
 var/global/list/all_areas                = list()
 var/global/list/ship_areas               = list()
-var/global/list/ships 					 = list()
+var/global/list/obj/effect/overmap/ship/ships 					 = list()
 
 
 //var/global/list/machines                 = list()		//Removed

--- a/code/global.dm
+++ b/code/global.dm
@@ -7,7 +7,8 @@
 var/global/datum/datacore/data_core = null
 var/global/datum/DB_search/db_search = new()
 var/global/list/all_areas                = list()
-var/global/list/ship_areas                = list()
+var/global/list/ship_areas               = list()
+var/global/list/ships 					 = list()
 
 
 //var/global/list/machines                 = list()		//Removed

--- a/code/global.dm
+++ b/code/global.dm
@@ -10,7 +10,7 @@ var/global/list/all_areas                = list()
 var/global/list/ship_areas               = list()
 
 
-var/global/list/obj/effect/overmap/ship/ships 	= list() // List of ships in the game.
+var/global/list/ships 	= list() // List of ships in the game.
 
 //var/global/list/machines                 = list()		//Removed
 //var/global/list/processing_objects       = list()		//Removed

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -18,6 +18,7 @@
 	var/in_space = 1	//can be accessed via lucky EVA
 
 	var/global/eris_start_set = FALSE //Tells us if we need to modify a random location for Eris to start at
+	var/global/eris
 
 /obj/effect/overmap/Initialize()
 	. = ..()
@@ -34,19 +35,10 @@
 	start_x = start_x || rand(OVERMAP_EDGE, GLOB.maps_data.overmap_size - OVERMAP_EDGE)
 	start_y = start_y || rand(OVERMAP_EDGE, GLOB.maps_data.overmap_size - OVERMAP_EDGE)
 
-	if (!eris_start_set)
-		// Find the eris object
-		for (var/obj/effect/overmap/ship/eris/O in world)
-			if (istype(O, /obj/effect/overmap/ship/eris))
-				if(O.name == "CEV Eris")
-					var/start_sector = O.start_sector
-					if(!start_sector)
-						continue
-
-					if(name == start_sector)
-						start_x = 9
-						start_y = 10
-						eris_start_set = TRUE
+	if ((!eris_start_set) && (name == config.start_location))
+		start_x = ships[eris].start_x
+		start_y = ships[eris].start_y
+		eris_start_set = TRUE
 
 	forceMove(locate(start_x, start_y, GLOB.maps_data.overmap_z))
 	testing("Located sector \"[name]\" at [start_x],[start_y], containing Z [english_list(map_z)]")

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -36,8 +36,9 @@
 	start_y = start_y || rand(OVERMAP_EDGE, GLOB.maps_data.overmap_size - OVERMAP_EDGE)
 
 	if ((!eris_start_set) && (name == config.start_location))
-		start_x = ships[eris].start_x
-		start_y = ships[eris].start_y
+		var/obj/effect/overmap/ship/eris/E = ships[eris]
+		start_x = E.start_x
+		start_y = E.start_y
 		eris_start_set = TRUE
 
 	forceMove(locate(start_x, start_y, GLOB.maps_data.overmap_z))

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -17,6 +17,8 @@
 	var/known = 1		//shows up on nav computers automatically
 	var/in_space = 1	//can be accessed via lucky EVA
 
+	var/global/eris_start_set //Tells us if we need to modify a random location for Eris to start at
+
 /obj/effect/overmap/Initialize()
 	. = ..()
 
@@ -27,8 +29,24 @@
 	for(var/zlevel in map_z)
 		map_sectors["[zlevel]"] = src
 
+	// Spawning location of area is randomized or default values, but can be changed to the Eris Coordinates in the code below.
+	// This provides a random starting location for Eris.
 	start_x = start_x || rand(OVERMAP_EDGE, GLOB.maps_data.overmap_size - OVERMAP_EDGE)
 	start_y = start_y || rand(OVERMAP_EDGE, GLOB.maps_data.overmap_size - OVERMAP_EDGE)
+
+	if (!eris_start_set)
+		// Find the eris object
+		for (var/obj/effect/overmap/ship/eris/O in world)
+			if (istype(O, /obj/effect/overmap/ship/eris))
+				if(O.name == "CEV Eris")
+					var/start_sector = O.start_sector
+					if(!start_sector)
+						continue
+
+					if(name == start_sector)
+						start_x = 9
+						start_y = 10
+						eris_start_set = TRUE
 
 	forceMove(locate(start_x, start_y, GLOB.maps_data.overmap_z))
 	testing("Located sector \"[name]\" at [start_x],[start_y], containing Z [english_list(map_z)]")

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -17,7 +17,7 @@
 	var/known = 1		//shows up on nav computers automatically
 	var/in_space = 1	//can be accessed via lucky EVA
 
-	var/global/eris_start_set //Tells us if we need to modify a random location for Eris to start at
+	var/global/eris_start_set = FALSE //Tells us if we need to modify a random location for Eris to start at
 
 /obj/effect/overmap/Initialize()
 	. = ..()

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -348,3 +348,9 @@ IPR_MINIMUM_AGE 5
 
 # Enable/disable 'panic bunker' (prevents new players from joining if they've never been seen before in the DB)
 #PANIC_BUNKER
+
+# Set start location for CEV Eris uncomment ONE only.
+RANDOM_START
+#ASTEROID_START
+#FORTRESS_START
+#RUINS_START

--- a/maps/CEVEris/overmap-eris.dm
+++ b/maps/CEVEris/overmap-eris.dm
@@ -9,6 +9,13 @@
 	start_x = 9
 	start_y = 10
 
+	var/start_sector // Determines where Eris should start
+	var/list/start_sector_list = list( // List of locations to pick from.
+		"asteroid", 
+		"abandoned fortress", 
+		"space ruins") 
+
+
 	restricted_waypoints = list(
 		"Vasiliy Dokuchaev" = list("nav_dock_expl"), 	//can't have random shuttles popping inside the ship
 		"Hulk" = list("nav_dock_hulk")
@@ -42,6 +49,12 @@
 		"nav_deck4_aquila",
 		"nav_bridge_aquila"
 	)*/
+
+/obj/effect/overmap/ship/eris/Initialize()
+	.=..()
+	var/pick = rand(1, start_sector_list.len)
+	start_sector = start_sector_list[pick]
+	admin_notice("Eris Start Sector is [start_sector]", R_DEBUG)
 
 /obj/machinery/computer/shuttle_control/explore/exploration_shuttle
 	name = "shuttle control console"

--- a/maps/CEVEris/overmap-eris.dm
+++ b/maps/CEVEris/overmap-eris.dm
@@ -9,13 +9,6 @@
 	start_x = 9
 	start_y = 10
 
-	var/start_sector // Determines where Eris should start
-	var/list/start_sector_list = list( // List of locations to pick from.
-		"asteroid", 
-		"abandoned fortress", 
-		"space ruins") 
-
-
 	restricted_waypoints = list(
 		"Vasiliy Dokuchaev" = list("nav_dock_expl"), 	//can't have random shuttles popping inside the ship
 		"Hulk" = list("nav_dock_hulk")
@@ -52,9 +45,8 @@
 
 /obj/effect/overmap/ship/eris/Initialize()
 	.=..()
-	var/pick = rand(1, start_sector_list.len)
-	start_sector = start_sector_list[pick]
-	admin_notice("Eris Start Sector is [start_sector]", R_DEBUG)
+	if(name == "CEV Eris")
+		ships[eris] = src
 
 /obj/machinery/computer/shuttle_control/explore/exploration_shuttle
 	name = "shuttle control console"

--- a/maps/encounters/asteroid/asteroid.dm
+++ b/maps/encounters/asteroid/asteroid.dm
@@ -9,8 +9,6 @@
 		"nav_asteroid_1",
 		"nav_asteroid_2"
 	)
-	start_x = 9
-	start_y = 10
 	known = 1
 	in_space = 0
 


### PR DESCRIPTION
…ocations will start where the CEV Eris is. It's random each round, and more can be added.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This request fills an order from the Discord to have the Eris start at one of the three areas on the overmap.
![Capture](https://user-images.githubusercontent.com/49131029/94215001-72a32500-fe98-11ea-8df3-b9fed8e677aa.PNG)

The Three locations are The asteroid, Abandonded Fortress, or Ruins. This is accomplished in a somewhat strange way, since the Eris is spawned first, I had to make it so the random landmark will spawn at the Eris instead. This also means the asteroid loses it's default spawn status at the Eris, and its default coordinates are now randomized, just like the fortress and ruins are.

It's also built to be expandable, create more sectors, and then add them to the list.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It should make rounds more varied, and offer players a chance to see the other areas, even when there's no captain or anyone driving the ship.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: yorpyorpyorp
add: Eris will now randomly start at 1 of 3 locations.
add: Lines in config file to determine starting location.
del: Asteroid loses its default location.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
