### PR TITLE
Misc maintloot fixes

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/maint_loot.dm
+++ b/code/game/objects/structures/crates_lockers/closets/maint_loot.dm
@@ -55,13 +55,12 @@
 /obj/structure/closet/random/spareparts
 	name = "\improper spare parts closet"
 	desc = "Somewhat old closet with spare parts in it."
-	icon_state = "eng"//bad icon
-	icon_door = "eng_secure_door"
+	icon_state = "eng"
+	icon_door = "eng_secure"
 	old_chance = 10
 	rarity_value = 50
-	bad_type = /obj/structure/closet/random/spareparts//bad icon
 
-/obj/structure/closet/random/tech/populate_contents()
+/obj/structure/closet/random/spareparts/populate_contents()
 	new /obj/spawner/lowkeyrandom/low_chance(src)
 	new /obj/spawner/lowkeyrandom/low_chance(src)
 	new /obj/spawner/lowkeyrandom/low_chance(src)
@@ -79,6 +78,7 @@
 	new /obj/spawner/lathe_disk/low_chance(src)
 	new /obj/spawner/pack/tech_loot/low_chance(src)
 	new /obj/spawner/pack/tech_loot/low_chance(src)
+
 
 
 

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -52,7 +52,7 @@
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "miningcar"
 	density = TRUE
-
+	spawn_blacklisted = TRUE
 // Flags.
 
 /obj/item/stack/flag


### PR DESCRIPTION
## About The Pull Request 

Removes the debug mining cart from maint loots

Fixes the spareparts closet

## Why It's Good For The Game
Locker's "bad icon" was just a bad icon_state that needed correcting (and wasn't spawning the right stuff anyway)

mining cart was just bad.

## Changelog
:cl:
/:cl: