### PR TITLE
Fixes a translation error for personal objectives.

### DIFF
--- a/code/datums/objective/individual_objective/individual_objective.dm
+++ b/code/datums/objective/individual_objective/individual_objective.dm
@@ -58,7 +58,7 @@
 	var/mob/living/carbon/human/H = owner.current
 	H.sanity.insight += insight_reward
 	H.sanity.insight_rest += insight_reward/2
-	to_chat(owner,  SPAN_NOTICE("You has completed the personal objective: [name]"))
+	to_chat(owner,  SPAN_NOTICE("You have completed the personal objective: [name]"))
 
 /datum/individual_objective/proc/get_description()
 	var/n_desc = desc


### PR DESCRIPTION
Fixes line 61

Fixes a translation error on line 61 for the personal objectives, instead of "You has completed..." it will now state "You have completed..."

## Changelog
:cl: Xoxeyos
spellcheck: Fixed a minor translation error.
/:cl:

