### PR TITLE
German now uses the "g" prefix

### DIFF
--- a/code/modules/mob/language/german.dm
+++ b/code/modules/mob/language/german.dm
@@ -3,7 +3,7 @@
 	name = LANGUAGE_GERMAN
 	desc = "Language used by the inhabitants of Oberth."
 	colour = "german"
-	key = "d"
+	key = "g"
 	space_chance = 80
 	shorthand = "GE"
 	syllables = list("Frau", "Mann", "Waffe", "Schiff", "Bombe", "Explosion", "Grenze", "Strasse", "Halle", "Pistole", "Gewehr", "Uniform", "Kind", "Arzt", \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
With Changeling gone, the "g" language prefix is no longer in regular use. The current prefix, ,d, is already in use by both drones and blitzshells and is preventing carbon mobs from being able to use that prefix.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Not having to use the language menu constantly to use a language is always a plus.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The prefix to speak in German is now ,g
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
