### PR TITLE
Corrects Mandella's design calling it a .35 when its a .25

### DIFF
--- a/code/datums/autolathe/guns.dm
+++ b/code/datums/autolathe/guns.dm
@@ -1,4 +1,10 @@
 
+// .25 handguns
+
+/datum/design/autolathe/gun/mandella
+	name = "FS HG .25 Auto \"Mandella\""
+	build_path = /obj/item/weapon/gun/projectile/mandella
+
 // .35 handguns
 
 /datum/design/autolathe/gun/olivaw
@@ -24,10 +30,6 @@
 /datum/design/autolathe/gun/mk58_wood
 	name = "NT HG .35 \"Mk58\""
 	build_path = /obj/item/weapon/gun/projectile/mk58/wood
-
-/datum/design/autolathe/gun/mandella
-	name = "FS HG .35 Auto \"Mandella\""
-	build_path = /obj/item/weapon/gun/projectile/mandella
 
 /datum/design/autolathe/gun/colt
 	name = "FS HG .35 Auto \"Colt M1911\""


### PR DESCRIPTION

## About The Pull Request
Simply moves the Mandella up on the list and corrects its name being .35 to .25 as thats its caliber 

## Why It's Good For The Game
Simple miss-caliber correct, help against confusion

## Changelog
:cl:
fix: Fixed the .25 Mandella being called .35 in its linense
/:cl: