### PR TITLE
Restricting telepad from accessing specific z-levels

### DIFF
--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -1,3 +1,5 @@
+#define UNAVAILABLE_Z_LEVELS list(6, 7)
+
 /obj/machinery/computer/telescience
 	name = "\improper Telepad Control Console"
 	desc = "Used to teleport objects to and from the telescience telepad."
@@ -206,6 +208,10 @@
 			if(sending)
 				source = dest
 				dest = target
+			
+			if((sending && (dest.z in UNAVAILABLE_Z_LEVELS)) || ((target.z in UNAVAILABLE_Z_LEVELS) && !sending))
+				temp_msg = "ERROR: Sector is unavailable."
+				return
 
 			flick("pad-beam", telepad)
 			playsound(telepad.loc, 'sound/weapons/emitter2.ogg', 25, 1, extrarange = 3, falloff = 5)
@@ -358,3 +364,5 @@
 		return message
 	else
 		return copytext(message, 1, length + 1)
+
+#undef UNAVAILABLE_Z_LEVELS


### PR DESCRIPTION
## About The Pull Request
Restricting telepad from accessing centcomm and dungeon z-level *for now*

## Why It's Good For The Game
Nerd guys from R&D can't take stuff from serb base.

## Changelog
:cl:
balance: Telepad can't access centcomm and the one star dungeon levels
/:cl: