### PR TITLE
Club minor remap second try

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -55061,6 +55061,9 @@
 /area/eris/maintenance/oldtele)
 "cxi" = (
 /obj/machinery/vending/boozeomat,
+/obj/machinery/door/window/eastleft{
+	req_access = list(28)
+	},
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
 "cxj" = (
@@ -55097,6 +55100,9 @@
 /area/eris/hallway/side/bridgehallway)
 "cxm" = (
 /obj/machinery/smartfridge/drinks,
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/eris/crew_quarters/bar)
 "cxn" = (
@@ -99626,14 +99632,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
-"ewq" = (
-/obj/structure/table/bar_special,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
-	},
-/turf/simulated/floor/tiled/steel/bar_light,
-/area/eris/crew_quarters/bar)
 "ewr" = (
 /obj/structure/closet,
 /obj/spawner/contraband/low_chance,
@@ -105179,6 +105177,17 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
+"lsO" = (
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "kitchen_hatch";
+	layer = 3.3;
+	name = "Maintenance Hatch"
+	},
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/bar)
 "ltJ" = (
 /obj/machinery/holomap{
 	dir = 4;
@@ -105673,6 +105682,17 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
+"qcs" = (
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "kitchen_hatch";
+	layer = 3.3;
+	name = "Maintenance Hatch"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/kitchen)
 "qkR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos{
@@ -105706,6 +105726,22 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/surgery)
+"qZg" = (
+/obj/structure/table/standard,
+/obj/machinery/door/window/eastright,
+/obj/machinery/door/window/westright{
+	name = "kitchen door";
+	req_access = list(28)
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "kitchen_hatch";
+	layer = 3.3;
+	name = "Maintenance Hatch"
+	},
+/turf/simulated/floor/tiled/white/cargo,
+/area/eris/crew_quarters/kitchen)
 "qZr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -105813,6 +105849,17 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/quartermaster/hangarsupply)
+"rPI" = (
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "kitchen_hatch";
+	layer = 3.3;
+	name = "Maintenance Hatch"
+	},
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/kitchen)
 "rUL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
@@ -105856,6 +105903,22 @@
 /obj/effect/shuttle_landmark/merc/sec2east,
 /turf/space,
 /area/space)
+"sGv" = (
+/obj/structure/table/rack,
+/obj/spawner/rations,
+/obj/spawner/rations,
+/obj/spawner/rations,
+/obj/spawner/rations/low_chance,
+/obj/spawner/rations/low_chance,
+/obj/spawner/rations/low_chance,
+/obj/machinery/button/remote/blast_door{
+	id = "kitchen_hatch";
+	name = "Kitchen Hatch Control";
+	pixel_y = -24;
+	req_access = null
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/eris/crew_quarters/kitchen)
 "sJL" = (
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/reinforced,
@@ -203417,7 +203480,7 @@ dXJ
 efF
 cpS
 cAS
-etq
+eiJ
 cCy
 etw
 cCB
@@ -203824,7 +203887,7 @@ egG
 ewE
 cCy
 cBr
-cCD
+sGv
 cAS
 abF
 cwU
@@ -204224,8 +204287,8 @@ czL
 dXP
 cAu
 ewv
-egG
-eiJ
+qcs
+etq
 cCi
 dZm
 epH
@@ -204424,9 +204487,9 @@ cjQ
 cjQ
 czL
 dXQ
-ewq
-aqa
-egG
+cjQ
+lsO
+rPI
 cBC
 cBr
 elW
@@ -204628,10 +204691,10 @@ czM
 dXR
 cAw
 etm
-egG
+rPI
 egG
 cDI
-egG
+qZg
 cAS
 cAS
 abF


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The minor club remap with windows, take-away counter, windoor for booze-o-mat. Now with 200% more shutters!

https://ibb.co/qybS4mF

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Like previous PR, easier to see into and out of kitchen to see if there is a chef or there are customers, added second table-windoor setup to facilitate deals, windoor for booze dispenser to at least delay theft and make it more noisy, blah blah.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: added windows with remote shutters to club kitchen
add: added windoor in front of booze-o-mat
add: added 'take-away' counter
tweak: switched places of condi-master and sink
tweak: moved a light fixture and air alarm

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
