### PR TITLE
Eotp disk list fix + Spears one tile ahead attack

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -25,13 +25,13 @@
 	* If you are diagonally adjacent, ensure you can pass through at least one of the mutually adjacent square.
 		* Passing through in this case ignores anything with the throwpass flag, such as tables, racks, and morgue trays.
 */
-/turf/Adjacent(var/atom/neighbor, var/atom/target = null)
+/turf/Adjacent(var/atom/neighbor, var/atom/target = null, var/distance = 1)
 	var/turf/T0 = get_turf(neighbor)
 
 	if(T0 == src)
 		return TRUE
 
-	if(get_dist(src, T0) > 1 || (src.z != T0.z))
+	if(get_dist(src, T0) > distance || (src.z != T0.z))
 		return FALSE
 
 	// Non diagonal case
@@ -84,7 +84,7 @@ Quick adjacency (to turf):
 	Note: Multiple-tile objects are created when the bound_width and bound_height are creater than the tile size.
 	This is not used in stock /tg/station currently.
 */
-/atom/movable/Adjacent(var/atom/neighbor)
+/atom/movable/Adjacent(var/atom/neighbor, var/distance = 1)
 	if(neighbor == loc)
 		return TRUE
 	if(!isturf(loc))
@@ -92,7 +92,7 @@ Quick adjacency (to turf):
 	for(var/turf/T in locs)
 		if(isnull(T))
 			continue
-		if(T.Adjacent(neighbor, src))
+		if(T.Adjacent(neighbor, src, distance))
 			return TRUE
 	return FALSE
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -153,7 +153,7 @@
 	// A is a turf or is on a turf, or in something on a turf (pen in a box); but not something in something on a turf (pen in a box in a backpack)
 	sdepth = A.storage_depth_turf()
 	if(isturf(A) || isturf(A.loc) || (sdepth != -1 && sdepth <= 1))
-		if(A.Adjacent(src)) // see adjacent.dm
+		if(A.Adjacent(src) || (W && W.attack_distance >= 2 && A.Adjacent(src, W.attack_distance))) // see adjacent.dm
 			if(W)
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
 				var/resolved = (SEND_SIGNAL(W, COMSIG_IATTACK, A, src, params)) || (SEND_SIGNAL(A, COMSIG_ATTACKBY, W, src, params)) || W.resolve_attackby(A, src, params)

--- a/code/datums/autolathe/biomatter.dm
+++ b/code/datums/autolathe/biomatter.dm
@@ -219,7 +219,7 @@
 
 /datum/design/autolathe/sword/nt_halberd
 	name = "NT Halberd"
-	build_path = /obj/item/weapon/tool/sword/nt/halberd
+	build_path = /obj/item/weapon/tool/spear/halberd
 
 /datum/design/autolathe/sword/nt_scourge
 	name = "NT Scourge"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -77,6 +77,7 @@
 	var/embed_mult = 0.5 //Multiplier for the chance of embedding in mobs. Set to zero to completely disable embedding
 	var/structure_damage_factor = STRUCTURE_DAMAGE_NORMAL	//Multiplier applied to the damage when attacking structures and machinery
 	//Does not affect damage dealt to mobs
+	var/attack_distance = 1
 
 	var/list/item_upgrades = list()
 	var/max_upgrades = 3

--- a/code/game/objects/items/weapons/improvised_components.dm
+++ b/code/game/objects/items/weapons/improvised_components.dm
@@ -38,8 +38,7 @@
 	..()
 	var/obj/item/finished
 	if(istype(I, /obj/item/weapon/material/shard))
-		var/obj/item/weapon/material/tmp_shard = I
-		finished = new /obj/item/weapon/material/spear(get_turf(user), tmp_shard.material.name)
+		finished = new /obj/item/weapon/tool/spear(get_turf(user))
 		to_chat(user, SPAN_NOTICE("You fasten \the [I] to the top of the rod with the cable."))
 	else if((QUALITY_CUTTING in I.tool_qualities) || (QUALITY_WIRE_CUTTING in I.tool_qualities))
 		finished = new /obj/item/weapon/melee/baton/cattleprod(get_turf(user))

--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -8,27 +8,3 @@
 	armor_penetration = ARMOR_PEN_MODERATE
 	force_divisor = 0.3 // 18 with hardness 60 (steel)
 	attack_verb = list("jabbed","stabbed","ripped")
-
-/obj/item/weapon/material/spear
-	icon_state = "spearglass0"
-	wielded_icon = "spearglass1"
-	name = "spear"
-	desc = "A haphazardly-constructed yet still deadly weapon of ancient design."
-	armor_penetration = ARMOR_PEN_MODERATE // It's a SPEAR!
-	structure_damage_factor = STRUCTURE_DAMAGE_WEAK
-	w_class = ITEM_SIZE_HUGE
-	slot_flags = SLOT_BACK
-	force_divisor = 0.5         // 15 when unwielded 22.5 when wielded with hardness 30 (glass)
-	thrown_force_divisor = 1.5 // 22 when thrown with weight 15 (glass)
-	throw_speed = 3
-	edge = TRUE
-	sharp = TRUE
-	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "poked", "jabbed", "torn", "gored")
-	default_material = MATERIAL_GLASS
-	embed_mult = 1.5
-
-/obj/item/weapon/material/spear/update_force()
-	..()
-	force_unwielded = force
-	force_wielded = force * 1.5

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -37,16 +37,17 @@
 	price_tag = 120
 	matter = list(MATERIAL_BIOMATTER = 10, MATERIAL_STEEL = 1)
 
-/obj/item/weapon/tool/sword/nt/halberd
+/obj/item/weapon/tool/spear/halberd
 	name = "NT Halberd"
 	desc = "A saint looking halberd, for emergency situation."
+	icon = 'icons/obj/nt_melee.dmi'
 	icon_state = "nt_halberd"
 	item_state = "nt_halberd"
 	wielded_icon = "nt_halberd_wielded"
 	force = WEAPON_FORCE_ROBUST
 	armor_penetration = ARMOR_PEN_MASSIVE
-	w_class = ITEM_SIZE_HUGE
-	slot_flags = SLOT_BACK
+	aspects = list(SANCTIFIED)
+	spawn_blacklisted = TRUE
 	price_tag = 600
 	matter = list(MATERIAL_BIOMATTER = 80, MATERIAL_STEEL = 8, MATERIAL_WOOD = 10, MATERIAL_PLASTEEL = 2)
 

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -39,7 +39,7 @@
 
 /obj/item/weapon/tool/spear/halberd
 	name = "NT Halberd"
-	desc = "A saint looking halberd, for emergency situation."
+	desc = "This weapon of ancient design appears to be a spear-axe hybrid. It saw a lot of use back in the Dark Ages back on Earth - in more recent times, NeoTheoligan crusaders of the elite variety tend to carry this weapon into battle due to it's fantastic armor-piercing capabilities. Additionally, due to the halberd being so long, you can attack enemies from up to a tile away with it - twice as far as most other weapons can."
 	icon = 'icons/obj/nt_melee.dmi'
 	icon_state = "nt_halberd"
 	item_state = "nt_halberd"

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -200,3 +200,24 @@
 	max_upgrades = 2
 	tool_qualities = list(QUALITY_HAMMERING = 5)
 	spawn_blacklisted = TRUE
+
+/obj/item/weapon/tool/spear //spear
+	icon = 'icons/obj/weapons.dmi'
+	icon_state = "spearglass0"
+	wielded_icon = "spearglass1"
+	name = "spear"
+	desc = "A haphazardly-constructed yet still deadly weapon of ancient design."
+	force = WEAPON_FORCE_PAINFUL
+	armor_penetration = ARMOR_PEN_MODERATE // It's a SPEAR!
+	structure_damage_factor = STRUCTURE_DAMAGE_WEAK
+	w_class = ITEM_SIZE_HUGE
+	slot_flags = SLOT_BACK
+	throw_speed = 3
+	edge = TRUE
+	sharp = TRUE
+	tool_qualities = list(QUALITY_CUTTING = 10)
+	origin_tech = list(TECH_COMBAT = 1)
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	attack_verb = list("attacked", "poked", "jabbed", "torn", "gored")
+	embed_mult = 1.5
+	attack_distance = 2

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -206,7 +206,7 @@
 	icon_state = "spearglass0"
 	wielded_icon = "spearglass1"
 	name = "spear"
-	desc = "A haphazardly-constructed yet still deadly weapon of ancient design."
+	desc = "A spiky bit of material tied onto a metal pole with some wire. It's an insult to spears across the galaxy - but it can still do some nasty damage and has some decent armor-piercing capabilities. Spears like these are often seen in the hands of vagrants, muggers, or desperate militias. Due to this weapon - if you could call it that - being so long, you're able to attack enemies from up to a tile away."
 	force = WEAPON_FORCE_PAINFUL
 	armor_penetration = ARMOR_PEN_MODERATE // It's a SPEAR!
 	structure_damage_factor = STRUCTURE_DAMAGE_WEAK

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -51,6 +51,7 @@ var/global/obj/machinery/power/eotp/eotp
 /obj/machinery/power/eotp/New()
 	..()
 	eotp = src
+	disk_reward_update()
 
 /obj/machinery/power/eotp/examine(user)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Spears can be used to attack enemies up to one tile away from you.
Fixing EotP disk list (Sometimes on server it don't want to update the list at the beginning)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: DarkLevel
balance: Spears can be used to attack enemies up to one tile away from you.
fix: Eotp disk list fix
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
