### PR TITLE
Erismed runtime fix

### DIFF
--- a/code/modules/organs/internal/internal_organ_processes.dm
+++ b/code/modules/organs/internal/internal_organ_processes.dm
@@ -31,11 +31,16 @@
 
 /mob/living/carbon/human/get_specific_organ_efficiency(process_define, parent_organ_tag)
 	var/effective_efficiency = 0
-	var/obj/item/organ/external/parent_organ = get_organ(parent_organ_tag)
-	for(var/organ in parent_organ.internal_organs)
-		var/obj/item/organ/internal/I = organ
-		if(process_define in I.organ_efficiency)
-			effective_efficiency += I.get_process_eficiency(process_define)
+	var/obj/item/organ/external/parent_organ
+	if(isorgan(parent_organ_tag))
+		parent_organ = parent_organ_tag
+	else
+		parent_organ = get_organ(parent_organ_tag)
+	if(parent_organ)
+		for(var/organ in parent_organ.internal_organs)
+			var/obj/item/organ/internal/I = organ
+			if(process_define in I.organ_efficiency)
+				effective_efficiency += I.get_process_eficiency(process_define)
 	
 	return effective_efficiency
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a runtime in internal_organ_processes.dm, it was caused due to def_zone in armor having inconsitant bahaviour, either being a organ tag or an organ.

## Why It's Good For The Game

Runtimes bad.

## Changelog
:cl:
fix: fixed a runtime in erismed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
