### PR TITLE
Remove .60 and .70 froma artist revolver

### DIFF
--- a/code/game/machinery/autolathe/artist_bench.dm
+++ b/code/game/machinery/autolathe/artist_bench.dm
@@ -178,7 +178,7 @@
 //	var/weight_cognition = 0 + LStats[STAT_COG]
 	var/weight_biology = 0 + LStats[STAT_BIO]
 	var/weight_robustness = 0 + LStats[STAT_ROB]
-	var/weight_toughness = 0 + LStats[STAT_TGH]
+//	var/weight_toughness = 0 + LStats[STAT_TGH]
 	var/weight_vigilance = 0 + LStats[STAT_VIG]
 
 	//var/list/LWeights = list(weight_mechanical, weight_cognition, weight_biology, weight_robustness, weight_toughness, weight_vigilance)
@@ -192,8 +192,6 @@
 			"shotgun" = 8 + weight_robustness,
 			"rifle" = 8 + weight_vigilance,
 			"cap" = 16 + weight_biology,
-			"rocket" = 8 + weight_toughness,
-			"grenade" = 8 + weight_toughness
 		))
 
 		switch(gun_pattern)
@@ -229,20 +227,6 @@
 
 			if("cap")
 				R.caliber = CAL_CAP
-
-			if("rocket")//From RPG.dm, Arbitrary values
-				R.caliber = CAL_ROCKET
-				R.fire_sound = 'sound/effects/bang.ogg'
-				R.bulletinsert_sound = 'sound/weapons/guns/interact/batrifle_magin.ogg'
-				R.one_hand_penalty = 15 + rand(-3,5)//From ak47.dm, temporary values
-				R.recoil_buildup = 15 + rand(-3,3)
-
-			if("grenade")
-				R.caliber = CAL_GRENADE
-				R.fire_sound = 'sound/weapons/guns/fire/grenadelauncher_fire.ogg'
-				R.bulletinsert_sound = 'sound/weapons/guns/interact/batrifle_magin.ogg'
-				R.one_hand_penalty = 15 + rand(-2,3)//from sniper.dm, Temporary values
-				R.recoil_buildup = 20 + rand(-5,5) //from projectile_grenade_launcher.dm
 
 		if(R.max_shells == 3 && (gun_pattern == "shotgun"||"rocket"))//From Timesplitters triple-firing RPG far as I know
 			R.init_firemodes = list(

--- a/code/game/machinery/autolathe/artist_bench.dm
+++ b/code/game/machinery/autolathe/artist_bench.dm
@@ -174,6 +174,8 @@
 	if(inspiration && user.stats.getPerk(PERK_ARTIST))
 		LStats = inspiration.calculate_statistics()
 
+//	var/weight_mechanical = 0 + LStats[STAT_MEC]
+//	var/weight_cognition = 0 + LStats[STAT_COG]
 	var/weight_biology = 0 + LStats[STAT_BIO]
 	var/weight_robustness = 0 + LStats[STAT_ROB]
 	var/weight_toughness = 0 + LStats[STAT_TGH]

--- a/code/game/machinery/autolathe/artist_bench.dm
+++ b/code/game/machinery/autolathe/artist_bench.dm
@@ -174,8 +174,6 @@
 	if(inspiration && user.stats.getPerk(PERK_ARTIST))
 		LStats = inspiration.calculate_statistics()
 
-	var/weight_mechanical = 0 + LStats[STAT_MEC]
-	var/weight_cognition = 0 + LStats[STAT_COG]
 	var/weight_biology = 0 + LStats[STAT_BIO]
 	var/weight_robustness = 0 + LStats[STAT_ROB]
 	var/weight_toughness = 0 + LStats[STAT_TGH]
@@ -191,8 +189,6 @@
 			"magnum" = 8 + weight_vigilance,
 			"shotgun" = 8 + weight_robustness,
 			"rifle" = 8 + weight_vigilance,
-			"sniper" = 8 + max(weight_vigilance + weight_cognition),
-			"gyro" = 1 + weight_mechanical,
 			"cap" = 16 + weight_biology,
 			"rocket" = 8 + weight_toughness,
 			"grenade" = 8 + weight_toughness
@@ -228,17 +224,6 @@
 			//No gun currently uses CAL_357 far as I know
 			//	if("revolver")
 			//		caliber = pick(CAL_357)
-
-			if("sniper")//From sniper.dm, Arbitrary values
-				R.caliber = CAL_ANTIM
-				R.bulletinsert_sound = 'sound/weapons/guns/interact/rifle_load.ogg'
-				R.fire_sound = 'sound/weapons/guns/fire/sniper_fire.ogg'
-				R.one_hand_penalty = 15 + rand(-3,5) //From sniper.dm, Temporary values
-				R.recoil_buildup = 90 + rand(-10,10)
-
-			if("gyro")//From gyropistol.dm, Arbitrary values
-				R.caliber = CAL_70
-				R.recoil_buildup = 0.1 * rand(1,20)
 
 			if("cap")
 				R.caliber = CAL_CAP


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes those calibers and associated vars.

## Why It's Good For The Game

.60 revolver which you can hide in a holster and which can de-cap a person in full bullet-proof armor is too funny. .70 is gyro and ammo/pistol was appearing due to bugs. It shouldn't exist at all.

## Changelog
:cl:
del: Removed .70 and .60, grenades and rockets from artist revolvers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
