### PR TITLE
Loot stuff

### DIFF
--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -85,7 +85,10 @@
 		return get_ammo()/ammo_magazine.max_ammo
 	return null
 
-/obj/item/mech_equipment/mounted_system/balistic_gun/pk
+/obj/item/mech_equipment/mounted_system/ballistic
+	bad_type = /obj/item/mech_equipment/mounted_system/ballistic
+
+/obj/item/mech_equipment/mounted_system/ballistic/pk
 	name = "SA \"VJP\""
 	desc = "A reverse engineered Pulemyot Kalashnikova fitted for mech use. Fires in 15 round bursts. Horribly inaccurate, but packs quite a punch."
 	icon_state = "mech_pk"

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -32,6 +32,8 @@
 	var/overcharge_level = 0 //What our current overcharge level is. Peaks at overcharge_max
 	var/overcharge_max = 10
 
+	bad_type = /obj/item/weapon/gun/energy
+
 /obj/item/weapon/gun/energy/switch_firemodes()
 	. = ..()
 	if(.)

--- a/code/modules/projectiles/guns/matter.dm
+++ b/code/modules/projectiles/guns/matter.dm
@@ -6,6 +6,8 @@
 	var/projectile_cost = 1
 	var/projectile_type
 
+	bad_type = /obj/item/weapon/gun/matter
+
 /obj/item/weapon/gun/matter/attackby(obj/item/I, mob/user)
 	var/obj/item/stack/material/M = I
 	if(istype(M) && M.material.name == matter_type)

--- a/code/modules/research/designs/mechs2/exosuits_equipment.dm
+++ b/code/modules/research/designs/mechs2/exosuits_equipment.dm
@@ -41,7 +41,7 @@
 
 /datum/design/research/item/exosuit/weapon/pk
 	name = "mounted rigged PK"
-	build_path = /obj/item/mech_equipment/mounted_system/balistic_gun/pk
+	build_path = /obj/item/mech_equipment/mounted_system/ballistic/pk
 
 //UTILITY
 /datum/design/research/item/exosuit/hydraulic_clamp


### PR DESCRIPTION
Prevents some parent objects from spawning in the loot tables.

Renames balistic_gun -> ballistic

## About The Pull Request

There were some strange things found in loot over the weekend, a matter gun that shouldn't spawn, the default energy gun that does nothing, and a piece of mech equipment that had no sprite.

## Why It's Good For The Game

No more cursed useless objects

## Changelog
Backfacing, no changelog required.
:cl:

/:cl: