### PR TITLE
Teleporter Rig module removal

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -76,6 +76,7 @@
 
 	interface_name = "VOID-shift phase projector"
 	interface_desc = "An advanced teleportation system. It is capable of pinpoint precision or random leaps forward."
+	spawn_blacklisted = TRUE
 
 /obj/item/rig_module/teleporter/proc/phase_in(var/mob/M,var/turf/T)
 

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -112,6 +112,7 @@
 		/obj/item/rig_module/datajack,
 		/obj/item/rig_module/self_destruct
 		)
+	spawn_blacklisted = TRUE
 
 /obj/item/clothing/gloves/rig/light/ninja
 	name = "insulated gloves"


### PR DESCRIPTION
I've removed you three times so far. How many more will it take?

## About The Pull Request

Removes the teleporter rig module from the loot tables, again.

## Why It's Good For The Game

It, combined with night vision/mesons/cameras, means you can just teleport anywhere instantly.

## Changelog
:cl:
balance: The rig teleport module has been removed from the loot tables, hopefully.
/:cl: