### PR TITLE
Chameleon Projector nerf

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -1,3 +1,8 @@
+#define CHAMELEON_MIN_PIXELS 32
+
+GLOBAL_LIST_INIT(champroj_blacklist, list(/obj/item/weapon/disk/nuclear))
+GLOBAL_LIST_INIT(champroj_whitelist, list())
+
 /obj/item/device/chameleon
 	name = "chameleon projector"
 	desc = "This is chameleion projector. Chose an item and activate projector. You're beautiful!"
@@ -41,13 +46,34 @@
 	if (istype(target, /obj/item/weapon/storage)) return
 	if(!proximity) return
 	if(!active_dummy)
-		if(istype(target,/obj/item) && !istype(target, /obj/item/weapon/disk/nuclear))
+		if(scan_item(target))
 			playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, 1, -6)
 			to_chat(user, SPAN_NOTICE("Scanned [target]."))
 			saved_item = target.type
 			saved_icon = target.icon
 			saved_icon_state = target.icon_state
 			saved_overlays = target.overlays
+			return
+		to_chat(user, SPAN_WARNING("\The [target] is an invalid target."))
+
+/obj/item/device/chameleon/proc/scan_item(var/obj/item/I)
+	if(!istype(I))
+		return FALSE
+	if(GLOB.champroj_blacklist.Find(I.type))
+		return FALSE
+	if(GLOB.champroj_whitelist.Find(I.type))
+		return TRUE
+	var/icon/icon_to_check = icon(I.icon, I.icon_state, I.dir)
+	var/total_pixels = 0
+	for(var/y = 0 to icon_to_check.Width())
+		for(var/x = 0 to icon_to_check.Height())
+			if(icon_to_check.GetPixel(x, y))
+				total_pixels++
+	if(total_pixels < CHAMELEON_MIN_PIXELS)
+		GLOB.champroj_blacklist.Add(I.type)
+		return FALSE
+	GLOB.champroj_whitelist.Add(I.type)
+	return TRUE
 
 /obj/item/device/chameleon/proc/toggle()
 	if(!can_use || !saved_item) return


### PR DESCRIPTION
## About The Pull Request 

Chameleon projectors can no longer copy things that are less than 32 pixels

## Why It's Good For The Game

After watching a cigarette butt (about 10 pixels in total) reload a valkyrie laser sniper, as all of NT ran past it, I felt it was time to deal with it.

## Changelog
:cl:
balance: The chameleon projector now requires an item have a minimum pixel count to their icon.
/:cl: