### PR TITLE
Makes armor disks way rarer

### DIFF
--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -1235,7 +1235,7 @@
 	disk_name = "Ironhammer Combat Equipment - Standard Armor"
 	icon_state = "ironhammer"
 	spawn_tags = SPAWN_TAG_DESING_ADVANCED_COMMON
-	rarity_value = 5 // one of the more common advanced disks
+	rarity_value = 12 // one of the more common advanced disks
 	license = 6 // 6 pieces, or 3 sets if you use helm + vest
 	designs = list(
 		/datum/design/autolathe/clothing/generic_helmet_basic,
@@ -1246,7 +1246,7 @@
 	disk_name = "Ironhammer Combat Equipment - Bulletproof Armor"
 	icon_state = "ironhammer"
 	spawn_tags = SPAWN_TAG_DESING_ADVANCED_COMMON
-	rarity_value = 10 // about as rare as a advanced tool disk - remember that this takes from the 'advanced' pool (which is rare) instead of the 'common' pool like the normal armor disk does
+	rarity_value = 15 // about as rare as a advanced tool disk - remember that this takes from the 'advanced' pool (which is rare) instead of the 'common' pool like the normal armor disk does
 	license = 4 // 4 pieces, or 2 sets
 	designs = list(
 		/datum/design/autolathe/clothing/bulletproof_helmet_generic,
@@ -1257,7 +1257,7 @@
 	disk_name = "Ironhammer Combat Equipment - Laserproof Armor"
 	icon_state = "ironhammer"
 	spawn_tags = SPAWN_TAG_DESING_ADVANCED_COMMON
-	rarity_value = 12 // slightly rarer than bulletproof gear
+	rarity_value = 16 // slightly rarer than bulletproof gear
 	license = 4 // 4 pieces, or 2 sets
 	designs = list(
 		/datum/design/autolathe/clothing/ablative_vest,

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -1235,7 +1235,7 @@
 	disk_name = "Ironhammer Combat Equipment - Standard Armor"
 	icon_state = "ironhammer"
 	spawn_tags = SPAWN_TAG_DESING_ADVANCED_COMMON
-	rarity_value = 2 // one of the more common advanced disks
+	rarity_value = 5 // one of the more common advanced disks
 	license = 6 // 6 pieces, or 3 sets if you use helm + vest
 	designs = list(
 		/datum/design/autolathe/clothing/generic_helmet_basic,
@@ -1246,7 +1246,7 @@
 	disk_name = "Ironhammer Combat Equipment - Bulletproof Armor"
 	icon_state = "ironhammer"
 	spawn_tags = SPAWN_TAG_DESING_ADVANCED_COMMON
-	rarity_value = 5 // about as rare as a advanced tool disk - remember that this takes from the 'advanced' pool (which is rare) instead of the 'common' pool like the normal armor disk does
+	rarity_value = 10 // about as rare as a advanced tool disk - remember that this takes from the 'advanced' pool (which is rare) instead of the 'common' pool like the normal armor disk does
 	license = 4 // 4 pieces, or 2 sets
 	designs = list(
 		/datum/design/autolathe/clothing/bulletproof_helmet_generic,
@@ -1257,7 +1257,7 @@
 	disk_name = "Ironhammer Combat Equipment - Laserproof Armor"
 	icon_state = "ironhammer"
 	spawn_tags = SPAWN_TAG_DESING_ADVANCED_COMMON
-	rarity_value = 5.5 // slightly rarer than bulletproof gear
+	rarity_value = 12 // slightly rarer than bulletproof gear
 	license = 4 // 4 pieces, or 2 sets
 	designs = list(
 		/datum/design/autolathe/clothing/ablative_vest,

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -130,7 +130,7 @@
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/robustcells
 	disk_name = "Asters Robustcells"
 	icon_state = "guild"
-	rarity_value = 2
+	rarity_value = 2.5
 	spawn_tags = SPAWN_TAG_DESING_COMMON
 	license = 10
 	designs = list(

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -130,7 +130,7 @@
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/robustcells
 	disk_name = "Asters Robustcells"
 	icon_state = "guild"
-	rarity_value = 1.56
+	rarity_value = 2
 	spawn_tags = SPAWN_TAG_DESING_COMMON
 	license = 10
 	designs = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/46986487/96282312-92fe6500-0fa8-11eb-8186-05eaa350439b.png)

( everything is way too common )

## Why It's Good For The Game

These disks are supposed to be uncommon or rare, not omnipresent

## Changelog
:cl:
tweak: Armor design disks no longer dominate disk spawns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
