### PR TITLE
Flashbang balance change

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -35,7 +35,7 @@
 //Checking for protections
 	var/eye_safety = 0
 	var/ear_safety = 0
-	var/ear_stun_mult = 1
+	var/stat_def = -STAT_LEVEL_ADEPT
 	if(iscarbon(M))
 		eye_safety = M.eyecheck()
 		if(ishuman(M))
@@ -46,23 +46,21 @@
 			if(istype(M:head, /obj/item/clothing/head/armor/helmet))
 				ear_safety += 1
 			if(M.stats.getPerk(PERK_EAR_OF_QUICKSILVER))
-				ear_stun_mult *= 2
+				stat_def *= 2
 
 //Flashing everyone
 	if(eye_safety < FLASH_PROTECTION_MODERATE)
 		if (M.HUDtech.Find("flash"))
 			flick("e_flash", M.HUDtech["flash"])
-		M.Stun(2)
-		M.Weaken(10)
+		M.eye_blurry = max(M.eye_blurry, 15)
+		M.eye_blind = max(M.eye_blind, 5)
 
 
 
 //Now applying sound
 	if((get_dist(M, T) <= 2 || loc == M.loc || loc == M))
-		if(ear_safety > 0)
-			M.Stun(1*ear_stun_mult)
-		else
-			M.Stun(5*ear_stun_mult)
+		if(ear_safety <= 0)
+			stat_def *= 5
 			if ((prob(14) || (M == loc && prob(70))))
 				M.adjustEarDamage(rand(1, 10))
 			else
@@ -71,12 +69,12 @@
 
 	else if(get_dist(M, T) <= 5)
 		if(!ear_safety)
-			M.Stun(4*ear_stun_mult)
+			stat_def *= 4
 			M.adjustEarDamage(rand(0, 3))
 			M.ear_deaf = max(M.ear_deaf,10)
 
 	else if(!ear_safety)
-		M.Stun(2*ear_stun_mult)
+		stat_def *= 2
 		M.adjustEarDamage(rand(0, 1))
 		M.ear_deaf = max(M.ear_deaf,5)
 
@@ -91,4 +89,8 @@
 	else
 		if (M.ear_damage >= 5)
 			to_chat(M, SPAN_DANGER("Your ears start to ring!"))
+	M.stats.addTempStat(STAT_VIG, stat_def, 10 SECONDS, "flashbang")
+	M.stats.addTempStat(STAT_COG, stat_def, 10 SECONDS, "flashbang")
+	M.stats.addTempStat(STAT_BIO, stat_def, 10 SECONDS, "flashbang")
+	M.stats.addTempStat(STAT_MEC, stat_def, 10 SECONDS, "flashbang")
 	M.update_icons()


### PR DESCRIPTION
Flashbangs no longer floor you, instead they render you blind, deaf, and confused

## About The Pull Request

Flashbangs no longer weaken and stun you when detonated. Instead, they blind you if you lack proper eye protection, apply the usual deafening effect they had previously, and now debuff your stats for a short time while you recover.

## Why It's Good For The Game

Being able to 1-second slap stun somebody for 10 seconds is a little anticlimatic. This change would prompt people to time their grenades properly, and actually breach and clear with them.

## Changelog
:cl:
balance: Flashbangs no longer floor you, instead they disorient you.
/:cl: