### PR TITLE
Robot Bones fix

### DIFF
--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -40,9 +40,9 @@
 				if(S.get_damage())
 					user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 					if(use(1))
-						S.heal_damage(15, 15, robo_repair = 1)
-					
-					
+						S.heal_damage(15, 15, TRUE)
+
+
 					user.visible_message(
 						"<span class='notice'>\The [user] applies some nanite paste at[user != M ? " \the [M]'s" : " \the"][S.name] with \the [src].</span>",
 						"<span class='notice'>You apply some nanite paste at [user == M ? "your" : "[M]'s"] [S.name].</span>"

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -974,7 +974,7 @@
 			if (S.brute_dam)
 				if (S.brute_dam < ROBOLIMB_SELF_REPAIR_CAP)
 					if (use_tool(user, H, WORKTIME_FAST, QUALITY_WELDING, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
-						S.heal_damage(15,0,0,1)
+						S.heal_damage(15,0,TRUE)
 						user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 						user.visible_message(SPAN_NOTICE("\The [user] patches some dents on \the [H]'s [S.name] with \the [src]."))
 						return 1

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -106,7 +106,7 @@
 			O.take_damage(amount, 0, sharp=is_sharp(damage_source), edge=has_edge(damage_source), used_weapon=damage_source)
 		else
 			//if you don't want to heal robot organs, they you will have to check that yourself before using this proc.
-			O.heal_damage(-amount, 0, internal=0, robo_repair=(BP_IS_ROBOTIC(O)))
+			O.heal_damage(-amount, 0, robo_repair=(BP_IS_ROBOTIC(O)))
 
 	BITSET(hud_updateflag, HEALTH_HUD)
 
@@ -119,7 +119,7 @@
 			O.take_damage(0, amount, sharp=is_sharp(damage_source), edge=has_edge(damage_source), used_weapon=damage_source)
 		else
 			//if you don't want to heal robot organs, they you will have to check that yourself before using this proc.
-			O.heal_damage(0, -amount, internal=0, robo_repair=(BP_IS_ROBOTIC(O)))
+			O.heal_damage(0, -amount, robo_repair=(BP_IS_ROBOTIC(O)))
 
 	BITSET(hud_updateflag, HEALTH_HUD)
 

--- a/code/modules/organs/external/damage.dm
+++ b/code/modules/organs/external/damage.dm
@@ -115,7 +115,7 @@
 
 	return update_damstate()
 
-/obj/item/organ/external/heal_damage(brute, burn, internal = 0, robo_repair = 0)
+/obj/item/organ/external/heal_damage(brute, burn, robo_repair = 0)
 	if(BP_IS_ROBOTIC(src) && !robo_repair)
 		return
 
@@ -129,10 +129,6 @@
 			burn = W.heal_damage(burn)
 		else
 			brute = W.heal_damage(brute)
-
-	if(internal)
-		status &= ~ORGAN_BROKEN
-		perma_injury = 0
 
 	//Sync the organ's damage with its wounds
 	src.update_damages()

--- a/code/modules/organs/internal/bones.dm
+++ b/code/modules/organs/internal/bones.dm
@@ -32,6 +32,35 @@
 	if(prob(25))
 		parent.release_restraints()
 
+/obj/item/organ/internal/bone/get_actions()
+	var/list/actions_list = list()
+	if(BP_IS_ROBOTIC(src))
+		if(parent.status & ORGAN_BROKEN)
+			actions_list.Add(list(list(
+				"name" = "Mend",
+				"organ" = "\ref[src]",
+				"step" = /datum/surgery_step/robotic/fix_bone
+			)))
+	else
+		actions_list.Add(list(list(
+			"name" = (parent.status & ORGAN_BROKEN) ? "Mend" : "Break",
+			"organ" = "\ref[src]",
+			"step" = (parent.status & ORGAN_BROKEN) ? /datum/surgery_step/mend_bone : /datum/surgery_step/break_bone
+		)))
+		if(parent.status & ORGAN_BROKEN)
+			actions_list.Add(list(list(
+					"name" = "Reinforce",
+					"organ" = "\ref[src]",
+					"step" = /datum/surgery_step/reinforce_bone
+				)))
+		actions_list.Add(list(list(
+				"name" = "Replace",
+				"organ" = "\ref[src]",
+				"step" = /datum/surgery_step/replace_bone
+			)))
+
+	return actions_list
+
 /obj/item/organ/internal/bone/proc/mend()
 	parent.status &= ~ORGAN_BROKEN
 	parent.status &= ~ORGAN_SPLINTED

--- a/code/modules/organs/internal/bones.dm
+++ b/code/modules/organs/internal/bones.dm
@@ -37,7 +37,7 @@
 	if(BP_IS_ROBOTIC(src))
 		if(parent.status & ORGAN_BROKEN)
 			actions_list.Add(list(list(
-				"name" = "Mend",
+				"name" = "Mend break",
 				"organ" = "\ref[src]",
 				"step" = /datum/surgery_step/robotic/fix_bone
 			)))

--- a/code/modules/organs/surgery_helpers.dm
+++ b/code/modules/organs/surgery_helpers.dm
@@ -72,6 +72,34 @@
 /obj/item/organ/proc/get_conditions()
 	return list()
 
+/obj/item/organ/proc/get_actions(var/obj/item/organ/external/parent)
+	var/list/actions_list = list()
+
+	if(BP_IS_ROBOTIC(src))
+		actions_list.Add(list(list(
+			"name" = (status & ORGAN_CUT_AWAY) ? "Connect" : "Disconnect",
+			"organ" = "\ref[src]",
+			"step" = /datum/surgery_step/robotic/connect_organ
+		)))
+	else
+		actions_list.Add(list(list(
+			"name" = (status & ORGAN_CUT_AWAY) ? "Attach" : "Separate",
+			"organ" = "\ref[src]",
+			"step" = (status & ORGAN_CUT_AWAY) ? /datum/surgery_step/attach_organ : /datum/surgery_step/detach_organ
+		)))
+
+	return actions_list
+
+/obj/item/organ/internal/proc/get_process_data()
+	var/list/processes = list()
+	for(var/efficiency in organ_efficiency)
+		processes += list(
+			list(
+				"title" = "[capitalize(efficiency)] efficiency",
+				"efficiency" = organ_efficiency[efficiency],
+				)
+			)
+	return processes
 
 // Is body part open for most surgerical operations?
 // To be overridden in subtypes

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -567,7 +567,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 
 		if(S.burn_dam)
 			if(S.burn_dam < ROBOLIMB_SELF_REPAIR_CAP)
-				S.heal_damage(0,15,0,1)
+				S.heal_damage(0,15,TRUE)
 				user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 				user.visible_message(SPAN_DANGER("\The [user] patches some damaged wiring on \the [M]'s [S.name] with \the [src]."))
 			else if(S.open != 2)

--- a/code/modules/surgery/robotic.dm
+++ b/code/modules/surgery/robotic.dm
@@ -136,12 +136,13 @@
 
 /datum/surgery_step/robotic/fix_bone
 	required_tool_quality = QUALITY_WELDING
+	target_organ_type = /obj/item/organ/internal
 	allowed_tools = list(/obj/item/stack/nanopaste = 100)
 
 	duration = 6 SECONDS
 
 /datum/surgery_step/robotic/fix_bone/can_use(mob/living/user, obj/item/organ/internal/organ, obj/item/stack/tool)
-	. = BP_IS_ROBOTIC(organ) && organ.is_open() && (organ.parent.status & ORGAN_BROKEN)
+	. = ..() && organ.is_open() && (organ.parent.status & ORGAN_BROKEN)
 
 	// Otherwise, it will just immediately fracture again
 	if(. && organ.parent.should_fracture())

--- a/code/modules/surgery/robotic.dm
+++ b/code/modules/surgery/robotic.dm
@@ -131,3 +131,43 @@
 		SPAN_NOTICE("You disconnect [organ.get_surgery_name()] with \the [tool].")
 	)
 	organ.droplimb(TRUE, DROPLIMB_EDGE)
+
+
+
+/datum/surgery_step/robotic/fix_bone
+	required_tool_quality = QUALITY_WELDING
+	allowed_tools = list(/obj/item/stack/nanopaste = 100)
+
+	duration = 6 SECONDS
+
+/datum/surgery_step/robotic/fix_bone/can_use(mob/living/user, obj/item/organ/internal/organ, obj/item/stack/tool)
+	. = BP_IS_ROBOTIC(organ) && organ.is_open() && (organ.parent.status & ORGAN_BROKEN)
+
+	// Otherwise, it will just immediately fracture again
+	if(. && organ.parent.should_fracture())
+		to_chat(user, SPAN_WARNING("[organ.parent.get_surgery_name()] is too damaged!"))
+		return FALSE
+
+	return .
+
+/datum/surgery_step/robotic/fix_bone/begin_step(mob/living/user, obj/item/organ/internal/bone/organ, obj/item/stack/tool)
+	user.visible_message(
+		SPAN_NOTICE("[user] starts mending [organ.get_surgery_name()] with \the [tool]."),
+		SPAN_NOTICE("You start mending [organ.get_surgery_name()] with \the [tool].")
+	)
+
+	organ.owner_custom_pain("The pain in your [organ.name] is living hell!", 1)
+
+/datum/surgery_step/robotic/fix_bone/end_step(mob/living/user, obj/item/organ/internal/bone/organ, obj/item/stack/tool)
+	user.visible_message(
+		SPAN_NOTICE("[user] mends [organ.get_surgery_name()] with \the [tool]."),
+		SPAN_NOTICE("You mend [organ.get_surgery_name()] with \the [tool].")
+	)
+	organ.mend()
+
+/datum/surgery_step/robotic/fix_bone/fail_step(mob/living/user, obj/item/organ/internal/organ, obj/item/stack/tool)
+	user.visible_message(
+		SPAN_WARNING("[user]'s hand slips, scraping [organ.get_surgery_name()] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, scraping [organ.get_surgery_name()] with \the [tool]!")
+	)
+	organ.take_damage(5, 0)

--- a/code/modules/surgery/robotic_damage.dm
+++ b/code/modules/surgery/robotic_damage.dm
@@ -64,7 +64,7 @@
 		SPAN_NOTICE("[user] finishes patching damage to [organ.get_surgery_name()] with \the [tool]."),
 		SPAN_NOTICE("You finish patching damage to [organ.get_surgery_name()] with \the [tool].")
 	)
-	organ.heal_damage(rand(30, 50), 0, 1, 1)
+	organ.heal_damage(rand(30, 50), 0, TRUE)
 
 /datum/surgery_step/robotic/fix_brute/fail_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
 	user.visible_message(
@@ -105,7 +105,7 @@
 		SPAN_NOTICE("You finish replacing damaged wiring in [organ.get_surgery_name()].")
 	)
 	if(tool.use(3))
-		organ.heal_damage(0, rand(30, 50), 1, 1)
+		organ.heal_damage(0, rand(30, 50), TRUE)
 
 /datum/surgery_step/robotic/fix_burn/fail_step(mob/living/user, obj/item/organ/external/organ, obj/item/stack/cable_coil/tool)
 	user.visible_message(

--- a/code/modules/surgery/surgery_ui.dm
+++ b/code/modules/surgery/surgery_ui.dm
@@ -62,73 +62,21 @@
 		organ_data["max_damage"] = organ.max_damage
 		organ_data["status"] = organ.get_status_data()
 		organ_data["conditions"] = organ.get_conditions()
+
 		organ_data["stored_blood"] = organ.current_blood
 		organ_data["max_blood"] = organ.max_blood_storage
 		if(BP_BRAIN in organ.organ_efficiency)
 			organ_data["show_oxy"] = TRUE
-
-		var/list/processes = list()
-		for(var/efficiency in organ.organ_efficiency)
-			processes += list(
-				list(
-					"title" = "[capitalize(efficiency)] efficiency",
-					"efficiency" = organ.organ_efficiency[efficiency],
-					)
-				)
-		organ_data["processes"] = processes
+		organ_data["processes"] = organ.get_process_data()
 
 		var/list/actions_list = list()
-
 		if(can_remove_item(organ))
-			var/list/remove_action = list(
-				"name" = "Extract",
-				"target" = "\ref[organ]",
-				"step" = BP_IS_ROBOTIC(src) ? /datum/surgery_step/robotic/remove_item : /datum/surgery_step/remove_item
-			)
-
-			actions_list.Add(list(remove_action))
-
-		var/list/connect_action
-
-		if(BP_IS_ROBOTIC(organ))
-			connect_action = list(
-				"name" = (organ.status & ORGAN_CUT_AWAY) ? "Connect" : "Disconnect",
-				"organ" = "\ref[organ]",
-				"step" = /datum/surgery_step/robotic/connect_organ
-			)
-		else if(istype(organ, /obj/item/organ/internal/bone))
-			var/obj/item/organ/internal/bone/B = organ
-			connect_action = list(
-				"name" = (organ.parent.status & ORGAN_BROKEN) ? "Mend" : "Break",
-				"organ" = "\ref[organ]",
-				"step" = (organ.parent.status & ORGAN_BROKEN) ? /datum/surgery_step/mend_bone : /datum/surgery_step/break_bone
-			)
-			if(!(organ.parent.status & ORGAN_BROKEN))
-				var/list/replace_bone_action = list(
-					"name" = "Replace",
-					"organ" = "\ref[organ]",
-					"step" = /datum/surgery_step/replace_bone
-				)
-
-				actions_list.Add(list(replace_bone_action))
-			else if(!(B.reinforced)) //Bone must be broken and not reinforced
-				var/list/reinforce_bone_action = list(
-					"name" = "Reinforce",
-					"organ" = "\ref[organ]",
-					"step" = /datum/surgery_step/reinforce_bone
-				)
-
-				actions_list.Add(list(reinforce_bone_action))
-
-		else
-			connect_action = list(
-				"name" = (organ.status & ORGAN_CUT_AWAY) ? "Attach" : "Separate",
-				"organ" = "\ref[organ]",
-				"step" = (organ.status & ORGAN_CUT_AWAY) ? /datum/surgery_step/attach_organ : /datum/surgery_step/detach_organ
-			)
-
-
-		actions_list.Add(list(connect_action))
+			actions_list.Add(list(list(
+					"name" = "Extract",
+					"target" = "\ref[organ]",
+					"step" = BP_IS_ROBOTIC(organ) ? /datum/surgery_step/robotic/remove_item : /datum/surgery_step/remove_item
+				)))
+		actions_list.Add(organ.get_actions())
 		organ_data["actions"] = actions_list
 
 		contents_list.Add(list(organ_data))
@@ -150,7 +98,6 @@
 		implant_data["processes"] = list()
 
 		var/list/actions_list = list()
-
 		if(can_remove_item(implant))
 			var/list/remove_action = list(
 				"name" = "Extract",


### PR DESCRIPTION
## About The Pull Request
You can now fix robot bones

Surgery UI data acquisition made more modular


## Why It's Good For The Game

I made it so you can break robot bones, but didn't realize that bone fixing was locked to organic bones for some reason.


## Changelog
:cl:
fix: You can now fix robot bones, using a welding tool, or some nanopaste.
/:cl: