### PR TITLE
You can now search the neon cocktails drinklist by taste tag

### DIFF
--- a/code/modules/modular_computers/file_system/catalog.dm
+++ b/code/modules/modular_computers/file_system/catalog.dm
@@ -322,6 +322,9 @@ GLOBAL_LIST_EMPTY(all_catalog_entries_by_type)
 		return TRUE
 	if(findtext(strength, value))
 		return TRUE
+	for(var/i in taste_tag)
+		if(findtext(i, value))
+			return TRUE
 
 /datum/catalog_entry/drink/New(var/datum/reagent/V)
 	if(!istype(V))


### PR DESCRIPTION
## About The Pull Request   

Previously, you could only search for the drink name, and how strong it was. This didn't prove very useful in narrowing down what a customer would want, as the new sanity system wants things of a certain taste, not of a certain name.

## Why It's Good For The Game

As people come by to ask for bitter, or sweet, or spicy drinks, you can now search by that given descript.

## Changelog
:cl:
add: You can now search by taste type in the neon cocktails catalogue
/:cl: