### PR TITLE
Fixes airlock electronics having no UI

### DIFF
--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -27,7 +27,7 @@
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "electronics/airlock.tmpl", src.name, 1000, 500, null, null, state)
+		ui = new(user, src, ui_key, "airlock_electronics.tmpl", src.name, 1000, 500, null, null, state)
 		ui.set_initial_data(data)
 		ui.open()
 


### PR DESCRIPTION
## About The Pull Request 

Seems that, during a refactor, somebody just CTRL+H'd *_electronics to electronics/*, without checking if they'd changed anything that wasn't a typepath.

## Why It's Good For The Game

Vagabonds keep breaking my damn doors, and technos couldn't fix them.

## Changelog
:cl:
fix: Airlock electronic boards now have their UI again.
/:cl: