### PR TITLE
Makes Robustcell disks actually spawn again

### DIFF
--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -130,6 +130,7 @@
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/robustcells
 	disk_name = "Asters Robustcells"
 	icon_state = "guild"
+	rarity_value = 1.56
 	spawn_tags = SPAWN_TAG_DESING_COMMON
 	license = 10
 	designs = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Somebody forgot to give robustcell disks a rarity, so they never spawned.

## Why It's Good For The Game

It's good to have things that you want to spawn actually spawn.

## Changelog
:cl:
fix: The 'Asters Robustcells' disk should now correctly spawn wherever common design disks would be found.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
