### PR TITLE
Revert "[BOUNTY] QoL: Press E to put in backpack . Press shift + e to put things in your belt"

### DIFF
--- a/code/modules/mob/inventory/equip.dm
+++ b/code/modules/mob/inventory/equip.dm
@@ -125,16 +125,3 @@ var/list/slot_equipment_priority = list(
 			Item.forceMove(src.back)
 			return backpack
 	return ..()
-/mob/living/carbon/human/proc/quick_equip_storage(obj/item/Item)
-	if(istype(src.back,/obj/item/weapon/storage))
-		var/obj/item/weapon/storage/backpack = src.back
-		backpack.attackby(Item,src)
-		return TRUE
-	return FALSE
-/mob/living/carbon/human/proc/quick_equip_belt(obj/item/Item)
-	if(istype(src.belt,/obj/item/weapon/storage/))
-		var/obj/item/weapon/storage/B= src.belt
-		B.attackby(Item,src)
-		return TRUE
-	return FALSE
-

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -11,21 +11,8 @@ This saves us from having to call add_fingerprint() any time something is put in
 	if(!I)
 		to_chat(src, SPAN_NOTICE("You are not holding anything to equip."))
 		return
-	if(quick_equip_storage(I))
-		return
 	if(!equip_to_appropriate_slot(I))
 		to_chat(src, SPAN_WARNING("You are unable to equip that."))
-
-/mob/living/carbon/human/verb/belt_equip()
-	set name = "belt-equip"
-	set hidden = 1
-
-	var/obj/item/I = get_active_hand()
-	if(!I)
-		to_chat(src, SPAN_NOTICE("You are not holding anything to equip."))
-		return
-	if(quick_equip_belt(I))
-		return
 
 //Puts the item into our active hand if possible. returns 1 on success.
 /mob/living/carbon/human/put_in_active_hand(var/obj/item/W)

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -67,7 +67,6 @@ Hotkey-Mode: (hotkey-mode must be on)
 \tw = up
 \tq = drop
 \te = equip
-\tShift+e = belt-equip
 \tr = throw
 \tt = say
 \t5 = emote

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -555,10 +555,7 @@ macro "hotkeymode"
 	elem 
 		name = "E"
 		command = "quick-equip"
-	elem
-		name = "SHIFT+E"
-		command = "belt-equip"
-	elem  
+	elem 
 		name = "CTRL+E"
 		command = "quick-equip"
 	elem 


### PR DESCRIPTION
Reverts discordia-space/CEV-Eris#5528 

Merge if https://github.com/discordia-space/CEV-Eris/pull/5543 isn't ready by server launch.

🆑
fix: Reverted "You can now put items easily into your backpack with E and into your belt with Shift E" due to bugs.
/🆑