### PR TITLE
ErisMed: Erismed Sequel 2 Rising: Revengeance - the game the movie: Cyberpunk Surgery Action. The Ultimate dating simulator. The New Cock. Final part Final Final Part. - Extended Enhanced Director's Cut Edition: Classic Extreme HD: With Warband and Wizard Wars Online II: The Pre-Sequel: Game of the Year Edition RU VR Early Access

### DIFF
--- a/code/__DEFINES/damage_organs.dm
+++ b/code/__DEFINES/damage_organs.dm
@@ -35,6 +35,10 @@
 #define ARMOR_BIO			"bio"
 #define ARMOR_RAD			"rad"
 
+//Blood levels. These are percentages based on the species blood_volume
+#define BLOOD_VOLUME_SAFE_MODIFIER    45
+#define BLOOD_VOLUME_OKAY_MODIFIER    35
+#define BLOOD_VOLUME_BAD_MODIFIER     20
 
 // Organ processes
 #define OP_EYES          "eyes"

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -11,6 +11,7 @@
 #define LEAPING     0x10
 #define REBUILDING_ORGANS     0x20
 #define PASSEMOTES  0x40    // Mob has a cortical borer or holders inside of it that need to see emotes.
+#define BLEEDOUT    0x80
 #define GODMODE     0x1000
 #define FAKEDEATH   0x2000  // Replaces stuff like carrion.carrion_fakedeath.
 #define DISFIGURED  0x4000  // Set but never checked. Remove this sometime and replace occurences with the appropriate organ code

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -200,9 +200,9 @@
 			var/blood_volume = H.vessel.get_reagent_amount("blood")
 			var/blood_percent =  round((blood_volume / H.species.blood_volume)*100)
 			var/blood_type = H.dna.b_type
-			if((blood_percent <= BLOOD_VOLUME_SAFE) && (blood_percent > BLOOD_VOLUME_BAD))
+			if((blood_percent <= H.total_blood_req + BLOOD_VOLUME_SAFE_MODIFIER) && (blood_percent > H.total_blood_req + BLOOD_VOLUME_BAD_MODIFIER))
 				dat += SPAN_DANGER("Warning: Blood Level LOW: [blood_percent]% [blood_volume]cl.</span> <span class='highlight'>Type: [blood_type]")
-			else if(blood_percent <= BLOOD_VOLUME_BAD)
+			else if(blood_percent <= H.total_blood_req + BLOOD_VOLUME_BAD_MODIFIER)
 				dat += SPAN_DANGER("<i>Warning: Blood Level CRITICAL: [blood_percent]% [blood_volume]cl.</i></span> <span class='highlight'>Type: [blood_type]")
 			else
 				dat += span("highlight", "Blood Level Normal: [blood_percent]% [blood_volume]cl. Type: [blood_type]")

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -6,7 +6,7 @@
 	icon_state = "large"
 	sharp = TRUE
 	edge = TRUE
-	w_class = ITEM_SIZE_SMALL
+	w_class = ITEM_SIZE_TINY
 	force_divisor = 0.2 // 6 with hardness 30 (glass)
 	thrown_force_divisor = 0.4 // 4 with weight 15 (glass)
 	item_state = "shard-glass"

--- a/code/game/objects/structures/medical_stand.dm
+++ b/code/game/objects/structures/medical_stand.dm
@@ -431,7 +431,7 @@
 				return
 
 			// If the human is losing too much blood, beep.
-			if(H.get_blood_volume() < BLOOD_VOLUME_SAFE * 1.05)
+			if(H.get_blood_volume() < (H.total_blood_req + BLOOD_VOLUME_SAFE_MODIFIER) * 1.05)
 				visible_message("\The [src] beeps loudly.")
 
 			var/datum/reagent/B = H.take_blood(beaker,amount)

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -9,12 +9,17 @@
 	icon_state = "brain2"
 	force = 1
 	w_class = ITEM_SIZE_SMALL
+	specific_organ_size = 2
 	throwforce = 1
 	throw_speed = 3
 	throw_range = 5
 	origin_tech = list(TECH_BIO = 3)
 	attack_verb = list("attacked", "slapped", "whacked")
 	price_tag = 900
+	blood_req = 8
+	max_blood_storage = 80
+	oxygen_req = 8
+	nutriment_req = 6
 	var/mob/living/carbon/brain/brainmob = null
 
 /obj/item/organ/internal/brain/New()

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -14,6 +14,11 @@
 	//Active emote/pose
 	var/pose
 
+	//Values from all base organs should add up to this
+	var/total_blood_req = 40
+	var/total_oxygen_req = 50
+	var/total_nutriment_req = DEFAULT_HUNGER_FACTOR
+
 	var/datum/reagents/metabolism/bloodstr
 	var/datum/reagents/metabolism/ingested
 	var/datum/reagents/metabolism/touching

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -78,6 +78,16 @@
 		if(life_tick % 2)	//Upadated every 2 life ticks, lots of for loops in this, needs to feel smother in the UI
 			for(var/obj/item/organ/external/E in organs)
 				E.update_limb_efficiency()
+			total_blood_req = 0
+			total_oxygen_req = 0
+			total_nutriment_req = 0
+			for(var/obj/item/organ/internal/I in internal_organs)
+				if(BP_IS_ROBOTIC(I))
+					continue
+				total_blood_req += I.blood_req
+				total_oxygen_req += I.oxygen_req
+				total_nutriment_req += (I.nutriment_req / 1000)
+			total_oxygen_req = min(total_oxygen_req, 100)
 
 		if(!client)
 			species.handle_npc(src)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -30,7 +30,7 @@
 	var/sanctified_attack = FALSE
 
 	if(damagetype == HALLOSS)
-		effective_damage = round(effective_damage * (get_specific_organ_efficiency(OP_NERVE, def_zone) / 100))
+		effective_damage = round(effective_damage * max(0.5, (get_specific_organ_efficiency(OP_NERVE, def_zone) / 100)))
 
 	if(effective_damage <= 0)
 		armor_message(SPAN_NOTICE("Your armor absorbs the blow!"))
@@ -72,7 +72,7 @@
 		//Pain part of the damage, that simulates impact from armor absorbtion
 		//For balance purposes, it's lowered by ARMOR_AGONY_COEFFICIENT
 		if(!(damagetype == HALLOSS ))
-			var/agony_gamage = round( ( effective_damage * armor_effectiveness * ARMOR_AGONY_COEFFICIENT *(get_specific_organ_efficiency(OP_NERVE, def_zone) / 100) / 100))
+			var/agony_gamage = round( ( effective_damage * armor_effectiveness * ARMOR_AGONY_COEFFICIENT * max(0.5, (get_specific_organ_efficiency(OP_NERVE, def_zone) / 100)) / 100))
 			apply_effect(agony_gamage, AGONY)
 
 		//Actual part of the damage that passed through armor

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -1,11 +1,6 @@
 /****************************************************
 				BLOOD SYSTEM
 ****************************************************/
-//Blood levels. These are percentages based on the species blood_volume far.
-var/const/BLOOD_VOLUME_SAFE =    85
-var/const/BLOOD_VOLUME_OKAY =    75
-var/const/BLOOD_VOLUME_BAD =     60
-var/const/BLOOD_VOLUME_SURVIVE = 40
 
 /mob/living/carbon
 	var/datum/reagents/vessel // Container for blood and BLOOD ONLY. Do not transfer other chems here.
@@ -277,7 +272,7 @@ proc/blood_splatter(var/target,var/datum/reagent/organic/blood/source,var/large)
 /mob/living/carbon/human/get_blood_oxygenation()
 	var/blood_volume = get_blood_circulation()
 	if(is_asystole()) // Heart is missing or isn't beating and we're not breathing (hardcrit)
-		return min(blood_volume, BLOOD_VOLUME_SURVIVE)
+		return min(blood_volume, total_blood_req)
 
 	if(!need_breathe())
 		return blood_volume

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -87,8 +87,7 @@
 	else if(default_description)
 		set_description(new default_description)
 
-	spawn(1)	//Last organs to be made, last organs in the UI
-		make_base_internal_organs()
+	make_base_internal_organs()
 
 	..(holder)
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -87,7 +87,9 @@
 	else if(default_description)
 		set_description(new default_description)
 
-	make_base_internal_organs()
+	spawn(1)	//Last organs to be made, last organs in the UI
+		make_base_internal_organs()
+
 	..(holder)
 
 	if(istype(holder))

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -98,6 +98,8 @@
 
 /obj/item/organ/internal/examine(mob/user)
 	. = ..()
+	if(user.stats?.getStat(STAT_BIO) > STAT_LEVEL_BASIC)
+		to_chat(user, SPAN_NOTICE("Organ size: [specific_organ_size]"))
 	if(user.stats?.getStat(STAT_BIO) > STAT_LEVEL_EXPERT)
 		to_chat(user, SPAN_NOTICE("Requirements: <span style='color:red'>[blood_req]</span>/<span style='color:blue'>[oxygen_req]</span>/<span style='color:orange'>[nutriment_req]</span>"))
 

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -6,7 +6,12 @@
 	var/list/owner_verbs = list()
 	var/list/organ_efficiency = list()	//Efficency of an organ, should become the most important variable
 	var/unique_tag	//If an organ is unique and doesn't scale off of organ processes
-	var/specific_organ_size = 1  // Space organs take up in weight calculations, unaffected by w_class for balance reasons
+	var/specific_organ_size = 1  //Space organs take up in weight calculations, unaffected by w_class for balance reasons
+	var/max_blood_storage = 0	//How much blood an organ stores. Base is 5 * blood_req, so the organ can survive without blood for 5 ticks beofre taking damage (+ blood supply of blood vessels)
+	var/current_blood = 100	//How much blood is currently in the organ
+	var/blood_req = 0	//How much blood an organ takes to funcion
+	var/nutriment_req = 0	//Controls passive nutriment loss
+	var/oxygen_req = 0	//If oxygen reqs are not satisfied, get debuff and brain starts taking damage
 
 /obj/item/organ/internal/New(mob/living/carbon/human/holder, datum/organ_description/OD)
 	..()
@@ -14,6 +19,7 @@
 
 /obj/item/organ/internal/Process()
 	..()
+	handle_blood()
 	handle_regeneration()
 
 /obj/item/organ/internal/removed_mob()
@@ -57,11 +63,43 @@
 		if(owner && parent && amount > 0 && !silent)
 			owner.custom_pain("Something inside your [parent.name] hurts a lot.", 1)
 
+/obj/item/organ/internal/proc/handle_blood()
+	if(BP_IS_ROBOTIC(src) || !owner)
+		return
+	if(OP_BLOOD_VESSEL in organ_efficiency && !(owner.status_flags & BLEEDOUT))
+		current_blood = min(current_blood + 5, max_blood_storage)	//Blood vessels get an extra flat 5 blood regen
+	if(!blood_req)
+		return
+
+	if(owner.status_flags & BLEEDOUT)
+		current_blood = max(current_blood - blood_req, 0)
+		if(!current_blood)	//When all blood is lost, take blood from blood vessels
+			var/obj/item/organ/internal/BV
+			for(var/organ in shuffle(parent.internal_organs))
+				var/obj/item/organ/internal/I = organ
+				if(OP_BLOOD_VESSEL in I.organ_efficiency)
+					BV = I
+					break
+			if(BV)
+				BV.current_blood = max(BV.current_blood - blood_req, 0)
+			if(BV?.current_blood == 0)	//When all blood from the organ and blood vessel is lost, 
+				take_damage(rand(2,5), prob(95))	//95% chance to not warn them, damage will proc on every organ in the limb
+
+		return
+
+	current_blood = min(current_blood + blood_req, max_blood_storage)
+
 /obj/item/organ/internal/proc/handle_regeneration()
-	if(!damage || BP_IS_ROBOTIC(src) || !owner || owner.chem_effects[CE_TOXIN] || owner.is_asystole())
+	if(!damage || BP_IS_ROBOTIC(src) || !owner || owner.chem_effects[CE_TOXIN] || owner.is_asystole() || !current_blood)
 		return
 	if(damage < 0.1*max_damage)
+		owner.adjustNutrition(-(nutriment_req * 10))
 		heal_damage(0.1)
+
+/obj/item/organ/internal/examine(mob/user)
+	. = ..()
+	if(user.stats?.getStat(STAT_BIO) > STAT_LEVEL_EXPERT)
+		to_chat(user, SPAN_NOTICE("Requirements: <span style='color:red'>[blood_req]</span>/<span style='color:blue'>[oxygen_req]</span>/<span style='color:orange'>[nutriment_req]</span>"))
 
 /obj/item/organ/internal/is_usable()
 	return ..() && !is_broken()

--- a/code/modules/organs/internal/blood_vessels.dm
+++ b/code/modules/organs/internal/blood_vessels.dm
@@ -4,3 +4,6 @@
 	organ_efficiency = list(OP_BLOOD_VESSEL= 100)
 	price_tag = 100
 	specific_organ_size = 0.5
+	max_blood_storage = 100
+	oxygen_req = 2
+	nutriment_req = 1

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -5,6 +5,10 @@
 	organ_efficiency = list(OP_EYES = 100)
 	parent_organ_base = BP_HEAD
 	price_tag = 100
+	blood_req = 2
+	max_blood_storage = 10
+	oxygen_req = 1
+	nutriment_req = 1
 	var/eyes_color = "#000000"
 	var/robo_color = "#000000"
 	var/cache_key = BP_EYES

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -6,6 +6,8 @@
 	dead_icon = "heart-off"
 	price_tag = 1000
 	specific_organ_size = 2
+	oxygen_req = 10
+	nutriment_req = 10
 	var/open
 
 /obj/item/organ/internal/heart/open

--- a/code/modules/organs/internal/kidneys.dm
+++ b/code/modules/organs/internal/kidneys.dm
@@ -4,6 +4,10 @@
 	organ_efficiency = list(OP_KIDNEYS = 50)
 	parent_organ_base = BP_GROIN
 	specific_organ_size = 1
+	blood_req = 1.5
+	max_blood_storage = 7.5
+	oxygen_req = 2.5
+	nutriment_req = 2
 	price_tag = 400	
 
 /obj/item/organ/internal/kidney/left

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -4,6 +4,10 @@
 	organ_efficiency = list(OP_LIVER = 100)
 	parent_organ_base = BP_GROIN
 	price_tag = 900
+	blood_req = 5
+	max_blood_storage = 25
+	oxygen_req = 7
+	nutriment_req = 5
 
 //We got it covered in Process with more detailed thing
 /obj/item/organ/internal/liver/handle_regeneration()

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -6,6 +6,9 @@
 	parent_organ_base = BP_CHEST
 	specific_organ_size = 2
 	price_tag = 300
+	blood_req = 10
+	max_blood_storage = 50
+	nutriment_req = 10
 	var/breath_modulo = 2
 
 /obj/item/organ/internal/lungs/long

--- a/code/modules/organs/internal/muscles.dm
+++ b/code/modules/organs/internal/muscles.dm
@@ -5,6 +5,9 @@
 	organ_efficiency = list(OP_MUSCLE = 100)
 	price_tag = 100
 	specific_organ_size = 0.5
+	blood_req = 0.5
+	max_blood_storage = 2.5
+	nutriment_req = 0.5
 
 /obj/item/organ/internal/muscle/robotic
 	name = "hydraulic"

--- a/code/modules/organs/internal/nerves.dm
+++ b/code/modules/organs/internal/nerves.dm
@@ -5,6 +5,9 @@
 	organ_efficiency = list(OP_NERVE = 100)
 	price_tag = 100
 	specific_organ_size = 0
+	blood_req = 0.5
+	max_blood_storage = 2.5
+	nutriment_req = 0.5
 
 /obj/item/organ/internal/nerve/robotic
 	name = "nerve wire"

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -4,3 +4,6 @@
 	organ_efficiency = list(OP_STOMACH = 100)
 	parent_organ_base = BP_CHEST
 	price_tag = 700
+	blood_req = 5
+	max_blood_storage = 25
+	oxygen_req = 5

--- a/code/modules/organs/organ_description.dm
+++ b/code/modules/organs/organ_description.dm
@@ -64,7 +64,7 @@
 	dislocated = -1
 
 	w_class = ITEM_SIZE_BULKY
-	max_volume = ITEM_SIZE_GARGANTUAN
+	max_volume = ITEM_SIZE_COLOSSAL
 
 	joint = "hip"
 	amputation_point = "lumbar"
@@ -84,7 +84,7 @@
 	vital = TRUE
 
 	w_class = ITEM_SIZE_NORMAL
-	max_volume = ITEM_SIZE_BULKY
+	max_volume = ITEM_SIZE_GARGANTUAN
 
 	joint = "jaw"
 	amputation_point = "neck"

--- a/code/modules/reagents/reagents/nanites.dm
+++ b/code/modules/reagents/reagents/nanites.dm
@@ -32,8 +32,8 @@
 
 /datum/reagent/nanites/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	eat_blood(M)
-	if(M.get_blood_volume() < BLOOD_VOLUME_OKAY)
-		var/removed = consumed_amount() * (BLOOD_VOLUME_OKAY - M.get_blood_volume() / 100)
+	if(M.get_blood_volume() < M.total_blood_req + BLOOD_VOLUME_OKAY_MODIFIER)
+		var/removed = consumed_amount() * (M.total_blood_req + BLOOD_VOLUME_OKAY_MODIFIER - M.get_blood_volume() / 100)
 		removed = min(volume,removed)
 		var/datum/reagents/metabolism/met = M.get_metabolism_handler(CHEM_BLOOD)
 		met.remove_reagent(id, removed)

--- a/code/modules/surgery/surgery_ui.dm
+++ b/code/modules/surgery/surgery_ui.dm
@@ -33,6 +33,8 @@
 	data["limb_efficiency"] = limb_efficiency
 	data["occupied_volume"] = get_total_occupied_volume()
 	data["max_volume"] = max_volume
+	data["owner_oxyloss"] = owner.getOxyLoss()
+	data["owner_oxymax"] = 100 - owner.total_oxygen_req
 
 	data["conditions"] = get_conditions()
 	data["diagnosed"] = diagnosed
@@ -59,6 +61,10 @@
 		organ_data["max_damage"] = organ.max_damage
 		organ_data["status"] = organ.get_status_data()
 		organ_data["conditions"] = organ.get_conditions()
+		organ_data["stored_blood"] = organ.current_blood
+		organ_data["max_blood"] = organ.max_blood_storage
+		if(BP_BRAIN in organ.organ_efficiency)
+			organ_data["show_oxy"] = TRUE
 
 		var/list/processes = list()
 		for(var/efficiency in organ.organ_efficiency)

--- a/nano/templates/surgery_organ.tmpl
+++ b/nano/templates/surgery_organ.tmpl
@@ -9,13 +9,26 @@
 			<div style ='float: left; height: 32px; width: 32px; margin: 4px' class='statusDisplayItem'><img src= {{:organ.icon_data}} height=32 width=32></div>
 			<article>
 				{{if data.diagnosed}}
-					{{if data.diagnosed && organ.max_damage}}
+					{{if organ.show_oxy}}
+					<section>
+						<span class="label">Oxygen:</span>
+						{{data.oxygen = Math.round((data.owner_oxymax - data.owner_oxyloss) * 10) / 10;}}
+						<div class="content">{{:helper.displayBar(data.oxygen, 0, data.owner_oxymax, 'average', data.oxygen + " / " + data.owner_oxymax)}}</div>
+					</section>
+					{{/if}}
+					{{if organ.max_damage}}
 					<section>
 						<span class="label">Health:</span>
 						{{organ.health = Math.round((organ.max_damage - organ.damage) * 10) / 10;}}
 						<div class="content">{{:helper.displayBar(organ.health, 0, organ.max_damage, !organ.damage ? 'good' : 'bad', organ.health + " / " + organ.max_damage)}}</div>
 					</section>
 					{{/if}}
+					{{if organ.max_blood}}
+					<section>
+						<span class="label">Blood:</span>
+						<div class="content">{{:helper.displayBar(organ.stored_blood, 0, organ.max_blood, 'bad', organ.stored_blood + " / " + organ.max_blood)}}</div>
+					</section>
+					{{/if}}			
 					{{if organ.processes.length}}
 							<div class="display">
 							{{for organ.processes}}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds blood/oxygen/nutriment requirements on organs from the disign doc.
If you don't fulfill you blood requirements your organs will start to loose blood, and eventualy take damage.
If you don't fulfill your oxygen requirements you will start getting debuffs, and if you have <10% of requirements you will start taking brain damage.
Nutriment requirements make you need more food when you have more organs.
![urgens](https://user-images.githubusercontent.com/61743710/102517531-722dbb00-4090-11eb-90e0-d4868a101013.png)
![river](https://user-images.githubusercontent.com/61743710/102517560-7bb72300-4090-11eb-8648-184ee9b82826.png)
You can preview these stats if you examine the organ with 40+ BIO.

## Why It's Good For The Game

The map with the cat.

## Changelog
:cl:
add: Blood/Oxygen/Nutriment requirements/
balance: nerves are capped at 50% agony damage reduction
balance: Some extrenal organs have extra space.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
