### PR TITLE
Non-excel can no longer use the excelsior teleporter

### DIFF
--- a/code/game/machinery/excelsior/ex_teleporter.dm
+++ b/code/game/machinery/excelsior/ex_teleporter.dm
@@ -20,7 +20,7 @@ var/global/excelsior_last_draft = 0
 	var/energy_gain = 1
 	var/processing_order = FALSE
 	var/nanoui_menu = 0 	// Based on Uplink
-	var/mob/current_user 
+	var/mob/current_user
 	var/time_until_scan
 
 	var/reinforcements_delay = 20 MINUTES
@@ -186,7 +186,7 @@ var/global/excelsior_last_draft = 0
 			) // list in a list because Byond merges the first list...
 
 	data["materials_list"] = order_list_m
-	
+
 	var/list/order_list_p = list()
 	for(var/item in parts_list)
 		var/obj/item/I = item
@@ -326,7 +326,7 @@ var/global/excelsior_last_draft = 0
 		teleport_out(affecting, user)
 		excelsior_conscripts += 1
 		return
-	
+
 	visible_message("\the [src] blinks, refusing [affecting].")
 	playsound(src.loc, 'sound/machines/ping.ogg', 50, 1 -3)
 /obj/machinery/complant_teleporter/proc/teleport_out(var/mob/living/affecting, var/mob/living/user)

--- a/nano/templates/excelsior_teleporter.tmpl
+++ b/nano/templates/excelsior_teleporter.tmpl
@@ -1,7 +1,7 @@
-<!-- 
+<!--
 Used In File(s): code/game/machinery/excelsior/ex_teleporter.dm
  -->
-{{:helper.excelsiorMode()}} 
+{{:helper.excelsiorMode()}}
 <h2>Welcome Comrade</h2>
 {{if data.menu == 0}}
 	<div class="item">
@@ -21,7 +21,7 @@ Used In File(s): code/game/machinery/excelsior/ex_teleporter.dm
 			<div class="itemContent">
 				- {{:data.time_until_scan}}
 			</div>
-		</div>		
+		</div>
 		<div class="item">
 			<div class="itemLabel">
 				Mandates:
@@ -42,7 +42,7 @@ Used In File(s): code/game/machinery/excelsior/ex_teleporter.dm
 			</table>
 		</div>
 		</div>
-	{{/if}}
+
 	<div class="item">
 		<div class="itemLabel" style="width: 100%;">
 			Materials:
@@ -80,7 +80,7 @@ Used In File(s): code/game/machinery/excelsior/ex_teleporter.dm
 			</tr>
 		{{/for}}
 	</table>
-	
+{{/if}}
 {{else data.menu == 1}}
 	<h2>Available Mandates:</h2>
 	<div class="item">


### PR DESCRIPTION
## About The Pull Request 

This locks the excel teleporter to only being usable by excelsior

## Why It's Good For The Game

No more invalidating 90% of the ship through one stash. A little boring, but the straightforward method of dealing with it.

## Changelog
:cl:
balance: The excelsior teleporter is now only usable by excelsior.
/:cl:
