### PR TITLE
Welding eye fix

### DIFF
--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -960,17 +960,6 @@
 			if(E.damage > 10)
 				to_chat(user, SPAN_WARNING("Your eyes are really starting to hurt. This can't be good for you!"))
 
-			if (E.damage >= E.min_broken_damage)
-				to_chat(H, SPAN_DANGER("You go blind!"))
-				H.sdisabilities |= BLIND
-			else if (E.damage >= E.min_bruised_damage)
-				to_chat(H, SPAN_DANGER("You go blind!"))
-				H.eye_blind = 5
-				H.eye_blurry = 5
-				H.disabilities |= NEARSIGHTED
-				spawn(100)
-					H.disabilities &= ~NEARSIGHTED
-
 
 /obj/item/weapon/tool/attack(mob/living/M, mob/living/user, var/target_zone)
 	if(isBroken)

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -44,9 +44,9 @@
 	if(!owner)
 		return
 	if(is_bruised())
-		owner.eye_blurry = 20
+		owner.eye_blurry = 1
 	if(is_broken())
-		owner.eye_blind = 20
+		owner.eye_blind = 1
 	owner.update_client_colour()
 
 /obj/item/organ/internal/eyes/proc/get_colourmatrix() //Returns a special colour matrix if the eyes are organic and the mob is colourblind, otherwise it uses the current one.


### PR DESCRIPTION
No longer will welding tools manipulate your genetics

## About The Pull Request

Using a tool that requires eye protection (Welding tools primarily) used to flick disabilities on and off to emulate flash-blindness. Now it no longer does this, so the eye can handle its own damages

## Why It's Good For The Game
The disability flickings only cure was to genemod yourself. Not something easily done, or intuitive to fix welder-eye.

Now, it can be treated through imidazoline, eye repair surgery, or eye switching surgery.

## Changelog
:cl:
tweak: Welder eye damage now can be treated through surgery or imidazoline.
/:cl:
