### PR TITLE
Removing an excelsior rev's implant now gives more feedback

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/excelsior.dm
+++ b/code/game/objects/items/weapons/implant/implants/excelsior.dm
@@ -99,10 +99,13 @@
 	for(var/datum/antagonist/A in wearer.mind.antagonist)
 		if(A.id == antag_id)
 			A.remove_antagonist()
-
+	wearer.visible_message(SPAN_DANGER("As \the [src] is removed from \the [wearer]..."))
 	if(prob(66))
+		wearer.visible_message(SPAN_DANGER("\The [wearer]'s [part.name] violently explodes from within!"))
 		wearer.adjustBrainLoss(200)
 		part.droplimb(FALSE, DROPLIMB_BLUNT)
+	else
+		wearer.visible_message(SPAN_NOTICE("Something fizzles in \the [wearer]'s [part.name], but nothing interesting happens."))
 
 //The leader version of the implant is the one given to antags spawned by the storyteller.
 //It has no special gameplay properties and is not attainable in normal gameplay, it just exists to


### PR DESCRIPTION
## About The Pull Request

Was requested

## Why It's Good For The Game
So people don't think you're just shit at surgery when the patient's head explodes.

## Changelog
:cl:
tweak: Removing an Excel's implant now gives a bit more feedback to viewers as to why that person's head explodes.
/:cl: