### PR TITLE
Adds generic pouches to NT bioprinter clothing disk

### DIFF
--- a/code/datums/autolathe/biomatter.dm
+++ b/code/datums/autolathe/biomatter.dm
@@ -147,6 +147,42 @@
 /datum/design/bioprinter/satchel
 	name = "Leather Satchel"
 	build_path = /obj/item/weapon/storage/backpack/satchel
+	
+/datum/design/bioprinter/small_generic
+	name= "Small generic pouch"
+	build_path = /obj/item/weapon/storage/pouch/small_generic
+
+/datum/design/bioprinter/medium_generic
+	name= "Medium generic pouch"
+	build_path = /obj/item/weapon/storage/pouch/medium_generic
+
+/datum/design/bioprinter/large_generic
+	name= "Large generic pouch"
+	build_path = /obj/item/weapon/storage/pouch/large_generic
+
+/datum/design/bioprinter/medical_supply
+	name= "Medical supply pouch"
+	build_path = /obj/item/weapon/storage/pouch/medical_supply
+
+/datum/design/bioprinter/engineering_tools
+	name= "Engineering tools pouch"
+	build_path = /obj/item/weapon/storage/pouch/engineering_tools
+
+/datum/design/bioprinter/engineering_supply
+	name= "Engineering supply pouch"
+	build_path = /obj/item/weapon/storage/pouch/engineering_supply
+
+/datum/design/bioprinter/ammo
+	name= "Ammo pouch"
+	build_path = /obj/item/weapon/storage/pouch/ammo
+
+/datum/design/bioprinter/tubular
+	name= "Tubular pouch"
+	build_path = /obj/item/weapon/storage/pouch/tubular
+
+/datum/design/bioprinter/tubular/vial
+	name= "Vial pouch"
+	build_path = /obj/item/weapon/storage/pouch/tubular/vial
 
 //[/CLOTHES, ARMOR AND ACCESORIES]
 

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -378,6 +378,16 @@
 		/datum/design/bioprinter/leather/holster/armpit,
 		/datum/design/bioprinter/leather/holster/waist,
 		/datum/design/bioprinter/leather/holster/hip,
+		
+		/datum/design/bioprinter/small_generic,
+		/datum/design/bioprinter/medium_generic,
+		/datum/design/bioprinter/large_generic,
+		/datum/design/bioprinter/medical_supply,
+		/datum/design/bioprinter/engineering_tools,
+		/datum/design/bioprinter/engineering_supply,
+		/datum/design/bioprinter/ammo,
+		/datum/design/bioprinter/tubular,
+		/datum/design/bioprinter/tubular/vial,
 
    		/datum/design/autolathe/device/headset_church,
 		/datum/design/bioprinter/leather/cash_bag

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -44,7 +44,7 @@
 	desc = "Can hold anything in it, but only about once."
 	icon_state = "small_generic"
 	item_state = "small_generic"
-	matter = list(MATERIAL_BIOMATTER = 9)
+	matter = list(MATERIAL_BIOMATTER = 9, MATERIAL_STEEL = 3)
 	storage_slots = null //Uses generic capacity
 	max_storage_space = DEFAULT_SMALL_STORAGE * 0.5
 	max_w_class = ITEM_SIZE_SMALL
@@ -55,7 +55,7 @@
 	desc = "Can hold anything in it, but only about twice."
 	icon_state = "medium_generic"
 	item_state = "medium_generic"
-	matter = list(MATERIAL_BIOMATTER = 24)
+	matter = list(MATERIAL_BIOMATTER = 24, MATERIAL_STEEL = 6 )
 	storage_slots = null //Uses generic capacity
 	max_storage_space = DEFAULT_SMALL_STORAGE
 	max_w_class = ITEM_SIZE_NORMAL
@@ -66,7 +66,7 @@
 	desc = "A mini satchel. Can hold a fair bit, but it won't fit in your pocket"
 	icon_state = "large_generic"
 	item_state = "large_generic"
-	matter = list(MATERIAL_BIOMATTER = 39)
+	matter = list(MATERIAL_BIOMATTER = 39, MATERIAL_STEEL = 9 )
 	w_class = ITEM_SIZE_NORMAL
 	slot_flags = SLOT_BELT | SLOT_DENYPOCKET
 	storage_slots = null //Uses generic capacity
@@ -79,7 +79,7 @@
 	desc = "Can hold medical equipment. But only about three pieces of it."
 	icon_state = "medical_supply"
 	item_state = "medical_supply"
-	matter = list(MATERIAL_BIOMATTER = 9)
+	matter = list(MATERIAL_BIOMATTER = 9, MATERIAL_STEEL = 1 )
 	rarity_value = 33
 
 	storage_slots = 3
@@ -107,7 +107,7 @@
 	desc = "Can hold small engineering tools. But only about three pieces of them."
 	icon_state = "engineering_tool"
 	item_state = "engineering_tool"
-	matter = list(MATERIAL_BIOMATTER = 9)
+	matter = list(MATERIAL_BIOMATTER = 9, MATERIAL_STEEL = 1 )
 	rarity_value = 20
 
 	storage_slots = 3
@@ -139,7 +139,7 @@
 	desc = "Can hold engineering equipment. But only about two pieces of it."
 	icon_state = "engineering_supply"
 	item_state = "engineering_supply"
-	matter = list(MATERIAL_BIOMATTER = 9)
+	matter = list(MATERIAL_BIOMATTER = 9, MATERIAL_STEEL = 1 )
 	rarity_value = 33
 
 	storage_slots = 2
@@ -167,7 +167,7 @@
 	desc = "Can hold ammo magazines and bullets, not the boxes though."
 	icon_state = "ammo"
 	item_state = "ammo"
-	matter = list(MATERIAL_BIOMATTER = 39)
+	matter = list(MATERIAL_BIOMATTER = 39, MATERIAL_STEEL = 3 )
 	rarity_value = 33
 
 	storage_slots = 3
@@ -184,7 +184,7 @@
 	desc = "Can hold five cylindrical and small items, including but not limiting to flares, glowsticks, syringes and even hatton tubes or rockets."
 	icon_state = "flare"
 	item_state = "flare"
-	matter = list(MATERIAL_BIOMATTER = 14)
+	matter = list(MATERIAL_BIOMATTER = 14, MATERIAL_STEEL = 1 )
 	rarity_value = 14
 
 	storage_slots = 5

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -44,6 +44,7 @@
 	desc = "Can hold anything in it, but only about once."
 	icon_state = "small_generic"
 	item_state = "small_generic"
+	matter = list(MATERIAL_BIOMATTER = 9)
 	storage_slots = null //Uses generic capacity
 	max_storage_space = DEFAULT_SMALL_STORAGE * 0.5
 	max_w_class = ITEM_SIZE_SMALL
@@ -54,6 +55,7 @@
 	desc = "Can hold anything in it, but only about twice."
 	icon_state = "medium_generic"
 	item_state = "medium_generic"
+	matter = list(MATERIAL_BIOMATTER = 24)
 	storage_slots = null //Uses generic capacity
 	max_storage_space = DEFAULT_SMALL_STORAGE
 	max_w_class = ITEM_SIZE_NORMAL
@@ -64,6 +66,7 @@
 	desc = "A mini satchel. Can hold a fair bit, but it won't fit in your pocket"
 	icon_state = "large_generic"
 	item_state = "large_generic"
+	matter = list(MATERIAL_BIOMATTER = 39)
 	w_class = ITEM_SIZE_NORMAL
 	slot_flags = SLOT_BELT | SLOT_DENYPOCKET
 	storage_slots = null //Uses generic capacity
@@ -76,6 +79,7 @@
 	desc = "Can hold medical equipment. But only about three pieces of it."
 	icon_state = "medical_supply"
 	item_state = "medical_supply"
+	matter = list(MATERIAL_BIOMATTER = 9)
 	rarity_value = 33
 
 	storage_slots = 3
@@ -103,6 +107,7 @@
 	desc = "Can hold small engineering tools. But only about three pieces of them."
 	icon_state = "engineering_tool"
 	item_state = "engineering_tool"
+	matter = list(MATERIAL_BIOMATTER = 9)
 	rarity_value = 20
 
 	storage_slots = 3
@@ -134,6 +139,7 @@
 	desc = "Can hold engineering equipment. But only about two pieces of it."
 	icon_state = "engineering_supply"
 	item_state = "engineering_supply"
+	matter = list(MATERIAL_BIOMATTER = 9)
 	rarity_value = 33
 
 	storage_slots = 2
@@ -161,6 +167,7 @@
 	desc = "Can hold ammo magazines and bullets, not the boxes though."
 	icon_state = "ammo"
 	item_state = "ammo"
+	matter = list(MATERIAL_BIOMATTER = 39)
 	rarity_value = 33
 
 	storage_slots = 3
@@ -177,6 +184,7 @@
 	desc = "Can hold five cylindrical and small items, including but not limiting to flares, glowsticks, syringes and even hatton tubes or rockets."
 	icon_state = "flare"
 	item_state = "flare"
+	matter = list(MATERIAL_BIOMATTER = 14)
 	rarity_value = 14
 
 	storage_slots = 5


### PR DESCRIPTION
## About The Pull Request

Adds following items to NT's clothes disk (cost in biomatter in brackets):
Small generic pouch (15); medium generic pouch (30); large generic pouch (45); ammo pouch (45); medical supplies pouch (15); engineering tools pouch (15); engineering storage pouch (15); tubular&vial pouches (20).  

## Why It's Good For The Game

More useful items and services for NT to produce and provide = more interaction with rest of the population = good.
As of now the only source of these items in game is junk and ordering crate from Guild, until now there was no way to craft these items otherwise. It's a nice niche for NT to fill, since they lready produce holsters and such.
## Changelog
:cl:
add: Pouches to NT's clothes disk.
add: Biomatter cost for pouches. 
/:cl:

