### PR TITLE
Stinging fruit fix

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -302,9 +302,9 @@
 	if(seed.get_trait(TRAIT_STINGS))
 		var/mob/living/carbon/human/H = user
 		if(istype(H) && H.gloves)
-			return FALSE
+			return TRUE //We have gloves, so we can pick it up safely
 		if(!reagents || reagents.total_volume <= 0)
-			return FALSE
+			return TRUE //Out of reagents
 		reagents.remove_any(rand(1,3)) //Todo, make it actually remove the reagents the seed uses.
 		seed.do_thorns(H,src)
 		seed.do_sting(H,src,pick(BP_R_ARM, BP_L_ARM))


### PR DESCRIPTION
Fixes being unable to pick up stinging fruits when you have gloves or it is out of reagents


## About The Pull Request

An agrolyte informed me that they couldn't pick up some stinging ambrosia while wearing gloves.

The cause was in the plants prepickup, if the plant had thorns, it would check for your gloves, or if it had no reagents. If so, it would return false.

Returning false on prepickup means you can't pick up the object. Incorrect logic.

## Why It's Good For The Game

Now ambitious agrolytes can actuate their agroculture

## Changelog
:cl:
fix: Stinging fruits can now be picked up if you are wearing gloves.
/:cl: