### PR TITLE
Crafting hotfix

### DIFF
--- a/code/datums/craft/step.dm
+++ b/code/datums/craft/step.dm
@@ -105,15 +105,10 @@
 			building = FALSE
 			return
 
-	if(req_amount)
-		if(istype(I, /obj/item/stack))
-			var/obj/item/stack/S = I
-			if(!S.can_use(req_amount))
-				to_chat(user, "Not enough items in [I]")
-				building = FALSE
-				return
-		else
-			to_chat(user, "This isn't a stack!")
+	if(req_amount && istype(I, /obj/item/stack))
+		var/obj/item/stack/S = I
+		if(!S.can_use(req_amount))
+			to_chat(user, "Not enough items in [I]")
 			building = FALSE
 			return
 


### PR DESCRIPTION
Silly of me to assume that single-item crafting steps wouldn't use req_amount

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reverts a change I made to req_amount in crafting steps, it no longer fails if the object in question is not a stack.

## Why It's Good For The Game

You can craft shivs again.

