### PR TITLE
Casings are now worthless

### DIFF
--- a/code/modules/economy/price_list.dm
+++ b/code/modules/economy/price_list.dm
@@ -988,7 +988,7 @@
 	for(var/obj/item/ammo_casing/i in stored_ammo)
 		. += i.get_item_cost(export)
 
-/obj/item/ammo_casing/price_tag = 20
+/obj/item/ammo_casing/price_tag = 0
 
 /obj/item/ammo_casing/get_item_cost(export)
 	. = ..() * amount


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

ammo casings no longer export for 20 credits per casing. They now export for 0 credits per casing. that's 100% less profit per casing!

## Why It's Good For The Game
money printer go brrrrrrrrr 

## Changelog
:cl:
balance: ammo casings no longer have any export value.
/:cl:
