### PR TITLE
Adds Excruciator lense disk to Eye of Protector + misc NT tweaks ( with Dante from Devil May Cry series)

### DIFF
--- a/code/datums/autolathe/biomatter.dm
+++ b/code/datums/autolathe/biomatter.dm
@@ -204,6 +204,10 @@
 	name = "NeoTheologian Medkit"
 	build_path = /obj/item/weapon/storage/firstaid/nt
 
+/datum/design/autolathe/excruciator
+	name = "NeoTheology \"EXCRUCIATOR\" giga lens"
+	build_path = /obj/item/weapon/gun_upgrade/barrel/excruciator
+
 //[MELEE]
 /datum/design/autolathe/sword/nt_sword
 	name = "NT Shortsword"

--- a/code/game/objects/items/weapons/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disks.dm
@@ -1284,6 +1284,13 @@
 		/datum/design/autolathe/grenade/nt_frag,
 		/datum/design/autolathe/grenade/nt_smokebomb
 	)
+	
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/excruciator
+	disk_name = "NeoTheology Armory - NT \"EXCRUCIATOR\" giga lens"
+	icon_state = "neotheology"
+	designs = list(
+		/datum/design/autolathe/excruciator
+	)
 
 // ARMOR
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/armor

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -167,7 +167,7 @@
 	desc = "Can hold ammo magazines and bullets, not the boxes though."
 	icon_state = "ammo"
 	item_state = "ammo"
-	matter = list(MATERIAL_BIOMATTER = 39, MATERIAL_STEEL = 3 )
+	matter = list(MATERIAL_BIOMATTER = 19, MATERIAL_STEEL = 1 )
 	rarity_value = 33
 
 	storage_slots = 3

--- a/code/modules/clothing/suits/neotheology.dm
+++ b/code/modules/clothing/suits/neotheology.dm
@@ -3,6 +3,9 @@
 	desc = "Even the most devout deserve head protection."
 	icon_state = "acolyte"
 	item_state = "acolyte"
+	action_button_name = "Toggle Helmet Light"
+	light_overlay = "helmet_light"
+	brightness_on = 4
 	armor = list(
 		melee = 35,
 		bullet = 30,
@@ -36,6 +39,9 @@
 	desc = "Don't want anything getting in your eyes."
 	icon_state = "botanist"
 	item_state = "botanist"
+	action_button_name = "Toggle Helmet Light"
+	light_overlay = "helmet_light"
+	brightness_on = 4
 	armor = list(
 		melee = 25,
 		bullet = 25,
@@ -68,6 +74,9 @@
 	desc = "Cleaning floors is more dangerous than it looks."
 	icon_state = "custodian"
 	item_state = "custodian"
+	action_button_name = "Toggle Helmet Light"
+	light_overlay = "helmet_light"
+	brightness_on = 4
 	armor = list(
 		melee = 25,
 		bullet = 25,

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -90,7 +90,7 @@
 	I.gun_loc_tag = GUN_BARREL
 	I.req_gun_tags = list(GUN_PROJECTILE)
 
-//For energy weapons, increases the damage output, but also the charge cost. Acquired through loot spawns.
+//For energy weapons, increases the damage output, but also the charge cost. Acquired through loot spawns or Eye of the Protector.
 /obj/item/weapon/gun_upgrade/barrel/excruciator
 	name = "NeoTheology \"EXCRUCIATOR\" giga lens"
 	desc = "It's time for us to shine."

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -95,6 +95,7 @@
 	name = "NeoTheology \"EXCRUCIATOR\" giga lens"
 	desc = "It's time for us to shine."
 	icon_state = "Excruciator"
+	matter = list(MATERIAL_BIOMATTER = 3, MATERIAL_PLASTEEL = 1, MATERIAL_GOLD = 1, MATERIAL_GLASS = 1)
 	rarity_value = 50
 
 /obj/item/weapon/gun_upgrade/barrel/excruciator/New()


### PR DESCRIPTION

## About The Pull Request

Added production cost for Excruciator (3 biomatter, 1 plasteel, 1 gold, 1 glass), added design disk for it that should spawn only from EotP as one of armanents disk.
Added lights back to NT helmets, they lost it when they transitioned from spacesuit to armor.
Rectifies my mistake of setting ammo pouch's cost to same as large pouch, now it's a bit less expensive to produce than medium one.

## Why It's Good For The Game

Nice having any way to actually produce these lenses I guess. More rewards from EotP ain't bad either I think.

## Changelog
:cl:
add: Excruciator disk
add: Excruciator's cost
balance: rebalanced ammo pouches
tweak: fixes light on NT helmets.

/:cl:

