### PR TITLE
Grammar Fixes, 'granade' to 'grenade'.

### DIFF
--- a/code/datums/contract.dm
+++ b/code/datums/contract.dm
@@ -33,7 +33,7 @@ GLOBAL_LIST_INIT(excel_item_targets,list(
 		"a Straylight sub machine gun" = /obj/item/weapon/gun/projectile/automatic/straylight,
 		"a Sol carbine" = /obj/item/weapon/gun/projectile/automatic/sol,
 		"a Colt handgun" = /obj/item/weapon/gun/projectile/colt,
-		"a Lenar granade launcher" = /obj/item/weapon/gun/launcher/grenade/lenar,
+		"a Lenar grenade launcher" = /obj/item/weapon/gun/launcher/grenade/lenar,
 		"an RCD" = /obj/item/weapon/rcd,
 		"a cruciform" = /obj/item/weapon/implant/core_implant/cruciform,
 		"the station blueprints" = /obj/item/blueprints,

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -105,7 +105,7 @@
 
 /obj/item/weapon/grenade/flashbang/nt
 	name = "NT FBG \"Holy Light\""
-	desc = "An old \"NanoTrasen\" flashbang granade, modified to spread the light of god."
+	desc = "An old \"NanoTrasen\" flashbang grenade, modified to spread the light of god."
 	icon_state = "flashbang_nt"
 	item_state = "flashbang_nt"
 	matter = list(MATERIAL_BIOMATTER = 75)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

flashbang/nt and the excelsior grenade launcher contract now have proper grammar.

## Why It's Good For The Game

Basic typo fixes.

## Changelog
:cl: Xoxeyos
spellcheck: 'granade' is now 'grenade'.
/:cl: