### PR TITLE
Fixes the roundstart moebius FBP having armour

### DIFF
--- a/code/modules/organs/external/subtypes/robotic_types.dm
+++ b/code/modules/organs/external/subtypes/robotic_types.dm
@@ -67,7 +67,7 @@
 
 /obj/item/organ/external/robotic/moebius
 	name = "\"Moebius\""
-	desc = "Streamlined, sleek, and sterile"
+	desc = "Streamlined, sleek, and sterile."
 	force_icon = 'icons/mob/human_races/cyberlimbs/moebius.dmi'
 	model = "moebius"
 	bad_type = /obj/item/organ/external/robotic/moebius

--- a/code/modules/organs/external/subtypes/robotic_types.dm
+++ b/code/modules/organs/external/subtypes/robotic_types.dm
@@ -67,42 +67,61 @@
 
 /obj/item/organ/external/robotic/moebius
 	name = "\"Moebius\""
-	desc = "Reinforced purple and white prosthesis designed for space exploration and light combat."
+	desc = "Streamlined, sleek, and sterile"
 	force_icon = 'icons/mob/human_races/cyberlimbs/moebius.dmi'
 	model = "moebius"
+	bad_type = /obj/item/organ/external/robotic/moebius
+
+/obj/item/organ/external/robotic/moebius/l_arm
+	default_description = /datum/organ_description/arm/left
+
+/obj/item/organ/external/robotic/moebius/r_arm
+	default_description = /datum/organ_description/arm/right
+
+/obj/item/organ/external/robotic/moebius/l_leg
+	default_description = /datum/organ_description/leg/left
+
+/obj/item/organ/external/robotic/moebius/r_leg
+	default_description = /datum/organ_description/leg/right
+
+/obj/item/organ/external/robotic/moebius/groin
+	default_description = /datum/organ_description/groin
+
+/obj/item/organ/external/robotic/moebius/torso
+	default_description = /datum/organ_description/chest
+
+/obj/item/organ/external/robotic/moebius/head
+	default_description = /datum/organ_description/head
+
+/obj/item/organ/external/robotic/moebius/reinforced
+	name = "\"Moebius\" R++"
+	desc = "Reinforced purple and white prosthesis designed for space exploration and light combat."
 	armor = list(melee = 35, bullet = 35, energy = 35, bomb = 35, bio = 0, rad = 100)
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_PLASTEEL = 1)
 	max_damage = 60
 	min_broken_damage = 40
 	price_tag = 300
-	bad_type = /obj/item/organ/external/robotic/moebius
+	bad_type = /obj/item/organ/external/robotic/moebius/reinforced
 
-/obj/item/organ/external/robotic/moebius/l_arm
-	name = "\"Moebius\" Left Arm"
+/obj/item/organ/external/robotic/moebius/reinforced/l_arm
 	default_description = /datum/organ_description/arm/left
 
-/obj/item/organ/external/robotic/moebius/r_arm
-	name = "\"Moebius\" Right Arm"
+/obj/item/organ/external/robotic/moebius/reinforced/r_arm
 	default_description = /datum/organ_description/arm/right
 
-/obj/item/organ/external/robotic/moebius/l_leg
-	name = "\"Moebius\" Left Leg"
+/obj/item/organ/external/robotic/moebius/reinforced/l_leg
 	default_description = /datum/organ_description/leg/left
 
-/obj/item/organ/external/robotic/moebius/r_leg
-	name = "\"Moebius\" Right Leg"
+/obj/item/organ/external/robotic/moebius/reinforced/r_leg
 	default_description = /datum/organ_description/leg/right
 
-/obj/item/organ/external/robotic/moebius/groin
-	name = "\"Moebius\" Groin"
+/obj/item/organ/external/robotic/moebius/reinforced/groin
 	default_description = /datum/organ_description/groin
 
-/obj/item/organ/external/robotic/moebius/torso
-	name = "\"Moebius\" Torso"
+/obj/item/organ/external/robotic/moebius/reinforced/torso
 	default_description = /datum/organ_description/chest
 
-/obj/item/organ/external/robotic/moebius/head
-	name = "\"Moebius\" Head"
+/obj/item/organ/external/robotic/moebius/reinforced/head
 	default_description = /datum/organ_description/head
 
 /obj/item/organ/external/robotic/excelsior

--- a/code/modules/research/designs/prosthesis_implants.dm
+++ b/code/modules/research/designs/prosthesis_implants.dm
@@ -24,19 +24,22 @@
 	category = CAT_PROSTHESIS
 
 /datum/design/research/item/mechfab/prosthesis_moebius/r_arm
-	build_path = /obj/item/organ/external/robotic/moebius/r_arm
+	build_path = /obj/item/organ/external/robotic/moebius/reinforced/r_arm
 
 /datum/design/research/item/mechfab/prosthesis_moebius/l_arm
-	build_path = /obj/item/organ/external/robotic/moebius/l_arm
+	build_path = /obj/item/organ/external/robotic/moebius/reinforced/l_arm
 
 /datum/design/research/item/mechfab/prosthesis_moebius/r_leg
-	build_path = /obj/item/organ/external/robotic/moebius/r_leg
+	build_path = /obj/item/organ/external/robotic/moebius/reinforced/r_leg
 
 /datum/design/research/item/mechfab/prosthesis_moebius/l_leg
-	build_path = /obj/item/organ/external/robotic/moebius/l_leg
+	build_path = /obj/item/organ/external/robotic/moebius/reinforced/l_leg
 
 /datum/design/research/item/mechfab/prosthesis_moebius/groin
-	build_path = /obj/item/organ/external/robotic/moebius/groin
+	build_path = /obj/item/organ/external/robotic/moebius/reinforced/groin
+
+/datum/design/research/item/mechfab/prosthesis_moebius/head
+	build_path = /obj/item/organ/external/robotic/moebius/reinforced/head
 
 //Modules ====================================
 


### PR DESCRIPTION
## About The Pull Request

Was told to, now there's some actual incentive to augmenting yourself via the moebius medical scheme

## Why It's Good For The Game
Roundstart FBPs having armor was apparently pretty BS.

## Changelog
:cl:
balance: The moebius roundstart prosthetics are no longer armored.
/:cl: