### PR TITLE
Robot limb rebalancing

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -777,12 +777,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 // Checks if the limb should get fractured by now
 /obj/item/organ/external/proc/should_fracture()
 	var/bone_efficiency = owner.get_specific_organ_efficiency(OP_BONE, organ_tag)
-	return config.bones_can_break && !BP_IS_ROBOTIC(src) && (brute_dam > ((min_broken_damage * ORGAN_HEALTH_MULTIPLIER) * (bone_efficiency / 100)))
+	return config.bones_can_break && (brute_dam > ((min_broken_damage * ORGAN_HEALTH_MULTIPLIER) * (bone_efficiency / 100)))
 
 // Fracture the bone in the limb
 /obj/item/organ/external/proc/fracture()
-	if(BP_IS_ROBOTIC(src))
-		return	//ORGAN_BROKEN doesn't have the same meaning for robot limbs
 	if((status & ORGAN_BROKEN) || cannot_break)
 		return
 	var/obj/item/organ/internal/bone/bone = get_bone()

--- a/code/modules/organs/external/damage.dm
+++ b/code/modules/organs/external/damage.dm
@@ -86,12 +86,12 @@
 	//If limb took enough damage, try to cut or tear it off
 	if(owner && loc == owner && !is_stump())
 		if(!cannot_amputate && config.limbs_can_break && (brute_dam + burn_dam) >= (max_damage * ORGAN_HEALTH_MULTIPLIER))
-			//organs can come off in three cases
+			//organs can come off in four cases
 			//1. If the damage source is edge_eligible and the brute damage dealt exceeds the edge threshold, then the organ is cut off.
 			//2. If the damage amount dealt exceeds the disintegrate threshold, the organ is completely obliterated.
 			//3. If the organ has already reached or would be put over it's max damage amount (currently redundant),
 			//   and the brute damage dealt exceeds the tearoff threshold, the organ is torn off.
-
+			//4. If the organ is robotic, and it has reached its max damage threshold, it will either drop off, or blow up.
 			//Check edge eligibility
 			var/edge_eligible = 0
 			if(edge)
@@ -110,6 +110,8 @@
 				droplimb(0, DROPLIMB_BLUNT)
 			else if((brute + prev_brute) >= max_damage * DROPLIMB_THRESHOLD_TEAROFF && prob(brute/5))
 				droplimb(0, DROPLIMB_EDGE)
+			else if(brute_dam && BP_IS_ROBOTIC(src) && (status & ORGAN_BROKEN) && prob(brute*2))
+				droplimb(prob(50), pick(DROPLIMB_EDGE, DROPLIMB_BLUNT))
 
 	return update_damstate()
 

--- a/code/modules/organs/external/subtypes/robotic.dm
+++ b/code/modules/organs/external/subtypes/robotic.dm
@@ -3,7 +3,6 @@
 	force_icon = 'icons/mob/human_races/cyberlimbs/generic.dmi'
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	dislocated = -1
-	cannot_break = 1
 	nature = MODIFICATION_SILICON
 	armor = list(melee = 20, bullet = 20, energy = 20, bomb = 20, bio = 100, rad = 100)
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2) // Multiplied by w_class


### PR DESCRIPTION
## About The Pull Request

Robot limbs can now break their internal bones

Robot limbs now break off or explode when they take too much damage

## Why It's Good For The Game

There are a few complaints about robot limbs being a bulwark, absorbing attacks when they have reached maximum damage threshold, with little negative effects to the user.

## Changelog
:cl:
balance: Robot limbs now have breakable bones
balance: Robot limbs now break off or explode when they take too much brute damage
/:cl:
