### PR TITLE
You can now examine telecomms machinery to see how damaged it is.

### DIFF
--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -40,6 +40,15 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	var/hide = 0				// Is it a hidden machine?
 	var/list/listening_levels = list() // 0 = auto set in Initialize() - this is the z level that the machine is listening to.
 
+/obj/machinery/telecomms/examine(mob/user)
+	..()
+	switch(integrity)
+		if(0 to 20)
+			to_chat(user, SPAN_WARNING("There is little life left in it."))
+		if(21 to 49)
+			to_chat(user, SPAN_WARNING("It is glitching incoherently."))
+		if(50 to 80)
+			to_chat(user, SPAN_WARNING("It is sparking and humming."))
 
 /obj/machinery/telecomms/proc/relay_information(datum/signal/signal, filter, copysig, amount = 20)
 	// relay signal to all linked machinery that are of type [filter]. If signal has been sent [amount] times, stop sending


### PR DESCRIPTION
## About The Pull Request 
This adds an examination override to telecomms machinery, that shows flavourtext depending on how much damage they have.

## Why It's Good For The Game
Trying to diagnose what is wrong with Tcomms can be a pain, considering how little feedback there is 

## Changelog
:cl:
add: You can now examine telecomms equipment to see how much damage it has taken.
/:cl: