### PR TITLE
Ladder peeking and grenade throwing

### DIFF
--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -64,14 +64,15 @@
 		det_time *= RAND_DECIMAL(1-variance, 1+variance)
 
 	spawn(det_time)
-		prime()
+		prime(user)
 		return
 
 
-/obj/item/weapon/grenade/proc/prime()
+/obj/item/weapon/grenade/proc/prime(mob/user as mob)
 	var/turf/T = get_turf(src)
 	if(T)
 		T.hotspot_expose(700,125)
+		user.hud_used.updatePlaneMasters(user)
 
 
 /obj/item/weapon/grenade/attackby(obj/item/I, mob/user as mob)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -41,7 +41,9 @@
 			if (move_intent.flags & MOVE_INTENT_EXERTIVE)
 				src.nutrition -= DEFAULT_HUNGER_FACTOR/10
 
-
+		if(is_watching == 1)
+			reset_view(null)
+			is_watching = 0
 		// Moving around increases germ_level faster
 		if(germ_level < GERM_LEVEL_MOVE_CAP && prob(8))
 			germ_level++

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -41,9 +41,9 @@
 			if (move_intent.flags & MOVE_INTENT_EXERTIVE)
 				src.nutrition -= DEFAULT_HUNGER_FACTOR/10
 
-		if(is_watching == 1)
+		if(is_watching == TRUE)
 			reset_view(null)
-			is_watching = 0
+			is_watching = FALSE
 		// Moving around increases germ_level faster
 		if(germ_level < GERM_LEVEL_MOVE_CAP && prob(8))
 			germ_level++

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -26,7 +26,7 @@
 	var/cpr_time = 1
 	nutrition = 400//Carbon
 
-	var/is_watching = 0  //used for remote viewing of multiz structures
+	var/is_watching = TRUE  //used for remote viewing of multiz structures
 
 	var/obj/item/weapon/tank/internal //Human/Monkey
 

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -26,6 +26,7 @@
 	var/cpr_time = 1
 	nutrition = 400//Carbon
 
+	var/is_watching = 0  //used for remote viewing of multiz structures
 
 	var/obj/item/weapon/tank/internal //Human/Monkey
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -96,3 +96,5 @@
 
 	var/language_blackout = 0
 	var/suppress_communication = 0
+
+	var/is_watching = 0 //used for remote viewing of multiz structures

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -97,4 +97,3 @@
 	var/language_blackout = 0
 	var/suppress_communication = 0
 
-	var/is_watching = 0 //used for remote viewing of multiz structures

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1036,6 +1036,8 @@
 			isRemoteObserve = TRUE
 		else if(client.eye && istype(client.eye,/obj/item/weapon/implant/carrion_spider/observer))
 			isRemoteObserve = TRUE
+		else if(client.eye && istype(client.eye,/obj/structure/multiz))
+			isRemoteObserve = TRUE
 		else if(((mRemote in mutations) || remoteviewer) && remoteview_target)
 			if(remoteview_target.stat == CONSCIOUS)
 				isRemoteObserve = TRUE

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -11,7 +11,6 @@
 	var/istop = TRUE
 	var/obj/structure/multiz/target
 	var/obj/structure/multiz/targeted_by
-	var/is_watching = 0
 /obj/structure/multiz/New()
 	. = ..()
 	for(var/obj/structure/multiz/M in loc)
@@ -174,21 +173,28 @@
 /obj/structure/multiz/ladder/AltClick(var/mob/living/carbon/human/user)
 	if(get_dist(src, user) <= 3)
 		if(!user.is_physically_disabled())
-			var/turf/peekTurf = istop ? GetBelow(src) : GetAbove(src)
 			if(target)
-				if(is_watching == 1)
-					user.reset_view(0)
-					is_watching = 0
-					return
-				if(is_watching == 0)
-					to_chat(src, SPAN_NOTICE("You look up."))
-					if(user.client)
-						user.reset_view(peekTurf)
-						is_watching = 1
-					return
-			to_chat(src, SPAN_NOTICE("You can see [peekTurf]."))
+				if(user.client)
+					if(user.is_watching == 1)
+						to_chat(user, SPAN_NOTICE("You look [istop ? "down" : "up"] \the [src]."))
+						user.client.eye = user.client.mob
+						user.client.perspective = MOB_PERSPECTIVE
+						user.hud_used.updatePlaneMasters(user)
+						user.is_watching = 0
+					else if(user.is_watching == 0)
+						user.client.eye = target
+						user.client.perspective = EYE_PERSPECTIVE
+						user.hud_used.updatePlaneMasters(user)
+						user.is_watching = 1
+				return
 		else
-			to_chat(src, SPAN_NOTICE("You can't do it right now."))
+			to_chat(user, SPAN_NOTICE("You can't do it right now."))
+		return
+	else 
+		user.client.eye = user.client.mob
+		user.client.perspective = MOB_PERSPECTIVE
+		user.hud_used.updatePlaneMasters(user)
+		user.is_watching = 0
 		return
 ////STAIRS////
 
@@ -256,6 +262,33 @@
 /obj/structure/multiz/stairs/active/attack_hand(mob/user)
 	. = ..()
 	Bumped(user)
+
+/obj/structure/multiz/stairs/AltClick(var/mob/living/carbon/human/user)
+	if(get_dist(src, user) <= 7)
+		if(!user.is_physically_disabled())
+			if(target)
+				if(user.client)
+					if(user.is_watching == 1)
+						to_chat(user, SPAN_NOTICE("You look [istop ? "down" : "up"] \the [src]."))
+						user.client.eye = user.client.mob
+						user.client.perspective = MOB_PERSPECTIVE
+						user.hud_used.updatePlaneMasters(user)
+						user.is_watching = 0
+					else if(user.is_watching == 0)
+						user.client.eye = target
+						user.client.perspective = EYE_PERSPECTIVE
+						user.hud_used.updatePlaneMasters(user)
+						user.is_watching = 1
+				return
+		else
+			to_chat(user, SPAN_NOTICE("You can't do it right now."))
+		return
+	else 
+		user.client.eye = user.client.mob
+		user.client.perspective = MOB_PERSPECTIVE
+		user.hud_used.updatePlaneMasters(user)
+		user.is_watching = 0
+		return
 
 /obj/structure/multiz/stairs/active/bottom
 	icon_state = "rampup"

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -121,7 +121,7 @@
 				user.drop_item()
 				G.forceMove(target.loc)
 				var/direction = pick(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
-				G.DoMove(direction, user)
+				G.Move(get_step(G, direction))
 				if(!G.active)
 					G.activate(user)
 				return TRUE

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -110,22 +110,21 @@
 /obj/structure/multiz/ladder/proc/throw_through(var/obj/item/C, var/mob/throw_man)
 	if(istype(throw_man,/mob/living/carbon/human))
 		var/mob/living/carbon/human/user = throw_man
-		if(istype(C,/obj/item/weapon/grenade))
-			var/through =  istop ? "down" : "up"
-			var/obj/item/weapon/grenade/G= C
-			user.visible_message("<span class='warning'>[user] takes position to throw [G] [through] \the [src].</span>",
-			"<span class='warning'>You take position to throw [G] [through] \the [src].</span>")
-			if(do_after(user, 10))
-				user.visible_message("<span class='warning'>[user] throws [G] [through] \the [src]!</span>",
-				"<span class='warning'>You throw [G] [through] \the [src]</span>")
-				user.drop_item()
-				G.forceMove(target.loc)
-				var/direction = pick(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
-				G.Move(get_step(G, direction))
+		var/through =  istop ? "down" : "up"
+		user.visible_message("<span class='warning'>[user] takes position to throw [C] [through] \the [src].</span>",
+		"<span class='warning'>You take position to throw [C] [through] \the [src].</span>")
+		if(do_after(user, 10))
+			user.visible_message("<span class='warning'>[user] throws [C] [through] \the [src]!</span>",
+			"<span class='warning'>You throw [C] [through] \the [src]</span>")
+			user.drop_item()
+			C.forceMove(target.loc)
+			var/direction = pick(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
+			C.Move(get_step(C, direction))
+			if(istype(C, /obj/item/weapon/grenade))
+				var/obj/item/weapon/grenade/G = C
 				if(!G.active)
 					G.activate(user)
-				return TRUE
-			return FALSE
+			return TRUE
 		return FALSE
 	return FALSE
 

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -111,11 +111,11 @@
 	if(istype(throw_man,/mob/living/carbon/human))
 		var/mob/living/carbon/human/user = throw_man
 		var/through =  istop ? "down" : "up"
-		user.visible_message("<span class='warning'>[user] takes position to throw [C] [through] \the [src].</span>",
-		"<span class='warning'>You take position to throw [C] [through] \the [src].</span>")
+		user.visible_message(SPAN_WARNING("[user] takes position to throw [C] [through] \the [src]."),
+		SPAN_WARNING("You take position to throw [C] [through] \the [src]."))
 		if(do_after(user, 10))
-			user.visible_message("<span class='warning'>[user] throws [C] [through] \the [src]!</span>",
-			"<span class='warning'>You throw [C] [through] \the [src]</span>")
+			user.visible_message(SPAN_WARNING("[user] throws [C] [through] \the [src]!"),
+			SPAN_WARNING("You throw [C] [through] \the [src]."))
 			user.drop_item()
 			C.forceMove(target.loc)
 			var/direction = pick(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
@@ -203,17 +203,17 @@
 		if(!user.is_physically_disabled())
 			if(target)
 				if(user.client)
-					if(user.is_watching == 1)
+					if(user.is_watching == TRUE)
 						to_chat(user, SPAN_NOTICE("You look [istop ? "down" : "up"] \the [src]."))
 						user.client.eye = user.client.mob
 						user.client.perspective = MOB_PERSPECTIVE
 						user.hud_used.updatePlaneMasters(user)
-						user.is_watching = 0
-					else if(user.is_watching == 0)
+						user.is_watching = FALSE
+					else if(user.is_watching == FALSE)
 						user.client.eye = target
 						user.client.perspective = EYE_PERSPECTIVE
 						user.hud_used.updatePlaneMasters(user)
-						user.is_watching = 1
+						user.is_watching = TRUE
 				return
 		else
 			to_chat(user, SPAN_NOTICE("You can't do it right now."))
@@ -222,7 +222,7 @@
 		user.client.eye = user.client.mob
 		user.client.perspective = MOB_PERSPECTIVE
 		user.hud_used.updatePlaneMasters(user)
-		user.is_watching = 0
+		user.is_watching = FALSE
 		return
 ////STAIRS////
 
@@ -296,17 +296,17 @@
 		if(!user.is_physically_disabled())
 			if(target)
 				if(user.client)
-					if(user.is_watching == 1)
+					if(user.is_watching == TRUE)
 						to_chat(user, SPAN_NOTICE("You look [istop ? "down" : "up"] \the [src]."))
 						user.client.eye = user.client.mob
 						user.client.perspective = MOB_PERSPECTIVE
 						user.hud_used.updatePlaneMasters(user)
-						user.is_watching = 0
-					else if(user.is_watching == 0)
+						user.is_watching = FALSE
+					else if(user.is_watching == FALSE)
 						user.client.eye = target
 						user.client.perspective = EYE_PERSPECTIVE
 						user.hud_used.updatePlaneMasters(user)
-						user.is_watching = 1
+						user.is_watching = TRUE
 				return
 		else
 			to_chat(user, SPAN_NOTICE("You can't do it right now."))
@@ -315,7 +315,7 @@
 		user.client.eye = user.client.mob
 		user.client.perspective = MOB_PERSPECTIVE
 		user.hud_used.updatePlaneMasters(user)
-		user.is_watching = 0
+		user.is_watching = FALSE
 		return
 
 /obj/structure/multiz/stairs/active/bottom

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -172,7 +172,7 @@
 		try_resolve_mob_pulling(M, src)
 
 /obj/structure/multiz/ladder/AltClick(var/mob/living/carbon/human/user)
-	if(in_range(src, user))
+	if(get_dist(src, user) <= 3)
 		if(!user.is_physically_disabled())
 			var/turf/peekTurf = istop ? GetBelow(src) : GetAbove(src)
 			if(target)

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -107,6 +107,35 @@
 /obj/structure/multiz/ladder/attack_generic(var/mob/M)
 	attack_hand(M)
 
+/obj/structure/multiz/ladder/proc/throw_through(var/obj/item/C, var/mob/throw_man)
+	if(istype(throw_man,/mob/living/carbon/human))
+		var/mob/living/carbon/human/user = throw_man
+		if(istype(C,/obj/item/weapon/grenade))
+			var/through =  istop ? "down" : "up"
+			var/obj/item/weapon/grenade/G= C
+			user.visible_message("<span class='warning'>[user] takes position to throw [G] [through] \the [src].</span>",
+			"<span class='warning'>You take position to throw [G] [through] \the [src].</span>")
+			if(do_after(user, 10))
+				user.visible_message("<span class='warning'>[user] throws [G] [through] \the [src]!</span>",
+				"<span class='warning'>You throw [G] [through] \the [src]</span>")
+				user.drop_item()
+				G.forceMove(target.loc)
+				var/direction = pick(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
+				G.DoMove(direction, user)
+				if(!G.active)
+					G.activate(user)
+				return TRUE
+			return FALSE
+		return FALSE
+	return FALSE
+
+/obj/structure/multiz/ladder/attackby(obj/item/I, mob/user)
+	. = ..()
+	if(throw_through(I,user))
+		return
+	else
+		attack_hand(user)
+
 /obj/structure/multiz/ladder/attack_hand(var/mob/M)
 	if (isrobot(M) && !isdrone(M))
 		var/mob/living/silicon/robot/R = M

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -11,7 +11,7 @@
 	var/istop = TRUE
 	var/obj/structure/multiz/target
 	var/obj/structure/multiz/targeted_by
-
+	var/is_watching = 0
 /obj/structure/multiz/New()
 	. = ..()
 	for(var/obj/structure/multiz/M in loc)
@@ -171,6 +171,25 @@
 		M.forceMove(T)
 		try_resolve_mob_pulling(M, src)
 
+/obj/structure/multiz/ladder/AltClick(var/mob/living/carbon/human/user)
+	if(in_range(src, user))
+		if(!user.is_physically_disabled())
+			var/turf/peekTurf = istop ? GetBelow(src) : GetAbove(src)
+			if(target)
+				if(is_watching == 1)
+					user.reset_view(0)
+					is_watching = 0
+					return
+				if(is_watching == 0)
+					to_chat(src, SPAN_NOTICE("You look up."))
+					if(user.client)
+						user.reset_view(peekTurf)
+						is_watching = 1
+					return
+			to_chat(src, SPAN_NOTICE("You can see [peekTurf]."))
+		else
+			to_chat(src, SPAN_NOTICE("You can't do it right now."))
+		return
 ////STAIRS////
 
 /obj/structure/multiz/stairs


### PR DESCRIPTION
## About The Pull Request

This PR adds the ability to see down and up ladders and also see down and up stairs by Alt Clicking the multiz structure 
This PR also adds the ability to thrown items up and down ladders by clicking on the ladder with the item
This PR has been heavily tested for ways to break the code and mess with planes
## Why It's Good For The Game

This completely destroys the z-level transverse camping that was possible before, in which you could wait for someone, and instantly open fire and kill them before they could know what was going on. Also the new functionality for  items

## Changelog
:cl:
add: You can now see down and up ladders, and up and down stairs by alt clicking the zlevel change structure, whether it be a ladder or a stair
add: You can now throw items up and down ladders by clicking on the ladder with the item inhand (grenades blow up)
/:cl: