### PR TITLE
Removes the excel teleporter from random excel stashes

### DIFF
--- a/code/modules/stashes/stash_types/excelsior.dm
+++ b/code/modules/stashes/stash_types/excelsior.dm
@@ -17,7 +17,6 @@
 	/obj/item/weapon/gun/projectile/automatic/ak47 = 30,
 	/obj/item/ammo_magazine/lrifle = 50,
 	/obj/item/ammo_magazine/lrifle = 50,
-	//obj/item/weapon/electronics/circuitboard/excelsior_teleporter = 30,
 	)
 	weight = 0.5
 

--- a/code/modules/stashes/stash_types/excelsior.dm
+++ b/code/modules/stashes/stash_types/excelsior.dm
@@ -17,7 +17,8 @@
 	/obj/item/weapon/gun/projectile/automatic/ak47 = 30,
 	/obj/item/ammo_magazine/lrifle = 50,
 	/obj/item/ammo_magazine/lrifle = 50,
-	/obj/item/weapon/electronics/circuitboard/excelsior_teleporter = 30)
+	//obj/item/weapon/electronics/circuitboard/excelsior_teleporter = 30,
+	)
 	weight = 0.5
 
 /datum/stash/excelsior/shipyard

--- a/code/modules/stashes/stash_types/excelsior.dm
+++ b/code/modules/stashes/stash_types/excelsior.dm
@@ -16,7 +16,7 @@
 	/obj/item/weapon/gun/projectile/automatic/ak47 = 30,
 	/obj/item/weapon/gun/projectile/automatic/ak47 = 30,
 	/obj/item/ammo_magazine/lrifle = 50,
-	/obj/item/ammo_magazine/lrifle = 50,
+	/obj/item/ammo_magazine/lrifle = 50
 	)
 	weight = 0.5
 


### PR DESCRIPTION
## About The Pull Request 

Removes the excelsior teleporter board from random excel stashes.

## Why It's Good For The Game

Excelsior teleporter invalidates 90% of the ship. This way the only way to get an excel teleporter is through raiding an actual excel base.

## Changelog
:cl:
balance: The excelsior teleporter board no longer shows up in randomly generated excel stashes.
/:cl:


