### PR TITLE
Extends the chemistry shutters

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -68125,6 +68125,14 @@
 	name = "Medbay Total Lockdown";
 	opacity = 0
 	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "chemcounter";
+	name = "Pharmacy Counter Shutters";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/eris/medical/chemistry)
 "dch" = (
@@ -68434,6 +68442,14 @@
 	id = "MedbayTotalLockdown";
 	layer = 2.6;
 	name = "Medbay Total Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "chemcounter";
+	name = "Pharmacy Counter Shutters";
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
@@ -75221,17 +75237,17 @@
 	name = "Medbay Total Lockdown";
 	opacity = 0
 	},
+/obj/machinery/door/window/westright{
+	name = "Chemistry Desk";
+	req_access = list(33)
+	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
-	dir = 2;
+	dir = 4;
 	icon_state = "shutter0";
 	id = "chemcounter";
 	name = "Pharmacy Counter Shutters";
 	opacity = 0
-	},
-/obj/machinery/door/window/westright{
-	name = "Chemistry Desk";
-	req_access = list(33)
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/chemistry)


### PR DESCRIPTION
## About The Pull Request

When chemistry was extended to reach the MBO's office, I forgot to put in shutters on the windows

## Why It's Good For The Game

No more staring at the dumb vagabonds as they ape on about wanting space drugs

## Changelog
:cl:
fix: The chemistry shutters now extend to the windows added in the extension.
/:cl: