### PR TITLE
Surplus crate nerf

### DIFF
--- a/code/game/objects/random/ammo.dm
+++ b/code/game/objects/random/ammo.dm
@@ -3,6 +3,11 @@
 	icon_state = "ammo-green"
 	tags_to_spawn = list(SPAWN_AMMO_S)
 
+/obj/spawner/ammo/low_cost
+	name = "random low-cost ammunition"
+	icon_state = "ammo-green-low"
+	top_price = 250
+
 /obj/spawner/ammo/low_chance
 	name = "low chance random ammunition"
 	icon_state = "ammo-green-low"

--- a/code/game/objects/random/spawner.dm
+++ b/code/game/objects/random/spawner.dm
@@ -13,7 +13,7 @@
 	var/max_amount = 1
 	var/top_price
 	var/low_price
-	var/list/tags_to_spawn = list(SPAWN_ITEM, SPAWN_MOB, SPAWN_MACHINERY, SPAWN_STRUCTURE)
+	var/list/tags_to_spawn = list(SPAWN_ITEM, SPAWN_MOB, SPAWN_MACHINERY, SPAWN_STRUCTURE) //The tags the item must have to be considered to spawn
 	var/list/should_be_include_tags = list()//TODO
 	var/allow_blacklist = FALSE
 	var/list/aditional_object = list()

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1419,9 +1419,9 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 /datum/supply_pack/randomised/guns
 	num_contained = 4
 	contains = list(/obj/spawner/gun/cheap,
-                /obj/spawner/gun/normal,
-                /obj/spawner/gun/energy_cheap,
-                /obj/spawner/gun/shotgun)
+					/obj/spawner/gun/cheap,
+					/obj/spawner/gun/cheap,
+					/obj/spawner/gun/cheap)
 	name = "Surplus Weaponry"
 	cost = 5000
 	crate_name = "Surplus Weapons Crate"
@@ -1430,14 +1430,15 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 
 /datum/supply_pack/randomised/ammo
 	num_contained = 8
-	contains = list(/obj/spawner/ammo,
-				/obj/spawner/ammo,
-				/obj/spawner/ammo,
-				/obj/spawner/ammo,
-				/obj/spawner/ammo,
-				/obj/spawner/ammo,
-				/obj/spawner/ammo,
-				/obj/spawner/ammo)
+	contains = list(/obj/spawner/ammo/low_cost,
+			/obj/spawner/ammo/low_cost,
+			/obj/spawner/ammo/low_cost,
+			/obj/spawner/ammo/low_cost,
+			/obj/spawner/ammo/low_cost,
+			/obj/spawner/ammo/low_cost,
+			/obj/spawner/ammo/low_cost,
+			/obj/spawner/ammo/low_cost,
+				)
 	name = "Surplus Ammo"
 	cost = 1500
 	crate_name = "Surplus Ammo Crate"

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -8,6 +8,7 @@
 	reload_delay = 30
 	ammo_mag = "box"
 	matter = list(MATERIAL_CARDBOARD = 1)
+	bad_type = /obj/item/ammo_magazine/ammobox
 
 /obj/item/ammo_magazine/ammobox/resolve_attackby(atom/A, mob/user)
 	if(isturf(A) && locate(/obj/item/ammo_casing) in A || istype(A, /obj/item/ammo_casing))


### PR DESCRIPTION
## About The Pull Request

Nerfs the guild's ability to gain top tier guns and top tier ammo and all the money they could ever need, from two crates.

## Why It's Good For The Game

Previously, surplus weapons and ammo crates would draw from all possible ammo types, and all possible weapon types

This would mean that ammo crates would be worth MUCH more than their cost, so could be sent straight back for 1000% profit in some cases.

![image](https://user-images.githubusercontent.com/30557196/103025968-ca5e3480-454a-11eb-834e-038c10828e1f.png)

The weapon crates would also spawn the best possible weapons incredibly often.

This would mean that, guild would not want to deal with the ship, as it had nothing to offer them that they couldn't already have.


## Changelog
:cl:
balance: The value of the contents of surplus weapon and ammo crates from guild, is now more or less equivalent to the cost of the crate.
/:cl: