### PR TITLE
Updates various messages for grenade-spiders giving more attention to themselves for others

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/implant/carrion_spider/explosive
 	name = "explosive spider"
-	desc = "A spider that's ready to bites the dust."
+	desc = "A spider that's about to blow the dust."
 	icon_state = "spiderling_explosive"
 	spider_price = 40
 	var/devastation_range = -1

--- a/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
@@ -12,9 +12,10 @@
 	..()
 	if(wearer)
 		src.uninstall()
-		visible_message(SPAN_WARNING("[src] pops out of [wearer] and flashes brightly!"))
+		visible_message(SPAN_DANGER("[src] pops out of [wearer] and flashes brightly!"))
 	else
-		visible_message(SPAN_WARNING("[src] flashes brightly!"))
+		visible_message(SPAN_DANGER("[src] flashes brightly!"))
+	playsound(src, 'sound/voice/insect_battle_screeching.ogg', 80, 1, 5)
 	src.set_light(3,3, COLOR_ORANGE)
 	spawn(det_time)
 		src?.prime()

--- a/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/implant/carrion_spider/explosive
 	name = "explosive spider"
-	desc = "A spider that's bulgy, like it's about to blow on someone. Better not put it in your pants."
+	desc = "A large, glowing spider, about the size of your fist. It's undulating and emitting a soft ticking noise."
 	icon_state = "spiderling_explosive"
 	spider_price = 40
 	var/devastation_range = -1

--- a/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/implant/carrion_spider/explosive
 	name = "explosive spider"
-	desc = "A spider that's bulgy, like it's about to burst. Better not put it in your pants."
+	desc = "A spider that's bulgy, like it's about to blow on someone. Better not put it in your pants."
 	icon_state = "spiderling_explosive"
 	spider_price = 40
 	var/devastation_range = -1

--- a/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
@@ -1,5 +1,6 @@
 /obj/item/weapon/implant/carrion_spider/explosive
 	name = "explosive spider"
+	desc = "A spider that's ready to bites the dust."
 	icon_state = "spiderling_explosive"
 	spider_price = 40
 	var/devastation_range = -1
@@ -11,8 +12,10 @@
 /obj/item/weapon/implant/carrion_spider/explosive/activate()
 	..()
 	if(wearer)
+		wearer.apply_damage(10, BRUTE, part)
 		src.uninstall()
-		visible_message(SPAN_DANGER("[src] pops out of [wearer] and flashes brightly!"))
+		to_chat(wearer, SPAN_WARNING("You feel something moving within [part]!"))
+		visible_message(SPAN_DANGER("[src] crawls out of [wearer] and flashes brightly!"))
 	else
 		visible_message(SPAN_DANGER("[src] flashes brightly!"))
 	playsound(src, 'sound/voice/insect_battle_screeching.ogg', 80, 1, 5)

--- a/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/implant/carrion_spider/explosive
 	name = "explosive spider"
-	desc = "A spider that's about to blow the dust."
+	desc = "A spider that's bulgy, like it's about to burst. Better not put it in your pants."
 	icon_state = "spiderling_explosive"
 	spider_price = 40
 	var/devastation_range = -1

--- a/code/game/objects/items/weapons/implant/implants/carrion/flashbang_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/flashbang_spider.dm
@@ -2,12 +2,22 @@
 	name = "flashbang spider"
 	icon_state = "spiderling_flashbang"
 	spider_price = 15
+	var/det_time = 2 SECONDS
 
 /obj/item/weapon/implant/carrion_spider/flashbang/activate()
 	..()
 	if(wearer)
 		wearer.apply_damage(10, BURN, part)
+		to_chat(wearer, SPAN_DANGER("You feel an uncomfortable heat build up within you!"))
+		visible_message(SPAN_WARNING("[wearer] suddenly turns brighter and brighter!"))
+	else
+		visible_message(SPAN_DANGER("[src] flashes brightly!"))
+	playsound(src, 'sound/voice/insect_battle_screeching.ogg', 80, 1, 5)
+	src.set_light(3,3, COLOR_YELLOW)
+	spawn(det_time)
+		src?.prime()
 
+/obj/item/weapon/implant/carrion_spider/flashbang/proc/prime()
 	for(var/obj/structure/closet/L in view(7, get_turf(src)))
 		if(locate(/mob/living/carbon/, L))
 			for(var/mob/living/carbon/M in L)

--- a/code/game/objects/items/weapons/implant/implants/carrion/flashbang_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/flashbang_spider.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/implant/carrion_spider/flashbang
 	name = "flashbang spider"
-	desc = "A spider filled with some sort of liquid, it feels warm."
+	desc = "A spider filled with some sort of glossy liquid, it emits a constant unpleasant noise."
 	icon_state = "spiderling_flashbang"
 	spider_price = 15
 	var/det_time = 2 SECONDS

--- a/code/game/objects/items/weapons/implant/implants/carrion/flashbang_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/flashbang_spider.dm
@@ -1,5 +1,6 @@
 /obj/item/weapon/implant/carrion_spider/flashbang
 	name = "flashbang spider"
+	desc = "A spider filled with some sort of liquid, it feels warm."
 	icon_state = "spiderling_flashbang"
 	spider_price = 15
 	var/det_time = 2 SECONDS
@@ -7,9 +8,10 @@
 /obj/item/weapon/implant/carrion_spider/flashbang/activate()
 	..()
 	if(wearer)
-		wearer.apply_damage(10, BURN, part)
-		to_chat(wearer, SPAN_DANGER("You feel an uncomfortable heat build up within you!"))
-		visible_message(SPAN_WARNING("[wearer] suddenly turns brighter and brighter!"))
+		wearer.apply_damage(15, BURN, part)
+		src.uninstall()
+		to_chat(wearer, SPAN_WARNING("You feel an uncomfortable heat build up within [part]!"))
+		visible_message(SPAN_DANGER("[src] crawls out of [wearer] and flashes brightly!"))
 	else
 		visible_message(SPAN_DANGER("[src] flashes brightly!"))
 	playsound(src, 'sound/voice/insect_battle_screeching.ogg', 80, 1, 5)

--- a/code/game/objects/items/weapons/implant/implants/carrion/toxic_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/toxic_spider.dm
@@ -9,8 +9,10 @@
 /obj/item/weapon/implant/carrion_spider/toxicbomb/activate()
 	..()
 	if(wearer)
+		wearer.apply_damage(10, BRUTE, part)
 		src.uninstall()
-		visible_message(SPAN_DANGER("[src] pops out of [wearer] and flashes brightly!"))
+		to_chat(wearer, SPAN_WARNING("You feel something moving within [part]!"))
+		visible_message(SPAN_DANGER("[src] crawls out of [wearer] and flashes brightly!"))
 	else
 		visible_message(SPAN_DANGER("[src] flashes brightly!"))
 	playsound(src, 'sound/voice/insect_battle_screeching.ogg', 80, 1, 5)
@@ -27,4 +29,3 @@
 	S.set_up(gas_storage, 10, 100, location)
 	S.start()
 	die()
-	..()

--- a/code/game/objects/items/weapons/implant/implants/carrion/toxic_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/toxic_spider.dm
@@ -4,15 +4,27 @@
 	icon_state = "spiderling_toxicbomb"
 	spider_price = 35
 	var/datum/reagents/gas_storage
+	var/det_time = 2 SECONDS
 
 /obj/item/weapon/implant/carrion_spider/toxicbomb/activate()
+	..()
+	if(wearer)
+		src.uninstall()
+		visible_message(SPAN_DANGER("[src] pops out of [wearer] and flashes brightly!"))
+	else
+		visible_message(SPAN_DANGER("[src] flashes brightly!"))
+	playsound(src, 'sound/voice/insect_battle_screeching.ogg', 80, 1, 5)
+	src.set_light(3,3, COLOR_GREEN)
+	spawn(det_time)
+		src?.prime()
+
+/obj/item/weapon/implant/carrion_spider/toxicbomb/proc/prime()
 	var/location = get_turf(src)
 	gas_storage = new /datum/reagents(100, src)
 	gas_storage.add_reagent("lexorin", 100)
 	var/datum/effect/effect/system/smoke_spread/chem/S = new
 	S.attach(location)
 	S.set_up(gas_storage, 10, 100, location)
-	spawn(0)
-		S.start()
+	S.start()
 	die()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
all around standardization of carrion grenade-y spiders
warning message is now bold red and emits romnche sound
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
please i just want to see them again
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Grenade-like spiders (Toxic, Explosive, Flashbang) now emit more obvious tell-tale signs before activating
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
