### PR TITLE
Removes poorly-implemented bay animals from the infestation event.

### DIFF
--- a/code/game/gamemodes/events/infestation.dm
+++ b/code/game/gamemodes/events/infestation.dm
@@ -20,18 +20,13 @@ It focuses on spawning large numbers of moderate-to-weak monsters, and includes 
 
 
 #define INFESTATION_MICE "mice"
-#define INFESTATION_LIZARDS "lizards"
 #define INFESTATION_SPACE_BATS "bats"
 #define INFESTATION_SPIDERLINGS "spiderlings"
 #define INFESTATION_SPIDERS "spider"
 #define INFESTATION_ROACHES "large insects"
 #define INFESTATION_HIVEBOTS "ancient synthetics"
 #define INFESTATION_SLIMES "slimes"
-#define INFESTATION_YITHIAN "yithian"
-#define INFESTATION_TINDALOS "tindalos"
-#define INFESTATION_DIYAAB "diyaab"
-#define INFESTATION_SAMAK "samak"
-#define INFESTATION_SHANTAK "shantak"
+
 /datum/event/infestation
 	startWhen = 1
 	announceWhen = 10
@@ -47,18 +42,11 @@ It focuses on spawning large numbers of moderate-to-weak monsters, and includes 
 	var/list/chosen_mob_classification = list()
 	var/list/possible_mobs_mundane = list(
 		INFESTATION_MICE = 17,
-		INFESTATION_LIZARDS = 12,
 		INFESTATION_SPIDERLINGS = 8,
-		INFESTATION_YITHIAN = 6,
-		INFESTATION_TINDALOS = 6,
-		INFESTATION_DIYAAB = 6,
-		INFESTATION_SPACE_BATS = 7
 	)
 
 	var/possible_mobs_moderate = list(
 		INFESTATION_SPACE_BATS = 10,
-		INFESTATION_SAMAK = 5,
-		INFESTATION_SHANTAK = 7,
 		INFESTATION_SPIDERS = 7,//This is a combination of spiderlings and adult spiders
 		INFESTATION_ROACHES = 7
 	)
@@ -155,10 +143,6 @@ It focuses on spawning large numbers of moderate-to-weak monsters, and includes 
 			event_name = "Bat Roost"
 			chosen_verb = "have been roosting in"
 			chosen_mob_classification += /mob/living/simple_animal/hostile/scarybat
-		if(INFESTATION_LIZARDS)
-			event_name = "Lizard Nest"
-			chosen_verb = "have been breeding in"
-			chosen_mob_classification += /mob/living/simple_animal/lizard
 		if(INFESTATION_MICE)
 			event_name = "Mouse Nest"
 			chosen_verb = "have been breeding in"
@@ -180,21 +164,6 @@ It focuses on spawning large numbers of moderate-to-weak monsters, and includes 
 			event_name = "Giant Roach Infestation"
 			chosen_verb = "have burrowed into"
 			chosen_mob_classification += /obj/spawner/mob/roaches
-		if(INFESTATION_YITHIAN)
-			unidentified = TRUE
-			chosen_mob_classification += /mob/living/simple_animal/yithian
-		if(INFESTATION_TINDALOS)
-			unidentified = TRUE
-			chosen_mob_classification += /mob/living/simple_animal/tindalos
-		if(INFESTATION_SAMAK)
-			unidentified = TRUE
-			chosen_mob_classification += /mob/living/simple_animal/hostile/samak
-		if(INFESTATION_SHANTAK)
-			unidentified = TRUE
-			chosen_mob_classification += /mob/living/simple_animal/hostile/shantak
-		if(INFESTATION_DIYAAB)
-			unidentified = TRUE
-			chosen_mob_classification += /mob/living/simple_animal/hostile/diyaab
 
 	//Chance for identification to fail even for normal mobs, to frustrate metagamers
 	if (prob(15))


### PR DESCRIPTION
## About The Pull Request 

I've been told a few times that the bay animals are wasted on an infestation event, as they provide nothing to the round. Most of the ones removed don't even fit the setting.

## Why It's Good For The Game
Less points wasted on NPCs that can't be butchered or interacted with in a meaningful way.

## Changelog
:cl:
del: Lizards, Yithians, Tindalos, Diyaabs, Samaks, and Shantaks have been removed from the infestation event.
/:cl:
