### PR TITLE
Leg efficiency speed nerf

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -332,7 +332,7 @@
 	if(status & ORGAN_SPLINTED)
 		. += 0.5
 
-	. += (-(limb_efficiency / 100 - 1) * 3)	//0 at 100 efficiency, -1.5 at 150, +1.5 at 50
+	. += (-(limb_efficiency / 100 - 1) * 1.5)	//0 at 100 efficiency, -0.75 at 150, +0.75 at 50
 
 	. += tally
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cuts the extra speed from leg efficiency in half.

## Why It's Good For The Game

When testing i did not realize most humans have, in fact, 2 legs so the base speed buff could be doubled. We may need even more nerfs in the future.

## Changelog
:cl:
balance: More leg efficiency makes you less fast, and less leg efficinecy makes you less slow.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
