### PR TITLE
Sanity optimizations

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -128,6 +128,7 @@
 	var/slowdown = 0              // Passive movement speed malus (or boost, if negative)
 	var/primitive_form            // Lesser form, if any (ie. monkey for humans)
 	var/greater_form              // Greater form, if any, ie. human for monkeys.
+	var/lower_sanity_process	  // Controls how much sanity is processed on the mob for performance reasons.
 	var/holder_type
 	var/gluttonous                // Can eat some mobs. Values can be GLUT_TINY, GLUT_SMALLER, GLUT_ANYTHING.
 	var/species_rarity_value = 1          // Relative rarity/collector value for this species.

--- a/code/modules/mob/living/carbon/human/species/station/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/station/monkey.dm
@@ -31,6 +31,7 @@
 	total_health = 75
 	brute_mod = 1.5
 	burn_mod = 1.5
+	lower_sanity_process = TRUE
 
 	spawn_flags = IS_RESTRICTED
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes on life sanity effects on NPC monkeys things like environment sanity gain and insight (player controled monkeys keep the full sanity effects) and makes on life sanity effects run once every 2 life ticks at double the effect.

Effects: (Tested with 15 roundstart monkeys and 1 player. Test was done before cutting the onLife() checks to once every 2 life ticks)
![sol1](https://user-images.githubusercontent.com/61743710/97575856-aa4c4200-19ed-11eb-9dcf-9076e657850b.png)
(without change)^

![sol2](https://user-images.githubusercontent.com/61743710/97575920-bf28d580-19ed-11eb-8b85-46618c199d81.png)
(with change)^

## Why It's Good For The Game

Optimization. Things like sanity damage from real damage or drugs are untouched, so in game effects should be minimal.

## Changelog
:cl:
tweak: NPC monkeys don't receive environment sanity damage and insight.
code: onLife() sanity procs effects trigger once every 2 life ticks.
/:cl:


