### PR TITLE
Flashbang sound stun nerf

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -60,11 +60,9 @@
 //Now applying sound
 	if((get_dist(M, T) <= 2 || loc == M.loc || loc == M))
 		if(ear_safety > 0)
-			M.Stun(2*ear_stun_mult)
-			M.Weaken(1*ear_stun_mult)
+			M.Stun(1*ear_stun_mult)
 		else
-			M.Stun(10*ear_stun_mult)
-			M.Weaken(3*ear_stun_mult)
+			M.Stun(5*ear_stun_mult)
 			if ((prob(14) || (M == loc && prob(70))))
 				M.ear_damage += rand(1, 10)
 			else
@@ -73,12 +71,12 @@
 
 	else if(get_dist(M, T) <= 5)
 		if(!ear_safety)
-			M.Stun(8*ear_stun_mult)
+			M.Stun(4*ear_stun_mult)
 			M.ear_damage += rand(0, 3)
 			M.ear_deaf = max(M.ear_deaf,10)
 
 	else if(!ear_safety)
-		M.Stun(4*ear_stun_mult)
+		M.Stun(2*ear_stun_mult)
 		M.ear_damage += rand(0, 1)
 		M.ear_deaf = max(M.ear_deaf,5)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Flashbangs have the `weaken` on the bang proc connected to ear protection removed and the `stun` reduced by 50%. `weaken` and `stun` on the check related to eye protection remain the same. 
## Why It's Good For The Game

Ear protection is almost non-existant in the game, and even *with* ear protection people could stll get knocked down.

## Changelog
:cl: TheShown
balance: Flashbangs no longer knockdown people with eye protection, and the stun on people with eye protection has been further reduced.
/:cl:
