### PR TITLE
Prosthetic repair standardization

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1184,7 +1184,7 @@
 
 		/obj/item/stack/medical/bruise_pack = 100, /obj/item/stack/medical/ointment = 100,
 		/obj/item/stack/medical/advanced/bruise_pack = 200, /obj/item/stack/medical/advanced/ointment = 200,
-		/obj/item/stack/nanopaste = 300,
+		/obj/item/stack/nanopaste = 1000,
 
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector/antitoxin = 100, /obj/item/weapon/reagent_containers/syringe/antitoxin = 200,
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector/tricordrazine = 150, /obj/item/weapon/reagent_containers/syringe/tricordrazine = 300,

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -41,10 +41,10 @@
 					return
 				if(amount <= 0)
 					break
-				if(!do_mob(user, M, W.damage/5) && use(1))
+				if(!do_mob(user, M, W.damage/5))
 					to_chat(user, SPAN_NOTICE("You must stand still to repair \the [S]."))
 					break
-				if(!can_use(1))
+				if(!use(1))
 					to_chat(user, SPAN_WARNING("You have run out of \the [src]."))
 					return
 				W.heal_damage(CLAMP(user.stats.getStat(STAT_MEC)/2.5, 5, 20))

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -37,20 +37,25 @@
 
 		if(S)
 			if(BP_IS_ROBOTIC(S))
+				if(!S.get_damage())
+					to_chat(user, SPAN_NOTICE("There is nothing to fix here."))
+					return
+				for(var/datum/wound/W in S.wounds)
+					if(W.internal)
+						return
+					if(amount <= 0)
+						break
+					if(!do_mob(user, M, W.damage/5) && use(1))
+						to_chat(user, SPAN_NOTICE("You must stand still to repair \the [S]."))
+						break
+					if(!use(1))
+						to_chat(user, SPAN_WARNING("You have run out of \the [src]."))
+						return
+					W.heal_damage(CLAMP(user.stats.getStat(STAT_MEC)/2.5, 5, 20))
+					to_chat(user, SPAN_NOTICE("You patch some wounds on \the [S]."))
+				S.update_damages()
 				if(S.get_damage())
-					user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-					if(use(1))
-						S.heal_damage(15, 15, TRUE)
-
-
-					user.visible_message(
-						"<span class='notice'>\The [user] applies some nanite paste at[user != M ? " \the [M]'s" : " \the"][S.name] with \the [src].</span>",
-						"<span class='notice'>You apply some nanite paste at [user == M ? "your" : "[M]'s"] [S.name].</span>"
-					)
-				else
-					to_chat(user, SPAN_NOTICE("Nothing to fix here."))
+					to_chat(user, SPAN_WARNING("\The [S] still needs further repair."))
+					return
 			if (can_operate(H, user) == CAN_OPERATE_ALL)        //Checks if mob is lying down on table for surgery
 				if (do_surgery(H,user,src, TRUE))
-					return
-			else
-				to_chat(user, SPAN_NOTICE("Nothing to fix in here.")) //back to the original

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -4,13 +4,13 @@
 	desc = "A tube of paste containing swarms of repair nanites. Very effective in repairing robotic machinery."
 	icon = 'icons/obj/stack/items.dmi'
 	icon_state = "nanopaste"
-	matter = list(MATERIAL_PLASTIC = 2)
+	matter = list(MATERIAL_PLASTEEL = 0.1, MATERIAL_STEEL = 1)
 	origin_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
 	amount = 10
 	w_class = ITEM_SIZE_SMALL //just so you can place same places that a brute pack would be
-	price_tag = 15
+	price_tag = 80
 	spawn_tags = SPAWN_TAG_MEDICINE
-	rarity_value = 20
+	rarity_value = 40
 
 
 /obj/item/stack/nanopaste/attack(mob/living/M, mob/user)

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -35,27 +35,23 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.get_organ(user.targeted_organ)
 
-		if(S)
-			if(BP_IS_ROBOTIC(S))
-				if(!S.get_damage())
-					to_chat(user, SPAN_NOTICE("There is nothing to fix here."))
+		if(S && BP_IS_ROBOTIC(S) && S.get_damage() && S.open == 0)
+			for(var/datum/wound/W in S.wounds)
+				if(W.internal)
 					return
-				for(var/datum/wound/W in S.wounds)
-					if(W.internal)
-						return
-					if(amount <= 0)
-						break
-					if(!do_mob(user, M, W.damage/5) && use(1))
-						to_chat(user, SPAN_NOTICE("You must stand still to repair \the [S]."))
-						break
-					if(!can_use(1))
-						to_chat(user, SPAN_WARNING("You have run out of \the [src]."))
-						return
-					W.heal_damage(CLAMP(user.stats.getStat(STAT_MEC)/2.5, 5, 20))
-					to_chat(user, SPAN_NOTICE("You patch some wounds on \the [S]."))
-				S.update_damages()
-				if(S.get_damage())
-					to_chat(user, SPAN_WARNING("\The [S] still needs further repair."))
+				if(amount <= 0)
+					break
+				if(!do_mob(user, M, W.damage/5) && use(1))
+					to_chat(user, SPAN_NOTICE("You must stand still to repair \the [S]."))
+					break
+				if(!can_use(1))
+					to_chat(user, SPAN_WARNING("You have run out of \the [src]."))
 					return
-			if (can_operate(H, user) == CAN_OPERATE_ALL)        //Checks if mob is lying down on table for surgery
-				do_surgery(H,user,src, TRUE)
+				W.heal_damage(CLAMP(user.stats.getStat(STAT_MEC)/2.5, 5, 20))
+				to_chat(user, SPAN_NOTICE("You patch some wounds on \the [S]."))
+			S.update_damages()
+			if(S.get_damage())
+				to_chat(user, SPAN_WARNING("\The [S] still needs further repair."))
+				return
+		if (can_operate(H, user) == CAN_OPERATE_ALL)        //Checks if mob is lying down on table for surgery
+			do_surgery(H,user,src, TRUE)

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -58,4 +58,4 @@
 					to_chat(user, SPAN_WARNING("\The [S] still needs further repair."))
 					return
 			if (can_operate(H, user) == CAN_OPERATE_ALL)        //Checks if mob is lying down on table for surgery
-				if (do_surgery(H,user,src, TRUE))
+				do_surgery(H,user,src, TRUE)

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -48,7 +48,7 @@
 					if(!do_mob(user, M, W.damage/5) && use(1))
 						to_chat(user, SPAN_NOTICE("You must stand still to repair \the [S]."))
 						break
-					if(!use(1))
+					if(!can_use(1))
 						to_chat(user, SPAN_WARNING("You have run out of \the [src]."))
 						return
 					W.heal_damage(CLAMP(user.stats.getStat(STAT_MEC)/2.5, 5, 20))

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -973,11 +973,20 @@
 		if (get_tool_type(user, list(QUALITY_WELDING), H)) //Prosthetic repair
 			if (S.brute_dam)
 				if (S.brute_dam < ROBOLIMB_SELF_REPAIR_CAP)
-					if (use_tool(user, H, WORKTIME_FAST, QUALITY_WELDING, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
-						S.heal_damage(15,0,TRUE)
-						user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-						user.visible_message(SPAN_NOTICE("\The [user] patches some dents on \the [H]'s [S.name] with \the [src]."))
-						return 1
+					for(var/datum/wound/W in S.wounds)
+						if(W.internal)
+							return
+						if(W.damtype_sanitize() != BRUTE)
+							continue
+						if(!use_tool(user, M, W.damage/5, QUALITY_WELDING, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
+							to_chat(user, SPAN_NOTICE("You must stand still to repair \the [S]."))
+							break
+						W.heal_damage(CLAMP(user.stats.getStat(STAT_MEC)/2.5, 5, 15))
+						to_chat(user, SPAN_NOTICE("You patch some wounds on \the [S]."))
+					S.update_damages()
+					if(S.brute_dam)
+						to_chat(user, SPAN_WARNING("\The [S] still needs further repair."))
+					return
 				else if (S.open != 2)
 					to_chat(user, SPAN_DANGER("The damage is far too severe to patch over externally."))
 					return 1

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -95,6 +95,11 @@
 		else if(damage_type == BURN)
 			return salved
 
+	proc/damtype_sanitize()
+		if(damage_type == BURN)
+			return BURN
+		return BRUTE
+
 	// Checks whether other other can be merged into src.
 	proc/can_merge(var/datum/wound/other)
 		if (other.type != src.type) return 0

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -567,9 +567,23 @@ obj/structure/cable/proc/cableColor(var/colorC)
 
 		if(S.burn_dam)
 			if(S.burn_dam < ROBOLIMB_SELF_REPAIR_CAP)
-				S.heal_damage(0,15,TRUE)
-				user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-				user.visible_message(SPAN_DANGER("\The [user] patches some damaged wiring on \the [M]'s [S.name] with \the [src]."))
+				for(var/datum/wound/W in S.wounds)
+					if(W.internal)
+						return
+					if(W.damtype_sanitize() != BURN)
+						continue
+					if(!do_mob(user, M, W.damage/5))
+						to_chat(user, SPAN_NOTICE("You must stand still to repair \the [S]."))
+						break
+					if(!use(1))
+						to_chat(user, SPAN_WARNING("You have run out of \the [src]."))
+						return
+					W.heal_damage(CLAMP(user.stats.getStat(STAT_MEC)/2.5, 5, 15))
+					to_chat(user, SPAN_NOTICE("You patch some wounds on \the [S]."))
+				S.update_damages()
+				if(S.burn_dam)
+					to_chat(user, SPAN_WARNING("\The [S] still needs further repair."))
+				return
 			else if(S.open != 2)
 				to_chat(user, SPAN_DANGER("The damage is far too severe to patch over externally."))
 			return 1

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -102,6 +102,7 @@ other types of metals and chemistry for reagents).
 	desc = "A tube of paste containing swarms of repair nanites. Very effective in repairing robotic machinery."
 	build_path = /obj/item/stack/nanopaste
 	sort_string = "MBAAA"
+	chemicals = list("nanites" = 5)
 
 /datum/design/research/item/scalpel_laser
 	desc = "A scalpel augmented with a directed laser, for more precise cutting without blood entering the field."


### PR DESCRIPTION
## About The Pull Request
Nanopaste being 20~ plastic for instant robotic treatment felt a little off, and I was suggested to have it require nanites.

Now, it requires nanites, 1 sheet of plasteel, and 10 sheets of steel to construct.

It is now considerably more valuable, and rarer.

Rather than healing every wound at once every click, when healing a prosthetic it now takes the medpatch approach of
 - Cycling through every wound
 - If it can be healed, it heals so much
 - Tells you if there's still more to heal

The amount you heal via nanopaste/welding/cabling scales off of MECH

## Why It's Good For The Game
FBPs are proving to be a pain to balance, considering they feel no pain and can be healed instantly.

This is a 3:30 AM PR, so I'm going to sleep on this and maybe something better will come to mind.


## Changelog
:cl:
tweak: Nanopaste now requires plasteel, steel, and nanites to construct. It is now considerably more valuable, and considerably rarer.
tweak: Nanopaste, welding, and cabling prosthetics now heals on a wound by wound basis.
/:cl: