### PR TITLE
bluespace entropy improvements

### DIFF
--- a/code/__HELPERS/bluespace_entropy.dm
+++ b/code/__HELPERS/bluespace_entropy.dm
@@ -137,6 +137,7 @@ GLOBAL_VAR_INIT(bluespace_distotion_cooldown, 10 MINUTES)
 		S.maxHealth = S.maxHealth/1.5
 		S.health = S.maxHealth
 		S.empy_cell = TRUE
+	log_and_message_admins("Stranger spawned: [jumplink(T)]")
 
 /proc/bluespace_roaches(turf/T, minor_distortion)
 	var/list/areas = list()

--- a/code/__HELPERS/bluespace_entropy.dm
+++ b/code/__HELPERS/bluespace_entropy.dm
@@ -97,9 +97,7 @@ GLOBAL_VAR_INIT(bluespace_distotion_cooldown, 10 MINUTES)
 			Ttarget = get_random_secure_turf_in_range(Ttarget, 4)
 			if(Ttarget)
 				new /obj/structure/bs_crystal_structure(Ttarget)
-				var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
-				sparks.set_up(3, 0, Ttarget)
-				sparks.start()
+				do_sparks(3, 0, Ttarget)
 
 /proc/bluespace_gift(turf/T, minor_distortion)
 	var/second_gift = rand(2,10)
@@ -116,18 +114,14 @@ GLOBAL_VAR_INIT(bluespace_distotion_cooldown, 10 MINUTES)
 		return
 	if(GLOB.bluespace_gift <= 0 && !minor_distortion)
 		new /obj/item/weapon/oddity/broken_necklace(T)
-		var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
-		sparks.set_up(3, 0, T)
-		sparks.start()
+		do_sparks(3, 0, T)
 		log_and_message_admins("Bluespace gif spawned: [jumplink(T)]") //unique item
 	else
 		second_gift *= 10
 	if(prob(second_gift))
 		var/obj/O = pickweight(RANDOM_RARE_ITEM - /obj/item/stash_spawner)
 		new O(T)
-		var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
-		sparks.set_up(3, 0, T)
-		sparks.start()
+		do_sparks(3, 0, T)
 
 /proc/bluespace_stranger(turf/T, minor_distortion)
 	var/area/A = get_area(T)
@@ -138,11 +132,10 @@ GLOBAL_VAR_INIT(bluespace_distotion_cooldown, 10 MINUTES)
 		if(newT)
 			T = newT
 	T = get_random_secure_turf_in_range(T, 4)
-	var/mob/living/simple_animal/hostile/stranger/S = new /mob/living/simple_animal/hostile/stranger(T)
+	var/mob/living/simple_animal/hostile/stranger/S = new (T)
 	if(minor_distortion && prob(95))
-		S.maxHealth = S.maxHealth/2
-		S.health = S.health/2
-		S.prob_tele = S.prob_tele/2
+		S.maxHealth = S.maxHealth/1.5
+		S.health = S.maxHealth
 		S.empy_cell = TRUE
 
 /proc/bluespace_roaches(turf/T, minor_distortion)
@@ -187,7 +180,5 @@ GLOBAL_VAR_INIT(bluespace_distotion_cooldown, 10 MINUTES)
 			Ttarget = get_random_secure_turf_in_range(Ttarget, 5)
 			if(Ttarget)
 				new /obj/spawner/junk(Ttarget)
-				var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
-				sparks.set_up(3, 0, Ttarget)
-				sparks.start()
+				do_sparks(3, 0, Ttarget)
 

--- a/code/datums/objective/individual_objective/technomancers.dm
+++ b/code/datums/objective/individual_objective/technomancers.dm
@@ -23,7 +23,7 @@
 	if(check_for_completion())
 		completed()
 		target_area.local_bluespace_entropy -= rand(25,50)
-		GLOB.bluespace_entropy -= rand(20,40)
+		GLOB.bluespace_entropy -= rand(5,25)
 
 /datum/individual_objective/disturbance/completed()
 	if(completed) return

--- a/code/datums/objective/individual_objective/technomancers.dm
+++ b/code/datums/objective/individual_objective/technomancers.dm
@@ -22,7 +22,8 @@
 		timer = world.time
 	if(check_for_completion())
 		completed()
-		target_area.local_bluespace_entropy -= 50
+		target_area.local_bluespace_entropy -= rand(25,50)
+		GLOB.bluespace_entropy -= rand(20,40)
 
 /datum/individual_objective/disturbance/completed()
 	if(completed) return

--- a/code/game/gamemodes/events/hidden_events/bluespace_crystal_infestation.dm
+++ b/code/game/gamemodes/events/hidden_events/bluespace_crystal_infestation.dm
@@ -1,5 +1,5 @@
 /*
-Nests of blue space crystals are spawned across the ship, mostly in maints. 
+Nests of blue space crystals are spawned across the ship, mostly in maints.
 They can be harvested for one use crystals that can be used for random teleportation.
 Additionally, not harvested nest will periodically teleport items and people to it.
 */
@@ -33,4 +33,6 @@ Additionally, not harvested nest will periodically teleport items and people to 
 /datum/event/bluespace_crystal_infestation/start()
 	var/space_to_spawn = event_area.random_space()
 	log_and_message_admins("Bluespace nest spawned: [jumplink(space_to_spawn)]")
-	new /obj/structure/bs_crystal_structure(space_to_spawn)
+	var/obj/structure/bs_crystal_structure/BSCS = new (space_to_spawn)
+	BSCS.entropy_value += 2//8 + 2 = 10
+	GLOB.bluespace_entropy += rand(BSCS.entropy_value, BSCS.entropy_value * 3)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -115,13 +115,22 @@ steam.start() -- spawns the effect
 // will always spawn at the items location.
 /////////////////////////////////////////////
 
+/proc/do_sparks(n, c, source)
+	// n - number of sparks
+	// c - cardinals, bool, do the sparks only move in cardinal directions?
+	// source - source of the sparks.
+
+	var/datum/effect/effect/system/spark_spread/sparks = new
+	sparks.set_up(n, c, source)
+	sparks.start()
+
 /obj/effect/sparks
 	name = "sparks"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "sparks"
-	var/amount = 6
 	anchored = TRUE
 	mouse_opacity = 0
+	var/amount = 6
 
 /obj/effect/sparks/New()
 	..()

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -7,13 +7,13 @@
 	density = TRUE
 	unacidable = 1//Can't destroy energy portals.
 	var/failchance = 5
-	var/atom/target = null
+	var/atom/target
 	anchored = TRUE
 	var/lifetime = 0
 	var/birthtime = 0
 	var/next_teleport
 	var/origin_turf //The last mob thing that attempted to enter this portal came from thus turf
-	var/entropy_value = 3
+	var/entropy_value = 4
 
 /obj/effect/portal/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(istype(mover)) // if mover is not null, e.g. mob
@@ -182,10 +182,12 @@ var/list/portal_cache = list()
 	mask = "portal_mask"
 	failchance = 0
 	admin_announce_new = FALSE
+	entropy_value = 50
 	var/teleportations_left
 
 /obj/effect/portal/wormhole/rift/New(loc, exit, msg_admins=TRUE)
 	teleportations_left = rand(3, 10)
+	entropy_value = round(entropy_value/teleportations_left)
 	..(loc, 0, exit)
 	deltimer(lifetime)
 	if(msg_admins)

--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -355,8 +355,8 @@
 	var/turf/T = get_turf(src)
 	if(T)
 		bluespace_entropy(80,T)
-		GLOB.bluespace_gift -= 1
 		new /obj/item/bluespace_dust(T)
+	GLOB.bluespace_gift -= 1
 	. = ..()
 
 /obj/item/weapon/oddity/broken_necklace/attack_self(mob/user)

--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -349,7 +349,15 @@
 /obj/item/weapon/oddity/broken_necklace/New()
 	..()
 	GLOB.bluespace_gift += 1
-	GLOB.bluespace_entropy -= rand(25, 50)
+	GLOB.bluespace_entropy -= rand(30, 50)
+
+/obj/item/weapon/oddity/broken_necklace/Destroy()
+	var/turf/T = get_turf(src)
+	if(T)
+		bluespace_entropy(80,T)
+		GLOB.bluespace_gift -= 1
+		new /obj/item/bluespace_dust(T)
+	. = ..()
 
 /obj/item/weapon/oddity/broken_necklace/attack_self(mob/user)
 	if(world.time < cooldown)
@@ -365,10 +373,6 @@
 		if(G.affecting)
 			go_to_bluespace(get_turf(user), entropy_value, FALSE, G.affecting, locate(T.x+rand(-1,1),T.y+rand(-1,1),T.z))
 	if(prob(1))
-		new /obj/item/bluespace_dust(user.loc)
-		new /obj/item/bluespace_dust(T)
-		GLOB.bluespace_gift -= 1
-		bluespace_entropy(50,T)
 		qdel(src)
 
 /obj/item/weapon/oddity/broken_necklace/throw_impact(atom/movable/hit_atom)
@@ -382,9 +386,6 @@
 			var/turf/NT = get_random_turf_in_range(hit_atom, blink_range, 2)
 			go_to_bluespace(T, entropy_value, TRUE, hit_atom, NT)
 		if(prob(1))
-			new /obj/item/bluespace_dust(T)
-			GLOB.bluespace_gift -= 1
-			bluespace_entropy(50,T)
 			qdel(src)
 
 //A randomized oddity with random stats, meant for artist job project

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -24,7 +24,7 @@
 	var/portal_type = /obj/effect/portal
 	var/portal_fail_chance
 	var/cell_charge_per_attempt = 33
-	var/entropy_value = 2  //for bluespace entropy
+	var/entropy_value = 1  //for bluespace entropy
 
 /obj/item/weapon/hand_tele/Initialize()
 	. = ..()
@@ -73,7 +73,7 @@
 	to_chat(user, SPAN_NOTICE("Portal locked in."))
 	var/obj/effect/portal/P = new portal_type(get_turf(src))
 	P.set_target(T)
-	P.entropy_value = entropy_value
+	P.entropy_value += entropy_value
 	if(portal_fail_chance)
 		P.failchance = portal_fail_chance
 	src.add_fingerprint(user)
@@ -98,7 +98,7 @@
 	portal_type = /obj/effect/portal/unstable
 	portal_fail_chance = 50
 	cell_charge_per_attempt = 50
-	entropy_value = 4 //for bluespace entropy
+	entropy_value = 3 //for bluespace entropy
 	spawn_blacklisted = FALSE
 	var/calibration_required = TRUE
 

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/bluespace.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/bluespace.dm
@@ -13,11 +13,9 @@
 	var/chance_tele_to_eat = 25
 	var/chance_tele_to_random = 10
 
-/mob/living/carbon/superior_animal/roach/bluespace/New()
-	..()
-	var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
-	sparks.set_up(3, 0, loc)
-	sparks.start()
+/mob/living/carbon/superior_animal/roach/bluespace/Initialize(mapload)
+	. = ..()
+	do_sparks(3, 0, src.loc)
 
 /mob/living/carbon/superior_animal/roach/bluespace/Life()
 	. = ..()
@@ -36,6 +34,7 @@
 		target = get_random_secure_turf_in_range(src, 7, 1)
 	if(target)
 		playsound(src, 'sound/voice/insect_battle_screeching.ogg', 30, 1, -3)
+		do_sparks(3, 0, src.loc)
 		do_teleport(src, target, 1)
 		playsound(src, 'sound/voice/insect_battle_screeching.ogg', 30, 1, -3)
 
@@ -45,9 +44,10 @@
 		if(target_mob)
 			source = target_mob
 		var/turf/T = get_random_secure_turf_in_range(source, 2, 1)
+		do_sparks(3, 0, src.loc)
 		do_teleport(src, T)
 		return FALSE
-	..()
+	. = ..()
 
 /mob/living/carbon/superior_animal/roach/bluespace/attack_hand(mob/living/carbon/M)
 	if(M.a_intent != I_HELP && prob(change_tele_to_mob))
@@ -55,9 +55,10 @@
 		if(target_mob)
 			source = target_mob
 		var/turf/T = get_random_secure_turf_in_range(source, 2, 1)
+		do_sparks(3, 0, src.loc)
 		do_teleport(src, T)
 		return FALSE
-	..()
+	. = ..()
 
 /mob/living/carbon/superior_animal/roach/bluespace/bullet_act(obj/item/projectile/P, def_zone)
 	if(prob(change_tele_to_mob))
@@ -65,9 +66,10 @@
 		if(target_mob)
 			source = target_mob
 		var/turf/T = get_random_secure_turf_in_range(source, 2, 1)
+		do_sparks(3, 0, src.loc)
 		do_teleport(src, T)
 		return FALSE
-	..()
+	. = ..()
 
 /mob/living/carbon/superior_animal/roach/bluespace/attack_generic(mob/user, damage, attack_message)
 	if(!damage || !istype(user))
@@ -77,6 +79,7 @@
 		if(target_mob)
 			source = target_mob
 		var/turf/T = get_random_secure_turf_in_range(source, 2, 1)
+		do_sparks(3, 0, src.loc)
 		do_teleport(src, T)
 		return FALSE
-	.=..()
+	. = ..()

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/bluespace.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/bluespace.dm
@@ -4,7 +4,7 @@
 	icon_state = "bluespaceroach"
 	maxHealth = 25
 	health = 25
-
+	meat_type = /obj/item/bluespace_crystal
 	melee_damage_lower = 3
 	melee_damage_upper = 10
 	sanity_damage = 1

--- a/code/modules/mob/living/simple_animal/hostile/stranger.dm
+++ b/code/modules/mob/living/simple_animal/hostile/stranger.dm
@@ -36,20 +36,18 @@
 	var/empy_cell = FALSE
 	var/prob_tele = 20
 
-/mob/living/simple_animal/hostile/stranger/New()
-	..()
-	var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
-	sparks.set_up(3, 0, src.loc)
-	sparks.start()
+/mob/living/simple_animal/hostile/stranger/Initialize(mapload)
+	. = ..()
+	do_sparks(3, 0, src.loc)
 
 /mob/living/simple_animal/hostile/stranger/death()
-	..()
-	var/obj/item/weapon/gun/energy/plasma/stranger/S = new /obj/item/weapon/gun/energy/plasma/stranger(src.loc)
+	. = ..()
+	var/obj/item/weapon/gun/energy/plasma/stranger/S = new (src.loc)
 	S.cell = new S.suitable_cell(S)
-	S.cell.charge = S.cell.maxcharge/2
 	if(empy_cell)
-		S.cell.charge = 0
-	S.cell.update_icon()
+		S.cell.use(S.cell.charge)
+	else
+		S.cell.use(S.cell.maxcharge/2)
 	S.update_icon()
 	new /obj/effect/decal/cleanable/ash (src.loc)
 	var/atom/movable/overlay/animation
@@ -59,9 +57,7 @@
 	animation.master = src
 	flick("dust2-h", animation)
 	addtimer(CALLBACK(src, .proc/check_delete, animation), 15)
-	var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
-	sparks.set_up(3, 0, src.loc)
-	sparks.start()
+	do_sparks(3, 0, src.loc)
 	qdel(src)
 
 /mob/living/simple_animal/hostile/stranger/attack_generic(mob/user, damage, attack_message)
@@ -72,9 +68,10 @@
 		if(target_mob)
 			source = target_mob
 		var/turf/T = get_random_secure_turf_in_range(source, 4, 2)
+		do_sparks(3, 0, src.loc)
 		do_teleport(src, T)
 		return FALSE
-	.=..()
+	. = ..()
 
 /mob/living/simple_animal/hostile/stranger/attackby(obj/item/W, mob/user, params)
 	if(prob(prob_tele))
@@ -82,10 +79,10 @@
 		if(target_mob)
 			source = target_mob
 		var/turf/T = get_random_secure_turf_in_range(source, 4, 2)
+		do_sparks(3, 0, src.loc)
 		do_teleport(src, T)
 		return FALSE
-	..()
-
+	. = ..()
 
 /mob/living/simple_animal/hostile/stranger/attack_hand(mob/living/carbon/M)
 	if(M.a_intent != I_HELP && prob(prob_tele))
@@ -93,9 +90,10 @@
 		if(target_mob)
 			source = target_mob
 		var/turf/T = get_random_secure_turf_in_range(source, 4, 2)
+		do_sparks(3, 0, src.loc)
 		do_teleport(src, T)
 		return FALSE
-	..()
+	. = ..()
 
 /mob/living/simple_animal/hostile/stranger/bullet_act(obj/item/projectile/P, def_zone)
 	if(prob(prob_tele))
@@ -103,9 +101,10 @@
 		if(target_mob)
 			source = target_mob
 		var/turf/T = get_random_secure_turf_in_range(source, 4, 2)
+		do_sparks(3, 0, src.loc)
 		do_teleport(src, T)
 		return FALSE
-	..()
+	. = ..()
 
 /mob/living/simple_animal/hostile/stranger/Life()
 	. = ..()
@@ -114,6 +113,7 @@
 		if(target_mob)
 			source = target_mob
 		var/turf/T = get_random_secure_turf_in_range(source, 4, 2)
+		do_sparks(3, 0, src.loc)
 		do_teleport(src, T)
 
 /obj/item/weapon/gun/energy/plasma/stranger

--- a/code/modules/trade/machinery/trade_beacon.dm
+++ b/code/modules/trade/machinery/trade_beacon.dm
@@ -3,6 +3,7 @@
 	icon_state = "beacon"
 	anchored = TRUE
 	density = TRUE
+	var/entropy_value = 1
 
 /obj/machinery/trade_beacon/attackby(obj/item/I, mob/user)
 	if(default_deconstruction(I, user))
@@ -15,9 +16,8 @@
 
 /obj/machinery/trade_beacon/proc/activate()
 	flick("[icon_state]_active", src)
-	var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-	spark_system.set_up(5, 0, loc)
-	spark_system.start()
+	do_sparks(5, 0, loc)
+	bluespace_entropy(2, get_turf(src))
 	playsound(loc, "sparks", 50, 1)
 
 /obj/machinery/trade_beacon/sending


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This pr is focused on making entropy-related events a little more frequent. As well as increasing the feedback when a cockroach disappears before your eyes. It also provides admins with information on where the Stranger spawned.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Completing the Technomancer's "Disturbance" objective reduces global entropy.
tweak: the narrator's events related to bluespace increase global entropy.
tweak: bluespace cockroach teleports create sparks.
tweak: the Stranger is a bit more powerful as a minor event.
tweak: portals produce a little more entropy.
tweak: destroying the gitf bluespace produces much more entropy.
tweak: creating the bluespace gift produces reduces entropy a bit more.
add: admins are informed about where the Stranger spawned. 
tweak: bluespace roaches now have bluespace crystals instead of roach meat.
tweak: trade beacons generate entropy when used.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
