### PR TITLE
High cap magazines for .35 guns

### DIFF
--- a/code/modules/projectiles/guns/projectile/pistol/colt.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/colt.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/projectile/colt
 	name = "FS HG .35 Auto \"Colt M1911\""
-	desc = "A cheap knock-off of a Colt M1911. Uses standard and high capacity magazines."
+	desc = "A cheap knock-off of a Colt M1911. Uses standard .35 and high capacity magazines."
 	icon = 'icons/obj/guns/projectile/colt.dmi'
 	icon_state = "colt"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)

--- a/code/modules/projectiles/guns/projectile/pistol/colt.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/colt.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/projectile/colt
 	name = "FS HG .35 Auto \"Colt M1911\""
-	desc = "A cheap knock-off of a Colt M1911. Uses standard .35 Auto mags."
+	desc = "A cheap knock-off of a Colt M1911. Uses standard and high capacity magazines."
 	icon = 'icons/obj/guns/projectile/colt.dmi'
 	icon_state = "colt"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
@@ -10,7 +10,7 @@
 	can_dual = 1
 	caliber = CAL_PISTOL
 	load_method = MAGAZINE
-	mag_well = MAG_WELL_PISTOL
+	mag_well = MAG_WELL_PISTOL|MAG_WELL_H_PISTOL
 	magazine_type = /obj/item/ammo_magazine/pistol
 	damage_multiplier = 1.5
 	recoil_buildup = 17

--- a/code/modules/projectiles/guns/projectile/pistol/mk58.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mk58.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/projectile/mk58
 	name = "NT HG .35 Auto \"Mk58\""
-	desc = "The NT Mk58 is a cheap, ubiquitous sidearm, that was produced by a NanoTrasen subsidiary. Uses standard and high capacity magazines."
+	desc = "The NT Mk58 is a cheap, ubiquitous sidearm, that was produced by a NanoTrasen subsidiary. Uses standard .35 and high capacity magazines."
 	icon = 'icons/obj/guns/projectile/mk58.dmi'
 	icon_state = "mk58"
 	item_state = "pistol"

--- a/code/modules/projectiles/guns/projectile/pistol/mk58.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mk58.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/projectile/mk58
 	name = "NT HG .35 Auto \"Mk58\""
-	desc = "The NT Mk58 is a cheap, ubiquitous sidearm, that was produced by a NanoTrasen subsidiary. Uses standard .35 Auto mags."
+	desc = "The NT Mk58 is a cheap, ubiquitous sidearm, that was produced by a NanoTrasen subsidiary. Uses standard and high capacity magazines."
 	icon = 'icons/obj/guns/projectile/mk58.dmi'
 	icon_state = "mk58"
 	item_state = "pistol"
@@ -11,7 +11,7 @@
 	can_dual = 1
 	caliber = CAL_PISTOL
 	load_method = MAGAZINE
-	mag_well = MAG_WELL_PISTOL
+	mag_well = MAG_WELL_PISTOL|MAG_WELL_H_PISTOL
 	magazine_type = /obj/item/ammo_magazine/pistol
 	damage_multiplier = 1.3
 	penetration_multiplier = 1.3

--- a/code/modules/projectiles/guns/projectile/pistol/paco.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/paco.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/projectile/paco
 	name = "FS HG .35 Auto \"Paco\""
-	desc = "A modern and reliable sidearm for the soldier in the field. Commonly issued as a sidearm to Ironhammer Operatives. Uses standard .35 Auto mags."
+	desc = "A modern and reliable sidearm for the soldier in the field. Commonly issued as a sidearm to Ironhammer Operatives. Uses standard and high capacity magazines."
 	icon = 'icons/obj/guns/projectile/paco.dmi'
 	icon_state = "paco"
 	item_state = "paco"
@@ -11,7 +11,7 @@
 	ammo_type = "/obj/item/ammo_casing/pistol"
 	caliber = CAL_PISTOL
 	load_method = MAGAZINE
-	mag_well = MAG_WELL_PISTOL
+	mag_well = MAG_WELL_PISTOL|MAG_WELL_H_PISTOL
 	magazine_type = /obj/item/ammo_magazine/pistol
 	auto_eject = 1
 	matter = list(MATERIAL_PLASTEEL = 14, MATERIAL_PLASTIC = 4)

--- a/code/modules/projectiles/guns/projectile/pistol/paco.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/paco.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/projectile/paco
 	name = "FS HG .35 Auto \"Paco\""
-	desc = "A modern and reliable sidearm for the soldier in the field. Commonly issued as a sidearm to Ironhammer Operatives. Uses standard and high capacity magazines."
+	desc = "A modern and reliable sidearm for the soldier in the field. Commonly issued as a sidearm to Ironhammer Operatives. Uses standard .35 and high capacity magazines."
 	icon = 'icons/obj/guns/projectile/paco.dmi'
 	icon_state = "paco"
 	item_state = "paco"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds high cap magazine support for colt, mk58 and paco.

## Why It's Good For The Game

Highcap magazines are used in very few guns, and with this they could be used for every .35 pistol except the giskard.

## Changelog
:cl:
add: Colt, mk58 and paco can use high cap magazines.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
