### PR TITLE
Tweak to Carrion Explosive Spider

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
@@ -2,9 +2,32 @@
 	name = "explosive spider"
 	icon_state = "spiderling_explosive"
 	spider_price = 40
+	var/devastation_range = -1
+	var/heavy_range = 0
+	var/weak_range = 2
+	var/flash_range = 6
+	var/det_time = 20
 
 /obj/item/weapon/implant/carrion_spider/explosive/activate()
 	..()
-	visible_message(SPAN_DANGER("[src] explodes!"))
-	explosion(get_turf(src), -1, 0, 2, 6)
+	var/obj/item/weapon/implant/carrion_spider/explosive/biteszadusto = new/obj/item/weapon/implant/carrion_spider/explosive(get_turf(src))
+	if((istype(wearer, /mob/living/simple_animal) || istype(wearer, /mob/living/carbon)))
+		visible_message(SPAN_WARNING("[src] pops out of [wearer] and flashes brightly!"))
+	else
+		visible_message(SPAN_WARNING("[src] flashes brightly!"))
+	biteszadusto.set_light(3,3, COLOR_ORANGE)
+	spawn(det_time)
+		biteszadusto.prime()
+	qdel(src)
+
+/obj/item/weapon/implant/carrion_spider/explosive/proc/prime()
+	var/turf/O = get_turf(src)
+	if(!O) return
+
+	on_explosion(O)
+
 	die()
+
+/obj/item/weapon/implant/carrion_spider/explosive/proc/on_explosion(var/turf/O)
+	visible_message(SPAN_DANGER("[src] explodes!"))
+	explosion(get_turf(src), devastation_range, heavy_range, weak_range, flash_range)

--- a/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
@@ -6,7 +6,7 @@
 	var/heavy_range = 0
 	var/weak_range = 2
 	var/flash_range = 6
-	var/det_time = 2SECONDS
+	var/det_time = 2 SECONDS
 
 /obj/item/weapon/implant/carrion_spider/explosive/activate()
 	..()

--- a/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
@@ -6,19 +6,18 @@
 	var/heavy_range = 0
 	var/weak_range = 2
 	var/flash_range = 6
-	var/det_time = 20
+	var/det_time = 2SECONDS
 
 /obj/item/weapon/implant/carrion_spider/explosive/activate()
 	..()
-	var/obj/item/weapon/implant/carrion_spider/explosive/biteszadusto = new/obj/item/weapon/implant/carrion_spider/explosive(get_turf(src))
-	if((istype(wearer, /mob/living/simple_animal) || istype(wearer, /mob/living/carbon)))
+	if(wearer)
+		src.uninstall()
 		visible_message(SPAN_WARNING("[src] pops out of [wearer] and flashes brightly!"))
 	else
 		visible_message(SPAN_WARNING("[src] flashes brightly!"))
-	biteszadusto.set_light(3,3, COLOR_ORANGE)
+	src.set_light(3,3, COLOR_ORANGE)
 	spawn(det_time)
-		biteszadusto.prime()
-	qdel(src)
+		src?.prime()
 
 /obj/item/weapon/implant/carrion_spider/explosive/proc/prime()
 	var/turf/O = get_turf(src)
@@ -28,6 +27,6 @@
 
 	die()
 
-/obj/item/weapon/implant/carrion_spider/explosive/proc/on_explosion(var/turf/O)
+/obj/item/weapon/implant/carrion_spider/explosive/proc/on_explosion(O)
 	visible_message(SPAN_DANGER("[src] explodes!"))
 	explosion(get_turf(src), devastation_range, heavy_range, weak_range, flash_range)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
i ded pls nerf
Carrion spiders now have a delay in explosion, two second, more importantly they now pop out when activated, glowing a bright orange hue along with a warning message in the chat.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
i ded pls nerf
Make it so carrion explosive spiders are able to be countered, instead of being haha i click you dead
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Carrion explosive spider now has a delay and pops out of the victim's body when it's activated
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
