### PR TITLE
Clamp muscle speed

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -251,9 +251,9 @@
 	limb_efficiency += owner.get_specific_organ_efficiency(OP_NERVE, organ_tag) + owner.get_specific_organ_efficiency(OP_MUSCLE, organ_tag)
 	if(BP_IS_ROBOTIC(src))
 		limb_efficiency = limb_efficiency / 2
-		return 
+		return
 	limb_efficiency = (limb_efficiency + owner.get_specific_organ_efficiency(OP_BLOOD_VESSEL, organ_tag)) / 3
-	
+
 /obj/item/organ/external/proc/update_bionics_hud()
 	switch(organ_tag)
 		if(BP_L_ARM)
@@ -311,6 +311,8 @@
 			to_chat(usr, SPAN_DANGER("There is \a [I] sticking out of it."))
 	return
 
+#define MAX_MUSCLE_SPEED -0.25
+
 /obj/item/organ/external/proc/get_tally()
 	if(is_broken() && !(status & ORGAN_SPLINTED))
 		. += 3
@@ -332,7 +334,10 @@
 	if(status & ORGAN_SPLINTED)
 		. += 0.5
 
-	. += (-(limb_efficiency / 100 - 1) * 3)	//0 at 100 efficiency, -1.5 at 150, +1.5 at 50
+	var/muscle_eff = -(limb_efficiency / 100 - 1)/2
+	var/muscle_tally = max(muscle_eff, MAX_MUSCLE_SPEED)	//0 at 100 efficiency, -1.5 at 150, +1.5 at 50
+
+	. += muscle_tally
 
 	. += tally
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -334,10 +334,7 @@
 	if(status & ORGAN_SPLINTED)
 		. += 0.5
 
-	var/muscle_eff = -(limb_efficiency / 100 - 1)/2
-	var/muscle_tally = max(muscle_eff, MAX_MUSCLE_SPEED)	//0 at 100 efficiency, -1.5 at 150, +1.5 at 50
-
-	. += muscle_tally
+	. += max(-(limb_efficiency / 100 - 1)/2, MAX_MUSCLE_SPEED)
 
 	. += tally
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -311,7 +311,7 @@
 			to_chat(usr, SPAN_DANGER("There is \a [I] sticking out of it."))
 	return
 
-#define MAX_MUSCLE_SPEED -0.25
+#define MAX_MUSCLE_SPEED -0.5
 
 /obj/item/organ/external/proc/get_tally()
 	if(is_broken() && !(status & ORGAN_SPLINTED))
@@ -334,7 +334,9 @@
 	if(status & ORGAN_SPLINTED)
 		. += 0.5
 
-	. += max(-(limb_efficiency / 100 - 1)/4, MAX_MUSCLE_SPEED)
+	var/muscle_eff = owner.get_specific_organ_efficiency(OP_MUSCLE, organ_tag)
+	muscle_eff = muscle_eff - (muscle_eff/(owner.get_specific_organ_efficiency(OP_NERVE, organ_tag)/100)) //Need more nerves to control those new muscles
+	. += max(-(muscle_eff/ 100 - 1)/4, MAX_MUSCLE_SPEED)
 
 	. += tally
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -334,7 +334,7 @@
 	if(status & ORGAN_SPLINTED)
 		. += 0.5
 
-	. += max(-(limb_efficiency / 100 - 1)/2, MAX_MUSCLE_SPEED)
+	. += max(-(limb_efficiency / 100 - 1)/4, MAX_MUSCLE_SPEED)
 
 	. += tally
 


### PR DESCRIPTION
## About The Pull Request

Previously, you could go up to 4 times speed if you filled your legs with hydraulics, and even moreso if you used nerves instead

## Why It's Good For The Game

No more super-speed moebius FBPs ruining the round for everyone.

## Changelog
:cl:
balance: There is now a hard limit on how much of a speed boost you can get from implanting muscles into your legs.
/:cl: