### PR TITLE
Doesn't update the bluespace relay icon when not needed.

### DIFF
--- a/code/game/machinery/bluespacerelay.dm
+++ b/code/game/machinery/bluespacerelay.dm
@@ -21,9 +21,9 @@
 
 
 /obj/machinery/bluespacerelay/update_icon()
-	if(on)
+	if(on && (icon_state != initial(icon_state)))
 		icon_state = initial(icon_state)
-	else
+	else if(icon_state != "[initial(icon_state)]_off")
 		icon_state = "[initial(icon_state)]_off"
 
 /obj/machinery/bluespacerelay/proc/update_power()


### PR DESCRIPTION
Because of BYOND updating icon_state even if the value doesn't change means that the sprite icon refreshes.
So running this on process() means that the icon updates over and over when nothing happens.

As far as I know, doing these extra checks should be much more efficient than updating the icon on every process tick.