### PR TITLE
Makes blitzshells rarer

### DIFF
--- a/code/game/gamemodes/roleset/simple.dm
+++ b/code/game/gamemodes/roleset/simple.dm
@@ -12,8 +12,9 @@
 	id = "blitz"
 	name = "blitzshell infiltration"
 	role_id = ROLE_BLITZ
-	weight = 1
+	weight = 0.6
 
+	req_crew = 10
 	base_quantity = 1
 	scaling_threshold = 15
 

--- a/code/game/gamemodes/roleset/simple.dm
+++ b/code/game/gamemodes/roleset/simple.dm
@@ -15,6 +15,8 @@
 	weight = 0.6
 
 	req_crew = 10
+	req_sec = 2
+
 	base_quantity = 1
 	scaling_threshold = 15
 

--- a/code/game/gamemodes/storyevent.dm
+++ b/code/game/gamemodes/storyevent.dm
@@ -46,7 +46,7 @@
 
 	//Things to configure
 	var/event_type
-	var/weight = 1
+	var/weight = 1 //Our base weight coefficient, which affects how likely we are to be picked from a list of other story events
 
 	//Which event pools this story event can appear in.
 	//Multiple options allowed, can be any combination of


### PR DESCRIPTION
## About The Pull Request 

When making the blitzshell to specification, I accidentally overlooked some things when making the storyteller roleset, as I was unfamiliar with it.

 - Blitzshells now only spawn if there are 10 or more people, along with a requirement for some leve of security, so there are potentially enough people to deal with them, considering how lethal they can be.
 - Blitzshell storyteller event is now less likely to fire, as it does not contribute as much to the round as traitors/excel/carrion.

## Why It's Good For The Game

Blitzshells do not contribute as much to the round as in-station antagonists, so should have less of a chance to spawn than traitors/excel/carrion, and require a certain amount of people to wrangle, security namely.



## Changelog
:cl:
balance: Blitzshells are now less likely to spawn
/:cl: