### PR TITLE
Bones now are reasonably sized when on the ground but still display full detail when interacted with.

### DIFF
--- a/code/modules/organs/internal/bones.dm
+++ b/code/modules/organs/internal/bones.dm
@@ -8,6 +8,9 @@
 	var/broken_description = ""
 	var/reinforced = FALSE
 
+/obj/item/organ/internal/bone/Initialize()
+    . = ..()
+    src.transform *= 0.5 // this little trick makes bone size small while keeping detail level of 32x32 bones.
 
 /obj/item/organ/internal/bone/proc/fracture()
 	if(owner)


### PR DESCRIPTION
Okay, Halloween is over. Time to fix these big bones. 
These big bones look pretty good though so I can only think of one way to preserve this full detail.

Using this simple BYOND trick bones are now reasonably sized when on the ground but display full 32x32 detail when interacted with.

![aOH42NhD3e](https://user-images.githubusercontent.com/24533979/99021093-8593b680-2525-11eb-807b-20314330003e.gif)


## Changelog
:cl: Hopek
add: Bones now are reasonably sized when on the ground but still display full detail when interacted with.
/:cl:
