### PR TITLE
Removes faction voidsuits from maint

### DIFF
--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -85,7 +85,7 @@
 	resilience = 0.08
 	species_restricted = list(SPECIES_HUMAN)
 	helmet = /obj/item/clothing/head/space/void/merc
-	rarity_value = 90
+	rarity_value = 160
 
 /obj/item/clothing/suit/space/void/merc/equipped
 	spawn_blacklisted = TRUE

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -83,7 +83,7 @@
 		rad = 75
 	)
 	helmet = /obj/item/clothing/head/space/void/mining
-	rarity_value = 10.11
+	spawn_blacklisted = TRUE
 
 //Medical
 /obj/item/clothing/head/space/void/medical

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -40,7 +40,7 @@
 		/obj/item/weapon/rcd
 	)
 	helmet = /obj/item/clothing/head/space/void/engineering
-	rarity_value = 10.1
+	spawn_blacklisted = TRUE
 
 /obj/item/clothing/suit/space/void/engineering/equipped
 	boots = /obj/item/clothing/shoes/magboots
@@ -169,7 +169,7 @@
 	)
 	siemens_coefficient = 0.7
 	helmet = /obj/item/clothing/head/space/void/security
-	rarity_value = 40
+	spawn_blacklisted = TRUE
 
 /obj/item/clothing/suit/space/void/security/equipped
 	boots = /obj/item/clothing/shoes/magboots


### PR DESCRIPTION
## About The Pull Request

People have been asking for this for a while(I think theres like 3 requests or so in the #feedback channel in discord) so I'm gunna go ahead and put it through the proper channels so that someone who has the authority can either approve, refuse, or request modifications to the proposed changes. I modified the rarity of the blood red voidsuit so that it wont become more common since the spawn pool is shrinking, see the spawn pool charts below.

## Why It's Good For The Game

1. The armored voidsuits in maint have been power creeping on the armor already in maint
2. The above reason has led to a reduced design space where people feel like a new armor needs to have 50-70 armor stats to be viable
3. Improved clarity, people often mistake vagabonds for technomancers, IH, or miners since vagabonds are so prone to wearing their voidsuits
 
## Changelog
:cl:
tweak: Removed faction voidsuits from maint loot
/:cl:

Before:
![Before](https://user-images.githubusercontent.com/22408776/100398487-652f2600-3014-11eb-97d8-e344531c686b.PNG)

After removal but before blood red rarity adjustment:
![beforeRarity](https://user-images.githubusercontent.com/22408776/100398500-7aa45000-3014-11eb-9edb-a307ad1f568e.PNG)

After:
![After](https://user-images.githubusercontent.com/22408776/100398507-842db800-3014-11eb-9f4c-a264a7f13e2b.PNG)
