### PR TITLE
Gives spiders japanese names and descriptions

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
@@ -1,7 +1,7 @@
 //basic spider mob, these generally guard nests
 /mob/living/carbon/superior_animal/giant_spider
-	name = "giant spider"
-	desc = "Furry and black, it makes you shudder to look at it. This one has deep red eyes."
+	name = "Senshi Spider"
+	desc = "An overgrown tarantula. It's fangs are coated in a discolored fluid, and it's chitin seems incredibly thick."
 	icon_state = "guard"
 	icon_living = "guard"
 	pass_flags = PASSTABLE

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
@@ -1,6 +1,7 @@
 //hunters have the most poison and move the fastest, so they can find prey
 /mob/living/carbon/superior_animal/giant_spider/hunter
-	desc = "Furry and black, it makes you shudder to look at it. This one has sparkling purple eyes."
+	name = "Sukauto Spider"
+	desc = "A massive widow spider. This insect skitters around deftly, and an unknown liquid drips from its fangs."
 	icon_state = "hunter"
 	icon_living = "hunter"
 	maxHealth = 90

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
@@ -1,6 +1,6 @@
 //hunters have the most poison and move the fastest, so they can find prey
 /mob/living/carbon/superior_animal/giant_spider/hunter
-	name = "Sukauto Spider"
+	name = "Sokuryou Spider"
 	desc = "A massive widow spider. This insect skitters around deftly, and an unknown liquid drips from its fangs."
 	icon_state = "hunter"
 	icon_living = "hunter"

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
@@ -5,7 +5,8 @@
 
 //nursemaids - these create webs and eggs
 /mob/living/carbon/superior_animal/giant_spider/nurse
-	desc = "Furry and black, it makes you shudder to look at it. This one has brilliant green eyes."
+	name = "Kenchikka Spider"
+	desc = "A massive tangleweb spider. It's abdomen takes up the majority of the creature's mass. For a giant insect, this one seems especially fragile."
 	icon_state = "nurse"
 	icon_living = "nurse"
 	maxHealth = 40

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
@@ -5,7 +5,7 @@
 
 //nursemaids - these create webs and eggs
 /mob/living/carbon/superior_animal/giant_spider/nurse
-	name = "Kenchikka Spider"
+	name = "Kouchiku Spider"
 	desc = "A massive tangleweb spider. It's abdomen takes up the majority of the creature's mass. For a giant insect, this one seems especially fragile."
 	icon_state = "nurse"
 	icon_living = "nurse"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives our favorite spiders three new names, similar to how roaches have german names.
The guard spider is now the Senshi Spider, or the Warrior Spider.
The nurse spider is now the Kouchiku Spider, or the Building Spider.
The hunter spider is now the Sokuryou Spider, or the Scout Spider.

## Why It's Good For The Game

Gives the spiders more character, does something Reere had been planning to do anyways, and makes it a standard for all our insects to have non-english prefixes. Very nice.

## Changelog
:cl:
tweak: Giant spiders now have class-specific names and descriptions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
