### PR TITLE
Moebius nerfs: Tool mods

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -1089,6 +1089,7 @@
 #include "code\game\objects\items\weapons\tools\wrenches.dm"
 #include "code\game\objects\items\weapons\tools\mods\_upgrades.dm"
 #include "code\game\objects\items\weapons\tools\mods\mod_types.dm"
+#include "code\game\objects\items\weapons\tools\mods\research_mods.dm"
 #include "code\game\objects\landmarks\costume.dm"
 #include "code\game\objects\landmarks\debug.dm"
 #include "code\game\objects\landmarks\event.dm"

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -83,40 +83,6 @@
 	I.required_qualities = list(QUALITY_CUTTING,QUALITY_DRILLING, QUALITY_SAWING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_WELDING, QUALITY_HAMMERING)
 	I.prefix = "shielded"
 
-// Plasmablock can be attached to any tool that uses fuel or power
-/obj/item/weapon/tool_upgrade/reinforcement/plasmablock
-	name = "plasmablock"
-	desc = "A plasmablock is way more efficient to dissipate heat than classic heatsinks or waterblocks thanks to the tremendous heat-transfer capacity of liquid plasma. The fluid that is actively pumped through a radiator and cooled by fans. It greatly extends the lifespan of power tools."
-	icon_state = "plasmablock"
-	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_PLASTIC = 2, MATERIAL_PLASMA = 1)
-
-/obj/item/weapon/tool_upgrade/reinforcement/plasmablock/New()
-	..()
-	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
-	I.tool_upgrades = list(
-		UPGRADE_DEGRADATION_MULT = 0.45,
-		UPGRADE_HEALTH_THRESHOLD = 10,
-		UPGRADE_POWERCOST_MULT = 1.05,
-		UPGRADE_FUELCOST_MULT = 1.05
-		)
-	I.prefix = "plasma-cooled"
-	I.req_fuel_cell = REQ_FUEL_OR_CELL
-
-/obj/item/weapon/tool_upgrade/reinforcement/rubbermesh
-	name = "rubber mesh"
-	desc = "A rubber mesh that can wrapped around sensitive parts of a tool, protecting them from impacts and debris."
-	icon_state = "rubbermesh"
-	matter = list(MATERIAL_PLASTIC = 3)
-
-/obj/item/weapon/tool_upgrade/reinforcement/rubbermesh/New()
-	..()
-	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
-	I.tool_upgrades = list(
-	UPGRADE_DEGRADATION_MULT = 0.7,
-	UPGRADE_HEALTH_THRESHOLD = 5
-	)
-	I.required_qualities = list(QUALITY_CUTTING,QUALITY_DRILLING, QUALITY_SAWING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_WELDING, QUALITY_HAMMERING)
-	I.prefix = "rubber-wrapped"
 
 // 	 PRODUCTIVITY: INCREASES WORKSPEED
 //------------------------------------------------
@@ -261,59 +227,6 @@
 	I.prefix = "high-power"
 	I.req_fuel_cell = REQ_FUEL_OR_CELL
 
-/obj/item/weapon/tool_upgrade/productivity/antistaining
-	name = "anti-staining paint"
-	desc = "Applying a thin coat of this paint on a tool prevents stains, dirt or dust to adhere to its surface. Everyone works better and faster with clean tools."
-	icon_state = "antistaining"
-	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 2)
-
-/obj/item/weapon/tool_upgrade/productivity/antistaining/New()
-	..()
-	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
-	I.tool_upgrades = list(
-	UPGRADE_WORKSPEED = 0.30,
-	UPGRADE_PRECISION = 5,
-	UPGRADE_ITEMFLAGPLUS = NOBLOODY
-	)
-	I.prefix = "anti-stain coated"
-
-/obj/item/weapon/tool_upgrade/productivity/booster
-	name = "booster"
-	desc = "When you do not care about energy comsumption and just want to get shit done quickly. This device shunts the power safeties of your tool whether it uses fuel or electricity."
-	icon_state = "booster"
-	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 2, MATERIAL_GOLD = 1)
-
-/obj/item/weapon/tool_upgrade/productivity/booster/New()
-	..()
-	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
-	I.tool_upgrades = list(
-	UPGRADE_WORKSPEED = 0.35,
-	UPGRADE_DEGRADATION_MULT = 1.15,
-	UPGRADE_POWERCOST_MULT = 1.25,
-	UPGRADE_FUELCOST_MULT = 1.25
-	)
-	I.prefix = "boosted"
-	I.req_fuel_cell = REQ_FUEL_OR_CELL
-
-/obj/item/weapon/tool_upgrade/productivity/injector
-	name = "plasma injector"
-	desc = "If the words \"safety regulations\" do not mean anything to you, you may consider installing this fine piece of technology on your tool. It injects small amounts of plasma in the fuel mix before combustion to greatly increase its power output, making all kinds of tasks easier to perform."
-	icon_state = "injector"
-	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 2, MATERIAL_PLASMA = 2)
-
-/obj/item/weapon/tool_upgrade/productivity/injector/New()
-	..()
-	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
-	I.tool_upgrades = list(
-	UPGRADE_WORKSPEED = 0.75,
-	UPGRADE_DEGRADATION_MULT = 1.3,
-	UPGRADE_POWERCOST_MULT = 1.3,
-	UPGRADE_FUELCOST_MULT = 1.3,
-	UPGRADE_HEALTH_THRESHOLD = -10
-	)
-	I.prefix = "plasma-fueled"
-	I.req_fuel_cell = REQ_FUEL
-
 // 	 REFINEMENT: INCREASES PRECISION
 //------------------------------------------------
 /obj/item/weapon/tool_upgrade/refinement
@@ -387,43 +300,6 @@
 	)
 	I.required_qualities = list(QUALITY_WELDING)
 	I.prefix = "ported"
-
-/obj/item/weapon/tool_upgrade/refinement/compensatedbarrel
-	name = "gravity compensated barrel"
-	desc = "A barrel extension for welding tools that integrates a miniaturized gravity generator that help keep the torch steady by compensating the weight of the tool."
-	icon_state = "compensatedbarrel"
-	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GOLD = 1)
-
-/obj/item/weapon/tool_upgrade/refinement/compensatedbarrel/New()
-	..()
-	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
-	I.tool_upgrades = list(
-	UPGRADE_PRECISION = 20,
-	UPGRADE_DEGRADATION_MULT = 1.15,
-	UPGRADE_POWERCOST_MULT = 1.05,
-	UPGRADE_FUELCOST_MULT = 1.05,
-	UPGRADE_BULK = 1
-	)
-	I.required_qualities = list(QUALITY_WELDING)
-	I.prefix = "gravity-compensated"
-	I.req_fuel_cell = REQ_FUEL_OR_CELL
-
-/obj/item/weapon/tool_upgrade/refinement/vibcompensator
-	name = "vibration compensator"
-	desc = "A ground-breaking innovation that dampens the vibration of a tool by emitting sound waves in a specific pattern. It does not make any sense but neither do you by installing that on your tool."
-	icon_state = "vibcompensator"
-	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 1, MATERIAL_GOLD = 1)
-
-/obj/item/weapon/tool_upgrade/refinement/vibcompensator/New()
-	..()
-	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
-	I.tool_upgrades = list(
-	UPGRADE_PRECISION = 15,
-	UPGRADE_HEALTH_THRESHOLD = 5,
-	UPGRADE_ITEMFLAGPLUS = HONKING
-	)
-	I.required_qualities = list(QUALITY_CUTTING,QUALITY_WIRE_CUTTING, QUALITY_SCREW_DRIVING, QUALITY_WELDING,QUALITY_PULSING, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_BONE_SETTING, QUALITY_LASER_CUTTING)
-	I.prefix = "vibration-compensated"
 
 // 		AUGMENTS: MISCELLANEOUS AND UTILITY
 //------------------------------------------------
@@ -630,23 +506,6 @@
 	UPGRADE_HEALTH_THRESHOLD = 10
 	)
 	I.prefix = "self-healing"
-
-/obj/item/weapon/tool_upgrade/augment/hydraulic
-	name = "hydraulic circuits"
-	desc = "A complex set of hydraulic circuits that can be installed on a tool to greatly improve its functions. It's loud as hell though so do not plan on being stealthy."
-	icon_state = "hydraulic"
-	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 3)
-	spawn_blacklisted = TRUE
-
-/obj/item/weapon/tool_upgrade/augment/hydraulic/New()
-	..()
-	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
-	I.tool_upgrades = list(
-	UPGRADE_WORKSPEED = 1,
-	UPGRADE_PRECISION = 10,
-	UPGRADE_ITEMFLAGPLUS = LOUD
-	)
-	I.prefix = "hydraulic"
 
 // Randomizes a bunch of weapon stats on application - stats are set on creation of the item to prevent people from re-rolling until they get what they want
 /obj/item/weapon/tool_upgrade/augment/randomizer

--- a/code/game/objects/items/weapons/tools/mods/research_mods.dm
+++ b/code/game/objects/items/weapons/tools/mods/research_mods.dm
@@ -1,0 +1,161 @@
+//REINFORCEMENTS
+
+// Plasmablock can be attached to any tool that uses fuel or power
+/obj/item/weapon/tool_upgrade/reinforcement/plasmablock
+	name = "plasmablock"
+	desc = "A plasmablock is way more efficient to dissipate heat than classic heatsinks or waterblocks thanks to the tremendous heat-transfer capacity of liquid plasma. The fluid that is actively pumped through a radiator and cooled by fans. It greatly extends the lifespan of power tools."
+	icon_state = "plasmablock"
+	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_PLASTIC = 2, MATERIAL_PLASMA = 1)
+
+/obj/item/weapon/tool_upgrade/reinforcement/plasmablock/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.tool_upgrades = list(
+		UPGRADE_DEGRADATION_MULT = 0.45,
+		UPGRADE_HEALTH_THRESHOLD = 10,
+		UPGRADE_POWERCOST_MULT = 1.1,
+		UPGRADE_FUELCOST_MULT = 1.1
+		)
+	I.prefix = "plasma-cooled"
+	I.req_fuel_cell = REQ_FUEL_OR_CELL
+
+
+/obj/item/weapon/tool_upgrade/reinforcement/rubbermesh
+	name = "rubber mesh"
+	desc = "A rubber mesh that can wrapped around sensitive parts of a tool, protecting them from impacts and debris."
+	icon_state = "rubbermesh"
+	matter = list(MATERIAL_PLASTIC = 3)
+
+/obj/item/weapon/tool_upgrade/reinforcement/rubbermesh/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.tool_upgrades = list(
+	UPGRADE_DEGRADATION_MULT = 0.7,
+	UPGRADE_BULK = 1,
+	UPGRADE_HEALTH_THRESHOLD = 5
+	)
+	I.required_qualities = list(QUALITY_CUTTING,QUALITY_DRILLING, QUALITY_SAWING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_WELDING, QUALITY_HAMMERING)
+	I.prefix = "rubber-wrapped"
+
+//REFINEMENTS
+
+
+/obj/item/weapon/tool_upgrade/refinement/compensatedbarrel
+	name = "gravity compensated barrel"
+	desc = "A barrel extension for welding tools that integrates a miniaturized gravity generator that help keep the torch steady by compensating the weight of the tool."
+	icon_state = "compensatedbarrel"
+	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GOLD = 1)
+
+/obj/item/weapon/tool_upgrade/refinement/compensatedbarrel/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.tool_upgrades = list(
+	UPGRADE_PRECISION = 20,
+	UPGRADE_DEGRADATION_MULT = 1.15,
+	UPGRADE_POWERCOST_MULT = 1.05,
+	UPGRADE_FUELCOST_MULT = 1.05,
+	UPGRADE_BULK = 1
+	)
+	I.required_qualities = list(QUALITY_WELDING)
+	I.prefix = "gravity-compensated"
+	I.req_fuel_cell = REQ_FUEL_OR_CELL
+
+
+
+/obj/item/weapon/tool_upgrade/refinement/vibcompensator
+	name = "vibration compensator"
+	desc = "A ground-breaking innovation that dampens the vibration of a tool by emitting sound waves in a specific pattern. It does not make any sense but neither do you by installing that on your tool."
+	icon_state = "vibcompensator"
+	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 1, MATERIAL_GOLD = 1)
+
+/obj/item/weapon/tool_upgrade/refinement/vibcompensator/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.tool_upgrades = list(
+	UPGRADE_PRECISION = 5,
+	UPGRADE_HEALTH_THRESHOLD = 5,
+	)
+	I.required_qualities = list(QUALITY_CUTTING,QUALITY_WIRE_CUTTING, QUALITY_SCREW_DRIVING, QUALITY_WELDING,QUALITY_PULSING, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_BONE_SETTING, QUALITY_LASER_CUTTING)
+	I.prefix = "vibration-compensated"
+
+
+//PRODUCTIVITY
+
+
+/obj/item/weapon/tool_upgrade/productivity/antistaining
+	name = "anti-staining paint"
+	desc = "Applying a thin coat of this paint on a tool prevents stains, dirt or dust to adhere to its surface."
+	icon_state = "antistaining"
+	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 2)
+
+/obj/item/weapon/tool_upgrade/productivity/antistaining/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.tool_upgrades = list(
+	UPGRADE_DEGRADATION_MULT = 0.7,
+	UPGRADE_ITEMFLAGPLUS = NOBLOODY
+	)
+	I.prefix = "anti-stain coated"
+
+
+
+/obj/item/weapon/tool_upgrade/productivity/booster
+	name = "booster"
+	desc = "When you do not care about energy comsumption and just want to get shit done quickly. This device shunts the power safeties of your tool whether it uses fuel or electricity."
+	icon_state = "booster"
+	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 2, MATERIAL_GOLD = 1)
+
+/obj/item/weapon/tool_upgrade/productivity/booster/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.tool_upgrades = list(
+	UPGRADE_WORKSPEED = 0.35,
+	UPGRADE_DEGRADATION_MULT = 1.15,
+	UPGRADE_POWERCOST_MULT = 2,
+	UPGRADE_FUELCOST_MULT = 2
+	)
+	I.prefix = "boosted"
+	I.req_fuel_cell = REQ_CELL
+
+
+/obj/item/weapon/tool_upgrade/productivity/injector
+	name = "plasma injector"
+	desc = "If the words \"safety regulations\" do not mean anything to you, you may consider installing this fine piece of technology on your tool. It injects small amounts of plasma in the fuel mix before combustion to greatly increase its power output, making all kinds of tasks easier to perform."
+	icon_state = "injector"
+	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 2, MATERIAL_PLASMA = 2)
+
+/obj/item/weapon/tool_upgrade/productivity/injector/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.tool_upgrades = list(
+	UPGRADE_WORKSPEED = 0.5,
+	UPGRADE_DEGRADATION_MULT = 1.3,
+	UPGRADE_FUELCOST_MULT = 1.3,
+	UPGRADE_HEALTH_THRESHOLD = -10
+	)
+	I.prefix = "plasma-fueled"
+	I.req_fuel_cell = REQ_FUEL
+
+
+//AUGMENTS
+
+/obj/item/weapon/tool_upgrade/augment/hydraulic
+	name = "hydraulic circuits"
+	desc = "A complex set of hydraulic circuits that can be installed on a tool to greatly improve its functions. It's loud as hell though so do not plan on being stealthy."
+	icon_state = "hydraulic"
+	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 3)
+	spawn_blacklisted = TRUE
+
+/obj/item/weapon/tool_upgrade/augment/hydraulic/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.tool_upgrades = list(
+	UPGRADE_WORKSPEED = 0.5,
+	UPGRADE_DEGRADATION_MULT = 1.5,
+	UPGRADE_FUELCOST_MULT = 1.5,
+	UPGRADE_POWERCOST_MULT = 1.5,
+	UPGRADE_ITEMFLAGPLUS = LOUD
+	)
+	I.prefix = "hydraulic"
+
+

--- a/code/modules/research/nodes/engineering.dm
+++ b/code/modules/research/nodes/engineering.dm
@@ -268,10 +268,7 @@
 	required_tech_levels = list()
 	cost = 1500
 
-	unlocks_designs = list(	/datum/design/research/item/weapon/toolmod/stick,
-							/datum/design/research/item/weapon/toolmod/heatsink,
-							/datum/design/research/item/weapon/toolmod/plating,
-							/datum/design/research/item/weapon/toolmod/guard,
+	unlocks_designs = list(
 							/datum/design/research/item/weapon/toolmod/plasmablock,
 							/datum/design/research/item/weapon/toolmod/rubbermesh
 							)
@@ -289,13 +286,7 @@
 	required_tech_levels = list()
 	cost = 1500
 
-	unlocks_designs = list(	/datum/design/research/item/weapon/toolmod/ergonomicgrip,
-							/datum/design/research/item/weapon/toolmod/ratchet,
-							/datum/design/research/item/weapon/toolmod/redpaint,
-							/datum/design/research/item/weapon/toolmod/whetstone,
-							/datum/design/research/item/weapon/toolmod/dblade,
-							/datum/design/research/item/weapon/toolmod/oxyjet,
-							/datum/design/research/item/weapon/toolmod/motor,
+	unlocks_designs = list(
 							/datum/design/research/item/weapon/toolmod/antistaining,
 							/datum/design/research/item/weapon/toolmod/booster,
 							/datum/design/research/item/weapon/toolmod/injector
@@ -314,10 +305,7 @@
 	required_tech_levels = list()
 	cost = 1500
 
-	unlocks_designs = list(	/datum/design/research/item/weapon/toolmod/laserguide,
-							/datum/design/research/item/weapon/toolmod/stabilizedgrip,
-							/datum/design/research/item/weapon/toolmod/magbit,
-							/datum/design/research/item/weapon/toolmod/portedbarrel,
+	unlocks_designs = list(
 							/datum/design/research/item/weapon/toolmod/compensatedbarrel,
 							/datum/design/research/item/weapon/toolmod/vibcompensator
 							)
@@ -335,11 +323,7 @@
 	required_tech_levels = list()
 	cost = 1500
 
-	unlocks_designs = list(	/datum/design/research/item/weapon/toolmod/cellmount,
-							/datum/design/research/item/weapon/toolmod/fueltank,
-							/datum/design/research/item/weapon/toolmod/expansion,
-							/datum/design/research/item/weapon/toolmod/spikes,
-							/datum/design/research/item/weapon/toolmod/hammeraddon,
+	unlocks_designs = list(
 							/datum/design/research/item/weapon/toolmod/hydraulic
 							)
 


### PR DESCRIPTION
## About The Pull Request

Nerfs some of the research mods, and moves them to their own file
 - Hydraulic Circuits
-   -  Before: - +100% workspeed, +10 Precision
-   - After: - **+50% workspeed, +50% degradation, +50% fuel/power cost**

- Anti-staining paint
-  - Before: +30% workspeed, +5 precision, can't be bloody
-  - After: **-30% degradation,** can't be bloody

- Booster
- - Before: +35% workspeed, +15% degradation, +25% power/fuel usage
- - After: +35% workspeed, +15% degradation, **+100% power/fuel usage**

- Vibration Compensator
- - Before: +15 precision, changes sound to honk
- - After: **+5 precision, no more honking**

- Rubber Mesh
- - Before: -30% degradation
- - After: -30% degradation, **Bulk+1**


Removes misc mods from research

## Why It's Good For The Game

 - Giving moebius no-drawback powerful cheap toolmods was a mistake
 - Giving moebius the ability to print most major toolmods was a mistake, and removed any dependence on external trade

## Changelog
:cl:
del: Most of the misc toolmods have been removed from research
tweak: The research specific toolmods have been nerfed or given suitable drawbacks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
