### PR TITLE
Hysteric breakdown delay increase

### DIFF
--- a/code/modules/sanity/breakdowns.dm
+++ b/code/modules/sanity/breakdowns.dm
@@ -215,7 +215,7 @@
 /datum/breakdown/negative/hysteric
 	name = "Hysteric"
 	duration = 1.5 MINUTES
-	delay = 30 SECONDS
+	delay = 60 SECONDS
 	restore_sanity_post = 50
 
 	start_messages = list(


### PR DESCRIPTION
## About The Pull Request

Increases the hysteric breakdown delay from 30 seconds to 60 seconds.

## Why It's Good For The Game

Hysteric is one of the most annoying and detremental breakdowns in the game, so players should have more time to react to it.

## Changelog
:cl:
balance: Hysteric breakdown takes 60 instead of 30 seconds to trigger.
/:cl:

