### PR TITLE
Fix firemode change that was erasing effects of gunmods

### DIFF
--- a/code/modules/projectiles/gun_firemode.dm
+++ b/code/modules/projectiles/gun_firemode.dm
@@ -38,6 +38,18 @@
 		if(propname in gun.vars)
 			gun.vars[propname] = settings[propname]
 
+			// Apply gunmods effects that have been erased by the previous line
+			if(propname == "charge_cost")
+				for(var/obj/I in gun.item_upgrades)
+					var/datum/component/item_upgrade/IU = I.GetComponent(/datum/component/item_upgrade)
+					if(IU.weapon_upgrades[GUN_UPGRADE_CHARGECOST])
+						gun.vars["charge_cost"] *= IU.weapon_upgrades[GUN_UPGRADE_CHARGECOST]
+			else if(propname == "fire_delay")
+				for(var/obj/I in gun.item_upgrades)
+					var/datum/component/item_upgrade/IU = I.GetComponent(/datum/component/item_upgrade)
+					if(IU.weapon_upgrades[GUN_UPGRADE_FIRE_DELAY_MULT])
+						gun.vars["fire_delay"] *= IU.weapon_upgrades[GUN_UPGRADE_FIRE_DELAY_MULT]
+
 //Called whenever the firemode is switched to, or the gun is picked up while its active
 /datum/firemode/proc/update()
 	return

--- a/code/modules/projectiles/guns/energy/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma.dm
@@ -20,7 +20,7 @@
 	twohanded = TRUE
 
 	init_firemodes = list(
-		list(mode_name="burn", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/Taser.ogg', fire_delay=8, charge_cost=null, icon="stun", projectile_color = "#0000FF"),
+		list(mode_name="burn", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/Taser.ogg', fire_delay=8, charge_cost=20, icon="stun", projectile_color = "#0000FF"),
 		list(mode_name="melt", projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/Laser.ogg', fire_delay=12, charge_cost=25, icon="kill", projectile_color = "#FF0000"),
 		list(mode_name="INCINERATE", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/pulse.ogg', fire_delay=14, charge_cost=30, icon="destroy", projectile_color = "#FFFFFF"),
 	)
@@ -50,7 +50,7 @@
 	fire_delay = 15
 
 	init_firemodes = list(
-		list(mode_name="INCINERATE", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/pulse.ogg', fire_delay=null, charge_cost=30, icon="kill", projectile_color = "#FFFF00"),
+		list(mode_name="INCINERATE", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/pulse.ogg', fire_delay=15, charge_cost=30, icon="kill", projectile_color = "#FFFF00"),
 		list(mode_name="VAPORIZE", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/pulse.ogg', fire_delay=5, charge_cost=70, icon="destroy", projectile_color = "#FF0000", recoil_buildup=3),
 	)
 
@@ -64,15 +64,15 @@
 	matter = list(MATERIAL_PLASTEEL = 18, MATERIAL_PLASTIC = 8, MATERIAL_SILVER = 6, MATERIAL_URANIUM = 6)
 	fire_sound = 'sound/weapons/pulse.ogg'
 	sel_mode = 1
-	charge_cost = 20 //40 shots per high medium-sized cell
-	fire_delay = 12
+	charge_cost = 15
+	fire_delay = 8
 	price_tag = 3000
 	zoom_factor = null
 	rarity_value = 12
 
 	init_firemodes = list(
 		list(mode_name="burn", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/Taser.ogg', fire_delay=8, charge_cost=15, icon="stun", projectile_color = "#00FFFF"),
-		list(mode_name="melt", projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/Laser.ogg', fire_delay=null, charge_cost=null, icon="kill", projectile_color = "#00AAFF"),
+		list(mode_name="melt", projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/Laser.ogg', fire_delay=12, charge_cost=20, icon="kill", projectile_color = "#00AAFF"),
 	)
 
 /obj/item/weapon/gun/energy/plasma/cassad/update_icon()


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Switching firemode on energy weapons now checks for equipped gunmods and applies their effects properly.

## Why It's Good For The Game

Remove cassad with battery shunt meme (switching firemode with battery shunt gave you a cassad with classic number of shots but with vastly increased firerate)

## Changelog
:cl: Hyperio
fix: Fixed firemode change that was erasing charge_cost and fire_delay of gunmods
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
