### PR TITLE
EMT Belt Redux

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -95,29 +95,26 @@
 	icon_state = "medicalbelt"
 	item_state = "medical"
 	can_hold = list(
+		/obj/item/bodybag,
+		/obj/item/clothing/mask/surgical,
+		/obj/item/clothing/head/surgery,
+		/obj/item/clothing/gloves/latex,
+		/obj/item/clothing/glasses/hud/health,
 		/obj/item/device/scanner/health,
-		/obj/item/weapon/dnainjector,
 		/obj/item/device/radio/headset,
+		/obj/item/device/lighting/toggleable/flashlight,
+		/obj/item/weapon/dnainjector,
+		/obj/item/weapon/reagent_containers/blood,
 		/obj/item/weapon/reagent_containers/dropper,
 		/obj/item/weapon/reagent_containers/glass/beaker,
 		/obj/item/weapon/reagent_containers/glass/bottle,
 		/obj/item/weapon/reagent_containers/pill,
 		/obj/item/weapon/reagent_containers/syringe,
+		/obj/item/weapon/reagent_containers/hypospray,
 		/obj/item/weapon/flame/lighter,
 		/obj/item/weapon/cell/small,
 		/obj/item/weapon/storage/fancy/cigarettes,
 		/obj/item/weapon/storage/pill_bottle,
-		/obj/item/stack/medical,
-		/obj/item/clothing/mask/surgical,
-		/obj/item/clothing/head/surgery,
-		/obj/item/clothing/gloves,
-		/obj/item/weapon/reagent_containers/hypospray,
-		/obj/item/clothing/glasses,
-		/obj/item/weapon/tool/crowbar,
-		/obj/item/device/lighting/toggleable/flashlight,
-		/obj/item/weapon/extinguisher/mini,
-		/obj/item/stack/nanopaste,
-		/obj/item/bodybag,
 		/obj/item/weapon/tool/bonesetter,
 		/obj/item/weapon/tool/scalpel,
 		/obj/item/weapon/tool/scalpel/advanced,
@@ -127,12 +124,9 @@
 		/obj/item/weapon/tool/retractor,
 		/obj/item/weapon/tool/saw/circular,
 		/obj/item/weapon/tool/hemostat,
-		/obj/item/weapon/reagent_containers/pill,
-		/obj/item/weapon/storage/pill_bottle,
-		/obj/item/bodybag/cryobag,
-		/obj/item/clothing/gloves,
-		/obj/item/clothing/glasses,
-		/obj/item/weapon/reagent_containers/blood
+		/obj/item/stack/medical,
+		/obj/item/stack/nanopaste,
+		/obj/item/taperoll/medical
 	)
 
 /obj/item/weapon/storage/belt/medical/emt
@@ -140,50 +134,11 @@
 	desc = "A sturdy black webbing belt with attached pouches."
 	icon_state = "emsbelt"
 	item_state = "emsbelt"
-	can_hold = list(
-		/obj/item/device/scanner/health,
-		/obj/item/weapon/dnainjector,
-		/obj/item/device/radio/headset,
-		/obj/item/weapon/reagent_containers/dropper,
-		/obj/item/weapon/reagent_containers/glass/beaker,
-		/obj/item/weapon/reagent_containers/glass/bottle,
-		/obj/item/weapon/reagent_containers/pill,
-		/obj/item/weapon/reagent_containers/syringe,
-		/obj/item/weapon/flame/lighter,
-		/obj/item/weapon/cell/small,
-		/obj/item/weapon/storage/fancy/cigarettes,
-		/obj/item/weapon/storage/pill_bottle,
-		/obj/item/stack/medical,
-		/obj/item/clothing/mask/surgical,
-		/obj/item/clothing/head/surgery,
-		/obj/item/clothing/gloves,
-		/obj/item/weapon/reagent_containers/hypospray,
-		/obj/item/clothing/glasses,
-		/obj/item/weapon/tool/crowbar,
-		/obj/item/device/lighting/toggleable/flashlight,
-		/obj/item/weapon/extinguisher/mini,
-		/obj/item/stack/nanopaste,
-		/obj/item/bodybag,
-		/obj/item/weapon/tool/bonesetter,
-		/obj/item/weapon/tool/scalpel,
-		/obj/item/weapon/tool/scalpel/advanced,
-		/obj/item/weapon/tool/scalpel/laser,
-		/obj/item/weapon/tool/surgicaldrill,
-		/obj/item/weapon/tool/cautery,
-		/obj/item/weapon/tool/retractor,
-		/obj/item/weapon/tool/saw/circular,
-		/obj/item/weapon/tool/hemostat,
-		/obj/item/weapon/reagent_containers/pill,
-		/obj/item/weapon/storage/pill_bottle,
-		/obj/item/bodybag/cryobag,
-		/obj/item/weapon/inflatable_dispenser,
+	can_hold_extra = list(
 		/obj/item/device/radio/off,
-		/obj/item/taperoll/medical,
+		/obj/item/weapon/inflatable_dispenser,
 		/obj/item/weapon/tool/crowbar,
-		/obj/item/weapon/extinguisher/mini,
-		/obj/item/clothing/gloves,
-		/obj/item/clothing/glasses
-
+		/obj/item/weapon/extinguisher/mini
 	)
 
 /obj/item/weapon/storage/belt/tactical


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes "can_hold" on the EMT belt, put it to a few extra items. Removed fun away from the medical belt, like being able to hold all clothing subtypes for gloves and glasses. Removed additional redundant entries on the list.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Removing fun is a tested and true design strategy, full /tg/-approval for these changes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Medical belts may only hold latex and medical HUDs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
