### PR TITLE
Resuscitator fixes and improvement

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -514,7 +514,7 @@
 		time_entered = world.time
 		if(ishuman(occupant) && applies_stasis)
 			var/mob/living/carbon/human/H = occupant
-			H.in_stasis = 1
+			H.EnterStasis()
 		new_occupant.forceMove(src)
 
 		if (notifications)
@@ -532,7 +532,7 @@
 			occupant.reset_view(null)
 			if(ishuman(occupant) && applies_stasis)
 				var/mob/living/carbon/human/H = occupant
-				H.in_stasis = 0
+				H.ExitStasis()
 		occupant = null
 
 	update_icon()

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -130,14 +130,14 @@
 /obj/structure/closet/body_bag/cryobag/Entered(atom/movable/AM)
 	if(ishuman(AM))
 		var/mob/living/carbon/human/H = AM
-		H.in_stasis = 1
+		H.EnterStasis()
 		src.used = 1
 	..()
 
 /obj/structure/closet/body_bag/cryobag/Exited(atom/movable/AM)
 	if(ishuman(AM))
 		var/mob/living/carbon/human/H = AM
-		H.in_stasis = 0
+		H.ExitStasis()
 	..()
 
 /obj/structure/closet/body_bag/cryobag/return_air() //Used to make stasis bags protect from vacuum.

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1597,17 +1597,25 @@ var/list/rank_prefix = list(\
 	reset_view(A)
 
 /mob/living/carbon/human/proc/resuscitate()
+	var/obj/item/organ/internal/heart_organ = random_organ_by_process(OP_HEART)
+	var/obj/item/organ/internal/brain_organ = random_organ_by_process(BP_BRAIN)
 
-	if(!is_asystole() && has_organ(OP_HEART, check_usablility = TRUE) && has_organ(BP_BRAIN, check_usablility = TRUE))
+	if(!is_asystole() && !(heart_organ && brain_organ) || (heart_organ.is_broken() || brain_organ.is_broken()))
 		return 0
 
 	if(world.time >= (timeofdeath + NECROZTIME))
 		return 0
 
-	visible_message(SPAN_NOTICE("\The [src] twitches a bit as their heart restarts!"))
 	var/oxyLoss = getOxyLoss()
-	if(oxyLoss > 40)
-		setOxyLoss(40)
+	if(oxyLoss > 20)
+		setOxyLoss(20)
+
+	if(health <= (HEALTH_THRESHOLD_DEAD - oxyLoss))
+		visible_message(SPAN_WARNING("\The [src] twitches a bit as their heart restarts! But he still to wounded to live."))
+		timeofdeath = 0
+		return 0
+
+	visible_message(SPAN_NOTICE("\The [src] twitches a bit as their heart restarts!"))
 	pulse = PULSE_NORM
 	handle_pulse()
 	timeofdeath = 0

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1611,7 +1611,7 @@ var/list/rank_prefix = list(\
 		setOxyLoss(20)
 
 	if(health <= (HEALTH_THRESHOLD_DEAD - oxyLoss))
-		visible_message(SPAN_WARNING("\The [src] twitches a bit as their heart restarts! But he still to wounded to live."))
+		visible_message(SPAN_WARNING("\The [src] twitches a bit, but their body is too damaged to sustain life!"))
 		timeofdeath = 0
 		return 0
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -32,13 +32,17 @@
 	var/fire_alert = FIRE_ALERT_NONE
 	var/pressure_alert = 0
 	var/temperature_alert = 0
-	var/in_stasis = 0
+	var/in_stasis = FALSE
+	var/stasis_timeofdeath = 0
 	var/pulse = PULSE_NORM
 	var/global/list/overlays_cache = null
 
 /mob/living/carbon/human/Life()
 	set invisibility = 0
 	set background = BACKGROUND_ENABLED
+
+	if(in_stasis && (stat == DEAD))
+		timeofdeath = world.time - stasis_timeofdeath
 
 	if (HAS_TRANSFORMATION_MOVEMENT_HANDLER(src))
 		return
@@ -1230,3 +1234,12 @@
 		return
 	if(XRAY in mutations)
 		sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
+
+/mob/living/carbon/human/proc/EnterStasis()
+	in_stasis = TRUE
+	stasis_timeofdeath = world.time - timeofdeath
+
+
+/mob/living/carbon/human/proc/ExitStasis()
+	in_stasis = FALSE
+	stasis_timeofdeath = 0

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -525,7 +525,7 @@
 		if(heart && !BP_IS_ROBOTIC(heart))
 			heart.damage += 0.5
 			if(prob(30))
-				to_chat(H, SPAN_DANGER("Your heart twitching insane!"))
+				to_chat(H, SPAN_DANGER("Your heart feels like it's going to tear itself out of you!"))
 		if(H.stat == DEAD)
 			H.resuscitate()
 

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -522,7 +522,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/internal/heart/heart = H.random_organ_by_process(OP_HEART)
-		if(heart && !BP_IS_ROBOTIC(heart))
+		if(heart)
 			heart.damage += 0.5
 			if(prob(30))
 				to_chat(H, SPAN_DANGER("Your heart feels like it's going to tear itself out of you!"))
@@ -535,5 +535,5 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/internal/heart/heart = H.random_organ_by_process(OP_HEART)
-		if(heart && !BP_IS_ROBOTIC(heart))
+		if(heart)
 			heart.die()

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -522,7 +522,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/internal/heart/heart = H.random_organ_by_process(OP_HEART)
-		if(heart)
+		if(heart && !BP_IS_ROBOTIC(heart))
 			heart.damage += 0.5
 			if(prob(30))
 				to_chat(H, SPAN_DANGER("Your heart twitching insane!"))
@@ -535,5 +535,5 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/internal/heart/heart = H.random_organ_by_process(OP_HEART)
-		if(heart)
+		if(heart && !BP_IS_ROBOTIC(heart))
 			heart.die()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixing organs checks, instead of using proc has_organ to random_organ_by_process, because has_organ are for external organs.
Also adding health check (without oxyloss), so people who are revived do not die instantly several times, making doctors go insane and dead people annoyed by that.
Reducing minimal oxyloss from 40 to 20.
Now stasis bags and cryopods can "stop" the death timer of necrosis. Now if you luckily place corpse in stasis bag before 5 minutes, you can revive this body later.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: DarkLevel
balance: reducing minimal oxyloss of resuscitator
fix: fixing resuscitator organs check.
code: Stasis now re-update death time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
