### PR TITLE
Shrapnel removal fix

### DIFF
--- a/code/modules/surgery/internal.dm
+++ b/code/modules/surgery/internal.dm
@@ -88,7 +88,7 @@
 	// Organs
 	if(istype(I, /obj/item/organ/internal))
 		var/obj/item/organ/internal/organ = I
-		
+
 		var/o_a =  (organ.gender == PLURAL) ? "" : "a "
 
 		if(organ.unique_tag)
@@ -242,13 +242,14 @@
 			else
 				I.forceMove(drop_location())
 
-		if(istype(I, /obj/item/organ_module))
+		else if(istype(I, /obj/item/organ_module))
 			if(I == module)
 				var/obj/item/organ_module/M = I
 				M.remove(src)
 			else
 				I.forceMove(drop_location())
-
+		else
+			I.forceMove(drop_location())
 		if(owner)
 			owner.update_implants()
 


### PR DESCRIPTION
Fixes shrapnel, and other things, not being removed properly

## About The Pull Request

Previously, when you removed shrapnel via surgery, it removed it from the embeds/implants list, but never physically moved it, so the character would just have a bunch of shrapnel in them.

## Why It's Good For The Game
Having dud objects is bad

Lets you actually do some autopsy investigation to see who was shot by what.

Lets you recycle some materials from corpses.

## Changelog
:cl:
fix: Shrapnel is now properly removed from the body during extraction surgery.
/:cl: