### PR TITLE
[BOUNTY] revive proc no longer causes the target to lose their cruciform.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1146,7 +1146,7 @@ var/list/rank_prefix = list(\
 //Needed for augmentation
 /mob/living/carbon/human/proc/rebuild_organs(from_preference)
 	if(!species)
-		return 0
+		return FALSE
 
 	status_flags |= REBUILDING_ORGANS
 
@@ -1157,14 +1157,14 @@ var/list/rank_prefix = list(\
 			C.removed_mob()
 			organs_to_readd += C
 
-	for(var/obj/item/organ/organ in (organs|internal_organs))
-		qdel(organ)
-
 	var/obj/item/weapon/implant/core_implant/CI = get_core_implant()
 	var/checkprefcruciform = FALSE	// To reset the cruciform to original form
 	if(CI)
 		checkprefcruciform = TRUE
 		qdel(CI)
+
+	for(var/obj/item/organ/organ in (organs|internal_organs))
+		qdel(organ)
 
 	if(organs.len)
 		organs.Cut()
@@ -1185,7 +1185,7 @@ var/list/rank_prefix = list(\
 		else
 			return
 
-		var/datum/body_modification/BM = null
+		var/datum/body_modification/BM
 
 		for(var/tag in species.has_limbs)
 			BM = Pref.get_modification(tag)
@@ -1216,7 +1216,7 @@ var/list/rank_prefix = list(\
 				C.access.Add(mind.assigned_job.cruciform_access)
 
 	else
-		var/organ_type = null
+		var/organ_type
 
 		for(var/limb_tag in species.has_limbs)
 			var/datum/organ_description/OD = species.has_limbs[limb_tag]

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -9,7 +9,7 @@
 	var/embedded_flag	  //To check if we've need to roll for damage on movement while an item is imbedded in us.
 	var/obj/item/weapon/rig/wearing_rig // This is very not good, but it's much much better than calling get_rig() every update_lying_buckled_and_verb_status() call.
 
-/mob/living/carbon/human/New(var/new_loc, var/new_species = null)
+/mob/living/carbon/human/New(var/new_loc, var/new_species)
 
 	if(!dna)
 		dna = new /datum/dna(null)
@@ -108,8 +108,8 @@
 			flick("flash", HUDtech["flash"])
 
 	var/shielded = 0
-	var/b_loss = null
-	var/f_loss = null
+	var/b_loss
+	var/f_loss
 	var/bomb_defense = getarmor(null, ARMOR_BOMB) + mob_bomb_defense
 	switch (severity)
 		if (1)
@@ -159,7 +159,7 @@
 		return 1
 	return 0
 
-/mob/living/carbon/human/var/co2overloadtime = null
+/mob/living/carbon/human/var/co2overloadtime
 /mob/living/carbon/human/var/temperature_resistance = T0C+75
 
 
@@ -167,7 +167,7 @@
 	if(user.incapacitated()  || !user.Adjacent(src))
 		return
 
-	var/obj/item/clothing/under/suit = null
+	var/obj/item/clothing/under/suit
 	if (istype(w_uniform, /obj/item/clothing/under))
 		suit = w_uniform
 
@@ -312,7 +312,7 @@ var/list/rank_prefix = list(\
 
 //Removed the horrible safety parameter. It was only being used by ninja code anyways.
 //Now checks siemens_coefficient of the affected area by default
-/mob/living/carbon/human/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, def_zone = null)
+/mob/living/carbon/human/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, def_zone)
 	if(status_flags & GODMODE)	return 0	//godmode
 
 	if (!def_zone)
@@ -1163,20 +1163,20 @@ var/list/rank_prefix = list(\
 		checkprefcruciform = TRUE
 		qdel(CI)
 
-	for(var/obj/item/organ/organ in (organs|internal_organs))
-		qdel(organ)
-
-	if(organs.len)
-		organs.Cut()
-	if(internal_organs.len)
-		internal_organs.Cut()
-	if(organs_by_name.len)
-		organs_by_name.Cut()
-	if(internal_organs_by_name.len)
-		internal_organs_by_name.Cut()
-
 
 	if(from_preference)
+		for(var/obj/item/organ/organ in (organs|internal_organs))
+			qdel(organ)
+
+		if(organs.len)
+			organs.Cut()
+		if(internal_organs.len)
+			internal_organs.Cut()
+		if(organs_by_name.len)
+			organs_by_name.Cut()
+		if(internal_organs_by_name.len)
+			internal_organs_by_name.Cut()
+
 		var/datum/preferences/Pref
 		if(istype(from_preference, /datum/preferences))
 			Pref = from_preference
@@ -1220,10 +1220,16 @@ var/list/rank_prefix = list(\
 
 		for(var/limb_tag in species.has_limbs)
 			var/datum/organ_description/OD = species.has_limbs[limb_tag]
+			var/obj/item/I = organs_by_name[limb_tag]
+			if(I && I.type == OD.default_type)
+				continue
 			OD.create_organ(src)
 
 		for(var/organ_tag in species.has_organ)
 			organ_type = species.has_organ[organ_tag]
+			var/obj/item/I = internal_organs_by_name[organ_tag]
+			if(I && I.type == organ_type)
+				continue
 			new organ_type(src)
 
 		if(checkprefcruciform)
@@ -1400,7 +1406,7 @@ var/list/rank_prefix = list(\
 
 	var/mob/S = src
 	var/mob/U = usr
-	var/self = null
+	var/self
 	if(S == U)
 		self = 1 // Removing object from yourself.
 


### PR DESCRIPTION

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: revive proc no longer destroys organs, it only heals them.
fix: revive proc no longer causes the target to lose their cruciform.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
