### PR TITLE
Cell rig examine

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -144,6 +144,10 @@
 	to_chat(user, "The manufacturer's label states this cell has a power rating of [maxcharge], and that you should not swallow it.")
 	to_chat(user, "The charge meter reads [round(percent() )]%.")
 
+	if(rigged && user.stats?.getStat(STAT_MEC) >= STAT_LEVEL_ADEPT)
+		to_chat(user, SPAN_WARNING("This cell is ready to short circuit!"))
+
+
 /obj/item/weapon/cell/attackby(obj/item/W, mob/user)
 	..()
 	if(istype(W, /obj/item/weapon/reagent_containers/syringe))


### PR DESCRIPTION
## About The Pull Request 

Having a high enough mechanical skill can tell you if a cell is rigged or not

## Why It's Good For The Game
Might as well have a practical use for mechanical skills when scavving

## Changelog
:cl:
tweak: Having a high enough mechanical skill can tell you if a cell is rigged to explode on use.
/:cl: