### PR TITLE
Gives club workers access to hydroponics

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -34883,7 +34883,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Hydroponics";
-	req_access = list(35)
+	req_access = list();
+	req_one_access = list(35,28)
 	},
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics)
@@ -37537,7 +37538,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Hydroponics";
-	req_access = list(35)
+	req_access = list();
+	req_one_access = list(35,28)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -50551,7 +50553,8 @@
 "cmf" = (
 /obj/machinery/door/airlock/glass{
 	name = "Hydroponics";
-	req_access = list(35)
+	req_access = list();
+	req_one_access = list(35,28)
 	},
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics)
@@ -56609,7 +56612,8 @@
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Hydroponics";
-	req_access = list(35)
+	req_access = list();
+	req_one_access = list(35,28)
 	},
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics)
@@ -92527,11 +92531,6 @@
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/eris/medical/paramedic)
-"egl" = (
-/obj/machinery/door/firedoor,
-/obj/structure/plasticflaps,
-/turf/simulated/floor/tiled/white/cargo,
-/area/eris/crew_quarters/kitchen)
 "egm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_research{
@@ -99404,6 +99403,9 @@
 	},
 /obj/machinery/firealarm{
 	pixel_y = 28
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/barbackroom)
@@ -203012,7 +203014,7 @@ dXJ
 dXJ
 dUH
 dUH
-egl
+cDI
 cBr
 cCg
 dYS


### PR DESCRIPTION
I can't make your sweet food request because the church are at war with moebius again, sorry.

## About The Pull Request 

The hydroponics doors now allow club workers to go through them, along side the church.

The club backdoor desk has had its plastic flap replaced with a door, so club workers can just leave through the back of the kitchen.

The club manager's room now has a lightbulb in it.

## Why It's Good For The Game

The club is the most neglected part of Eris. They need some love.

## Changelog

:cl:
tweak: Club workers now have access to hydroponics, alongside the church.
/:cl:
