### PR TITLE
[BOUNTY] Posibrains now give more feedback regarding player eligibility to aspiring ghosts

### DIFF
--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -41,7 +41,7 @@ GLOBAL_LIST_EMPTY(ghost_trap_users)
 // Check for bans, proper atom types, etc.
 /datum/ghosttrap/proc/assess_candidate(mob/observer/ghost/candidate, mob/target, check_respawn_timer=TRUE)
 	if(check_respawn_timer)
-		if(!candidate.MayRespawn(0, respawn_type ? respawn_type : CREW))
+		if(!candidate.MayRespawn(1, respawn_type ? respawn_type : CREW))
 			return 0
 	if(islist(ban_checks))
 		for(var/bantype in ban_checks)
@@ -64,10 +64,12 @@ GLOBAL_LIST_EMPTY(ghost_trap_users)
 	for(var/mob/observer/ghost/O in GLOB.player_list)
 		src.respawn_type = respawn_type
 		if(!O.MayRespawn(0, respawn_type))
+			to_chat(O, "[request_string] However, you are not currently able to respawn, and thus are not eligible.")
 			continue
 		if(islist(ban_checks))
 			for(var/bantype in ban_checks)
 				if(jobban_isbanned(O, "[bantype]"))
+					to_chat(O, "[request_string] However, you are banned from playing it.")
 					continue
 		if(pref_check && !(pref_check in O.client.prefs.be_special_role))
 			continue

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -33,9 +33,11 @@
 		M.show_message(SPAN_NOTICE("The positronic brain buzzes quietly, and the golden lights fade away. Perhaps you could try again?"))
 
 /obj/item/device/mmi/digital/posibrain/attack_ghost(var/mob/observer/ghost/user)
-	if(!searching || (src.brainmob && src.brainmob.key))
+	if(src.brainmob && src.brainmob.key)
 		return
-
+	if(!searching)
+		to_chat(user, SPAN_WARNING("The positronic brain has to be activated before you can enter it."))
+		return
 	var/datum/ghosttrap/G = get_ghost_trap("positronic brain")
 	if(!G.assess_candidate(user, check_respawn_timer = FALSE))
 		return


### PR DESCRIPTION
Posibrains will now inform
- Deadchat about whether they can use a posibrain (which includes if they can respawn and if they are jobbanned)
- Ghosts that use it whether they are eligible to play it (which includes if the posibrain is currently active and searching for ghosts, if the player can respawn and if the player is jobbanned)


:cl:
tweak: Players will now receive more feedback regarding their eligibility to use posibrains. Remember that you have to be able to respawn as a crewmember before you can become a robot!
/:cl: