### PR TITLE
Firing shotgun with one hand

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -179,12 +179,9 @@
 			to_chat(user, SPAN_DANGER("The gun's safety is on!"))
 			handle_click_empty(user)
 			return FALSE
-	if(twohanded)
-		if(!wielded)
-			if (world.time >= recentwield + 1 SECONDS)
-				to_chat(user, SPAN_DANGER("The gun is too heavy to shoot in one hand!"))
-				recentwield = world.time
-			return FALSE
+	
+	if(!twohanded_check(M))
+		return FALSE
 
 	if((CLUMSY in M.mutations) && prob(40)) //Clumsy handling
 		var/obj/P = consume_next_projectile()
@@ -212,6 +209,15 @@
 			if(rigged > TRUE)
 				explosion(get_turf(src), 1, 2, 3, 3)
 				qdel(src)
+			return FALSE
+	return TRUE
+
+/obj/item/weapon/gun/proc/twohanded_check(user)
+	if(twohanded)
+		if(!wielded)
+			if (world.time >= recentwield + 1 SECONDS)
+				to_chat(user, SPAN_DANGER("The gun is too heavy to shoot in one hand!"))
+				recentwield = world.time
 			return FALSE
 	return TRUE
 

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -5,3 +5,20 @@
 	bad_type = /obj/item/weapon/gun/projectile/shotgun
 	rarity_value = 10
 	spawn_frequency = 10
+	twohanded = TRUE
+	var/fired_one_handed = FALSE
+
+/obj/item/weapon/gun/projectile/shotgun/twohanded_check(var/mob/living/user)
+	if(twohanded && !wielded)
+		user.recoil += 10
+		fired_one_handed = TRUE
+	return TRUE
+
+/obj/item/weapon/gun/projectile/shotgun/handle_post_fire(var/mob/living/user)
+	..()
+	if(fired_one_handed)
+		fired_one_handed = FALSE
+		var/robustness = user.stats.getStat(STAT_ROB)
+		if(robustness < STAT_LEVEL_GODLIKE)
+			if(!prob(robustness))
+				step(user, pick(cardinal - user.dir))

--- a/code/modules/projectiles/guns/projectile/shotgun/sawnoff.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/sawnoff.dm
@@ -13,3 +13,4 @@
 	damage_multiplier = 0.8 //slightly weaker due to sawn-off barrels
 	recoil_buildup = 15 //gonna have solid grip on those, point-blank shots adviced
 	one_hand_penalty = 10 //compact shotgun level
+	twohanded = FALSE


### PR DESCRIPTION
## About The Pull Request
Now when somebody not wielding a shotgun (except sawn off) decides to fire it while not having godlike robustness will stumble most of the times. There is probability based on robustness - more robustness = less chance to stumble.

## Why It's Good For The Game
Ask genessee on discord.

## Changelog
:cl:
balance: You'll now stumble when firing shotguns (except sawn off) with one hand based on yours robustness.
/:cl: