### PR TITLE
Harpoon out-of-sight fix

### DIFF
--- a/code/game/objects/items/weapons/space_harpoon.dm
+++ b/code/game/objects/items/weapons/space_harpoon.dm
@@ -40,6 +40,8 @@
 /obj/item/weapon/bluespace_harpoon/afterattack(atom/A, mob/user)
 	if(get_dist(A, user) > range)
 		return ..()
+	if(!(A in view(user)))
+		return ..()
 	if(istype(A, /obj/item/weapon/storage/))
 		return ..()
 	else if(istype(A, /obj/structure/table/) && (get_dist(A, user) <= 1))


### PR DESCRIPTION
One of two PRs relating to the harpoon. either, neither or both could be merged.
About The Pull Request

The bluespace harpoon can be used to access areas you can't see, through clicking on the black space therein.
Why It's Good For The Game

Being used to rush the spare roundstart, and generally make the round inhospitable for anyone but moebius
Changelog

🆑
del: The bluespace harpoon gun can no longer receive and send items to places you can't directly see.
/🆑