### PR TITLE
double spawn mine fix

### DIFF
--- a/code/game/objects/items/weapons/mine.dm
+++ b/code/game/objects/items/weapons/mine.dm
@@ -67,7 +67,7 @@
 
 	update_icon()
 
-/obj/item/weapon/mine/attack_hand(mob/user as mob)
+/obj/item/weapon/mine/attack_hand(mob/user)
 	if (deployed)
 		user.visible_message(
 				SPAN_DANGER("[user] extends its hand to reach the [src]!"),
@@ -79,7 +79,8 @@
 				SPAN_DANGER("you attempts to pick up the [src] only to hear a beep as it explodes in your hands!")
 				)
 			explode()
-	.=..()
+			return
+	. =..()
 
 /obj/item/weapon/mine/attackby(obj/item/I, mob/user)
 	if(QUALITY_PULSING in I.tool_qualities)


### PR DESCRIPTION
## About The Pull Request

Previously, if you tried to take a planted mine in your hands, it exploded and another mine was added under the mob

## Why It's Good For The Game

Bug fix 🐱 

## Changelog
:cl:
fix: fixed double mine bug
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
