### PR TITLE
Makes bones stronger

### DIFF
--- a/code/modules/organs/internal/bones.dm
+++ b/code/modules/organs/internal/bones.dm
@@ -5,6 +5,7 @@
 	organ_efficiency = list(OP_BONE = 100)
 	price_tag = 100
 	force = WEAPON_FORCE_NORMAL
+	max_damage = 100
 	var/broken_description = ""
 	var/reinforced = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes bones have 100 hp instead of 60.

## Why It's Good For The Game

A few players were complaining that bones are too easy to brake, this makes them a bit more resileant on average.

## Changelog
:cl:
balance: Bones are harder to break.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
