### PR TITLE
Knocks down control spider duration to 15-20 seconds

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/carrion/control_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/control_spider.dm
@@ -48,7 +48,7 @@
 	active = TRUE
 	last_use = world.time
 
-	addtimer(CALLBACK(src, .proc/return_mind), rand(45 SECONDS, 70 SECONDS))
+	addtimer(CALLBACK(src, .proc/return_mind), rand(15 SECONDS, 20 SECONDS))
 
 /obj/item/weapon/implant/carrion_spider/control/on_uninstall()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does what it says on the tin. Reduces the control spider duration from a maximum 75 seconds to a maximum of 20 seconds.

## Why It's Good For The Game

At the moment, control spiders are a complete death sentence. The carrion can literally just get you to commit suicide and end your round - and it only kills the carrion's shell, not the core.

This doesn't really fix that problem, but what it does do is make it far harder for the carrion to remotely slaughter people via control spider. 

Control spiders should be used for spreading bits of misinformation and starting conflicts between crew - not just used as a remote killswitch. 20 seconds is enough time for a carrion to dump a few shots into a crewmember's ally or to screech that a crewmember is killing them when they aren't. 70 seconds is more than enough time that a control spider really should warrant.

## Changelog
:cl:
balance: Control Spiders now control for far, far less time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
