### PR TITLE
Soda, beer, and industrial chem dispenser fixes

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -964,7 +964,7 @@
 #include "code\game\objects\items\weapons\circuitboards\computer\telecomms.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\bar.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\biogenerator.dm"
-#include "code\game\objects\items\weapons\circuitboards\machinery\chemestry.dm"
+#include "code\game\objects\items\weapons\circuitboards\machinery\chemistry.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\cloning.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\commsantenna.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\excelsior.dm"

--- a/code/game/objects/items/weapons/circuitboards/machinery/chemistry.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/chemistry.dm
@@ -32,38 +32,17 @@
 		/obj/item/weapon/cell/medium = 1
 	)
 
-/obj/item/weapon/electronics/circuitboard/industeral_chemical_dispenser
+/obj/item/weapon/electronics/circuitboard/chemical_dispenser/industrial
 	name = T_BOARD("Industeral Chemical Dispenser")
 	build_path = /obj/machinery/chemical_dispenser/industrial
-	req_components = list(
-		/obj/item/weapon/stock_parts/matter_bin = 2,
-		/obj/item/weapon/stock_parts/capacitor = 1,
-		/obj/item/weapon/stock_parts/manipulator = 1,
-		/obj/item/weapon/stock_parts/console_screen = 1,
-		/obj/item/weapon/cell/medium = 1
-	)
 
-/obj/item/weapon/electronics/circuitboard/soda_chemical_dispenser
+/obj/item/weapon/electronics/circuitboard/chemical_dispenser/soda
 	name = T_BOARD("Soda Chemical Dispenser")
 	build_path = /obj/machinery/chemical_dispenser/soda
-	req_components = list(
-		/obj/item/weapon/stock_parts/matter_bin = 2,
-		/obj/item/weapon/stock_parts/capacitor = 1,
-		/obj/item/weapon/stock_parts/manipulator = 1,
-		/obj/item/weapon/stock_parts/console_screen = 1,
-		/obj/item/weapon/cell/medium = 1
-	)
 
-/obj/item/weapon/electronics/circuitboard/beer_chemical_dispenser
+/obj/item/weapon/electronics/circuitboard/chemical_dispenser/beer
 	name = T_BOARD("Booze Chemical Dispenser")
 	build_path = /obj/machinery/chemical_dispenser/beer
-	req_components = list(
-		/obj/item/weapon/stock_parts/matter_bin = 2,
-		/obj/item/weapon/stock_parts/capacitor = 1,
-		/obj/item/weapon/stock_parts/manipulator = 1,
-		/obj/item/weapon/stock_parts/console_screen = 1,
-		/obj/item/weapon/cell/medium = 1
-	)
 
 /obj/item/weapon/electronics/circuitboard/electrolyzer
 	name = T_BOARD("Electrolyzer")

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -184,7 +184,7 @@
 	layer = OBJ_LAYER
 	ui_title = "Soda Dispens-o-matic"
 
-	circuit = /obj/item/weapon/electronics/circuitboard/soda_chemical_dispenser
+	circuit = /obj/item/weapon/electronics/circuitboard/chemical_dispenser/soda
 
 	accept_beaker = FALSE
 	density = FALSE
@@ -209,7 +209,7 @@
 	layer = OBJ_LAYER
 	ui_title = "Booze Portal 9001"
 
-	circuit = /obj/item/weapon/electronics/circuitboard/beer_chemical_dispenser
+	circuit = /obj/item/weapon/electronics/circuitboard/chemical_dispenser/beer
 
 	accept_beaker = FALSE
 	density = FALSE
@@ -256,7 +256,7 @@
 	icon_state = "industrial_dispenser"
 	ui_title = "Industrial Dispenser 4835"
 
-	circuit = /obj/item/weapon/electronics/circuitboard/industeral_chemical_dispenser
+	circuit = /obj/item/weapon/electronics/circuitboard/chemical_dispenser/industrial
 
 	dispensable_reagents = list(
 		"acetone","aluminum","ammonia",

--- a/code/modules/research/designs/circuits.dm
+++ b/code/modules/research/designs/circuits.dm
@@ -95,8 +95,8 @@
 	sort_string = "FAHAC"
 	category = CAT_MEDI
 
-/datum/design/research/circuit/chemical_dispenser_industeral
-	name = "Industeral Chemical Dispenser"
+/datum/design/research/circuit/chemical_dispenser_industrial
+	name = "Industrial Chemical Dispenser"
 	build_path = /obj/item/weapon/electronics/circuitboard/chemical_dispenser/industrial
 	sort_string = "FAHAD"
 	category = CAT_MEDI

--- a/code/modules/research/designs/circuits.dm
+++ b/code/modules/research/designs/circuits.dm
@@ -97,19 +97,19 @@
 
 /datum/design/research/circuit/chemical_dispenser_industeral
 	name = "Industeral Chemical Dispenser"
-	build_path = /obj/item/weapon/electronics/circuitboard/industeral_chemical_dispenser
+	build_path = /obj/item/weapon/electronics/circuitboard/chemical_dispenser/industrial
 	sort_string = "FAHAD"
 	category = CAT_MEDI
 
 /datum/design/research/circuit/chemical_dispenser_soda
 	name = "Soda Chemical Dispenser"
-	build_path = /obj/item/weapon/electronics/circuitboard/soda_chemical_dispenser
+	build_path = /obj/item/weapon/electronics/circuitboard/chemical_dispenser/soda
 	sort_string = "FAHAE"
 	category = CAT_MISC
 
 /datum/design/research/circuit/chemical_dispenser_beer
 	name = "Beer Chemical Dispenser"
-	build_path = /obj/item/weapon/electronics/circuitboard/beer_chemical_dispenser
+	build_path = /obj/item/weapon/electronics/circuitboard/chemical_dispenser/beer
 	sort_string = "FAHAF"
 	category = CAT_MISC
 

--- a/code/modules/research/nodes/biotech.dm
+++ b/code/modules/research/nodes/biotech.dm
@@ -227,7 +227,7 @@
 							/datum/design/research/item/medical/adv_reagent_scanner,
 							/datum/design/research/item/weapon/chemsprayer,
 							/datum/design/research/item/weapon/rapidsyringe,
-							/datum/design/research/circuit/chemical_dispenser_industeral
+							/datum/design/research/circuit/chemical_dispenser_industrial
 							)
 
 /datum/technology/top_biotech


### PR DESCRIPTION
## About The Pull Request
Fixes the inability to construct soda, beer, and industrial chem dispensers

Makes the circuitboards a child of the chem dispenser board, as they all copypasted the same thing anyway.

Fixes a typo in the chemistry board filename


## Why It's Good For The Game

Being able to build an automatic beer dispenser is a sovereign right of all spessmen

## Changelog
:cl:
fix: Soda, beer, and industrial chem dispensers can now be built again.
/:cl: