### PR TITLE
Borer paralysis fix

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -263,7 +263,7 @@
 
 	to_chat(src, SPAN_WARNING("You focus your psychic lance on [M] and freeze their limbs with a wave of terrible dread."))
 	to_chat(M, SPAN_DANGER("You feel a creeping, horrible sense of dread come over you, freezing your limbs and setting your heart racing."))
-	M.Weaken(10)
+	M.Paralyse(10)
 
 	used_dominate = world.time
 


### PR DESCRIPTION
**About The Pull Request**
Borer players cant actually paralyse victims

**Why It's Good For The Game**
Players that have played borer have been reporting that they cant infect someone due to the victim being able to crawl away while downed which cancels the infection attemp immediately.

**Changelog**
🆑 
fix: Switches out the Weaken mob state in the borer's paralyse ability with the Paralyse mob state
/🆑