### PR TITLE
Fixes altyn bugs with minor refactor

### DIFF
--- a/code/game/objects/items/weapons/storage/deferred.dm
+++ b/code/game/objects/items/weapons/storage/deferred.dm
@@ -52,7 +52,7 @@
 	. = ..()
 
 
-/obj/item/weapon/storage/deferred/rations //DO this before merging 
+/obj/item/weapon/storage/deferred/rations //DO this before merging
 	name = "infantryman's rations kit"
 	icon_state = "irp_box"
 	item_state = "irp_box"
@@ -242,7 +242,7 @@
 	/obj/item/clothing/under/serbiansuit = 1,
 	/obj/item/clothing/head/soft/green2soft = 1,
 	/obj/item/clothing/suit/armor/bulletproof/serbian/green = 1,
-	/obj/item/clothing/head/armor/altyn = 1,
+	/obj/item/clothing/head/armor/faceshield/altyn = 1,
 	/obj/item/clothing/mask/balaclava/tactical = 1,
 	/obj/item/clothing/shoes/jackboots = 1,
 	/obj/item/clothing/gloves/fingerless = 1)
@@ -255,7 +255,7 @@
 	/obj/item/clothing/under/serbiansuit/brown = 1,
 	/obj/item/clothing/head/soft/tan2soft = 1,
 	/obj/item/clothing/suit/armor/bulletproof/serbian/tan = 1,
-	/obj/item/clothing/head/armor/altyn/brown = 1,
+	/obj/item/clothing/head/armor/faceshield/altyn/brown = 1,
 	/obj/item/clothing/mask/balaclava/tactical = 1,
 	/obj/item/clothing/shoes/jackboots = 1,
 	/obj/item/clothing/suit/armor/greatcoat/serbian_overcoat_brown = 1)
@@ -267,7 +267,7 @@
 	initial_contents = list(
 	/obj/item/clothing/under/serbiansuit/black = 1,
 	/obj/item/clothing/suit/armor/bulletproof/serbian = 1,
-	/obj/item/clothing/head/armor/altyn/black = 1,
+	/obj/item/clothing/head/armor/faceshield/altyn/black = 1,
 	/obj/item/clothing/mask/balaclava/tactical = 1,
 	/obj/item/clothing/shoes/jackboots = 1,
 	/obj/item/clothing/gloves/fingerless = 1,
@@ -280,7 +280,7 @@
 	initial_contents = list(
 	/obj/item/clothing/under/serbiansuit = 1,
 	/obj/item/clothing/suit/armor/flak/green = 1,
-	/obj/item/clothing/head/armor/altyn/maska = 1,
+	/obj/item/clothing/head/armor/faceshield/altyn/maska = 1,
 	/obj/item/clothing/mask/balaclava/tactical = 1,
 	/obj/item/clothing/shoes/jackboots = 1,
 	/obj/item/clothing/gloves/fingerless = 1,

--- a/code/modules/cargo/exports/gear.dm
+++ b/code/modules/cargo/exports/gear.dm
@@ -20,7 +20,7 @@
 /datum/export/gear/riot_helmet
 	cost = 250
 	unit_name = "riot helmet"
-	export_types = list(/obj/item/clothing/head/armor/riot)
+	export_types = list(/obj/item/clothing/head/armor/faceshield/riot)
 
 /datum/export/gear/riot_armor
 	cost = 500

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -343,9 +343,9 @@
 	icon_state = up ? "[initial(icon_state)]_up" : initial(icon_state)
 
 //I wanted to name it set_up() but some how I thought that would be misleading
-/obj/item/clothing/head/armor/faceshield/proc/set_is_up(u)
-	up = u
-	if(u)
+/obj/item/clothing/head/armor/faceshield/proc/set_is_up(is_up)
+	up = is_up
+	if(up)
 		armor = getArmor(arglist(armor_up))
 		flash_protection = initial(flash_protection)
 		tint = initial(tint)

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -305,58 +305,75 @@
 		MATERIAL_GLASS = 10 // glass is reflective yo, make it cost a lot of it - also, visor
 	)
 
-// Riot helmet
-/obj/item/clothing/head/armor/riot
+// toggleable face guard
+/obj/item/clothing/head/armor/faceshield
+	//We cant just use the armor var to store the original since initial(armor) will return a null pointer
+	var/list/armor_up = list(melee = 0, bullet = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
+	var/list/armor_down = list(melee = 0, bullet = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
+
+	var/tint_down = TINT_MODERATE
+	flags_inv = HIDEEARS
+	var/flags_inv_down = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHEADHAIR
+	body_parts_covered = HEAD|EARS
+	var/body_parts_covered_down = HEAD|EARS|EYES|FACE
+	flash_protection = FLASH_PROTECTION_NONE
+	var/flash_protection_down = FLASH_PROTECTION_MAJOR
+	action_button_name = "Flip Face Shield"
+	var/up = FALSE
+	bad_type = /obj/item/clothing/head/armor/faceshield
+
+/obj/item/clothing/head/armor/faceshield/riot
 	name = "riot helmet"
 	desc = "It's a helmet specifically designed to protect against close range attacks."
 	icon_state = "riot"
-	body_parts_covered = HEAD|FACE|EARS
-	var/list/armor_up = list(melee = 35, bullet = 25, energy = 25, bomb = 20, bio = 0, rad = 0)
-	var/list/armor_down = list(melee = 40, bullet = 40, energy = 30, bomb = 35, bio = 0, rad = 0)
+	armor_up = list(melee = 35, bullet = 25, energy = 25, bomb = 20, bio = 0, rad = 0)
+	armor_down = list(melee = 40, bullet = 40, energy = 30, bomb = 35, bio = 0, rad = 0)
 	item_flags = THICKMATERIAL | COVER_PREVENT_MANIPULATION
-	tint = TINT_MODERATE
-	flash_protection = FLASH_PROTECTION_MAJOR
-	action_button_name = "Flip Face Shield"
-	var/up = FALSE
 	price_tag = 150
 	rarity_value = 25
 
-/obj/item/clothing/head/armor/riot/Initialize()
+/obj/item/clothing/head/armor/faceshield/Initialize()
 	. = ..()
-	armor = up ? armor_up : armor_down
-	update_icon()
+	set_is_up(up)
 
-/obj/item/clothing/head/armor/riot/attack_self()
+/obj/item/clothing/head/armor/faceshield/attack_self()
 	toggle()
 
-/obj/item/clothing/head/armor/riot/update_icon()
+/obj/item/clothing/head/armor/faceshield/update_icon()
 	icon_state = up ? "[initial(icon_state)]_up" : initial(icon_state)
 
-/obj/item/clothing/head/armor/riot/verb/toggle()
+//I wanted to name it set_up() but some how I thought that would be misleading
+/obj/item/clothing/head/armor/faceshield/proc/set_is_up(u)
+	up = u
+	if(u)
+		armor = getArmor(arglist(armor_up))
+		flash_protection = initial(flash_protection)
+		tint = initial(tint)
+		flags_inv = initial(flags_inv)
+		body_parts_covered = initial(body_parts_covered)
+	else
+		armor = getArmor(arglist(armor_down))
+		flash_protection = flash_protection_down
+		tint = tint_down
+		flags_inv = flags_inv_down
+		body_parts_covered = body_parts_covered_down
+
+	update_icon()
+	update_wear_icon()	//update our mob overlays
+
+/obj/item/clothing/head/armor/faceshield/verb/toggle()
 	set category = "Object"
-	set name = "Adjust riot helmet"
+	set name = "Adjust face shield"
 	set src in usr
 
 	if(!usr.incapacitated())
-		src.up = !src.up
+		src.set_is_up(!src.up)
 
 		if(src.up)
-			body_parts_covered &= ~(EYES|FACE)
-			tint = TINT_NONE
-			flags_inv &= ~(HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
-			flash_protection = FLASH_PROTECTION_NONE
-			armor = armor_up
 			to_chat(usr, "You push the [src] up out of your face.")
 		else
-			body_parts_covered |= (EYES|FACE)
-			tint = initial(tint)
-			flags_inv |= (HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
-			flash_protection = initial(flash_protection)
-			armor = armor_down
 			to_chat(usr, "You flip the [src] down to protect your face.")
 
-		update_icon()
-		update_wear_icon()	//update our mob overlays
 		usr.update_action_buttons()
 
 
@@ -445,67 +462,23 @@
 	body_parts_covered = HEAD|EARS
 	siemens_coefficient = 1
 
-/obj/item/clothing/head/armor/altyn
+/obj/item/clothing/head/armor/faceshield/altyn
 	name = "altyn helmet"
 	desc = "A titanium helmet of serbian origin. Still widely used despite being discontinued."
 	icon_state = "altyn"
-	var/list/armor_up = list(melee = 20, bullet = 15, energy = 0, bomb = 15, bio = 0, rad = 0)
-	var/list/armor_down = list(melee = 40, bullet = 40, energy = 0, bomb = 35, bio = 0, rad = 0) // slightly better than usual due to mask
-	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHEADHAIR
-	flash_protection = FLASH_PROTECTION_MAJOR
-	body_parts_covered = HEAD|FACE|EARS
+	armor_up = list(melee = 20, bullet = 15, energy = 0, bomb = 15, bio = 0, rad = 0)
+	armor_down = list(melee = 40, bullet = 40, energy = 0, bomb = 35, bio = 0, rad = 0)
 	siemens_coefficient = 1
 	rarity_value = 50
+	up = TRUE
 
-	action_button_name = "Flip Face Shield"
-	var/up = TRUE
-
-
-/obj/item/clothing/head/armor/altyn/Initialize()
-	. = ..()
-	armor = up ? armor_up : armor_down
-	update_icon()
-
-/obj/item/clothing/head/armor/altyn/update_icon()
-	icon_state = up ? "[initial(icon_state)]_up" : initial(icon_state)
-
-/obj/item/clothing/head/armor/altyn/attack_self()
-	toggle()
-
-
-/obj/item/clothing/head/armor/altyn/verb/toggle()
-	set category = "Object"
-	set name = "Adjust face shield"
-	set src in usr
-
-	if(!usr.incapacitated())
-		src.up = !src.up
-
-		if(src.up)
-			body_parts_covered &= ~(EYES|FACE)
-			flags_inv &= ~(HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
-			flash_protection = FLASH_PROTECTION_NONE
-			armor = armor_up
-			to_chat(usr, "You push the [src] up out of your face.")
-		else
-			body_parts_covered |= (EYES|FACE)
-			flags_inv |= (HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
-			flash_protection = initial(flash_protection)
-			armor = armor_down
-			to_chat(usr, "You flip the [src] down to protect your face.")
-
-		update_icon()
-		update_wear_icon()	//update our mob overlays
-		usr.update_action_buttons()
-
-
-/obj/item/clothing/head/armor/altyn/brown
+/obj/item/clothing/head/armor/faceshield/altyn/brown
 	icon_state = "altyn_brown"
 
-/obj/item/clothing/head/armor/altyn/black
+/obj/item/clothing/head/armor/faceshield/altyn/black
 	icon_state = "altyn_black"
 
-/obj/item/clothing/head/armor/altyn/maska
+/obj/item/clothing/head/armor/faceshield/altyn/maska
 	name = "maska helmet"
 	desc = "\"I do not know who I am, I don\'t know why I\'m here. All I know is that I must kill.\""
 	icon_state = "maska"

--- a/code/modules/random_map/drop/drop_types.dm
+++ b/code/modules/random_map/drop/drop_types.dm
@@ -91,11 +91,11 @@ var/global/list/datum/supply_drop_loot/supply_drop
 /datum/supply_drop_loot/armour/New()
 	..()
 	contents = list(
-		/obj/item/clothing/head/armor/riot,
+		/obj/item/clothing/head/armor/faceshield/riot,
 		/obj/item/clothing/suit/armor/heavy/riot,
-		/obj/item/clothing/head/armor/riot,
+		/obj/item/clothing/head/armor/faceshield/riot,
 		/obj/item/clothing/suit/armor/heavy/riot,
-		/obj/item/clothing/head/armor/riot,
+		/obj/item/clothing/head/armor/faceshield/riot,
 		/obj/item/clothing/suit/armor/heavy/riot,
 		/obj/item/clothing/suit/armor/vest,
 		/obj/item/clothing/suit/armor/vest,


### PR DESCRIPTION
## About The Pull Request

Fixes some bugs with a small refactor to the altyn, maska, and old riot helmets. Basically altyns copy pasted riot helmet code for some reason instead of just inheriting it so I merged the two types. I also wrapped the variable tracking if the face shield was up or down in a setter function so that way if someone expands the code they won't reintroduce the bugs this fixes.

The 1st bug was occurring because the armor list wasn't turning into an armor datum, and the second bug was occurring because someone copy pasted the code and didn't modify the other values after making it start with the face shield up, both are fixed by the setter proc.

## Why It's Good For The Game

Adhering to DRY standards and encapsulation to improve maintainability

## Changelog
:cl:
fix: Fixed the stats UI not working for altyn, maska, and old riot helmets
fix: Fixed altyn, maska, and old riot helmets sometimes not showing gear underneath the helmet(and other things)
refactor: Merged the altyn and old riot helmets into the same type
refactor: Properly wrapped the variable tracking if the face shield was up to avoid future bugs
/:cl:
