### PR TITLE
Odditys rebalance

### DIFF
--- a/code/datums/mob_stats.dm
+++ b/code/datums/mob_stats.dm
@@ -116,10 +116,12 @@
 
 /// The main, public proc to add a perk to a mob. Accepts a path or a stringified path.
 /datum/stat_holder/proc/addPerk(perkType)
+	. = FALSE
 	if(!getPerk(perkType))
 		var/datum/perk/P = new perkType
 		perks += P
 		P.assign(holder)
+		. = TRUE
 
 
 /// The main, public proc to remove a perk from a mob. Accepts a path or a stringified path.

--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -45,6 +45,7 @@
 
 //Common - you can find those everywhere
 /obj/item/weapon/oddity/common
+	prob_perk = 60
 	bad_type = /obj/item/weapon/oddity/common
 	spawn_blacklisted = FALSE
 

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -263,7 +263,8 @@
 			to_chat(owner, SPAN_NOTICE("Your [stat] stat goes up by [stat_up]"))
 			owner.stats.changeStat(stat, stat_up)
 		if(I.perk)
-			owner.stats.addPerk(I.perk)
+			if(owner.stats.addPerk(I.perk))
+				I.perk = null
 		for(var/mob/living/carbon/human/H in viewers(owner))
 			SEND_SIGNAL(H, COMSIG_HUMAN_ODDITY_LEVEL_UP, owner, O)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
1. Now odditys lose their perk on first use.
2. Odditys now have a 60% chance to have an associated perk.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![Screenshot_2](https://user-images.githubusercontent.com/49106866/102566091-217c8900-40b5-11eb-829b-bbe439a7cea9.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Now odditys lose their perk on first use.
tweak: Odditys now have a 60% chance to have an associated perk.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
