### PR TITLE
Fix Brigador and Svalinn slots

### DIFF
--- a/code/modules/projectiles/guns/energy/nt_svalinn.dm
+++ b/code/modules/projectiles/guns/energy/nt_svalinn.dm
@@ -8,6 +8,7 @@
 	fire_sound = 'sound/weapons/Laser.ogg'
 	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 1)
 	w_class = ITEM_SIZE_SMALL
+	slot_flags = SLOT_HOLSTER|SLOT_BELT
 	projectile_type = /obj/item/projectile/beam
 	charge_cost = 50
 	can_dual = 1

--- a/code/modules/projectiles/guns/energy/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma.dm
@@ -87,18 +87,14 @@
 	charge_meter = FALSE
 	w_class = ITEM_SIZE_NORMAL
 	twohanded = FALSE
+	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	suitable_cell = /obj/item/weapon/cell/small
-
-	projectile_type=/obj/item/projectile/plasma/light
+	projectile_type =/obj/item/projectile/plasma/light
 	projectile_color = "#00FFFF"
-
-	fire_sound='sound/weapons/Taser.ogg'
-
-	fire_delay=8
-	charge_cost=15
-
+	fire_sound ='sound/weapons/Taser.ogg'
+	fire_delay = 8
+	charge_cost = 15
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 8, MATERIAL_PLASMA = 2, MATERIAL_SILVER = 3, MATERIAL_URANIUM = 3)
-
 	init_firemodes = list()
 
 /obj/item/weapon/gun/energy/plasma/brigador/update_icon()

--- a/code/modules/projectiles/guns/energy/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma.dm
@@ -89,9 +89,9 @@
 	twohanded = FALSE
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	suitable_cell = /obj/item/weapon/cell/small
-	projectile_type =/obj/item/projectile/plasma/light
+	projectile_type = /obj/item/projectile/plasma/light
 	projectile_color = "#00FFFF"
-	fire_sound ='sound/weapons/Taser.ogg'
+	fire_sound = 'sound/weapons/Taser.ogg'
 	fire_delay = 8
 	charge_cost = 15
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 8, MATERIAL_PLASMA = 2, MATERIAL_SILVER = 3, MATERIAL_URANIUM = 3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes Svalinn and Brigador slot_flags and cleans a bit of Brigador code.
I'm unsure about why Svalinn can't be put into holster slot. Brigador is a child of "Dominion" which is a rifle that can't be put into holster, that's why it lacked those flags.

## Why It's Good For The Game

Put pistols into pistol holsters.

## Changelog
:cl:
fix: Brigador and Svalinn can be put into holster and belt slots.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
