### PR TITLE
Recoil and click handlers update

### DIFF
--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -60,9 +60,7 @@
 #define WEAPON_NORMAL		list(mode_name="standard", icon="semi")
 #define WEAPON_CHARGE		list(mode_name="charge mode", mode_type = /datum/firemode/charge, icon="charge")
 
-#define BASE_ACCURACY_REGEN 0.75 //Recoil reduction per ds with 0 VIG
-#define VIG_ACCURACY_REGEN  0.015 //Recoil reduction per ds per VIG
-#define MIN_ACCURACY_REGEN  0.4 //How low can we get with negative VIG
-#define MAX_ACCURACY_OFFSET  75 //It's both how big gun recoil can build up, and how hard you can miss
+#define MAX_ACCURACY_OFFSET  30 //It's both how big gun recoil can build up, and how hard you can miss
+#define RECOIL_REDUCTION_TIME 1 SECOND
 
 #define VIG_OVERCHARGE_GEN 0.05

--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -46,16 +46,16 @@
 #define STRUCTURE_DAMAGE_BORING 		3
 
 //Quick defines for fire modes
-#define FULL_AUTO_300		list(mode_name="full auto",  mode_type = /datum/firemode/automatic, fire_delay=2  , icon="auto")
-#define FULL_AUTO_400		list(mode_name="full auto",  mode_type = /datum/firemode/automatic, fire_delay=1.5, icon="auto")
-#define FULL_AUTO_600		list(mode_name="full auto",  mode_type = /datum/firemode/automatic, fire_delay=1  , icon="auto")
-#define FULL_AUTO_800		list(mode_name="full auto",  mode_type = /datum/firemode/automatic, fire_delay=0.8, icon="auto")
+#define FULL_AUTO_300		list(mode_name="full auto",  mode_type = /datum/firemode/automatic, fire_delay=2  , icon="auto", damage_multiplier = 0.9)
+#define FULL_AUTO_400		list(mode_name="full auto",  mode_type = /datum/firemode/automatic, fire_delay=1.5, icon="auto", damage_multiplier = 0.9)
+#define FULL_AUTO_600		list(mode_name="full auto",  mode_type = /datum/firemode/automatic, fire_delay=1  , icon="auto", damage_multiplier = 0.9)
+#define FULL_AUTO_800		list(mode_name="full auto",  mode_type = /datum/firemode/automatic, fire_delay=0.8, icon="auto", damage_multiplier = 0.9)
 
-#define SEMI_AUTO_NODELAY	list(mode_name="semiauto", burst=1, fire_delay=0, move_delay=null, icon="semi")
+#define SEMI_AUTO_NODELAY	list(mode_name="semiauto", burst=1, fire_delay=0, move_delay=null, icon="semi", damage_multiplier = 1)
 
-#define BURST_3_ROUND		list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=4, icon="burst")
-#define BURST_5_ROUND		list(mode_name="5-round bursts", burst=5, fire_delay=null, move_delay=6, icon="burst")
-#define BURST_8_ROUND		list(mode_name="8-round bursts", burst=8, fire_delay=null, move_delay=8, icon="burst")
+#define BURST_3_ROUND		list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=4, icon="burst", damage_multiplier = 0.9)
+#define BURST_5_ROUND		list(mode_name="5-round bursts", burst=5, fire_delay=null, move_delay=6, icon="burst", damage_multiplier = 0.9)
+#define BURST_8_ROUND		list(mode_name="8-round bursts", burst=8, fire_delay=null, move_delay=8, icon="burst", damage_multiplier = 0.9)
 
 #define WEAPON_NORMAL		list(mode_name="standard", icon="semi")
 #define WEAPON_CHARGE		list(mode_name="charge mode", mode_type = /datum/firemode/charge, icon="charge")

--- a/code/datums/datum_click_handlers.dm
+++ b/code/datums/datum_click_handlers.dm
@@ -76,23 +76,14 @@
 *****************************/
 /datum/click_handler/fullauto
 	var/atom/target = null
-	var/firing = FALSE
 	var/obj/item/weapon/gun/reciever //The thing we send firing signals to.
 	//Todo: Make this work with callbacks
 
 /datum/click_handler/fullauto/Click()
 	return TRUE //Doesn't work with normal clicks
 
-/datum/click_handler/fullauto/proc/start_firing()
-	firing = TRUE
-	while (firing && target)
-		do_fire()
-		sleep(0.5) //Keep spamming events every frame as long as the button is held
-	stop_firing()
-
 //Next loop will notice these vars and stop shooting
 /datum/click_handler/fullauto/proc/stop_firing()
-	firing = FALSE
 	target = null
 	if(reciever)
 		reciever.cursor_check()
@@ -100,42 +91,33 @@
 /datum/click_handler/fullauto/proc/do_fire()
 	reciever.afterattack(target, owner.mob, FALSE)
 
-/datum/click_handler/fullauto/MouseDown(object,location,control,params)
+/datum/click_handler/fullauto/MouseDown(object, location, control, params)
 	if(!isturf(owner.mob.loc)) // This stops from firing full auto weapons inside closets or in /obj/effect/dummy/chameleon chameleon projector
 		return FALSE
-	
+
 	object = resolve_world_target(object)
-	if (object)
+	if(object)
 		target = object
-		owner.mob.face_atom(target)
-		spawn()
-			start_firing()
-		return FALSE
+		while(target)
+			owner.mob.face_atom(target)
+			do_fire()
+			sleep(reciever.burst_delay)		
 	return TRUE
 
-/datum/click_handler/fullauto/MouseDrag(over_object,src_location,over_location,src_control,over_control,params)
+/datum/click_handler/fullauto/MouseDrag(over_object, src_location, over_location, src_control, over_control, params)
 	src_location = resolve_world_target(src_location)
-	if (src_location && firing)
-		target = src_location //This var contains the thing the user is hovering over, oddly
-		owner.mob.face_atom(target)
+	if(src_location)
+		target = src_location
 		return FALSE
 	return TRUE
 
-/datum/click_handler/fullauto/MouseUp(object,location,control,params)
+/datum/click_handler/fullauto/MouseUp(object, location, control, params)
 	stop_firing()
 	return TRUE
 
 /datum/click_handler/fullauto/Destroy()
-	stop_firing()//Without this it keeps firing in an infinite loop when deleted
+	stop_firing() //Without this it keeps firing in an infinite loop when deleted
 	.=..()
-
-
-
-
-
-
-
-
 
 /datum/click_handler/human/mob_check(mob/living/carbon/human/user)
 	if(ishuman(user))

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -69,8 +69,7 @@
 
 	//Used in living/recoil.dm
 	var/recoil = 0 //What our current recoil level is
-	var/last_recoil_update = 0 //When our last recoil update was
-	var/recoil_timer //Holds the timer ID
+	var/recoil_reduction_timer
 	var/falls_mod = 1
 	var/mob_bomb_defense = 0	// protection from explosives
 	var/mod_climb_delay = 1 // delay for climb

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -418,7 +418,7 @@
 	if(params)
 		P.set_clickpoint(params)
 	var/offset = init_offset
-	if(user.calc_recoil())
+	if(user.recoil)
 		offset += user.recoil
 	offset = min(offset, MAX_ACCURACY_OFFSET)
 	offset = rand(-offset, offset)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -286,7 +286,7 @@
 
 		projectile.multiply_projectile_damage(damage_multiplier)
 
-		projectile.multiply_projectile_penetration(penetration_multiplier)
+		projectile.multiply_projectile_penetration(penetration_multiplier + user.stats.getStat(STAT_VIG) * 0.2)
 
 		projectile.multiply_pierce_penetration(pierce_multiplier)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -575,6 +575,7 @@
 	if(new_mode)
 		playsound(src.loc, 'sound/weapons/guns/interact/selector.ogg', 100, 1)
 		to_chat(user, SPAN_NOTICE("\The [src] is now set to [new_mode.name]."))
+		refresh_upgrades()
 
 /obj/item/weapon/gun/proc/toggle_safety(mob/living/user)
 	if(restrict_safety || src != user.get_active_hand())
@@ -685,7 +686,6 @@
 
 /obj/item/weapon/gun/refresh_upgrades()
 	//First of all, lets reset any var that could possibly be altered by an upgrade
-	damage_multiplier = initial(damage_multiplier)
 	penetration_multiplier = initial(penetration_multiplier)
 	pierce_multiplier = initial(pierce_multiplier)
 	proj_step_multiplier = initial(proj_step_multiplier)
@@ -703,6 +703,7 @@
 	zoom_factor = initial(zoom_factor)
 	initialize_scope()
 	initialize_firemodes()
+	update_firemode()
 
 	//Now lets have each upgrade reapply its modifications
 	SEND_SIGNAL(src, COMSIG_ADDVAL, src)


### PR DESCRIPTION
## About The Pull Request
This PR changes recoil to be like in FPS games, so you can't keep clicking your target with single fire mode and don't get recoil. Also vig now increases penetration, ask Reere why. Damage when autofiring is lowered, you can ask Reere about that too.

Click handlers changed, so it will (possibly not) reduce lag when autofiring.

## Why It's Good For The Game
Recoil increases when firing with single fire modes. Also Reere requested this changes.

## Changelog
:cl:
code: Recoil will now act differently, reducing to zero after second without firing guns.
tweak: Vig now affects penetration, not recoil gains.
tweak: Autofire damage is slightly lower.
refactor: Full Auto click handler refactoring
/:cl: