### PR TITLE
Adds new autolathe design disks that print armor

### DIFF
--- a/code/datums/autolathe/clothing.dm
+++ b/code/datums/autolathe/clothing.dm
@@ -2,3 +2,59 @@
 /datum/design/autolathe/clothing/excelsior_armor
 	name = "excelsior armor"
 	build_path = /obj/item/clothing/suit/space/void/excelsior
+	
+// Standard
+
+/datum/design/autolathe/clothing/generic_helmet_basic
+	name = "helmet"
+	build_path = /obj/item/clothing/head/armor/helmet
+	
+/datum/design/autolathe/clothing/generic_helmet_visored // Unused ATM
+	name = "visored helmet"
+	build_path = /obj/item/clothing/head/armor/helmet/visor
+	
+/datum/design/autolathe/clothing/generic_vest
+	name = "armor vest"
+	build_path = /obj/item/clothing/suit/armor/vest
+	
+/datum/design/autolathe/clothing/generic_vest_security // Unused ATM
+	name = "security armor"
+	build_path = /obj/item/clothing/suit/armor/vest/security
+	
+// Bulletproof
+
+/datum/design/autolathe/clothing/bulletproof_vest_generic
+	name = "bulletproof vest"
+	build_path = /obj/item/clothing/suit/armor/bulletproof
+	
+/datum/design/autolathe/clothing/bulletproof_helmet_generic
+	name = "bulletproof helmet"
+	build_path = /obj/item/clothing/head/armor/bulletproof
+	
+// Ablative
+
+/datum/design/autolathe/clothing/ablative_vest
+	name = "ablative armor vest"
+	build_path = /obj/item/clothing/suit/armor/laserproof
+	
+/datum/design/autolathe/clothing/ablative_helmet
+	name = "ablative helmet"
+	build_path = /obj/item/clothing/head/armor/laserproof
+
+// IH
+
+/datum/design/autolathe/clothing/ih_helmet_basic
+	name = "operator helmet"
+	build_path = /obj/item/clothing/head/armor/helmet/ironhammer
+	
+/datum/design/autolathe/clothing/ih_helmet_full
+	name = "full ballistic helmet"
+	build_path = /obj/item/clothing/head/armor/bulletproof/ironhammer_full
+	
+/datum/design/autolathe/clothing/ih_vest_basic
+	name = "operator armor"
+	build_path = /obj/item/clothing/suit/armor/vest/ironhammer
+	
+/datum/design/autolathe/clothing/ih_vest_full
+	name = "full bulletproof suit"
+	build_path = /obj/item/clothing/suit/armor/bulletproof/ironhammer

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1214,7 +1214,10 @@
 					/obj/item/device/hailer = 8,
 					/obj/item/taperoll/police = 8,
 					/obj/item/device/holowarrant = 8,
-					/obj/item/weapon/storage/box/evidence = 2)
+					/obj/item/weapon/storage/box/evidence = 2,
+					/obj/item/weapon/computer_hardware/hard_drive/portable/design/security = 2,
+					/obj/item/weapon/computer_hardware/hard_drive/portable/design/armor/ih = 2,
+					/obj/item/weapon/computer_hardware/hard_drive/portable/design/armor/ih/bulletproof = 1)
 	contraband = list(/obj/item/weapon/tool/knife/tacknife = 4,/obj/item/weapon/reagent_containers/food/snacks/donut/normal = 12)
 	auto_price = FALSE
 
@@ -1411,6 +1414,7 @@
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design/computer = 10,
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design/medical = 10,
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design/security = 5,
+					/obj/item/weapon/computer_hardware/hard_drive/portable/design/armor/generic = 5,
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_cheap_guns = 5,
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design/nonlethal_ammo = 10,
 					/obj/item/weapon/electronics/circuitboard/autolathe = 3,
@@ -1428,6 +1432,7 @@
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design/medical = 400,
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design/computer = 500,
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design/security = 600,
+					/obj/item/weapon/computer_hardware/hard_drive/portable/design/armor/generic = 800,
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_cheap_guns = 3000,
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design/nonlethal_ammo = 700,
 					/obj/item/weapon/electronics/circuitboard/autolathe = 700,

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -1216,6 +1216,61 @@
 		/datum/design/autolathe/gun/plasma/cassad = 3, // "FS PR \"Cassad\""
 		/datum/design/autolathe/cell/medium/high,
 	)
+	
+// ARMOR
+
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/armor/generic
+	disk_name = "Ironhammer Combat Equipment - Standard Armor"
+	icon_state = "ironhammer"
+	spawn_tags = SPAWN_TAG_DESING_ADVANCED_COMMON
+	rarity_value = 2 // one of the more common advanced disks
+	license = 6 // 6 pieces, or 3 sets if you use helm + vest
+	designs = list(
+		/datum/design/autolathe/clothing/generic_helmet_basic,
+		/datum/design/autolathe/clothing/generic_vest
+	)
+	
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/armor/generic/bulletproof
+	disk_name = "Ironhammer Combat Equipment - Bulletproof Armor"
+	icon_state = "ironhammer"
+	spawn_tags = SPAWN_TAG_DESING_ADVANCED_COMMON
+	rarity_value = 5 // about as rare as a advanced tool disk - remember that this takes from the 'advanced' pool (which is rare) instead of the 'common' pool like the normal armor disk does
+	license = 4 // 4 pieces, or 2 sets
+	designs = list(
+		/datum/design/autolathe/clothing/bulletproof_helmet_generic,
+		/datum/design/autolathe/clothing/bulletproof_vest_generic
+	)
+	
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/armor/generic/ablative
+	disk_name = "Ironhammer Combat Equipment - Laserproof Armor"
+	icon_state = "ironhammer"
+	spawn_tags = SPAWN_TAG_DESING_ADVANCED_COMMON
+	rarity_value = 5.5 // slightly rarer than bulletproof gear
+	license = 4 // 4 pieces, or 2 sets
+	designs = list(
+		/datum/design/autolathe/clothing/ablative_vest,
+		/datum/design/autolathe/clothing/ablative_helmet
+	)
+	
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/armor/ih
+	disk_name = "Ironhammer Combat Equipment - Operator Armor"
+	icon_state = "ironhammer"
+	spawn_blacklisted = TRUE //should only be obtainable from the sectech
+	license = 6
+	designs = list(
+		/datum/design/autolathe/clothing/ih_helmet_basic,
+		/datum/design/autolathe/clothing/ih_vest_basic
+	)
+
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/armor/ih/bulletproof
+	disk_name = "Ironhammer Combat Equipment - Bulletproof Operator Armor"
+	icon_state = "ironhammer"
+	spawn_blacklisted = TRUE
+	license = 4
+	designs = list(
+		/datum/design/autolathe/clothing/ih_helmet_full,
+		/datum/design/autolathe/clothing/ih_vest_full
+	)
 
 // SPECIAL
 

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -34,12 +34,21 @@
 		bio = 0,
 		rad = 0
 	)
+	matter = list(
+		MATERIAL_STEEL = 5,
+		MATERIAL_PLASTEEL = 1 //a lil bit of plasteel since it's better than handmade shit
+	)
 
 /obj/item/clothing/head/armor/helmet/visor
 	desc = "Standard Security gear. Protects the head from impacts. Has a permanently affixed visor to protect the eyes."
 	icon_state = "helmet_visor"
 	body_parts_covered = HEAD | EARS | EYES
 	rarity_value = 6.66
+	matter = list(
+		MATERIAL_STEEL = 5,
+		MATERIAL_PLASTEEL = 1,
+		MATERIAL_GLASS = 2 // costs some glass cause of the visor and the included eye protection
+	)
 
 /obj/item/clothing/head/armor/helmet/merchelm
 	name = "Heavy Armour Helmet"
@@ -127,6 +136,11 @@
 	)
 	price_tag = 400
 	flash_protection = FLASH_PROTECTION_MAJOR
+	matter = list(
+		MATERIAL_STEEL = 8,
+		MATERIAL_PLASTEEL = 2, //Higher plasteel cost since it's booletproof
+		MATERIAL_GLASS = 3 //For the visor parts
+	)
 
 /obj/item/clothing/head/armor/bulletproof/ironhammer_nvg //currently junk-only
 	name = "tactical ballistic helmet"
@@ -209,6 +223,11 @@
 	action_button_name = "Toggle Security Hud"
 	var/obj/item/clothing/glasses/hud/security/hud
 	price_tag = 500
+	matter = list(
+		MATERIAL_STEEL = 10, // also comes with a hud with it's own prices
+		MATERIAL_PLASTEEL = 2,
+		MATERIAL_GLASS = 2
+	)
 
 /obj/item/clothing/head/armor/bulletproof/ironhammer_full/New()
 	..()
@@ -279,6 +298,11 @@
 	)
 	siemens_coefficient = 0
 	price_tag = 325
+	matter = list(
+		MATERIAL_STEEL = 4, // slightly less steel cost
+		MATERIAL_PLASTEEL = 1,
+		MATERIAL_GLASS = 10 // glass is reflective yo, make it cost a lot of it - also, visor
+	)
 
 // Riot helmet
 /obj/item/clothing/head/armor/riot

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -29,6 +29,10 @@
 		bio = 0,
 		rad = 0
 	)
+	matter = list(
+		MATERIAL_STEEL = 8,
+		MATERIAL_PLASTEEL = 1, //Small plasteel cost since it's better than a handmade vest, which only costs steel
+	)
 
 /obj/item/clothing/suit/armor/vest/security
 	name = "security armor"
@@ -135,6 +139,10 @@
 		rad = 0
 	)
 	price_tag = 500
+	matter = list(
+		MATERIAL_STEEL = 10, // costs a bit more steel than standard vest
+		MATERIAL_PLASTEEL = 3, // costs lots more plasteel than standard vest
+	)
 
 /obj/item/clothing/suit/armor/bulletproof/ironhammer
 	name = "full bulletproof suit"
@@ -149,6 +157,10 @@
 		bomb = 10,
 		bio = 0,
 		rad = 0
+	)
+	matter = list(
+		MATERIAL_STEEL = 15, // fullbody suit, so it costs a lot of steel compared to the non-ih one
+		MATERIAL_PLASTEEL = 3,
 	)
 
 /obj/item/clothing/suit/armor/bulletproof/serbian
@@ -190,6 +202,11 @@
 	)
 	siemens_coefficient = 0
 	price_tag = 650
+	matter = list(
+		MATERIAL_STEEL = 6, // slightly less steel cost to make room for reflective glass
+		MATERIAL_PLASTEEL = 1,
+		MATERIAL_GLASS = 15 // reflective material, lots of it
+	)
 
 /obj/item/clothing/suit/armor/laserproof/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack") //TODO: Refactor this all into humandefense
 	if(istype(damage_source, /obj/item/projectile/energy) || istype(damage_source, /obj/item/projectile/beam))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds five new autolathe design disks, all produced by the Ironhammer Combat Equipment division.
_'Standard Armor'_, which has designs for the basic helmet and basic armor vest. This disk can be bought at an Asters Print-o-Mat for 800 credits, and is uncommon in maintenance.
_'Bulletproof Armor'_, which has designs for a bulletproof helmet and bulletproof vest, and can found relatively rarely in maintenance.
_'Laserproof Armor'_, which has designs for an ablative helmet and ablative vest, and can be found rarely in maintenance.

_'Operator Armor'_, which has designs for the IH helmet and IH vest. This disk can be grabbed for free at a SecTech (but there are only two disks!), and cannot be found in maintenance.
_'Bulletproof Operator Armor'_, which has designs for the full IH headgear and full IH body-armor. This disk can be grabbed for free at a SecTech (but there's only one disk!) and cannot be found in maintenance.

**This PR also adds the Ironhammer Miscellaneous Disk to the SecTech, in case IH needs to print more knives with their Autolathe.**

## Why It's Good For The Game

It's weird how we can print guns, but not armor. This also gives IH some more branded disks, since at the moment there's only one IH disk.

Here is me getting approval from a maintainer to go ahead and make this PR.
![image](https://user-images.githubusercontent.com/46986487/95712140-3d395e00-0c32-11eb-96eb-ffda432862fb.png)


## Changelog
:cl:
add: Three new autolathe disks that can print armor can now be found in maintenance, one of which that can also be bought at an Asters Print-o-Mat. Two more disks that print IH faction armor can be found in the SecTech.
tweak: The SecTech now vends Ironhammer Miscellaneous Pack design disks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
