### PR TITLE
Random Design Disks from Trade Beacons

### DIFF
--- a/code/modules/trade/datums/trade_stations_presets/zarya.dm
+++ b/code/modules/trade/datums/trade_stations_presets/zarya.dm
@@ -36,7 +36,8 @@
 			/obj/item/clothing/head/welding,
 			/obj/item/weapon/tool/omnitool,
 			/obj/structure/reagent_dispensers/fueltank,
-			/obj/machinery/floodlight
+			/obj/machinery/floodlight,
+			/obj/spawner/lathe_disk
 		)
 	)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can now gamble a small amount of cash at the Zarya to get a random design disk for autolathes. This uses the same spawner for non-advanced design disks, so you're not going to get anything amazing - and it's possible you'll pull a dud, such as an Asters Tool Pack or Moebius Medical disk.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

In order for Cargo to get any good disks to print stuff from, they need to buy from vagabonds or get lucky when a techie is poking through maint. You still need to poke around in maintenance for the advanced disks, but you can at least get some decent ones by buying from the trade beacons.

It also encourages trade beacon use instead of using the shuttle, which is good.

![image](https://user-images.githubusercontent.com/46986487/95025029-c3630c80-0654-11eb-96c1-44682f089021.png)
Pictured above is me asking a maintainer if this was okay.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can now buy autolathe design disks from the 'Zarya' in the cargo trade beacons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
