### PR TITLE
Fixed tables in onestar ruins being labled "onestar" not "onestar table"

### DIFF
--- a/code/modules/tables/presets.dm
+++ b/code/modules/tables/presets.dm
@@ -92,5 +92,5 @@
 		material = get_material_by_name(MATERIAL_STEEL)
 		custom_appearance = custom_table_appearance["OneStar"] //one star table
 		reinforced = get_material_by_name(MATERIAL_STEEL)
-		name = "onestar table"
+		name = "one star table"
 		..()

--- a/code/modules/tables/presets.dm
+++ b/code/modules/tables/presets.dm
@@ -92,4 +92,5 @@
 		material = get_material_by_name(MATERIAL_STEEL)
 		custom_appearance = custom_table_appearance["OneStar"] //one star table
 		reinforced = get_material_by_name(MATERIAL_STEEL)
+		name = "onestar table"
 		..()


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/24533979/94357596-d6c41580-005f-11eb-987a-68eb0af07a3e.png)


## Changelog
:cl: Hopek

fix: fixed a few things
/:cl: Fixed tables in onestar ruins being labled "onestar" instead of "onestar table"
