### PR TITLE
Damage reduction

### DIFF
--- a/code/modules/projectiles/guns/energy/crossbow.dm
+++ b/code/modules/projectiles/guns/energy/crossbow.dm
@@ -16,7 +16,6 @@
 	charge_meter = 0
 	charge_cost = 200
 	price_tag = 2500
-	damage_multiplier = 1.5
 
 /obj/item/weapon/gun/energy/crossbow/ninja
 	name = "energy dart thrower"
@@ -32,4 +31,3 @@
 	matter = list(MATERIAL_PLASTEEL = 35, MATERIAL_PLASTIC = 20, MATERIAL_SILVER = 9, MATERIAL_URANIUM = 9)
 	projectile_type = /obj/item/projectile/energy/bolt/large
 	price_tag = 4000
-	damage_multiplier = 1.7

--- a/code/modules/projectiles/guns/energy/crossbow.dm
+++ b/code/modules/projectiles/guns/energy/crossbow.dm
@@ -16,7 +16,7 @@
 	charge_meter = 0
 	charge_cost = 200
 	price_tag = 2500
-	damage_multiplier = 2.2
+	damage_multiplier = 1.5
 
 /obj/item/weapon/gun/energy/crossbow/ninja
 	name = "energy dart thrower"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -12,7 +12,7 @@
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 8, MATERIAL_SILVER = 5)
 	zoom_factor = 0.5
-	damage_multiplier = 0.9
+	damage_multiplier = 1.3
 	charge_cost = 50
 	price_tag = 2500
 	rarity_value = 12
@@ -66,7 +66,7 @@
 	projectile_type = /obj/item/projectile/beam
 	fire_delay = 10 //old technology
 	zoom_factor = 0
-	damage_multiplier = 1.1
+	damage_multiplier = 1
 	charge_cost = 100
 	price_tag = 2000
 	rarity_value = 10

--- a/code/modules/projectiles/guns/energy/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma.dm
@@ -18,7 +18,6 @@
 	recoil_buildup = 1 //pulse weapons have a bit more recoil
 	one_hand_penalty = 10
 	twohanded = TRUE
-	damage_multiplier = 1.3
 
 	init_firemodes = list(
 		list(mode_name="burn", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/Taser.ogg', fire_delay=8, charge_cost=20, icon="stun", projectile_color = "#0000FF"),

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -27,7 +27,6 @@
 	price_tag = 2500
 	rarity_value = 20
 	spawn_tags = SPAWN_TAG_GUN_SHOTGUN_ENERGY
-	damage_multiplier = 1.15
 
 /obj/item/weapon/gun/energy/shrapnel/consume_next_projectile()
 	.=..()

--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -24,7 +24,7 @@
 	cocked_sound 	= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
 	recoil_buildup = 1.8
 	one_hand_penalty = 15 //automatic rifle level
-	damage_multiplier = 1.6
+	damage_multiplier = 1.2
 
 	init_firemodes = list(
 		FULL_AUTO_400,
@@ -65,7 +65,7 @@
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 10)
 	price_tag = 3000
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
-	damage_multiplier = 1.6
+	damage_multiplier = 1
 	init_firemodes = list(
 	SEMI_AUTO_NODELAY,
 	BURST_3_ROUND,

--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -24,7 +24,6 @@
 	cocked_sound 	= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
 	recoil_buildup = 1.8
 	one_hand_penalty = 15 //automatic rifle level
-	damage_multiplier = 1.2
 
 	init_firemodes = list(
 		FULL_AUTO_400,
@@ -65,7 +64,6 @@
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 10)
 	price_tag = 3000
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
-	damage_multiplier = 1
 	init_firemodes = list(
 	SEMI_AUTO_NODELAY,
 	BURST_3_ROUND,

--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -24,7 +24,7 @@
 	cocked_sound 	= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
 	recoil_buildup = 1.8
 	one_hand_penalty = 15 //automatic rifle level
-	damage_multiplier = 3
+	damage_multiplier = 1.6
 
 	init_firemodes = list(
 		FULL_AUTO_400,

--- a/code/modules/projectiles/guns/projectile/automatic/atreides.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/atreides.dm
@@ -18,7 +18,7 @@
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 13, MATERIAL_PLASTIC = 2)
 	price_tag = 1200
 	rarity_value = 19.2
-	damage_multiplier = 1.2
+	damage_multiplier = 0.8
 	recoil_buildup = 1.2
 	one_hand_penalty = 5 //smg level
 	gun_tags = list(GUN_SILENCABLE)

--- a/code/modules/projectiles/guns/projectile/automatic/c20r.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/c20r.dm
@@ -22,7 +22,7 @@
 	unload_sound 	= 'sound/weapons/guns/interact/sfrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/sfrifle_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/sfrifle_cock.ogg'
-	damage_multiplier = 1.2
+	damage_multiplier = 1
 	penetration_multiplier = 1.5 //7.5 with regular lethal ammo, 15 with HV, seems legit
 	zoom_factor = 0.4
 	recoil_buildup = 1.2

--- a/code/modules/projectiles/guns/projectile/automatic/dallas.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/dallas.dm
@@ -19,7 +19,7 @@
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/m41_reload.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/m41_cocked.ogg'
-	damage_multiplier = 1.55
+	damage_multiplier = 1.35
 	penetration_multiplier = 1
 	recoil_buildup = 1.3
 	one_hand_penalty = 10 //heavy, but very advanced, so bullpup rifle level despite not being bullpup

--- a/code/modules/projectiles/guns/projectile/automatic/sol.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sol.dm
@@ -24,7 +24,7 @@
 
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY,
-		list(mode_name="3-round bursts", burst=3, fire_delay = 3, move_delay=4, icon="burst", damage_multiplier = 0.05)
+		BURST_3_ROUND
 		)
 
 /obj/item/weapon/gun/projectile/automatic/sol/proc/update_charge()

--- a/code/modules/projectiles/guns/projectile/automatic/straylight.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/straylight.dm
@@ -18,7 +18,7 @@
 	price_tag = 1400
 	rarity_value = 12
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
-	damage_multiplier = 0.75	 //made with rubber rounds in mind. For lethality refer to Wintermute. Still quite lethal if you manage to land most shots.
+	damage_multiplier = 0.65	 //made with rubber rounds in mind. For lethality refer to Wintermute. Still quite lethal if you manage to land most shots.
 	penetration_multiplier = 0.5 //practically no AP, 2.5 with regular rounds and 5 with HV. Still deadly to unarmored targets.
 	recoil_buildup = 1
 	one_hand_penalty = 5 //smg level

--- a/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
@@ -17,7 +17,7 @@
 	price_tag = 4000
 	zoom_factor = 0.8 // double as IH_heavy
 	penetration_multiplier = 1.2
-	damage_multiplier = 1.5
+	damage_multiplier = 1.2
 	recoil_buildup = 1.3
 	one_hand_penalty = 15 //automatic rifle level
 	silenced = TRUE

--- a/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
@@ -17,7 +17,7 @@
 	price_tag = 4000
 	zoom_factor = 0.8 // double as IH_heavy
 	penetration_multiplier = 1.2
-	damage_multiplier = 1.9
+	damage_multiplier = 1.5
 	recoil_buildup = 1.3
 	one_hand_penalty = 15 //automatic rifle level
 	silenced = TRUE

--- a/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
@@ -24,12 +24,11 @@
 	zoom_factor = 0.4
 	recoil_buildup = 2
 	one_hand_penalty = 15 //automatic rifle level
-	damage_multiplier = 1.5
 
 	init_firemodes = list(
 		FULL_AUTO_400,
 		SEMI_AUTO_NODELAY,
-		list(mode_name="3-round bursts", burst=3, fire_delay = 3, move_delay=4, icon="burst", damage_multiplier = -1.2)
+		BURST_3_ROUND
 		)
 
 /obj/item/weapon/gun/projectile/automatic/wintermute/update_icon()

--- a/code/modules/projectiles/guns/projectile/automatic/z8.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/z8.dm
@@ -21,7 +21,7 @@
 	cocked_sound 	= 'sound/weapons/guns/interact/batrifle_cock.ogg'
 	recoil_buildup = 1
 	penetration_multiplier = 1.1
-	damage_multiplier = 1.45
+	damage_multiplier = 1.1
 	zoom_factor = 0.2
 	one_hand_penalty = 10 //bullpup rifle level
 

--- a/code/modules/projectiles/guns/projectile/automatic/zoric.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/zoric.dm
@@ -16,7 +16,7 @@
 	magazine_type = /obj/item/ammo_magazine/msmg
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_STEEL = 6, MATERIAL_PLASTIC = 4)
 	price_tag = 2000
-	damage_multiplier = 0.6
+	damage_multiplier = 1	 // 34 lethal
 	penetration_multiplier = 0.5 // 7.5 lethal
 	recoil_buildup = 0.7
 	twohanded = FALSE

--- a/code/modules/projectiles/guns/projectile/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun.dm
@@ -11,7 +11,7 @@
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	caliber = CAL_LRIFLE
 	fire_delay = 12 // double the standart
-	damage_multiplier = 2.4
+	damage_multiplier = 1.4
 	penetration_multiplier  = 1.5
 	recoil_buildup = 40 //same as AMR
 	handle_casings = HOLD_CASINGS

--- a/code/modules/projectiles/guns/projectile/pistol/avasarala.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/avasarala.dm
@@ -13,7 +13,7 @@
 	price_tag = 1600
 	rarity_value = 13.74
 	can_dual = 1
-	damage_multiplier = 1.95
+	damage_multiplier = 1.45
 	penetration_multiplier = 1.35
 	recoil_buildup = 33
 	fire_sound = 'sound/weapons/guns/fire/hpistol_fire.ogg'

--- a/code/modules/projectiles/guns/projectile/pistol/clarissa.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/clarissa.dm
@@ -50,7 +50,7 @@
 	desc = "Old-designed pistol of space communists. Small and easily concealable. Uses .35 Auto rounds."
 	icon = 'icons/obj/guns/projectile/makarov.dmi'
 	icon_state = "makarov"
-	damage_multiplier = 1.8
+	damage_multiplier = 1.2
 	recoil_buildup = 21
 	price_tag = 1400
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2, TECH_COVERT = 3)

--- a/code/modules/projectiles/guns/projectile/pistol/lamia.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/lamia.dm
@@ -20,7 +20,7 @@
 	unload_sound 	= 'sound/weapons/guns/interact/hpistol_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/hpistol_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/hpistol_cock.ogg'
-	damage_multiplier = 1.1
+	damage_multiplier = 1.4
 	penetration_multiplier = 1.4
 	recoil_buildup = 21
 

--- a/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
@@ -14,7 +14,7 @@
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
 	price_tag = 800
 	rarity_value = 12
-	damage_multiplier = 1.3
+	damage_multiplier = 1.2
 	penetration_multiplier = 1.2
 	recoil_buildup = 6
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
@@ -14,7 +14,7 @@
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
 	price_tag = 800
 	rarity_value = 12
-	damage_multiplier = 1.6
+	damage_multiplier = 1.3
 	penetration_multiplier = 1.2
 	recoil_buildup = 6
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/pistol/paco.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/paco.dm
@@ -19,7 +19,7 @@
 	rarity_value = 24
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
-	damage_multiplier = 1.8
+	damage_multiplier = 1.5
 	penetration_multiplier = 0.9
 	recoil_buildup = 10
 	gun_tags = list(GUN_SILENCABLE)

--- a/code/modules/projectiles/guns/projectile/revolver/consul.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/consul.dm
@@ -11,7 +11,7 @@
 	ammo_type = /obj/item/ammo_casing/magnum/rubber
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 8)
 	price_tag = 1700
-	damage_multiplier = 1.5
+	damage_multiplier = 1.4
 	penetration_multiplier = 1.5
 	recoil_buildup = 35
 	rarity_value = 8

--- a/code/modules/projectiles/guns/projectile/revolver/consul.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/consul.dm
@@ -11,7 +11,7 @@
 	ammo_type = /obj/item/ammo_casing/magnum/rubber
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 8)
 	price_tag = 1700
-	damage_multiplier = 1.4
+	damage_multiplier = 1.35
 	penetration_multiplier = 1.5
 	recoil_buildup = 35
 	rarity_value = 8

--- a/code/modules/projectiles/guns/projectile/revolver/deckard.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/deckard.dm
@@ -9,7 +9,7 @@
 	ammo_type = /obj/item/ammo_casing/magnum/rubber
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
 	price_tag = 3100 //one of most robust revolvers here
-	damage_multiplier = 1.65
+	damage_multiplier = 1.45
 	penetration_multiplier = 1.65
 	recoil_buildup = 40
 	rarity_value = 12

--- a/code/modules/projectiles/guns/projectile/revolver/sky_driver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/sky_driver.dm
@@ -11,7 +11,7 @@
 	ammo_type = /obj/item/ammo_casing/pistol
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
 	price_tag = 20000
-	damage_multiplier = 1.5
+	damage_multiplier = 1.1
 	penetration_multiplier = 20
 	pierce_multiplier =  5
 	recoil_buildup = 50

--- a/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
@@ -19,7 +19,7 @@
 	unload_sound = 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound = 'sound/weapons/guns/interact/ltrifle_magin.ogg'
 	cocked_sound = 'sound/weapons/guns/interact/ltrifle_cock.ogg'
-	damage_multiplier = 1
+	damage_multiplier = 0.8
 	penetration_multiplier = 1.4 // this is not babies first gun. It's a Serb-level weapon.
 	recoil_buildup = 7.4 // at least somewhat controllable
 	one_hand_penalty = 20 //automatic shotgun level

--- a/code/modules/projectiles/guns/projectile/shotgun/gladstone.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/gladstone.dm
@@ -14,3 +14,4 @@
 	recoil_buildup = 10
 	one_hand_penalty = 15 //full sized shotgun level
 	rarity_value = 20
+	damage_multiplier = 0.8

--- a/code/modules/projectiles/guns/projectile/shotgun/regulator.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/regulator.dm
@@ -10,7 +10,7 @@
 	ammo_type = /obj/item/ammo_casing/shotgun
 	matter = list(MATERIAL_PLASTEEL = 25, MATERIAL_PLASTIC = 12)
 	price_tag = 1500
-	damage_multiplier = 0.6
+	damage_multiplier = 1.15
 	penetration_multiplier = 0.9
 	recoil_buildup = 10
 	one_hand_penalty = 15 //full sized shotgun level

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -23,7 +23,7 @@
 	var/item_suffix = ""
 	zoom_factor = 2
 	twohanded = TRUE
-	damage_multiplier = 2
+	damage_multiplier = 1.5
 
 /obj/item/weapon/gun/projectile/heavysniper/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -23,7 +23,6 @@
 	var/item_suffix = ""
 	zoom_factor = 2
 	twohanded = TRUE
-	damage_multiplier = 1.5
 
 /obj/item/weapon/gun/projectile/heavysniper/update_icon()
 	..()

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -68,7 +68,7 @@
 /obj/item/projectile/beam/xray
 	name = "xray beam"
 	icon_state = "xray"
-	damage_types = list(BURN = 20)
+	damage_types = list(BURN = 25)
 	armor_penetration = 40
 
 	muzzle_type = /obj/effect/projectile/xray/muzzle


### PR DESCRIPTION
## About The Pull Request
Reverting damage of all guns to pre #5446 state, except Gladstone.
<details>
<summary>Reason for Gladstone nerf</summary>

![image](https://user-images.githubusercontent.com/32336957/103125138-3bacfd00-469b-11eb-873a-0997176546f5.png)
</details>
 

## Why It's Good For The Game
***balance***

## Changelog
:cl:
balance: Guns damage reverted.
balance: Gladstone now have reduced damage.
/:cl: