### PR TITLE
Control spider rebalance

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/carrion/control_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/control_spider.dm
@@ -48,7 +48,7 @@
 	active = TRUE
 	last_use = world.time
 
-	addtimer(CALLBACK(src, .proc/return_mind), rand(15 SECONDS, 20 SECONDS))
+	addtimer(CALLBACK(src, .proc/return_mind), rand(50 SECONDS, 60 SECONDS))
 
 /obj/item/weapon/implant/carrion_spider/control/on_uninstall()
 	..()
@@ -66,7 +66,7 @@
 		if(isghost(owner_mind_last.current))
 			to_chat(owner_mind_last.current, SPAN_NOTICE("You are yanked back to your body from beyond the void."))
 		owner_mind_last.transfer_to(owner_mob)
-	if(wearer_last)
+	if(wearer_last && !(wearer_last.stat == DEAD))
 		if(host_brain)
 			host_brain.mind?.transfer_to(wearer_last)
 			qdel(host_brain)
@@ -84,3 +84,8 @@
 				owner_mob.adjustFireLoss((wearer_last.fireloss - start_damage[4]) * 2)
 	else
 		owner_mob.gib()
+		spawn(1)
+			if(owner_core)
+				var/mob/living/L = owner_core.loc
+				if(istype(L))
+					L.gib()

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -67,14 +67,15 @@
 		for(var/obj/O in embedded)
 			O.forceMove(loc)
 		embedded = list()
-	for(var/obj/item/weapon/implant/carrion_spider/control/C in src)
-		C.return_mind()
 
 	for(var/mob/living/carbon/human/H in oviewers(src))
 		H.sanity.onSeeDeath(src)
 		SEND_SIGNAL(H, COMSIG_MOB_DEATH, src)
 
 	stat = DEAD
+	for(var/obj/item/weapon/implant/carrion_spider/control/C in src)
+		C.return_mind()
+
 	update_lying_buckled_and_verb_status()
 	reset_plane_and_layer()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changed the control spider duration from 15-20 to 50-60 seconds and made the spider core die with the host body if the victim dies during control spider mind control.

## Why It's Good For The Game

This is a better way to balance it so carrions would still need to think hard to avoid death while having a lot of time during mind control for various plans instead of whiping out a gun and shooting the victim in the head.

## Changelog
:cl:
balance: Control spider duration incersed to 50-60 seconds, but if the controled victim dies under mind control the spider core dies with it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
