### PR TITLE
Fixes the NT cruciform's odd interaction with stat holders

### DIFF
--- a/code/datums/mob_stats.dm
+++ b/code/datums/mob_stats.dm
@@ -35,7 +35,7 @@
 	var/datum/stat/S = stat_list[statName]
 	S.changeValue(Value)
 	SEND_SIGNAL(holder, COMSIG_STAT, S.name, S.getValue(), S.getValue(TRUE))
-	
+
 /datum/stat_holder/proc/setStat(statName, Value)
 	var/datum/stat/S = stat_list[statName]
 	S.setValue(Value)
@@ -90,6 +90,18 @@
 		return 0
 	var/avg = getSumOfStat(namesList, pure)
 	return avg / namesList.len
+
+/datum/stat_holder/proc/copyTo(var/datum/stat_holder/recipient)
+	to_chat(world, "copying stats")
+	for(var/i in stat_list)
+		var/datum/stat/S = stat_list[i]
+		var/datum/stat/RS = recipient.stat_list[i]
+		to_chat(world, "[i], [S]:[S.value]. [RS]:[RS.value]")
+		S.copyTo(RS)
+
+	for(var/datum/perk/P in perks)
+		recipient.addPerk(P.type)
+
 
 // return value from 0 to 1 based on value of stat, more stat value less return value
 // use this proc to get multiplier for decreasing delay time (exaple: "50 * getMult(STAT_ROB, STAT_LEVEL_ADEPT)"  this will result in 5 seconds if stat STAT_ROB = 0 and result will be 0 if STAT_ROB = STAT_LEVEL_ADEPT)
@@ -183,6 +195,9 @@
 
 /datum/stat/proc/setValue(value)
 	src.value = value
+
+/datum/stat/proc/copyTo(var/datum/stat/recipient)
+	recipient.value = getValue(TRUE)
 
 /datum/stat/productivity
 	name = STAT_MEC

--- a/code/datums/mob_stats.dm
+++ b/code/datums/mob_stats.dm
@@ -92,11 +92,9 @@
 	return avg / namesList.len
 
 /datum/stat_holder/proc/copyTo(var/datum/stat_holder/recipient)
-	to_chat(world, "copying stats")
 	for(var/i in stat_list)
 		var/datum/stat/S = stat_list[i]
 		var/datum/stat/RS = recipient.stat_list[i]
-		to_chat(world, "[i], [S]:[S.value]. [RS]:[RS.value]")
 		S.copyTo(RS)
 
 	for(var/datum/perk/P in perks)

--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -6,10 +6,12 @@
 
 /datum/perk/fate/paper_worm/assign(mob/living/carbon/human/H)
 	..()
-	holder.sanity.positive_prob += 20
+	if(holder)
+		holder.sanity.positive_prob += 20
 
 /datum/perk/fate/paper_worm/remove()
-	holder.sanity.positive_prob -= 20
+	if(holder)
+		holder.sanity.positive_prob -= 20
 	..()
 
 /datum/perk/fate/freelancer
@@ -42,13 +44,15 @@
 
 /datum/perk/fate/nihilist/assign(mob/living/carbon/human/H)
 	..()
-	holder.sanity.positive_prob += 10
-	holder.sanity.negative_prob += 20
+	if(holder)
+		holder.sanity.positive_prob += 10
+		holder.sanity.negative_prob += 20
 
 /datum/perk/fate/nihilist/remove()
-	holder.sanity.positive_prob -= 10
-	holder.sanity.negative_prob -= 20
-	holder.stats.removeTempStat(STAT_COG, "Fate Nihilist")
+	if(holder)
+		holder.sanity.positive_prob -= 10
+		holder.sanity.negative_prob -= 20
+		holder.stats.removeTempStat(STAT_COG, "Fate Nihilist")
 	..()
 
 /datum/perk/fate/moralist
@@ -102,14 +106,16 @@
 
 /datum/perk/fate/alcoholic_active/assign(mob/living/carbon/human/H)
 	..()
-	holder.stats.addTempStat(STAT_ROB, 10, INFINITY, "Fate Alcoholic")
-	holder.stats.addTempStat(STAT_TGH, 10, INFINITY, "Fate Alcoholic")
-	holder.stats.addTempStat(STAT_VIG, 10, INFINITY, "Fate Alcoholic")
+	if(holder)
+		holder.stats.addTempStat(STAT_ROB, 10, INFINITY, "Fate Alcoholic")
+		holder.stats.addTempStat(STAT_TGH, 10, INFINITY, "Fate Alcoholic")
+		holder.stats.addTempStat(STAT_VIG, 10, INFINITY, "Fate Alcoholic")
 
 /datum/perk/fate/alcoholic_active/remove()
-	holder.stats.removeTempStat(STAT_ROB, "Fate Alcoholic")
-	holder.stats.removeTempStat(STAT_TGH, "Fate Alcoholic")
-	holder.stats.removeTempStat(STAT_VIG, "Fate Alcoholic")
+	if(holder)
+		holder.stats.removeTempStat(STAT_ROB, "Fate Alcoholic")
+		holder.stats.removeTempStat(STAT_TGH, "Fate Alcoholic")
+		holder.stats.removeTempStat(STAT_VIG, "Fate Alcoholic")
 	..()
 
 /datum/perk/fate/noble
@@ -120,6 +126,8 @@
 
 /datum/perk/fate/noble/assign(mob/living/carbon/human/H)
 	..()
+	if(!holder)
+		return
 	holder.sanity.environment_cap_coeff -= 1
 	if(!holder.last_name)
 		holder.stats.removePerk(src.type)
@@ -149,7 +157,8 @@
 		holder.equip_to_storage_or_drop(W)
 
 /datum/perk/fate/noble/remove()
-	holder.sanity.environment_cap_coeff += 1
+	if(holder)
+		holder.sanity.environment_cap_coeff += 1
 	..()
 
 /datum/perk/fate/rat
@@ -161,10 +170,12 @@
 
 /datum/perk/fate/rat/assign(mob/living/carbon/human/H)
 	..()
-	holder.sanity.max_level -= 10
+	if(holder)
+		holder.sanity.max_level -= 10
 
 /datum/perk/fate/rat/remove()
-	holder.sanity.max_level += 10
+	if(holder)
+		holder.sanity.max_level += 10
 	..()
 
 /datum/perk/fate/rejected_genius
@@ -176,16 +187,18 @@
 
 /datum/perk/fate/rejected_genius/assign(mob/living/carbon/human/H)
 	..()
-	holder.sanity.environment_cap_coeff -= 1
-	holder.sanity.positive_prob_multiplier -= 1
-	holder.sanity.insight_passive_gain_multiplier *= 1.5
-	holder.sanity.max_level -= 20
+	if(holder)
+		holder.sanity.environment_cap_coeff -= 1
+		holder.sanity.positive_prob_multiplier -= 1
+		holder.sanity.insight_passive_gain_multiplier *= 1.5
+		holder.sanity.max_level -= 20
 
 /datum/perk/fate/rejected_genius/remove()
-	holder.sanity.environment_cap_coeff += 1
-	holder.sanity.positive_prob_multiplier += 1
-	holder.sanity.insight_passive_gain_multiplier /= 1.5
-	holder.sanity.max_level += 20
+	if(holder)
+		holder.sanity.environment_cap_coeff += 1
+		holder.sanity.positive_prob_multiplier += 1
+		holder.sanity.insight_passive_gain_multiplier /= 1.5
+		holder.sanity.max_level += 20
 	..()
 
 /datum/perk/fate/oborin_syndrome
@@ -197,12 +210,14 @@
 
 /datum/perk/fate/oborin_syndrome/assign(mob/living/carbon/human/H)
 	..()
-	holder.sanity.max_level += 20
-	spawn(1)
-		holder.update_client_colour() //Handle the activation of the colourblindness on the mob.
+	if(holder)
+		holder.sanity.max_level += 20
+		spawn(1)
+			holder.update_client_colour() //Handle the activation of the colourblindness on the mob.
 
 /datum/perk/fate/oborin_syndrome/remove()
-	holder.sanity.max_level -= 20
+	if(holder)
+		holder.sanity.max_level -= 20
 	..()
 
 /datum/perk/fate/lowborn
@@ -213,8 +228,10 @@
 
 /datum/perk/fate/lowborn/assign(mob/living/carbon/human/H)
 	..()
-	holder.sanity.max_level += 10
+	if(holder)
+		holder.sanity.max_level += 10
 
 /datum/perk/fate/lowborn/remove()
-	holder.sanity.max_level -= 10
+	if(holder)
+		holder.sanity.max_level -= 10
 	..()

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -6,10 +6,12 @@
 
 /datum/perk/survivor/assign(mob/living/carbon/human/H)
 	..()
-	holder?.sanity.death_view_multiplier *= 0.5
+	if(holder)
+		holder.sanity.death_view_multiplier *= 0.5
 
 /datum/perk/survivor/remove()
-	holder?.sanity.death_view_multiplier *= 2
+	if(holder)
+		holder.sanity.death_view_multiplier *= 2
 	..()
 
 /datum/perk/selfmedicated
@@ -20,12 +22,14 @@
 
 /datum/perk/selfmedicated/assign(mob/living/carbon/human/H)
 	..()
-	holder?.metabolism_effects.addiction_chance_multiplier = 0.5
-	holder?.metabolism_effects.nsa_threshold += 10
+	if(holder)
+		holder.metabolism_effects.addiction_chance_multiplier = 0.5
+		holder.metabolism_effects.nsa_threshold += 10
 
 /datum/perk/selfmedicated/remove()
-	holder?.metabolism_effects.addiction_chance_multiplier = 1
-	holder?.metabolism_effects.nsa_threshold -= 10
+	if(holder)
+		holder.metabolism_effects.addiction_chance_multiplier = 1
+		holder.metabolism_effects.nsa_threshold -= 10
 	..()
 
 /datum/perk/vagabond
@@ -36,10 +40,12 @@
 
 /datum/perk/vagabond/assign(mob/living/carbon/human/H)
 	..()
-	holder?.sanity.view_damage_threshold += 20
+	if(holder)
+		holder.sanity.view_damage_threshold += 20
 
 /datum/perk/vagabond/remove()
-	holder?.sanity.view_damage_threshold -= 20
+	if(holder)
+		holder.sanity.view_damage_threshold -= 20
 	..()
 
 /datum/perk/merchant
@@ -50,10 +56,12 @@
 
 /datum/perk/merchant/assign(mob/living/carbon/human/H)
 	..()
-	holder?.sanity.valid_inspirations += /obj/item/weapon/spacecash/bundle
+	if(holder)
+		holder.sanity.valid_inspirations += /obj/item/weapon/spacecash/bundle
 
 /datum/perk/merchant/remove()
-	holder?.sanity.valid_inspirations -= /obj/item/weapon/spacecash/bundle
+	if(holder)
+		holder.sanity.valid_inspirations -= /obj/item/weapon/spacecash/bundle
 	..()
 
 #define CHOICE_LANG "language" // Random language chosen from a pool
@@ -70,6 +78,8 @@
 
 /datum/perk/deep_connection/assign(mob/living/carbon/human/H)
 	..()
+	if(!holder)
+		return
 	var/list/choices = list(CHOICE_RAREOBJ)
 	if(GLOB.various_antag_contracts.len)
 		choices += CHOICE_TCONTRACT
@@ -82,7 +92,7 @@
 	var/list/valid_languages = list(LANGUAGE_CYRILLIC, LANGUAGE_SERBIAN, LANGUAGE_GERMAN) // Not static, because we're gonna remove languages already known by the user
 	for(var/l in valid_languages)
 		var/datum/language/L = all_languages[l]
-		if(L in holder?.languages)
+		if(L in holder.languages)
 			valid_languages -= l
 	if(valid_languages.len)
 		choices += CHOICE_LANG
@@ -90,23 +100,23 @@
 	switch(pick(choices))
 		if(CHOICE_LANG)
 			var/language = pick(valid_languages)
-			holder?.add_language(language)
+			holder.add_language(language)
 			desc += " In particular, you happen to know [language]."
 		if(CHOICE_TCONTRACT)
 			var/datum/antag_contract/A = pick(GLOB.various_antag_contracts)
 			desc += " You feel like you remembered something important."
-			holder?.mind.store_memory("Thanks to your connections, you were tipped off about some suspicious individuals on the station. In particular, you were told that they have a contract: " + A.name + ": " + A.desc)
+			holder.mind.store_memory("Thanks to your connections, you were tipped off about some suspicious individuals on the station. In particular, you were told that they have a contract: " + A.name + ": " + A.desc)
 		if(CHOICE_STASHPAPER)
 			desc += " You have a special note in your storage."
 			stash.spawn_stash()
 			var/obj/item/weapon/paper/stash_note = stash.spawn_note()
-			holder?.equip_to_storage_or_drop(stash_note)
+			holder.equip_to_storage_or_drop(stash_note)
 		if(CHOICE_RAREOBJ)
 			desc += " You managed to smuggle a rare item aboard."
 			var/obj/O = pickweight(RANDOM_RARE_ITEM - /obj/item/stash_spawner)
 			var/obj/item/weapon/storage/box/B = new
 			new O(B) // Spawn the random spawner in the box, so that the resulting random item will be within the box
-			holder?.equip_to_storage_or_drop(B)
+			holder.equip_to_storage_or_drop(B)
 
 #undef CHOICE_LANG
 #undef CHOICE_TCONTRACT
@@ -120,10 +130,12 @@
 
 /datum/perk/sanityboost/assign(mob/living/carbon/human/H)
 	..()
-	holder?.sanity.sanity_passive_gain_multiplier *= 1.5
+	if(holder)
+		holder.sanity.sanity_passive_gain_multiplier *= 1.5
 
 /datum/perk/sanityboost/remove()
-	holder?.sanity.sanity_passive_gain_multiplier /= 1.5
+	if(holder)
+		holder.sanity.sanity_passive_gain_multiplier /= 1.5
 	..()
 
 /// Basically a marker perk. If the user has this perk, another will be given in certain conditions.
@@ -138,12 +150,14 @@
 
 /datum/perk/active_inspiration/assign(mob/living/carbon/human/H)
 	..()
-	holder?.stats.addTempStat(STAT_COG, 5, INFINITY, "Exotic Inspiration")
-	holder?.stats.addTempStat(STAT_MEC, 10, INFINITY, "Exotic Inspiration")
+	if(holder)
+		holder.stats.addTempStat(STAT_COG, 5, INFINITY, "Exotic Inspiration")
+		holder.stats.addTempStat(STAT_MEC, 10, INFINITY, "Exotic Inspiration")
 
 /datum/perk/active_inspiration/remove()
-	holder?.stats.removeTempStat(STAT_COG, "Exotic Inspiration")
-	holder?.stats.removeTempStat(STAT_MEC, "Exotic Inspiration")
+	if(holder)
+		holder.stats.removeTempStat(STAT_COG, "Exotic Inspiration")
+		holder.stats.removeTempStat(STAT_MEC, "Exotic Inspiration")
 	..()
 
 /datum/perk/sommelier

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -6,10 +6,10 @@
 
 /datum/perk/survivor/assign(mob/living/carbon/human/H)
 	..()
-	holder.sanity.death_view_multiplier *= 0.5
+	holder?.sanity.death_view_multiplier *= 0.5
 
 /datum/perk/survivor/remove()
-	holder.sanity.death_view_multiplier *= 2
+	holder?.sanity.death_view_multiplier *= 2
 	..()
 
 /datum/perk/selfmedicated
@@ -20,12 +20,12 @@
 
 /datum/perk/selfmedicated/assign(mob/living/carbon/human/H)
 	..()
-	holder.metabolism_effects.addiction_chance_multiplier = 0.5
-	holder.metabolism_effects.nsa_threshold += 10
+	holder?.metabolism_effects.addiction_chance_multiplier = 0.5
+	holder?.metabolism_effects.nsa_threshold += 10
 
 /datum/perk/selfmedicated/remove()
-	holder.metabolism_effects.addiction_chance_multiplier = 1
-	holder.metabolism_effects.nsa_threshold -= 10
+	holder?.metabolism_effects.addiction_chance_multiplier = 1
+	holder?.metabolism_effects.nsa_threshold -= 10
 	..()
 
 /datum/perk/vagabond
@@ -36,10 +36,10 @@
 
 /datum/perk/vagabond/assign(mob/living/carbon/human/H)
 	..()
-	holder.sanity.view_damage_threshold += 20
+	holder?.sanity.view_damage_threshold += 20
 
 /datum/perk/vagabond/remove()
-	holder.sanity.view_damage_threshold -= 20
+	holder?.sanity.view_damage_threshold -= 20
 	..()
 
 /datum/perk/merchant
@@ -50,10 +50,10 @@
 
 /datum/perk/merchant/assign(mob/living/carbon/human/H)
 	..()
-	holder.sanity.valid_inspirations += /obj/item/weapon/spacecash/bundle
+	holder?.sanity.valid_inspirations += /obj/item/weapon/spacecash/bundle
 
 /datum/perk/merchant/remove()
-	holder.sanity.valid_inspirations -= /obj/item/weapon/spacecash/bundle
+	holder?.sanity.valid_inspirations -= /obj/item/weapon/spacecash/bundle
 	..()
 
 #define CHOICE_LANG "language" // Random language chosen from a pool
@@ -82,7 +82,7 @@
 	var/list/valid_languages = list(LANGUAGE_CYRILLIC, LANGUAGE_SERBIAN, LANGUAGE_GERMAN) // Not static, because we're gonna remove languages already known by the user
 	for(var/l in valid_languages)
 		var/datum/language/L = all_languages[l]
-		if(L in holder.languages)
+		if(L in holder?.languages)
 			valid_languages -= l
 	if(valid_languages.len)
 		choices += CHOICE_LANG
@@ -90,23 +90,23 @@
 	switch(pick(choices))
 		if(CHOICE_LANG)
 			var/language = pick(valid_languages)
-			holder.add_language(language)
+			holder?.add_language(language)
 			desc += " In particular, you happen to know [language]."
 		if(CHOICE_TCONTRACT)
 			var/datum/antag_contract/A = pick(GLOB.various_antag_contracts)
 			desc += " You feel like you remembered something important."
-			holder.mind.store_memory("Thanks to your connections, you were tipped off about some suspicious individuals on the station. In particular, you were told that they have a contract: " + A.name + ": " + A.desc)
+			holder?.mind.store_memory("Thanks to your connections, you were tipped off about some suspicious individuals on the station. In particular, you were told that they have a contract: " + A.name + ": " + A.desc)
 		if(CHOICE_STASHPAPER)
 			desc += " You have a special note in your storage."
 			stash.spawn_stash()
 			var/obj/item/weapon/paper/stash_note = stash.spawn_note()
-			holder.equip_to_storage_or_drop(stash_note)
+			holder?.equip_to_storage_or_drop(stash_note)
 		if(CHOICE_RAREOBJ)
 			desc += " You managed to smuggle a rare item aboard."
 			var/obj/O = pickweight(RANDOM_RARE_ITEM - /obj/item/stash_spawner)
 			var/obj/item/weapon/storage/box/B = new
 			new O(B) // Spawn the random spawner in the box, so that the resulting random item will be within the box
-			holder.equip_to_storage_or_drop(B)
+			holder?.equip_to_storage_or_drop(B)
 
 #undef CHOICE_LANG
 #undef CHOICE_TCONTRACT
@@ -120,10 +120,10 @@
 
 /datum/perk/sanityboost/assign(mob/living/carbon/human/H)
 	..()
-	holder.sanity.sanity_passive_gain_multiplier *= 1.5
+	holder?.sanity.sanity_passive_gain_multiplier *= 1.5
 
 /datum/perk/sanityboost/remove()
-	holder.sanity.sanity_passive_gain_multiplier /= 1.5
+	holder?.sanity.sanity_passive_gain_multiplier /= 1.5
 	..()
 
 /// Basically a marker perk. If the user has this perk, another will be given in certain conditions.
@@ -138,12 +138,12 @@
 
 /datum/perk/active_inspiration/assign(mob/living/carbon/human/H)
 	..()
-	holder.stats.addTempStat(STAT_COG, 5, INFINITY, "Exotic Inspiration")
-	holder.stats.addTempStat(STAT_MEC, 10, INFINITY, "Exotic Inspiration")
+	holder?.stats.addTempStat(STAT_COG, 5, INFINITY, "Exotic Inspiration")
+	holder?.stats.addTempStat(STAT_MEC, 10, INFINITY, "Exotic Inspiration")
 
 /datum/perk/active_inspiration/remove()
-	holder.stats.removeTempStat(STAT_COG, "Exotic Inspiration")
-	holder.stats.removeTempStat(STAT_MEC, "Exotic Inspiration")
+	holder?.stats.removeTempStat(STAT_COG, "Exotic Inspiration")
+	holder?.stats.removeTempStat(STAT_MEC, "Exotic Inspiration")
 	..()
 
 /datum/perk/sommelier

--- a/code/datums/perks/oddity.dm
+++ b/code/datums/perks/oddity.dm
@@ -51,12 +51,14 @@
 
 /datum/perk/oddity/space_asshole/assign(mob/living/carbon/human/H)
 	..()
-	holder.mob_bomb_defense += 25
-	holder.falls_mod -= 0.4
+	if(holder)
+		holder.mob_bomb_defense += 25
+		holder.falls_mod -= 0.4
 
 /datum/perk/oddity/space_asshole/remove()
-	holder.mob_bomb_defense -= 25
-	holder.falls_mod += 0.4
+	if(holder)
+		holder.mob_bomb_defense -= 25
+		holder.falls_mod += 0.4
 	..()
 
 /datum/perk/oddity/parkour
@@ -66,10 +68,12 @@
 
 /datum/perk/oddity/parkour/assign(mob/living/carbon/human/H)
 	..()
-	holder.mod_climb_delay -= 0.5
+	if(holder)
+		holder.mod_climb_delay -= 0.5
 
 /datum/perk/oddity/parkour/remove()
-	holder.mod_climb_delay += 0.5
+	if(holder)
+		holder.mod_climb_delay += 0.5
 	..()
 
 /datum/perk/oddity/charming_personality
@@ -80,10 +84,12 @@
 
 /datum/perk/oddity/charming_personality/assign(mob/living/carbon/human/H)
 	..()
-	holder.sanity_damage -= 2
+	if(holder)
+		holder.sanity_damage -= 2
 
 /datum/perk/oddity/charming_personality/remove()
-	holder.sanity_damage += 2
+	if(holder)
+		holder.sanity_damage += 2
 	..()
 
 /datum/perk/oddity/horrible_deeds
@@ -94,10 +100,12 @@
 
 /datum/perk/oddity/horrible_deeds/assign(mob/living/carbon/human/H)
 	..()
-	holder.sanity_damage += 2
+	if(holder)
+		holder.sanity_damage += 2
 
 /datum/perk/oddity/horrible_deeds/remove()
-	holder.sanity_damage -= 2
+	if(holder)
+		holder.sanity_damage -= 2
 	..()
 
 /datum/perk/oddity/chaingun_smoker
@@ -125,10 +133,12 @@
 
 /datum/perk/oddity/quiet_as_mouse/assign(mob/living/carbon/human/H)
 	..()
-	holder.noise_coeff -= 0.5
+	if(holder)
+		holder.noise_coeff -= 0.5
 
 /datum/perk/oddity/quiet_as_mouse/remove()
-	holder.noise_coeff += 0.5
+	if(holder)
+		holder.noise_coeff += 0.5
 	..()
 
 /datum/perk/oddity/balls_of_plasteel
@@ -151,10 +161,12 @@
 
 /datum/perk/oddity/ass_of_concrete/assign(mob/living/carbon/human/H)
 	..()
-	holder.mob_bump_flag = HEAVY
+	if(holder)
+		holder.mob_bump_flag = HEAVY
 
 /datum/perk/oddity/ass_of_concrete/remove()
-	holder.mob_bump_flag = ~HEAVY
+	if(holder)
+		holder.mob_bump_flag = ~HEAVY
 	..()
 
 /datum/perk/oddity/toxic_revenger

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -251,6 +251,8 @@
 			continue
 		get_option(options_name).apply(character)
 
+	character.post_prefinit()
+
 
 /datum/preferences/proc/open_load_dialog(mob/user)
 	var/dat  = list()

--- a/code/modules/core_implant/core_implant.dm
+++ b/code/modules/core_implant/core_implant.dm
@@ -107,6 +107,10 @@
 		L |= M.GetAccess()
 	return L
 
+/obj/item/weapon/implant/core_implant/on_uninstall()
+	for(var/datum/core_module/M in modules)
+		M.on_implant_uninstall()
+
 /obj/item/weapon/implant/core_implant/hear_talk(mob/living/carbon/human/H, message, verb, datum/language/speaking, speech_volume)
 	var/group_ritual_leader = FALSE
 	for(var/datum/core_module/group_ritual/GR in src.modules)

--- a/code/modules/core_implant/cruciform/machinery/cloning.dm
+++ b/code/modules/core_implant/cruciform/machinery/cloning.dm
@@ -229,7 +229,7 @@
 			occupant.UpdateAppearance()
 			occupant.sync_organ_dna()
 			occupant.flavor_text = R.flavor
-			occupant.stats = R.stats
+			R.stats.copyTo(occupant.stats)
 
 		if(progress == CLONING_BODY || progress <= CLONING_BODY && progress > CLONING_BODY-10)
 			var/datum/effect/effect/system/spark_spread/s = new

--- a/code/modules/core_implant/cruciform/modules.dm
+++ b/code/modules/core_implant/cruciform/modules.dm
@@ -64,8 +64,10 @@
 
 /datum/core_module/cruciform/cloning/proc/write_wearer(var/mob/living/carbon/human/H)
 	dna = H.dna
-	ckey = H.ckey
-	mind = H.mind
+	if(H.ckey)
+		ckey = H.ckey
+	if(H.mind)
+		mind = H.mind
 	languages = H.languages
 	flavor = H.flavor_text
 	age = H.age

--- a/code/modules/core_implant/cruciform/modules.dm
+++ b/code/modules/core_implant/cruciform/modules.dm
@@ -69,7 +69,9 @@
 	languages = H.languages
 	flavor = H.flavor_text
 	age = H.age
-	stats = H.stats
+	QDEL_NULL(stats)
+	stats = new /datum/stat_holder()
+	H.stats.copyTo(stats)
 
 /datum/core_module/cruciform/cloning/preinstall()
 	if(ishuman(implant.wearer))
@@ -84,7 +86,9 @@
 		languages = H.languages
 		flavor = H.flavor_text
 		age = H.age
-		stats = H.stats
+		QDEL_NULL(stats)
+		stats = new /datum/stat_holder
+		H.stats.copyTo(stats)
 
 
 /datum/core_module/cruciform/obey/install()

--- a/code/modules/core_implant/cruciform/modules.dm
+++ b/code/modules/core_implant/cruciform/modules.dm
@@ -73,23 +73,17 @@
 	stats = new /datum/stat_holder()
 	H.stats.copyTo(stats)
 
+/datum/core_module/cruciform/cloning/on_implant_uninstall()
+	if(ishuman(implant.wearer))
+		write_wearer(implant.wearer)
+
 /datum/core_module/cruciform/cloning/preinstall()
 	if(ishuman(implant.wearer))
 		implant.remove_modules(CRUCIFORM_CLONING)
 
 /datum/core_module/cruciform/cloning/install()
 	if(ishuman(implant.wearer))
-		var/mob/living/carbon/human/H = implant.wearer
-		dna = H.dna
-		ckey = H.ckey
-		mind = H.mind
-		languages = H.languages
-		flavor = H.flavor_text
-		age = H.age
-		QDEL_NULL(stats)
-		stats = new /datum/stat_holder
-		H.stats.copyTo(stats)
-
+		write_wearer(implant.wearer)
 
 /datum/core_module/cruciform/obey/install()
 	var/laws = list("You are enslaved. You must obey the laws below.",

--- a/code/modules/core_implant/module.dm
+++ b/code/modules/core_implant/module.dm
@@ -22,6 +22,8 @@
 /datum/core_module/proc/GetAccess()
 	return access.Copy()
 
+/datum/core_module/proc/on_implant_uninstall()
+
 
 //ACTIVATABLE
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1243,6 +1243,14 @@ var/list/rank_prefix = list(\
 
 	update_body()
 
+/mob/living/carbon/human/proc/post_prefinit()
+	var/obj/item/weapon/implant/core_implant/C = locate() in src
+	if(C)
+		C.install(src)
+		C.activate()
+		C.install_default_modules_by_job(mind.assigned_job)
+		C.access |= mind.assigned_job.cruciform_access
+
 /mob/living/carbon/human/proc/bloody_doodle()
 	set category = "IC"
 	set name = "Write in blood"

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -171,6 +171,10 @@
 	for(var/atom/movable/implant in implants)
 		//large items and non-item objs fall to the floor, everything else stays
 		var/obj/item/I = implant
+		if(istype(I, /obj/item/weapon/implant))
+			var/obj/item/weapon/implant/Imp = I
+			Imp.uninstall()
+			continue
 		if(istype(I) && I.w_class < ITEM_SIZE_NORMAL)
 			implant.forceMove(get_turf(owner))
 		else


### PR DESCRIPTION
## About The Pull Request 

Currently, the cruciform points towards the users stats holder. This can be deleted if the body itself is destroyed.

If the stats holder is deleted after a clone has been made, the clone starts to runtime out (Able to move at super speed, unable to die, unable to perform certain actions that depend on a perk)

## Why It's Good For The Game

NT shouldn't have access to making ubergolems

## Changelog
:cl:
fix: Fixes NT cloning turning people into statless power husks.
/:cl:
