### PR TITLE
Body scanner now shows NSA

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -248,7 +248,9 @@
 		"lung_ruptured" = H.is_lung_ruptured(),
 		"external_organs" = H.organs.Copy(),
 		"internal_organs" = H.internal_organs.Copy(),
-		"species_organs" = H.species.has_process //Just pass a reference for this, it shouldn't ever be modified outside of the datum.
+		"species_organs" = H.species.has_process, //Just pass a reference for this, it shouldn't ever be modified outside of the datum.
+		"NSA" = max(0, H.metabolism_effects.get_nsa()),
+		"NSA_threshold" = H.metabolism_effects.nsa_threshold
 		)
 	return occupant_data
 
@@ -276,6 +278,7 @@
 	dat += text("[]\tRadiation Level %: []</font><br>", ("<font color='[occ["rads"] < 10  ? "blue" : "red"]'>"), occ["rads"])
 	dat += text("[]\tGenetic Tissue Damage %: []</font><br>", ("<font color='[occ["cloneloss"] < 1  ? "blue" : "red"]'>"), occ["cloneloss"])
 	dat += text("[]\tApprox. Brain Damage %: []</font><br>", ("<font color='[occ["brainloss"] < 1  ? "blue" : "red"]'>"), occ["brainloss"])
+	dat += text("[]\tNeural System Accumulation: []/[]<br>", ("<font color='[occ["NSA"] < occ["NSA_threshold"]  ? "blue" : "red"]'>"), occ["NSA"], occ["NSA_threshold"])
 	dat += text("Paralysis Summary %: [] ([] seconds left!)<br>", occ["paralysis"], round(occ["paralysis"] / 4))
 	dat += text("Body Temperature: [occ["bodytemp"]-T0C]&deg;C ([occ["bodytemp"]*1.8-459.67]&deg;F)<br><HR>")
 

--- a/code/modules/reagents/metabolism.dm
+++ b/code/modules/reagents/metabolism.dm
@@ -51,7 +51,7 @@
 	for(var/i in nerve_system_accumulations)
 		if(findtext(i, tag, 1, 0) == 1)
 			nerve_system_accumulations.Remove(i)
-		
+
 
 /datum/metabolism_effects/proc/get_nsa_value(tag)
 	if(nerve_system_accumulations[tag])
@@ -62,7 +62,7 @@
 	return nsa_current
 
 /datum/metabolism_effects/proc/get_nsa_target()
-	var/accumulatedNSA
+	var/accumulatedNSA = 0
 	for(var/tag in nerve_system_accumulations)
 		accumulatedNSA += nerve_system_accumulations[tag]
 	return accumulatedNSA
@@ -116,7 +116,7 @@
 /datum/metabolism_effects/proc/check_reagent(datum/reagent/R, metabolism_class)
 	present_reagent_ids += R.id
 
-	//Nerve System Accumulation 
+	//Nerve System Accumulation
 	parent.metabolism_effects.adjust_nsa(R.nerve_system_accumulations, "[R.id]_[metabolism_class]")
 
 	// Withdrawals
@@ -160,7 +160,7 @@
 /datum/metabolism_effects/proc/process()
 	process_withdrawals()
 	handle_nsa()
-	
+
 	if(addiction_tick == 6)
 		addiction_tick = 1
 		process_addictions()


### PR DESCRIPTION
## About The Pull Request 

The body scanner now shows the NSA of the patient. It shows it as a ratio against NSA_threshold. If it goes above the NSA threshold, it shows as red.

Also fixes NSA returning null sometimes, due to an uninitialized variable. This fixes the HUD element being invisible sometimes.

## Why It's Good For The Game

No longer will people ahelp to ask why the chemist dropped dead, after he was riding high on bicaridine, tramadol, and hyperzine for 30 minutes

## Changelog
:cl:
add: Body scanners now show the NSA of the patient.
/:cl:
