### PR TITLE
Fixes repeating medical_stand.dm runtime

### DIFF
--- a/code/game/objects/structures/medical_stand.dm
+++ b/code/game/objects/structures/medical_stand.dm
@@ -392,7 +392,7 @@
 			if(internalsHud)
 				internalsHud.icon_state = "internal0"
 			breather.internal = null
-	else if (valve_opened)
+	else if (tank && valve_opened)
 		var/datum/gas_mixture/removed = tank.remove_air(0.01)
 		var/datum/gas_mixture/environment = loc.return_air()
 		environment.merge(removed)


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/24533979/94876665-f7a0b800-041d-11eb-9c6d-f431e52d6ce4.png)


## Changelog
:cl: Hopek
fix: The medical stand no longer runtimes a few thousand times per round.
/:cl:
