### PR TITLE
Borer rebalance, flavor text changed and devour brain re-enabled

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -122,13 +122,13 @@
 		if(health < maxHealth)
 			adjustBruteLoss(-1)
 
-		if(host.reagents.has_reagent("sugar"))
+		if(host.reagents.has_reagent("mindbreaker"))
 			if(!docile)
-				to_chat(get_borer_control(), SPAN_DANGER("You feel the soporific flow of sugar in your host's blood, lulling you into docility."))
+				to_chat(get_borer_control(), SPAN_DANGER("An evasive mind altering drug has entered your host's blood, forcing you into docility."))
 				docile = TRUE
 		else
 			if(docile)
-				to_chat(get_borer_control(), SPAN_DANGER("You shake off your lethargy as the sugar leaves your host's blood."))
+				to_chat(get_borer_control(), SPAN_DANGER("You shake off your lethargy as the evasive drug leaves your host's blood."))
 				docile = FALSE
 
 		if(chemicals < 250)

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -85,7 +85,7 @@
 	// It's harder for a borer to infest NTs
 	if(is_neotheology_disciple(M))
 		to_chat(src, SPAN_DANGER("A nanofiber mesh implant inside [M]'s head tries to cut you off on your way in. You can work around it, but it will take time."))
-		infestation_delay *= 3
+		infestation_delay *= 4
 
 	// Borer gets host abilities before actually getting inside the host
 	// Workaround for a BYOND bug: http://www.byond.com/forum/post/1833666
@@ -121,7 +121,6 @@
 			var/obj/item/organ/external/head = H.get_organ(BP_HEAD)
 			head.implants += src
 
-/*
 /mob/living/simple_animal/borer/verb/devour_brain()
 	set category = "Abilities"
 	set name = "Devour Brain"
@@ -145,7 +144,6 @@
 
 	to_chat(src, "<span class = 'danger'>It only takes a few moments to render the dead host brain down into a nutrient-rich slurry...</span>")
 	replace_brain()
-*/
 
 // BRAIN WORM ZOMBIES AAAAH.
 /mob/living/simple_animal/borer/proc/replace_brain()
@@ -232,13 +230,13 @@
 
 /mob/living/simple_animal/borer/proc/paralyze_victim()
 	set category = "Abilities"
-	set name = "Paralyze Victim"
-	set desc = "Freeze the limbs of a potential host with supernatural fear."
+	set name = "Paralysis Stinger"
+	set desc = "Fires a stinger at the victim and puts them to sleep"
 
 	if(src.stat)
 		return
 
-	if(world.time - used_dominate < 150)
+	if(world.time - used_dominate < 250)
 		to_chat(src, "You cannot use that ability again so soon.")
 		return
 
@@ -249,11 +247,11 @@
 
 		choices += C
 
-	if(world.time - used_dominate < 150)
+	if(world.time - used_dominate < 250)
 		to_chat(src, "You cannot use that ability again so soon.")
 		return
 
-	var/mob/living/carbon/M = input(src,"Who do you wish to dominate?") in null|choices
+	var/mob/living/carbon/M = input(src,"Who do you wish to Paralyse?") in null|choices
 
 	if(!M || !(M in view(3, get_turf(src)))) return
 
@@ -261,9 +259,9 @@
 		to_chat(src, "You cannot infest someone who is already infested!")
 		return
 
-	to_chat(src, SPAN_WARNING("You focus your psychic lance on [M] and freeze their limbs with a wave of terrible dread."))
-	to_chat(M, SPAN_DANGER("You feel a creeping, horrible sense of dread come over you, freezing your limbs and setting your heart racing."))
-	M.Paralyse(10)
+	to_chat(src, SPAN_WARNING("You you fire your stinger at [M] freezing their limbs and putting them to sleep."))
+	to_chat(M, SPAN_DANGER("You feel a tiny prick on your neck and blackout immediately after."))
+	M.Paralyse(20)
 
 	used_dominate = world.time
 


### PR DESCRIPTION
## About The Pull Request
Made the delay timer for infecting a NT take longer, increased the cooldown timer and effect duration for the paralyse ability, also changed its flavor text to lean more into a biological parasite that doesn't have pyschic abilities. Re-enabled the devour ability which will allow the borer to convert the dead host into a husk if the borer was controlling it when it died. Switched the docile reagent from sugar to mindbreaker.

## Why It's Good For The Game
Currently if the borer were to be controlling the host when it died, there would be no additional options in the ability verb window, but re-enabling the devour brain ability will give the option to permanently fuse with the host and come back as a mutant abomination which is the husk. other than manually going into the OOC window and ghosting even though the borer is technically not dead only the host is, perhaps in the future someone with better coding skills can fix this issue and re-disable it after it has been resolved. As a recommendation, maybe have it automatically release control when the host dies.

I buffed and nerfed the borer's paralysis ability so it lasts longer but has a longer cooldown to prevent spam, the time it takes to infect a person with a cruciform has been increased so it would be more difficult and gives poeple around the victim time to react if you do it in public.

I also changed the reagent required to make the borer docile, from sugar to mindbreaker as it makes more sense and actually affects the brain, which is where the borer is located, plus sugar is kinda too common which makes it easy to beat the borer.

The flavor text for the borer has been changed to lean more into a biological parasite that doesn't has magic pyschic abilitie, instead it uses a stinger to paralyse its victims.

Now the actual reason i wanted to make these changes is to make the borer more of a actual threat to the crew, instead of a brain slug that gives the host chems and reproduces time to time.

## Changelog
:cl:
tweak/balanced: re-enables the devour brain ability, buffed a few things and re-did a bit of the flavor text.
/:cl: