### PR TITLE
Guild nerf eternal

### DIFF
--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -151,7 +151,22 @@ SUBSYSTEM_DEF(supply)
 			if(!typepath)
 				continue
 
-			var/atom/B2 = new typepath(A)
+			var/atom/movable/B2
+			if(ispath(typepath, /obj/spawner))
+				var/obj/randomcatcher/CATCH = new /obj/randomcatcher
+				B2 = CATCH.get_item(typepath)
+				B2.forceMove(A)
+			else
+				B2 = new typepath(A)
+			B2.surplus_tag = TRUE
+			var/list/n_contents = B2.GetAllContents()
+			for(var/atom/movable/I in n_contents)
+				I.surplus_tag = TRUE
+			/* So you can't really just buy crates, then instantly resell them for a potential profit depending on if the crate hasn't had its cost scaled properly.
+			*  Yes, there are limits, I could itterate over every content of the item too and set its surplus_tag to TRUE
+			*  But that doesn't work with stackables when you can just make a new stack, and gets comp-expensive and not worth it just to spite people getting extra numbers
+			*/
+
 			if(SP.amount && B2:amount) B2:amount = SP.amount
 			if(slip) slip.info += "<li>[B2.name]</li>" //add the item to the manifest
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -19,6 +19,7 @@
 
 	//spawn_values
 	var/price_tag = 0 // The item price in credits. atom/movable so we can also assign a price to animals and other things.
+	var/surplus_tag = FALSE //If true, attempting to export this will net you a greatly reduced amount of credits, but we don't want to affect the actual price tag for selling to others.
 	var/spawn_tags
 	var/rarity_value = 1 //min:1
 	var/spawn_frequency = 0 //min:0
@@ -401,7 +402,7 @@
 /atom/movable/proc/onTransitZ(old_z, new_z)//uncomment when something is receiving this signal
 	/*SEND_SIGNAL(src, COMSIG_MOVABLE_Z_CHANGED, old_z, new_z)
 	for(var/atom/movable/AM in src) // Notify contents of Z-transition. This can be overridden IF we know the items contents do not care.
-		AM.onTransitZ(old_z,new_z)*/ 
+		AM.onTransitZ(old_z,new_z)*/
 
 /mob/living/proc/update_z(new_z) // 1+ to register, null to unregister
 	if (registered_z != new_z)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -162,7 +162,7 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.stats.getPerk(PERK_MARKET_PROF))
-			message += SPAN_NOTICE("\nThis item cost: [price_tag == null ? 0 : price_tag][CREDITS]")
+			message += SPAN_NOTICE("\nThis item cost: [get_item_cost()][CREDITS]")
 
 	return ..(user, distance, "", message)
 

--- a/code/game/objects/items/devices/scanners/price.dm
+++ b/code/game/objects/items/devices/scanners/price.dm
@@ -35,10 +35,9 @@
 
 	if(price)
 		data += "<span class='notice'>Scanned [target], value: <b>[price]</b> \
-			credits[target.contents.len ? " (contents included)" : ""].</span>"
+			credits[target.contents.len ? " (contents included)" : ""]. [target.surplus_tag?"(surplus)":""]</span>"
 	else
 		data += "<span class='warning'>Scanned [target], no export value. \
 			</span>"
-
 	data = jointext(data, "<br>")
 	return data

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -54,6 +54,8 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 				break
 		if(!found_export)
 			var/item_value = thing.get_item_cost(TRUE)
+			if(thing.surplus_tag)
+				item_value = round(item_value * 0.4)
 			if(item_value)
 				cost += item_value
 				sold_str += " [thing.name]"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -44,7 +44,20 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 
 /datum/supply_pack/proc/fill(obj/structure/closet/crate/C)
 	for(var/item in contains)
-		var/n_item = new item(C)
+		var/atom/movable/n_item
+		if(ispath(item, /obj/spawner))
+			var/obj/randomcatcher/CATCH = new /obj/randomcatcher
+			n_item = CATCH.get_item(item)
+		else
+			n_item = new item(C)
+		n_item.surplus_tag = TRUE
+		var/list/n_contents = n_item.GetAllContents()
+		for(var/atom/movable/I in n_contents)
+			n_item.surplus_tag = TRUE
+		/*So you can't really just buy crates, then instantly resell them for a potential profit depending on if the crate hasn't had its cost scaled properly.
+		* Yes, there are limits, I could itterate over every content of the item too and set its surplus_tag to TRUE
+		* But that doesn't work with stackables when you can just make a new stack, and gets comp-expensive and not worth it just to spite people getting extra numbers
+		*/
 		if(src.amount && istype(n_item, /obj/item/stack/material/steel))
 			var/obj/item/stack/material/n_sheet = n_item
 			n_sheet.amount = src.amount


### PR DESCRIPTION
## About The Pull Request
Adds the surplus tag, which marks anything bought via the guild's supply shuttle.

This is currently used to drop exported surplus items value by 60%

## Why It's Good For The Game

Being able to buy then resell the same item to the same company for infinite recursion profit makes no damn sense.

## Changelog
:cl:
balance: Items purchased via the supply shuttle are now only resellable to the supply shuttle for 40% base value, unless processed
/:cl: