### PR TITLE
VV drop everything fix

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -10,7 +10,8 @@
 		return
 
 	for(var/obj/item/W in M)
-		M.drop_from_inventory(W)
+		if(W.is_equipped())
+			M.drop_from_inventory(W)
 
 	log_admin("[key_name(usr)] made [key_name(M)] drop everything!")
 	message_admins("[key_name_admin(usr)] made [key_name_admin(M)] drop everything!", 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

VV drop everything now only dropes equiped items (and not organs).

## Why It's Good For The Game

Bug bad and admins can instantly ERP now without needing to take off clothes without the fear of losing their organs.

## Changelog
:cl: TheShown
admin: Drop everything in VV does not drop EVERYTHING including organs anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
