### PR TITLE
borer devour ability (re-enabled)

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -122,13 +122,13 @@
 		if(health < maxHealth)
 			adjustBruteLoss(-1)
 
-		if(host.reagents.has_reagent("sugar"))
+		if(host.reagents.has_reagent("mindbreaker"))
 			if(!docile)
-				to_chat(get_borer_control(), SPAN_DANGER("You feel the soporific flow of sugar in your host's blood, lulling you into docility."))
+				to_chat(get_borer_control(), SPAN_DANGER("An evasive mind altering drug has entered your host's blood, forcing you into docility."))
 				docile = TRUE
 		else
 			if(docile)
-				to_chat(get_borer_control(), SPAN_DANGER("You shake off your lethargy as the sugar leaves your host's blood."))
+				to_chat(get_borer_control(), SPAN_DANGER("You shake off your lethargy as the evasive drug leaves your host's blood."))
 				docile = FALSE
 
 		if(chemicals < 250)

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -121,7 +121,6 @@
 			var/obj/item/organ/external/head = H.get_organ(BP_HEAD)
 			head.implants += src
 
-/*
 /mob/living/simple_animal/borer/verb/devour_brain()
 	set category = "Abilities"
 	set name = "Devour Brain"
@@ -145,7 +144,6 @@
 
 	to_chat(src, "<span class = 'danger'>It only takes a few moments to render the dead host brain down into a nutrient-rich slurry...</span>")
 	replace_brain()
-*/
 
 // BRAIN WORM ZOMBIES AAAAH.
 /mob/living/simple_animal/borer/proc/replace_brain()

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -85,7 +85,7 @@
 	// It's harder for a borer to infest NTs
 	if(is_neotheology_disciple(M))
 		to_chat(src, SPAN_DANGER("A nanofiber mesh implant inside [M]'s head tries to cut you off on your way in. You can work around it, but it will take time."))
-		infestation_delay *= 3
+		infestation_delay *= 5 SECONDS
 
 	// Borer gets host abilities before actually getting inside the host
 	// Workaround for a BYOND bug: http://www.byond.com/forum/post/1833666
@@ -231,12 +231,12 @@
 /mob/living/simple_animal/borer/proc/paralyze_victim()
 	set category = "Abilities"
 	set name = "Paralyze Victim"
-	set desc = "Freeze the limbs of a potential host with supernatural fear."
+	set desc = "Knockout a potential host with your poisonous dart."
 
 	if(src.stat)
 		return
 
-	if(world.time - used_dominate < 150)
+	if(world.time - used_dominate < 350)
 		to_chat(src, "You cannot use that ability again so soon.")
 		return
 
@@ -247,7 +247,7 @@
 
 		choices += C
 
-	if(world.time - used_dominate < 150)
+	if(world.time - used_dominate < 350)
 		to_chat(src, "You cannot use that ability again so soon.")
 		return
 
@@ -259,9 +259,9 @@
 		to_chat(src, "You cannot infest someone who is already infested!")
 		return
 
-	to_chat(src, SPAN_WARNING("You focus your psychic lance on [M] and freeze their limbs with a wave of terrible dread."))
-	to_chat(M, SPAN_DANGER("You feel a creeping, horrible sense of dread come over you, freezing your limbs and setting your heart racing."))
-	M.Paralyse(10)
+	to_chat(src, SPAN_WARNING("You you spit a poison dart at [M] freezing their limbs and putting them to sleep."))
+	to_chat(M, SPAN_DANGER("You feel a tiny prick on your neck and blackout immediately after."))
+	M.Paralyse(30)
 
 	used_dominate = world.time
 

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -85,7 +85,7 @@
 	// It's harder for a borer to infest NTs
 	if(is_neotheology_disciple(M))
 		to_chat(src, SPAN_DANGER("A nanofiber mesh implant inside [M]'s head tries to cut you off on your way in. You can work around it, but it will take time."))
-		infestation_delay *= 5 SECONDS
+		infestation_delay *= 3
 
 	// Borer gets host abilities before actually getting inside the host
 	// Workaround for a BYOND bug: http://www.byond.com/forum/post/1833666
@@ -236,7 +236,7 @@
 	if(src.stat)
 		return
 
-	if(world.time - used_dominate < 350)
+	if(world.time - used_dominate < 250)
 		to_chat(src, "You cannot use that ability again so soon.")
 		return
 
@@ -247,7 +247,7 @@
 
 		choices += C
 
-	if(world.time - used_dominate < 350)
+	if(world.time - used_dominate < 250)
 		to_chat(src, "You cannot use that ability again so soon.")
 		return
 
@@ -261,7 +261,7 @@
 
 	to_chat(src, SPAN_WARNING("You you spit a poison dart at [M] freezing their limbs and putting them to sleep."))
 	to_chat(M, SPAN_DANGER("You feel a tiny prick on your neck and blackout immediately after."))
-	M.Paralyse(30)
+	M.Paralyse(20)
 
 	used_dominate = world.time
 


### PR DESCRIPTION
## About The Pull Request
Re-enables the borer's ability to devour the brain of the host to make it into a husk or brain slug zombie.

## Why It's Good For The Game
When the host dies while the borer is in control, the borer has no option to release itself from the host's brain and so i think re-enabling this would add an option for the borer to have a chance at getting revenge, rather than just manually going to the OOC tab and ghosting even though technically its not dead.

## Changelog
:cl:
add: Re-adds the borer's devour ability
/:cl: