### PR TITLE
Tweaks the values on handmade, bulletproof, heavy, and IH ballistic proof armor.

### DIFF
--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -133,7 +133,7 @@
 	body_parts_covered = HEAD | EARS | EYES | FACE
 	armor = list(
 		melee = 30,
-		bullet = 50,
+		bullet = 55,
 		energy = 25,
 		bomb = 25,
 		bio = 0,
@@ -219,7 +219,7 @@
 	armor = list(
 		melee = 40,
 		bullet = 60,
-		energy = 35,
+		energy = 25,
 		bomb = 25,
 		bio = 0,
 		rad = 0

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -217,7 +217,7 @@
 	desc = "Standard-issue Ironhammer ballistic helmet with a basic HUD included, covers the operator's entire face."
 	icon_state = "ironhammer_full"
 	armor = list(
-		melee = 40,
+		melee = 30,
 		bullet = 60,
 		energy = 25,
 		bomb = 25,

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -85,7 +85,7 @@
 	icon_state = "armor_handmade"
 	armor = list(
 		melee = 30,
-		bullet = 20,
+		bullet = 25,
 		energy = 15,
 		bomb = 10,
 		bio = 0,
@@ -422,14 +422,14 @@
 	item_state = "mercwebvest"
 	rarity_value = 90
 	armor = list(
-		melee = 55,
-		bullet = 55,
-		energy = 55,
+		melee = 50,
+		bullet = 50,
+		energy = 50,
 		bomb = 25,
 		bio = 0,
 		rad = 0
 	)
-	
+
 /obj/item/clothing/suit/storage/vest/merc/full
 	name = "full heavy armor vest"
 	desc = "A high-quality armor vest in a fetching tan. This one is webbed, and has kneepads and shoulderpads for extra coverage."


### PR DESCRIPTION
It felt weird to me that the values on these armors were different on the helmets and vests. Deny this if there was a reason for the armors being like this, but otherwise I have this done.

Handmade: Slight buff to the vest (20 --> 25 bullet protection)

Bulletproof (non IH) armor: Helmet buffed (50 --> 55 bullet protection)

Heavy armor: vest nerfed slightly (55 --> 50 to melee, bullet, and energy protection)

IH ballistic proof armor: Helmet nerfed (40 --> 30 melee protection, 35 --> 25 energy protection)

Lemme know if there's anything I should change.