### PR TITLE
Stun guns now don't ignore armor.

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -170,7 +170,7 @@
 	nodamage = 1
 	taser_effect = 1
 	agony = 30
-	damage_types = list(HALLOSS = 30)
+	damage_types = list(BURN = 1)
 
 	muzzle_type = /obj/effect/projectile/stun/muzzle
 	tracer_type = /obj/effect/projectile/stun/tracer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stun guns now take account burn(energy) armor and as compensation they get a whopping 1 burn damage.
![hallos more like hell](https://user-images.githubusercontent.com/61743710/94991122-1d929d80-0581-11eb-9755-aecb65a73064.png)
left(naked)(slight delay on refreshing hallos) / right(techno voidsuit)(30% energy) - NT SP "Counselor" used for tests

## Why It's Good For The Game

Making armor choice apply to stun guns is cool, also no more dual wielding 60 hitscan damage a hit with small guns.

## Changelog
:cl: TheShown
balance: stun beams don't bypass armor anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
