### PR TITLE
Nerfs the amount of research points you gain from autopsies

### DIFF
--- a/code/modules/research/experiment.dm
+++ b/code/modules/research/experiment.dm
@@ -1,5 +1,5 @@
 // Contains everything related to earning research points
-#define AUTOPSY_WEAPON_PAMT rand(5,10) * 200 // 1000-2000 points for random weapon
+#define AUTOPSY_WEAPON_PAMT rand(1,5) * 20 // 50-100 points for random weapon
 #define ARTIFACT_PAMT rand(5,10) * 1000 // 5000-10000 points for random artifact
 
 GLOBAL_LIST_EMPTY(explosion_watcher_list)


### PR DESCRIPTION
## About The Pull Request 

Nerfs the amount of research you gain from an autopsy, from 1000-2000 per unique weapon, to 50-100 per unique weapon.

## Why It's Good For The Game

Previously all you had to do was raid the morgue, steal the autopsy scanner, grab a monkey, and hit it with a toolbox and other assorted surgical equipment in order to max research.

Now, a cadaver will yield an average amount of research equivalent to an unresearched item, so it is better to inspect a vagabond who died an untimely but unique death, than beath a monkey to death with every item in the R&D lab. It's less the primary method of research acquisition, and now just another unique branch of research acquisition.

## Changelog
:cl:
balance: The amount of research points you receive from researching an autopsy report has been nerfed
/:cl: