### PR TITLE
Fixes timeofdeath being nonstandard in carrion and zombiepowder

### DIFF
--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -233,7 +233,7 @@
 	owner.status_flags |= FAKEDEATH
 	owner.update_lying_buckled_and_verb_status()
 	owner.emote("gasp")
-	owner.timeofdeath = stationtime2text()
+	owner.timeofdeath = world.time
 	var/last_owner = owner
 
 	spawn(rand(1 MINUTES, 3 MINUTES))

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -197,7 +197,7 @@
 	M.adjustOxyLoss(0.6 * effect_multiplier)
 	M.Weaken(10)
 	M.silent = max(M.silent, 10)
-	M.timeofdeath = stationtime2text()
+	M.timeofdeath = world.time
 	M.add_chemical_effect(CE_NOPULSE, 1)
 
 /datum/reagent/toxin/zombiepowder/Destroy()


### PR DESCRIPTION
## About The Pull Request

Carrions were causing a bunch of runtimes

## Why It's Good For The Game
 No more runtimes

## Changelog
:cl:
/:cl: