### PR TITLE
Tool spawn tweaks

### DIFF
--- a/code/__DEFINES/spawner.dm
+++ b/code/__DEFINES/spawner.dm
@@ -450,3 +450,11 @@
 #define SPAWN_TAG_SPAWNER_SCRAP "spawner,spawner_scrap"
 #define SPAWN_TAG_SPAWNER_LARGE_SCRAP "spawner,spawner_scrap,spawner_large_scrap"
 
+// FACTION KEYWORDS
+#define SPAWN_ASTERS "asters"
+#define SPAWN_FROZEN_STAR "frozen_star"
+#define SPAWN_IRONHAMMER "ironhammer"
+#define SPAWN_NANOTRASEN "nanotrasen"
+#define SPAWN_NEOTHEOLOGY "neotheology"
+#define SPAWN_MOEBIUS "moebius"
+#define SPAWN_SERBIAN "serbian"

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -16,6 +16,7 @@
 
 	//spawn values
 	bad_types = /obj/item/weapon/tool
+	spawn_tags = SPAWN_TAG_TOOL
 
 	var/tool_in_use = FALSE
 

--- a/code/game/objects/items/weapons/tools/crowbars.dm
+++ b/code/game/objects/items/weapons/tools/crowbars.dm
@@ -22,6 +22,7 @@
 	degradation = 5 //This one breaks REALLY fast
 	max_upgrades = 5 //all makeshift tools get more mods to make them actually viable for mid-late game
 	rarity_value = 2
+	spawn_tags = SPAWN_TAG_TOOL_TAG_JUNK
 
 /obj/item/weapon/tool/crowbar/onestar
 	name = "One Star crowbar"

--- a/code/game/objects/items/weapons/tools/hammer.dm
+++ b/code/game/objects/items/weapons/tools/hammer.dm
@@ -28,6 +28,8 @@
 	tool_qualities = list(QUALITY_HAMMERING = 15)
 	matter = list(MATERIAL_STEEL = 15, MATERIAL_PLASTIC = 1)
 	max_upgrades = 5
+	spawn_tags = SPAWN_TAG_TOOL_TAG_JUNK
+	rarity_value = 32
 
 /obj/item/weapon/tool/hammer/powered_hammer //to be made into proper two-handed tool as small "powered" hammer doesn't make sense
 	name = "powered hammer"					//lacks normal sprites, both icon, item and twohanded for this
@@ -74,11 +76,10 @@
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "mace"
 	item_state = "mace"
-
 	armor_penetration = ARMOR_PEN_DEEP
 	force = WEAPON_FORCE_DANGEROUS
-
 	tool_qualities = list(QUALITY_HAMMERING = 20)
+	spawn_tags = SPAWN_TAG_WEAPON
 
 /obj/item/weapon/tool/hammer/mace/makeshift
 	name = "makeshift mace"
@@ -91,6 +92,8 @@
 	tool_qualities = list(QUALITY_HAMMERING = 15)
 	degradation = 5 //This one breaks REALLY fast
 	max_upgrades = 5 //all makeshift tools get more mods to make them actually viable for mid-late game
+	rarity_value = 30
+	spawn_tags = SPAWN_TAG_JUNK
 
 /obj/item/weapon/tool/hammer/charge
 	name = "charge hammer"
@@ -107,6 +110,8 @@
 	slot_flags = SLOT_BACK
 	suitable_cell = /obj/item/weapon/cell/medium
 	use_power_cost = 15
+	rarity_value = 100
+	spawn_frequency = 4
 	var/datum/effect/effect/system/trail/T
 	var/last_launch
 

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -51,7 +51,6 @@
 	name = "reinforced plating"
 	desc = "A sturdy bit of plasteel that can be bolted onto any tool to protect it. Tough, but bulky."
 	icon_state = "plate"
-	rarity_value = 10
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 2) //steel to compensate for metal rods used in crafting
 
 /obj/item/weapon/tool_upgrade/reinforcement/plating/New()

--- a/code/game/objects/items/weapons/tools/saws.dm
+++ b/code/game/objects/items/weapons/tools/saws.dm
@@ -13,7 +13,6 @@
 	edge = TRUE
 	tool_qualities = list(QUALITY_SAWING = 30, QUALITY_CUTTING = 20, QUALITY_WIRE_CUTTING = 20)
 	embed_mult = 1 //Serrated blades catch on bone more easily
-	rarity_value = 6
 
 /obj/item/weapon/tool/saw/improvised //tier 1
 	name = "choppa"
@@ -23,6 +22,7 @@
 	tool_qualities = list(QUALITY_SAWING = 15, QUALITY_CUTTING = 10, QUALITY_WIRE_CUTTING = 10)
 	degradation = 1
 	max_upgrades = 5 //all makeshift tools get more mods to make them actually viable for mid-late game
+	spawn_tags = SPAWN_TAG_TOOL_TAG_JUNK
 	rarity_value = 3
 
 /obj/item/weapon/tool/saw/circular //tier 3

--- a/code/game/objects/items/weapons/tools/scalpels.dm
+++ b/code/game/objects/items/weapons/tools/scalpels.dm
@@ -64,3 +64,4 @@
 	tool_qualities = list(QUALITY_CUTTING = 15, QUALITY_WIRE_CUTTING = 5, QUALITY_DRILLING = 5)
 	degradation = 4 //Gets worse with use
 	max_upgrades = 5 //all makeshift tools get more mods to make them actually viable for mid-late game
+	spawn_tags = SPAWN_TAG_TOOL_TAG_JUNK

--- a/code/game/objects/items/weapons/tools/screwdrivers.dm
+++ b/code/game/objects/items/weapons/tools/screwdrivers.dm
@@ -19,6 +19,7 @@
 	degradation = 2
 	max_upgrades = 5 //all makeshift tools get more mods to make them actually viable for mid-late game
 	rarity_value = 3
+	spawn_tags = SPAWN_TAG_TOOL_TAG_JUNK
 
 /obj/item/weapon/tool/screwdriver/electric
 	name = "electric screwdriver"

--- a/code/game/objects/items/weapons/tools/shovel.dm
+++ b/code/game/objects/items/weapons/tools/shovel.dm
@@ -24,6 +24,7 @@
 	degradation = 1.5
 	max_upgrades = 5 //all makeshift tools get more mods to make them actually viable for mid-late game
 	rarity_value = 4.8
+	spawn_tags = SPAWN_TAG_TOOL_TAG_JUNK
 
 /obj/item/weapon/tool/shovel/spade
 	name = "spade"

--- a/code/game/objects/items/weapons/tools/tape.dm
+++ b/code/game/objects/items/weapons/tools/tape.dm
@@ -13,7 +13,6 @@
 	flags = NOBLUDGEON //Its not a weapon
 	max_upgrades = 0 //These are consumable, so no wasting upgrades on them
 	rarity_value = 4
-	spawn_tags = SPAWN_TAG_TOOL_TAG_JUNK
 
 /obj/item/weapon/tool/tape_roll/web
 	name = "web tape"
@@ -23,7 +22,7 @@
 	max_stock = 30
 	alpha = 150
 	rarity_value = 2
-	spawn_tags = SPAWN_TAG_TOOL
+	spawn_tags = SPAWN_TAG_TOOL_TAG_JUNK
 
 /obj/item/weapon/tool/tape_roll/fiber
 	name = "fiber tape"
@@ -33,6 +32,7 @@
 	matter = list(MATERIAL_PLASTIC = 20)
 	use_stock_cost = 0.10
 	max_stock = 100
+	spawn_frequency = 8
 	rarity_value = 24
 	spawn_tags = SPAWN_TAG_TOOL_ADVANCED
 
@@ -122,8 +122,10 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "tape"
 	w_class = ITEM_SIZE_TINY
-	layer = 4
-	anchored = 1 //it's sticky, no you cant move it
+	layer = BELOW_MOB_LAYER
+	anchored = TRUE //it's sticky, no you cant move it
+	spawn_frequency = 0
+	bad_types = /obj/item/weapon/ducttape
 
 	var/obj/item/weapon/stuck
 

--- a/code/game/objects/items/weapons/tools/weldingtools.dm
+++ b/code/game/objects/items/weapons/tools/weldingtools.dm
@@ -49,12 +49,13 @@
 	desc = "An assembly of pipes attached to a little gas tank. Serves capably as a welder, though a bit risky. Can be improved greatly with large amount of tool mods."
 	icon_state = "ghettowelder"
 	item_state = "ghettowelder"
-	rarity_value = 3
 	switched_on_force = WEAPON_FORCE_PAINFUL * 0.8
 	max_fuel = 15
 	switched_on_qualities = list(QUALITY_WELDING = 15, QUALITY_CAUTERIZING = 10, QUALITY_WIRE_CUTTING = 10)
 	degradation = 1.5
 	max_upgrades = 5 //all makeshift tools get more mods to make them actually viable for mid-late game
+	rarity_value = 4
+	spawn_tags = SPAWN_TAG_TOOL_TAG_JUNK
 
 //The improvised welding tool is created with a full tank of fuel.
 //It's implied that it's burning the oxygen in the emergency tank that was used to create it
@@ -94,4 +95,3 @@
 	spawn_blacklisted = TRUE
 	rarity_value = 10
 	spawn_tags = SPAWN_TAG_OS_TOOL
-

--- a/code/game/objects/items/weapons/tools/wirecutters.dm
+++ b/code/game/objects/items/weapons/tools/wirecutters.dm
@@ -24,6 +24,7 @@
 	degradation = 1.5
 	max_upgrades = 5 //all makeshift tools get more mods to make them actually viable for mid-late game
 	rarity_value = 6
+	spawn_tags = SPAWN_TAG_TOOL_TAG_JUNK
 
 /obj/item/weapon/tool/wirecutters/armature
 	name = "armature cutter"

--- a/code/game/objects/items/weapons/tools/wrenches.dm
+++ b/code/game/objects/items/weapons/tools/wrenches.dm
@@ -22,6 +22,7 @@
 	matter = list(MATERIAL_STEEL = 1)
 	max_upgrades = 5 //all makeshift tools get more mods to make them actually viable for mid-late game
 	rarity_value = 3
+	spawn_tags = SPAWN_TAG_TOOL_TAG_JUNK
 
 /obj/item/weapon/tool/wrench/big_wrench
 	name = "big wrench"

--- a/code/game/objects/random/tools.dm
+++ b/code/game/objects/random/tools.dm
@@ -3,7 +3,7 @@
 	icon_state = "tool-grey"
 	spawn_nothing_percentage = 15
 	tags_to_spawn = list(SPAWN_TOOL, SPAWN_DIVICE, SPAWN_GLOVES_INSULATED, SPAWN_JETPACK, SPAWN_ITEM_UTILITY)
-	restricted_tags = list(SPAWN_SURGERY_TOOL, SPAWN_KNIFE)
+	restricted_tags = list(SPAWN_SURGERY_TOOL, SPAWN_KNIFE, SPAWN_JUNK)
 
 //Randomly spawned tools will often be in imperfect condition if they've been left lying out
 /obj/spawner/tool/post_spawn(list/spawns)

--- a/code/modules/research/experiment.dm
+++ b/code/modules/research/experiment.dm
@@ -232,7 +232,8 @@ GLOBAL_LIST_EMPTY(explosion_watcher_list)
 	matter = list(MATERIAL_STEEL = 5)
 	origin_tech = list(TECH_ENGINEERING = 1, TECH_BIO = 1)
 	spawn_tags = SPAWN_TAG_DIVICE_SCIENCE
-	rarity_value = 7.5
+	spawn_frequency = 5
+	rarity_value = 8
 
 	var/datum/experiment_data/experiments
 	var/list/scanned_autopsy_weapons = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tool spawner will no longer spawn only from a list of duct tape. Circular saws will no longer dominate places where surgical tools randomly spawn.

Tool spawners will no longer spawn items with the "junk" tag. Added junk tag to all improvised tools.

Adjusted various rarity values on tools, and removed reinforced plating's lower rarity value.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better, more varied, item spawns.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Tool spawners will no longer spawn items with the "junk" tag. Added junk tag to all improvised tools.
balance: Adjusted various rarity values on tools, and removed reinforced plating's lower rarity value.
fix: Tool spawner will no longer spawn only from a list of duct tape. Circular saws will no longer dominate places where surgical tools randomly spawn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
