### PR TITLE
Fixes lots of divided by zero SM runtimes

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -348,7 +348,7 @@
 		var/distance = get_dist(R, src)
 		if(distance <= 15)
 			//for collectors using standard plasma tanks at 1013 kPa, the actual power generated will be this transfer_energy*20*29 = transfer_energy*580
-			R.receive_pulse(transfer_energy * (min(3/distance, 1))**2)
+			R.receive_pulse(transfer_energy * (min(3/(distance != 0 ? distance : 1), 1))**2)
 
 
 /obj/machinery/power/supermatter/attackby(obj/item/weapon/W as obj, mob/living/user as mob)


### PR DESCRIPTION
Lazy fix vs finding exactly why the 0 is created and painstakingly making sure it will never become zero but it'll work.

![image](https://user-images.githubusercontent.com/24533979/94869742-8fe17180-040b-11eb-82f5-3e4b6dc73a83.png)


## Changelog
:cl: Hopek
fix: The SM no longer divides by zero creating thousands of runtime errors
/:cl:
