### PR TITLE
Removes the harpoon from the MEO office(s)

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -54269,7 +54269,6 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/item/weapon/bluespace_harpoon,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -84962,7 +84961,6 @@
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/item/weapon/bluespace_harpoon,
 /turf/simulated/floor/wood,
 /area/eris/command/meo/quarters)
 "dOj" = (


### PR DESCRIPTION
One of two PRs relating to the harpoon. either, neither or both could be merged.

## About The Pull Request

The MEO previously had access to two harpoon teleguns, now they have access to zero at roundstart

## Why It's Good For The Game

Being used to rush the spare roundstart, and generally make the round inhospitable for anyone but moebius
## Changelog
:cl:
del: The bluespace harpoon gun has been removed from the MEO's offices.
/:cl: