### PR TITLE
Voidsuit cleaning fix

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -749,7 +749,7 @@
 
 /obj/item/weapon/rig/proc/retract()
 	if (wearer)
-		for(var/piece in list("helmet","gauntlets","chest","boots"))
+		for(var/piece in list("helmet","chest","gauntlets","boots"))
 			toggle_piece(piece, wearer, ONLY_RETRACT)
 
 /obj/item/weapon/rig/proc/remove()

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -85,6 +85,12 @@
 
 	return ..()
 
+/obj/item/clothing/suit/space/void/make_young()
+	..()
+	if(boots) boots.make_young()
+	if(helmet) helmet.make_young()
+	if(tank) tank.make_young()
+
 /obj/item/clothing/suit/space/void/equipped(mob/M)
 	..()
 

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -13,6 +13,8 @@
 
 /datum/component/oldficator/proc/make_young()
 	for(var/V in all_vars)
+		if(istype(parent.vars[V], /datum) || ismob(parent.vars[V]) || isHUDobj(parent.vars[V]) || isobj(parent.vars[V]))
+			continue	// Best not to mess with by-reference variables
 		parent.vars[V] = all_vars[V]
 	var/obj/O = parent
 	if(isitem(parent))


### PR DESCRIPTION
## About The Pull Request

Cleaning a voidsuit now makes its helmet, boots, and tank young too

## Why It's Good For The Game

Being able to clean your voidsuit is nice

## Changelog
:cl:
tweak: Cleaning a voidsuit now also youngifys the helmet, tank, and boots
fix: Cleaning your voidsuit in the washing machine no longer deletes magboots attached post spawn
fix: Rigs no longer eat your shoes and gloves when unequipping the rigsuit.
/:cl: