### PR TITLE
China Lake and it's ammo can now be found

### DIFF
--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -220,24 +220,28 @@
 	w_class = ITEM_SIZE_SMALL
 	caliber = CAL_GRENADE
 	maxamount = 1
+	spawn_tags = SPAWN_TAG_AMMO
+	rarity_value = 10
 
 /obj/item/ammo_casing/grenade/blast
 	name = "blast grenade shell"
 	desc = "An explosive grenade shell, designed to be fired from grenade launchers"
 	icon_state = "blast"
 	projectile_type = /obj/item/projectile/bullet/grenade
+	rarity_value = 25
 
 /obj/item/ammo_casing/grenade/frag
 	name = "frag grenade shell"
 	desc = "A frag grenade shell, designed to be fired from grenade launchers"
 	icon_state = "frag"
 	projectile_type = /obj/item/projectile/bullet/grenade/frag
+	rarity_value = 25
 
 /obj/item/ammo_casing/grenade/emp
 	name = "emp grenade shell"
 	desc = "An EMP grenade shell, designed to be fired from grenade launchers"
 	icon_state = "emp"
-	projectile_type = /obj/item/projectile/bullet/grenade/emp
+	projectile_type = /obj/item/projectile/bullet/grenade/emp // gonna keep this from being maint-lootable for now
 
 //// Other ////
 

--- a/code/modules/projectiles/guns/launcher/projectile_grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/projectile_grenade_launcher.dm
@@ -20,6 +20,8 @@
     max_shells = 3
     recoil_buildup = 20
     twohanded = TRUE
+
+/obj/item/weapon/gun/projectile/shotgun/pump/china/preloaded
     spawn_tags = SPAWN_TAG_GUN_PROJECTILE
     rarity_value = 30
     loaded = list(/obj/item/ammo_casing/grenade,/obj/item/ammo_casing/grenade)

--- a/code/modules/projectiles/guns/launcher/projectile_grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/projectile_grenade_launcher.dm
@@ -20,6 +20,5 @@
     max_shells = 3
     recoil_buildup = 20
     twohanded = TRUE
-
-
-
+    spawn_tags = SPAWN_TAG_GUN_PROJECTILE
+    rarity_value = 30

--- a/code/modules/projectiles/guns/launcher/projectile_grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/projectile_grenade_launcher.dm
@@ -22,3 +22,4 @@
     twohanded = TRUE
     spawn_tags = SPAWN_TAG_GUN_PROJECTILE
     rarity_value = 30
+    loaded = list(/obj/item/ammo_casing/grenade,/obj/item/ammo_casing/grenade)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The China Lake can now be found (extremely rarely) wherever a projectile gun can be found. It's ammunition (rubber grenade shells, explosive grenade shells, or frag grenade shells) can now be found (rarely) wherever ammunition can be found.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/46986487/95850603-1a38a800-0d1f-11eb-8a7e-bb55a195d658.png)
Gray and Reere told me to do this

## Changelog
:cl:
tweak: The China Lake and it's specialized ammunition should now correctly spawn in places across the ship.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
