### PR TITLE
Fixes some DMM code, instigates Roomba re-emergence in dungeon rooms.

### DIFF
--- a/maps/submaps/dungeon_rooms/rooms/1.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/1.dmm
@@ -26,7 +26,7 @@
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/crawler)
 "h" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/crawler)
 

--- a/maps/submaps/dungeon_rooms/rooms/Escape_Pod_West-East.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/Escape_Pod_West-East.dmm
@@ -31,7 +31,7 @@
 /turf/simulated/wall/untinted/onestar,
 /area/crawler)
 "j" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/techmaint,
 /area/crawler)
 

--- a/maps/submaps/dungeon_rooms/rooms/Hallway_4way.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/Hallway_4way.dmm
@@ -29,7 +29,7 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "h" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "j" = (

--- a/maps/submaps/dungeon_rooms/rooms/Hallway_North-South.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/Hallway_North-South.dmm
@@ -28,11 +28,11 @@
 /turf/simulated/wall/untinted/onestar,
 /area/crawler)
 "h" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/grass,
 /area/crawler)
 "i" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "j" = (

--- a/maps/submaps/dungeon_rooms/rooms/anomaly.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/anomaly.dmm
@@ -137,7 +137,7 @@
 /turf/simulated/floor/plating/under,
 /area/crawler)
 "x" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/crawler)
 "y" = (

--- a/maps/submaps/dungeon_rooms/rooms/armory.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/armory.dmm
@@ -72,7 +72,7 @@
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/crawler)
 "o" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/crawler)
 "p" = (

--- a/maps/submaps/dungeon_rooms/rooms/armory_secure.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/armory_secure.dmm
@@ -47,7 +47,7 @@
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/crawler)
 "k" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /obj/spawner/firstaid,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/crawler)
@@ -61,7 +61,7 @@
 /turf/simulated/floor/tiled/dark/cargo,
 /area/crawler)
 "n" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba, 
 /obj/spawner/contraband,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/crawler)

--- a/maps/submaps/dungeon_rooms/rooms/autolathe_South-East.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/autolathe_South-East.dmm
@@ -50,7 +50,7 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/crawler)
 "o" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/crawler)
 "p" = (
@@ -87,7 +87,7 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crawler)
 "x" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/crawler)
 "y" = (
@@ -116,7 +116,7 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/crawler)
 "E" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/crawler)
 "F" = (

--- a/maps/submaps/dungeon_rooms/rooms/cargo_horizontal.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/cargo_horizontal.dmm
@@ -54,7 +54,7 @@
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/crawler)
 "l" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/crawler)
 "m" = (
@@ -87,11 +87,11 @@
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/crawler)
 "s" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/crawler)
 "t" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/crawler)
 "u" = (

--- a/maps/submaps/dungeon_rooms/rooms/cargo_vertical.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/cargo_vertical.dmm
@@ -109,11 +109,11 @@
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "v" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/crawler)
 "w" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/crawler)
 "x" = (

--- a/maps/submaps/dungeon_rooms/rooms/checkpoint_horizontal.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/checkpoint_horizontal.dmm
@@ -67,7 +67,7 @@
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "n" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "o" = (
@@ -93,7 +93,7 @@
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/crawler)
 "t" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/crawler)
 "u" = (

--- a/maps/submaps/dungeon_rooms/rooms/checkpoint_vertical.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/checkpoint_vertical.dmm
@@ -77,7 +77,7 @@
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "t" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "u" = (
@@ -103,7 +103,7 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "y" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/crawler)
 

--- a/maps/submaps/dungeon_rooms/rooms/crematorium.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/crematorium.dmm
@@ -30,7 +30,7 @@
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "i" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "j" = (

--- a/maps/submaps/dungeon_rooms/rooms/garden.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/garden.dmm
@@ -79,7 +79,7 @@
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "r" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/grass,
 /area/crawler)
 "s" = (

--- a/maps/submaps/dungeon_rooms/rooms/hallway_West-East.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/hallway_West-East.dmm
@@ -28,7 +28,7 @@
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "i" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "l" = (

--- a/maps/submaps/dungeon_rooms/rooms/hallway_executive.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/hallway_executive.dmm
@@ -101,7 +101,7 @@
 /turf/simulated/floor/wood,
 /area/crawler)
 "t" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "u" = (

--- a/maps/submaps/dungeon_rooms/rooms/hallway_storage.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/hallway_storage.dmm
@@ -78,7 +78,7 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/crawler)
 "s" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "t" = (

--- a/maps/submaps/dungeon_rooms/rooms/hallwayatmos_west-east.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/hallwayatmos_west-east.dmm
@@ -144,7 +144,7 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/plating/under,
 /area/crawler)
 "A" = (
@@ -180,7 +180,7 @@
 "E" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/yellow,
 /obj/structure/catwalk,
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/plating/under,
 /area/crawler)
 "F" = (

--- a/maps/submaps/dungeon_rooms/rooms/mechbay.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/mechbay.dmm
@@ -224,7 +224,7 @@
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "Q" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "R" = (
@@ -233,7 +233,7 @@
 /turf/simulated/floor/tiled/dark/panels,
 /area/crawler)
 "S" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 

--- a/maps/submaps/dungeon_rooms/rooms/office.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/office.dmm
@@ -376,7 +376,7 @@
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/crawler)
 "aT" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "aU" = (

--- a/maps/submaps/dungeon_rooms/rooms/penitentiary.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/penitentiary.dmm
@@ -80,7 +80,7 @@
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "t" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "u" = (

--- a/maps/submaps/dungeon_rooms/rooms/refinery.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/refinery.dmm
@@ -198,7 +198,7 @@
 /turf/simulated/floor/plating,
 /area/crawler)
 "M" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/crawler)
 

--- a/maps/submaps/dungeon_rooms/rooms/secure_storage_horizontal.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/secure_storage_horizontal.dmm
@@ -94,7 +94,7 @@
 /area/crawler)
 "q" = (
 /obj/structure/catwalk,
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/plating/under,
 /area/crawler)
 "s" = (

--- a/maps/submaps/dungeon_rooms/rooms/shootingrange.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/shootingrange.dmm
@@ -116,7 +116,7 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "y" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "z" = (

--- a/maps/submaps/dungeon_rooms/rooms/showers.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/showers.dmm
@@ -52,7 +52,7 @@
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "m" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/crawler)
 "n" = (

--- a/maps/submaps/dungeon_rooms/rooms/surgery.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/surgery.dmm
@@ -115,7 +115,7 @@
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "x" = (
-/obj/random/mob/roomba,
+/obj/spawner/mob/roomba,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "y" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR re-adds roombas as they were meant to be implemented but by a mapping typo were left off the dungeon rooms; the most rudimentary form of roomba is harmless as it nuzzles enthusiastically, but its unslowing approach adds more health to the robotic swarm of much meaner roombas. I clean my hands of any balance related injuries as explosive landmine roombas hide amongst their ranks, able to explode; as i simply repaired the code to where they would spawn anyway, and other people would have a much intuition of whether its fair.

My most functional advice is to bring anti-robotic tailored equipment and try not to get caught in a corner. The dungeon doesn't have any doors to hide behind and some tight corners. Stay alert.

- I have not been able to try this successfully when i have compiled to validate with my own eyes due to a strange glossy over effect in observer and a reluctance to load the dungeon. Any advice on the matter would be appreicated. The changes were conducted via a quick notepad tweak of the DMM but i did view the DMM schematics myself to ensure the spawners are placed correctly and it should work with the standard DME.

## Why It's Good For The Game

From multiple perspectives the dungeon rooms will be less empty and more challenging to spelunk through, as previous by the roomba spawners not being there, players could figuratively just take whatever they wanted. More conservation of your valuable ammunition would be required, melee is discouraged.

- Also allows deepmaint DMM's to be opened externally in dream-maker without complaints about incompatible code. Meaning that mappers can now interact with the rooms and help understand enough on how to expand their concept without hitting a barrier.

## Changelog
:cl: fantasticfwoosh
add: A mechanical tide of oneeye roombas have reactivated and now infest the derelict rooms within the deep-maintenance in all their horrible varieties with arnament of weapons varying from gentle nudging to explosives. Tresspass at your peril.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Closes: #5553
