### PR TITLE
Makes the blood-red voidsuit much rarer

### DIFF
--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -85,11 +85,13 @@
 	resilience = 0.08
 	species_restricted = list("Human")
 	helmet = /obj/item/clothing/head/space/void/merc
-	rarity_value = 50
+	rarity_value = 90
 
 /obj/item/clothing/suit/space/void/merc/equipped
+	spawn_blacklisted = TRUE
 	boots = /obj/item/clothing/shoes/magboots
 	tank = /obj/item/weapon/tank/oxygen
 
 /obj/item/clothing/suit/space/void/merc/boxed
+	spawn_blacklisted = TRUE
 	tank = /obj/item/weapon/tank/emergency_oxygen/double


### PR DESCRIPTION
## About The Pull Request 

People were saying that the blood-red voidsuit was much too common, this was due to two reasons

1. It had a rarity level 50 chance to roll
2. There were three of them, giving them a much larger chance of spawning

I have made it so the two subtypes can not spawn, and made its rarity level 90

## Why It's Good For The Game

Rare armor is now actually rare

## Changelog
:cl:
balance: The bloodred voidsuit is now much rarer from maint loot.
/:cl: