### PR TITLE
Hivemind tyrant fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -180,10 +180,6 @@ var/list/mydirs = list(NORTH, SOUTH, EAST, WEST, SOUTHWEST, NORTHWEST, NORTHEAST
 
 	return L
 
-/mob/living/simple_animal/hostile/death()
-	..()
-	walk(src, 0)
-
 /mob/living/simple_animal/hostile/Life()
 
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -269,5 +269,5 @@ var/list/mydirs = list(NORTH, SOUTH, EAST, WEST, SOUTHWEST, NORTHWEST, NORTHEAST
 					obstacle.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext)
 					return
 			var/obj/structure/obstacle = locate(/obj/structure, get_step(src, dir))
-			if(istype(obstacle, /obj/structure/window) || istype(obstacle, /obj/structure/closet) || istype(obstacle, /obj/structure/table) || istype(obstacle, /obj/structure/grille))
+			if(istype(obstacle, /obj/structure/window) || istype(obstacle, /obj/structure/closet) || istype(obstacle, /obj/structure/table) || istype(obstacle, /obj/structure/grille) || istype(obstacle, /obj/structure/railing))
 				obstacle.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hivetechboss.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hivetechboss.dm
@@ -73,13 +73,14 @@
 	ranged_cooldown = world.time + 120
 	walk(src, 0)
 	telegraph()
-	if(prob(50))
-		random_shots()
-		move_to_delay = initial(move_to_delay)
-		MoveToTarget()
-		return
-	else
-		select_spiral_attack()
-		move_to_delay = initial(move_to_delay)
-		MoveToTarget()
-		return
+	spawn(rand(megafauna_min_cooldown, megafauna_max_cooldown))
+		if(prob(50))
+			random_shots()
+			move_to_delay = initial(move_to_delay)
+			MoveToTarget()
+			return
+		else
+			select_spiral_attack()
+			move_to_delay = initial(move_to_delay)
+			MoveToTarget()
+			return

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hivetechboss.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hivetechboss.dm
@@ -68,26 +68,11 @@
 		health_marker_3 = !health_marker_3
 		telenode()
 
-	if(!stat)
-		switch(stance)
-			if(HOSTILE_STANCE_IDLE)
-				target_mob = FindTarget()
-
-			if(HOSTILE_STANCE_ATTACK)
-				if(destroy_surroundings)
-					DestroySurroundings()
-				MoveToTarget()
-
-			if(HOSTILE_STANCE_ATTACKING)
-				if(destroy_surroundings)
-					DestroySurroundings()
-				AttackTarget()
-
 /mob/living/simple_animal/hostile/megafauna/hivemind_tyrant/OpenFire()
 	anger_modifier = CLAMP(((maxHealth - health)/50),0,20)
 	ranged_cooldown = world.time + 120
 	walk(src, 0)
-	INVOKE_ASYNC(src, .proc/telegraph)
+	telegraph()
 	if(prob(50))
 		random_shots()
 		move_to_delay = initial(move_to_delay)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hivetechboss.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hivetechboss.dm
@@ -30,7 +30,6 @@
 /mob/living/simple_animal/hostile/megafauna/hivemind_tyrant/death()
 	..()
 	delhivetech()
-	walk(src, 0)
 
 /mob/living/simple_animal/hostile/megafauna/hivemind_tyrant/proc/telenode()
 	var/list/atom/NODES = list()
@@ -46,7 +45,7 @@
 			othertyrant = 1
 	if(othertyrant == 0)
 		for(var/obj/machinery/hivemind_machine/NODE in world)
-			qdel(NODE)
+			NODE.destruct()
 
 /mob/living/simple_animal/hostile/megafauna/hivemind_tyrant/Life()
 
@@ -88,7 +87,7 @@
 	anger_modifier = CLAMP(((maxHealth - health)/50),0,20)
 	ranged_cooldown = world.time + 120
 	walk(src, 0)
-	telegraph()
+	INVOKE_ASYNC(src, .proc/telegraph)
 	if(prob(50))
 		random_shots()
 		move_to_delay = initial(move_to_delay)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -23,7 +23,6 @@
 	var/list/attack_action_types = list()
 	var/megafauna_min_cooldown = 10
 	var/megafauna_max_cooldown = 20
-	var/next_telegraph
 
 /mob/living/simple_animal/hostile/megafauna/Initialize(mapload)
 	. = ..()
@@ -110,27 +109,26 @@
 	INVOKE_ASYNC(src, .proc/spiral_shoot, TRUE)
 
 /mob/living/simple_animal/hostile/megafauna/proc/telegraph()
-	if(world.time < next_telegraph)
-		return
 	for(var/mob/M in range(10,src))
 		if(M.client)
 			shake_camera(M, 4, 3)
 	visible_message(SPAN_DANGER(pick("Prepare to die!", "JUSTICE", "Run!")))
-	next_telegraph = world.time + rand(megafauna_min_cooldown, megafauna_max_cooldown)
 
 /mob/living/simple_animal/hostile/megafauna/proc/spiral_shoot(negative = pick(TRUE, FALSE), rounds = 20)
+	set waitfor = 0
 	var/turf/start_turf = get_step(src, pick(GLOB.alldirs))
 	var/incvar = negative ? -1 : 1
-	var/startpoint = 0
+	var/dirpoint = 1
 	var/list/alldirs = GLOB.alldirs.Copy()
-	var/firedir = alldirs[1]
+	var/firedir = alldirs[dirpoint]
 	for(var/i = 0 to rounds)
 		shoot_projectile(start_turf, firedir)
-		startpoint += incvar
-		if(startpoint < 1)
-			startpoint = alldirs.len
-		else if(startpoint > alldirs.len)
-			startpoint = 0
+		dirpoint += incvar
+		if(dirpoint < 1)
+			dirpoint = alldirs.len
+		else if(dirpoint > alldirs.len)
+			dirpoint = 1
+		firedir = alldirs[dirpoint]
 		sleep(rand(1,3))
 
 /mob/living/simple_animal/hostile/megafauna/proc/shoot_projectile(turf/marker, var/dir)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -34,19 +34,14 @@
 	return TRUE
 
 /mob/living/simple_animal/hostile/megafauna/death(gibbed, var/list/force_grant)
-	if(health <= 0)
-		qdel(src)
-		return
+	..()
+	qdel(src)
 
 /mob/living/simple_animal/hostile/megafauna/gib()
-	if(health <= 0)
-		qdel(src)
-		return
+	qdel(src)
 
 /mob/living/simple_animal/hostile/megafauna/dust(just_ash, drop_items, force)
-	if(health <= 0)
-		qdel(src)
-		return
+	qdel(src)
 
 /mob/living/simple_animal/hostile/megafauna/AttackingTarget()
 	if(recovery_time >= world.time)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -23,6 +23,7 @@
 	var/list/attack_action_types = list()
 	var/megafauna_min_cooldown = 10
 	var/megafauna_max_cooldown = 20
+	var/next_telegraph
 
 /mob/living/simple_animal/hostile/megafauna/Initialize(mapload)
 	. = ..()
@@ -109,29 +110,30 @@
 	INVOKE_ASYNC(src, .proc/spiral_shoot, TRUE)
 
 /mob/living/simple_animal/hostile/megafauna/proc/telegraph()
+	if(world.time < next_telegraph)
+		return
 	for(var/mob/M in range(10,src))
 		if(M.client)
 			shake_camera(M, 4, 3)
 	visible_message(SPAN_DANGER(pick("Prepare to die!", "JUSTICE", "Run!")))
-	sleep(rand(megafauna_min_cooldown, megafauna_max_cooldown))
+	next_telegraph = world.time + rand(megafauna_min_cooldown, megafauna_max_cooldown)
 
-/mob/living/simple_animal/hostile/megafauna/proc/spiral_shoot(negative = pick(TRUE, FALSE), counter_start = 8)
+/mob/living/simple_animal/hostile/megafauna/proc/spiral_shoot(negative = pick(TRUE, FALSE), rounds = 20)
 	var/turf/start_turf = get_step(src, pick(GLOB.alldirs))
-	var/counter = counter_start
-	for(var/i in 1 to 80)
-		if(prob(35))
-			sleep(rand(1,3))
-		if(negative)
-			counter--
-		else
-			counter++
-		if(counter > 16)
-			counter = 1
-		if(counter < 1)
-			counter = 16
-		shoot_projectile(start_turf, counter * 22.5)
+	var/incvar = negative ? -1 : 1
+	var/startpoint = 0
+	var/list/alldirs = GLOB.alldirs.Copy()
+	var/firedir = alldirs[1]
+	for(var/i = 0 to rounds)
+		shoot_projectile(start_turf, firedir)
+		startpoint += incvar
+		if(startpoint < 1)
+			startpoint = alldirs.len
+		else if(startpoint > alldirs.len)
+			startpoint = 0
+		sleep(rand(1,3))
 
-/mob/living/simple_animal/hostile/megafauna/proc/shoot_projectile(turf/marker)
+/mob/living/simple_animal/hostile/megafauna/proc/shoot_projectile(turf/marker, var/dir)
 	if(!marker || marker == loc)
 		return
 	var/turf/startloc = get_turf(src)
@@ -139,7 +141,7 @@
 	P.firer = src
 	if(target)
 		P.original = target
-	P.launch( get_step(marker, pick(SOUTH, NORTH, WEST, EAST, SOUTHEAST, SOUTHWEST, NORTHEAST, NORTHWEST)) )
+	P.launch(get_step(marker, dir))
 
 /mob/living/simple_animal/hostile/megafauna/proc/random_shots()
 	ranged_cooldown = world.time + 30
@@ -147,7 +149,7 @@
 	for(var/T in RANGE_TURFS(12, U) - U)
 		if(prob(6))
 			sleep(rand(0,1))
-			shoot_projectile(T)
+			shoot_projectile(T, pick(GLOB.alldirs))
 
 /mob/living/simple_animal/hostile/megafauna/proc/wave_shots()
 	ranged_cooldown = world.time + 30


### PR DESCRIPTION
Fixes the tyrant destroying half the ship on death
Removes redundant checks
Removes redundant walk(src,0) calls
Fixes the tyrant from stopping time every time it shit talks you, and then embedding you with 80 ~~knives~~ globs of goo

## About The Pull Request 

AAAAAAAAAAAAA asked me for a little help on fixing the tyrant, so I fixed some surface-level bugs.

 - The tyrant, on death, is supposed to kill all hivemind-controlled machines on the ship. Issue was it called qdel() rather than node.destruct, so it would also destroy the underlying machines.
 - The tyrant, in combat, mocks people every 3~5 seconds. Issue is it sleeps for this amount of time, which would also sleep the entire Mob subsystem. Same goes for it firing projectiles
 - It would call the usual hostile attack chain within its own Life(), after previously calling the hostile attack chain in a parent call. This led to megafauna attacking twice.
 - for some reason, all of the megafauna death calls had a redundant health check in them, when most of them were called below 0 health anyway. This interfered with debugging and was removed
 - The hostile death() function called walk(src,0), which was redundant as simple_animal death() already called it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

 - It's probably best that the gravity generator doesn't get obliterated when you win against the hivemind, by shooting its cyber demon until it dies
 - It's also probably best that it doesn't stop time across the entire ship every 3~5 seconds when you fight it.
 - redundant health checks begone
 - redundant walk calls begone

## Changelog
:cl:
balance: The hivemind tyrant no longer stops time for the entire server during combat
balance: The hivemind tyrant no longer destroys a majority of the ship upon death
/:cl:
