### PR TITLE
Serbian uniform crates in maint

### DIFF
--- a/code/__DEFINES/items.dm
+++ b/code/__DEFINES/items.dm
@@ -111,4 +111,8 @@
 					/obj/spawner/exosuit_equipment = 3,\
 					/obj/spawner/cloth/holster = 4,\
 					/obj/item/stash_spawner = 4,\
-					/obj/item/weapon/storage/deferred/crate/german_uniform = 4)
+					/obj/item/weapon/storage/deferred/crate/german_uniform = 4,\
+					/obj/item/weapon/storage/deferred/crate/uniform_flak = 4,\
+					/obj/item/weapon/storage/deferred/crate/uniform_black = 4,\
+					/obj/item/weapon/storage/deferred/crate/uniform_brown = 4,\
+					/obj/item/weapon/storage/deferred/crate/uniform_green = 4)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin. You can now find 4 types of serbian uniform crates - the ones you can buy from the serb vendor at IH - in maintenance. They spawn as rarely as Oberth crates do.

![image](https://user-images.githubusercontent.com/46986487/99886470-c5842900-2c0a-11eb-8a47-8cfbd1a3c31e.png)
_Above: Maintainer approval for this idea_

## Why It's Good For The Game

More armor variety in maint, for one. Two, some of these crates are worse than others (basic uniform crates are worse than german/flak), making oberth crate more rare so people don't only wear that.

Also, I want to wear a fucking turtleneck as a vag and none of you can stop me.

## Changelog
:cl:
add: Can now find serbian uniform crates in maintenance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
