### PR TITLE
Various toxins map fixes

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -43574,11 +43574,6 @@
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/table/rack,
-/obj/item/device/von_krabin,
-/obj/machinery/door/blast/shutters/glass{
-	id = "Von-Krabin"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/rnd/lab)
 "bVE" = (
@@ -44119,10 +44114,10 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/hallway/side/section3port)
 "bWS" = (
-/obj/machinery/atmospherics/binary/passive_gate{
-	dir = 8;
-	name = "Mixing"
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/white/danger,
 /area/eris/rnd/mixing)
 "bWT" = (
@@ -44143,13 +44138,14 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/security/inspectors_office)
 "bWV" = (
-/obj/machinery/meter,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (NORTH)";
-	dir = 1
+/obj/machinery/atmospherics/omni/filter{
+	tag_east = 1;
+	tag_south = 5;
+	tag_west = 2;
+	use_power = 0
 	},
 /turf/simulated/floor/tiled/white/danger,
 /area/eris/rnd/mixing)
@@ -44446,8 +44442,8 @@
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/eris/rnd/mixing)
 "bXJ" = (
-/obj/machinery/atmospherics/binary/passive_gate{
-	name = "Mix to Space"
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/danger,
 /area/eris/rnd/mixing)
@@ -46720,7 +46716,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck4central)
 "cdg" = (
-/obj/structure/closet/bombcloset,
+/obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/eris/rnd/mixing)
 "cdh" = (
@@ -46746,11 +46742,11 @@
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/clothingstorage)
 "cdl" = (
-/obj/structure/closet/bombcloset,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/pipedispenser,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/eris/rnd/mixing)
 "cdm" = (
@@ -47726,7 +47722,7 @@
 "cfl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/ignition{
-	id = "toxin_chamber2";
+	id = "toxin_chamber1";
 	pixel_y = -5
 	},
 /obj/machinery/button/remote/blast_door{
@@ -48503,9 +48499,8 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/quartermaster/storage)
 "chf" = (
-/obj/machinery/atmospherics/binary/passive_gate{
-	dir = 8;
-	name = "Chamber to Port"
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white/danger,
 /area/eris/rnd/mixing)
@@ -49264,13 +49259,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/eris/command/fo)
-"ciX" = (
-/obj/machinery/atmospherics/binary/passive_gate{
-	dir = 4;
-	name = "Port to Chamber"
-	},
-/turf/simulated/floor/tiled/white/danger,
-/area/eris/rnd/mixing)
 "ciY" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 8
@@ -49446,10 +49434,12 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/atmoscontrol)
 "cjv" = (
-/obj/machinery/computer/general_air_control{
+/obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 8;
 	frequency = 1430;
-	name = "Mixing Chamber Monitor";
+	input_tag = "toxins1_in";
+	name = "Mixing Chamber 1 Monitor";
+	output_tag = "toxins1_out";
 	sensors = list("toxins_mixing_1" = "Mixing Chamber - 1")
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
@@ -49875,10 +49865,12 @@
 /turf/simulated/open,
 /area/eris/quartermaster/storage)
 "ckv" = (
-/obj/machinery/computer/general_air_control{
+/obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 8;
 	frequency = 1430;
-	name = "Mixing Chamber Monitor";
+	input_tag = "toxins2_in";
+	name = "Mixing Chamber 2 Monitor";
+	output_tag = "toxins2_out";
 	sensors = list("toxins_mixing_2" = "Mixing Chamber - 2")
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
@@ -50026,6 +50018,9 @@
 "ckP" = (
 /obj/item/weapon/storage/toolbox/mechanical,
 /obj/structure/table/reinforced,
+/obj/item/weapon/storage/belt/utility,
+/obj/item/weapon/storage/belt/utility,
+/obj/item/clothing/head/welding,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/eris/rnd/mixing)
 "ckQ" = (
@@ -50039,10 +50034,11 @@
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
 "ckR" = (
-/obj/item/weapon/storage/belt/utility,
-/obj/item/weapon/storage/belt/utility,
-/obj/item/clothing/head/welding,
-/obj/structure/table/reinforced,
+/obj/structure/table/rack,
+/obj/item/device/von_krabin,
+/obj/machinery/door/blast/shutters/glass{
+	id = "Von-Krabin"
+	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/eris/rnd/mixing)
 "ckS" = (
@@ -50275,11 +50271,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/closet/bombcloset,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/eris/rnd/mixing)
 "clA" = (
@@ -50304,8 +50300,8 @@
 /turf/simulated/open,
 /area/eris/rnd/chargebay)
 "clC" = (
-/obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/closet/bombcloset,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/eris/rnd/mixing)
 "clD" = (
@@ -50802,7 +50798,9 @@
 	dir = 8;
 	external_pressure_bound = 0;
 	external_pressure_bound_default = 0;
+	frequency = 1430;
 	icon_state = "map_vent_in";
+	id_tag = "toxins1_out";
 	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	internal_pressure_bound_default = 4000;
@@ -51117,8 +51115,8 @@
 "cnB" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
-	frequency = 1443;
-	id = "air_in";
+	frequency = 1430;
+	id = "toxins1_in";
 	use_power = 1
 	},
 /obj/machinery/shield_diffuser,
@@ -51489,7 +51487,7 @@
 /area/eris/maintenance/section4deck3port)
 "cot" = (
 /obj/machinery/sparker{
-	id = "toxin_chamber2";
+	id = "toxin_chamber1";
 	pixel_y = -21
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
@@ -67558,7 +67556,7 @@
 /area/shuttle/mining/station)
 "daN" = (
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/effect/window_lwall_spawn/plasma,
 /turf/simulated/floor/plating,
 /area/eris/rnd/mixing)
 "daO" = (
@@ -70000,7 +69998,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/effect/window_lwall_spawn/plasma,
 /turf/simulated/floor/plating,
 /area/eris/rnd/mixing)
 "dgq" = (
@@ -75511,10 +75509,10 @@
 /area/eris/maintenance/section3deck4starboard)
 "dsx" = (
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawnplasma,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 10
 	},
+/obj/effect/window_lwall_spawn/plasma/reinforced,
 /turf/simulated/floor/plating,
 /area/eris/rnd/mixing)
 "dsy" = (
@@ -76996,7 +76994,7 @@
 	dir = 6
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/effect/window_lwall_spawn/plasma/reinforced,
 /turf/simulated/floor/plating,
 /area/eris/rnd/mixing)
 "dvY" = (
@@ -79399,8 +79397,8 @@
 /area/eris/medical/medbay)
 "dBK" = (
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawnplasma,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/effect/window_lwall_spawn/plasma/reinforced,
 /turf/simulated/floor/plating,
 /area/eris/rnd/mixing)
 "dBL" = (
@@ -79409,7 +79407,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/effect/window_lwall_spawn/plasma/reinforced,
 /turf/simulated/floor/plating,
 /area/eris/rnd/mixing)
 "dBM" = (
@@ -79852,10 +79850,10 @@
 /area/eris/medical/reception)
 "dCL" = (
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawnplasma,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
 	},
+/obj/effect/window_lwall_spawn/plasma/reinforced,
 /turf/simulated/floor/plating,
 /area/eris/rnd/mixing)
 "dCM" = (
@@ -79864,7 +79862,7 @@
 	dir = 5
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/effect/window_lwall_spawn/plasma/reinforced,
 /turf/simulated/floor/plating,
 /area/eris/rnd/mixing)
 "dCN" = (
@@ -80142,15 +80140,6 @@
 /obj/spawner/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck1central)
-"dDv" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/machinery/meter,
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/turf/simulated/floor/plating,
-/area/eris/rnd/mixing)
 "dDw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -91895,9 +91884,8 @@
 	},
 /area/shuttle/research/station)
 "eeP" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet,
 /obj/machinery/camera/network/research_outpost,
+/obj/machinery/doppler_array,
 /turf/simulated/shuttle/floor/science{
 	icon_state = "6,15"
 	},
@@ -105681,6 +105669,11 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
+"qcf" = (
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/plasma/reinforced,
+/turf/simulated/floor/plating,
+/area/eris/rnd/mixing)
 "qcs" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/blast/shutters{
@@ -105877,6 +105870,14 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/engineering/engine_room)
+"sss" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/plasma/reinforced,
+/turf/simulated/floor/plating,
+/area/eris/rnd/mixing)
 "ssB" = (
 /obj/structure/closet/crate/medical,
 /obj/spawner/firstaid,
@@ -106032,6 +106033,24 @@
 /obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/medical/chemistry)
+"uga" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	frequency = 1430;
+	icon_state = "map_vent_in";
+	id_tag = "toxins2_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/eris/rnd/mixing)
 "uiz" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	tag = "icon-intact (SOUTHWEST)";
@@ -106279,6 +106298,12 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section3deck2starboard)
+"wAI" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/techfloor_grid,
+/area/eris/rnd/mixing)
 "wEJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -106300,6 +106325,16 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/medical/chemstor)
+"wYi" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8;
+	frequency = 1430;
+	id = "toxins2_in";
+	use_power = 1
+	},
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/reinforced/airless,
+/area/eris/rnd/mixing)
 "wYD" = (
 /obj/spawner/medical/low_chance,
 /obj/spawner/medical/low_chance,
@@ -213546,15 +213581,15 @@ abF
 abF
 daN
 bWW
-bXI
+wAI
 bZY
 cfl
 chf
-ciX
+chf
 cjv
 ckc
 ckv
-ciX
+chf
 chf
 clQ
 cmy
@@ -213750,15 +213785,15 @@ daN
 daN
 daN
 dgp
-daN
-dgp
-dgp
+qcf
+sss
+sss
 dvX
 dBL
 dCM
-dgp
-dDv
-daN
+sss
+sss
+qcf
 dgp
 daN
 daN
@@ -213952,15 +213987,15 @@ abF
 abF
 abF
 aMH
-daN
+qcf
 cmM
 cnB
 cot
-daN
+qcf
 cqo
-cnB
-cmM
-daN
+wYi
+uga
+qcf
 aMH
 abF
 abF
@@ -214154,15 +214189,15 @@ aaa
 aaa
 abF
 abF
-daN
+qcf
 cmN
 cnA
 cou
-daN
+qcf
 cou
 crk
 cmN
-daN
+qcf
 abF
 abF
 abF
@@ -214356,15 +214391,15 @@ aad
 aad
 aad
 aad
-daN
+qcf
 dUy
-daN
+qcf
 dsx
 dBK
 dCL
-daN
+qcf
 dUz
-daN
+qcf
 aad
 aad
 aad


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There were a lot of problems related to Eris's toxins room and this fixes them

## Why It's Good For The Game

Toxins is the best part of science

## Changelog
:cl:
add: Added a pipe dispenser to toxins
add: Added a gas filter to toxins
add: Added a connector port directly to space
add: Replaced a bedroom with a tachyon array room on the science shuttle
tweak: The mixing chamber monitors can now control the air injectors and vents in the chambers
del: Removed pumps from toxins that are no longer needed
tweak: Moved the von krabin infront of toxins so you can reach the rnd apc
tweak: Replaced the plasma glass on the mixing chamber with reinforced plasma glass so it doesn't break so easily
fix: Fixed the toxins igniter buttons firing both igniters despite which button you pressed
/:cl:

![image](https://user-images.githubusercontent.com/22408776/99928196-ade19900-2d0d-11eb-98af-54a671b3efde.png)

![image](https://user-images.githubusercontent.com/22408776/99928095-4e838900-2d0d-11eb-8ae3-14b207737e47.png)
