### PR TITLE
Remove ninja

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -24,6 +24,8 @@
 	boot_type =  /obj/item/clothing/shoes/magboots/rig/light
 	glove_type = /obj/item/clothing/gloves/rig/light
 
+	spawn_blacklisted = TRUE
+
 /obj/item/clothing/suit/space/rig/light
 	name = "suit"
 
@@ -112,7 +114,6 @@
 		/obj/item/rig_module/datajack,
 		/obj/item/rig_module/self_destruct
 		)
-	spawn_blacklisted = TRUE
 
 /obj/item/clothing/gloves/rig/light/ninja
 	name = "insulated gloves"


### PR DESCRIPTION
## About The Pull Request

This removes ALL light rigs from the loot table.

## Why It's Good For The Game

The light suit sucks to play against as its invisibility has no counter, and has been removed several times

## Changelog
:cl:
del: The Lightsuit rig has been removed from loot tables
/:cl: