### PR TITLE
Retouch bullet printing

### DIFF
--- a/code/datums/autolathe/ammo.dm
+++ b/code/datums/autolathe/ammo.dm
@@ -22,17 +22,21 @@
 
 // Shotgun mags
 
-/datum/design/autolathe/ammo/m12beanbag
+/datum/design/autolathe/ammo/m12/beanbag
 	name = "ammo drum (.50 beanbag)"
 	build_path = /obj/item/ammo_magazine/m12/beanbag
 
-/datum/design/autolathe/ammo/m12pellet
+/datum/design/autolathe/ammo/m12/pellet
 	name = "ammo drum (.50 pellet)"
 	build_path = /obj/item/ammo_magazine/m12/pellet
 
-/datum/design/autolathe/ammo/m12slug
+/datum/design/autolathe/ammo/m12/slug
 	name = "ammo drum (.50 slug)"
 	build_path = /obj/item/ammo_magazine/m12
+
+/datum/design/autolathe/ammo/m12/empty
+	name = "ammo drum (.50 empty)"
+	build_path = /obj/item/ammo_magazine/m12/empty
 
 // .35 Speed Loaders
 
@@ -213,7 +217,7 @@
 	build_path = /obj/item/ammo_magazine/ammobox/srifle
 
 /datum/design/autolathe/ammo/srifle_ammobox/rubber
-	name = "ammunition box (.20 Rifle practice)"
+	name = "ammunition box (.20 Rifle rubber)"
 	build_path = /obj/item/ammo_magazine/ammobox/srifle/rubber
 
 /datum/design/autolathe/ammo/srifle_ammobox_small

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1431,6 +1431,7 @@
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design/armor/generic = 5,
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_cheap_guns = 5,
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design/nonlethal_ammo = 10,
+					/obj/item/weapon/computer_hardware/hard_drive/portable/design/ammo_magazines = 5,
 					/obj/item/weapon/electronics/circuitboard/autolathe = 3,
 					/obj/item/weapon/electronics/circuitboard/vending = 10)
 	contraband = list(/obj/item/weapon/computer_hardware/hard_drive/portable/design/lethal_ammo = 3, /obj/item/weapon/electronics/circuitboard/autolathe_disk_cloner = 3)
@@ -1449,6 +1450,7 @@
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design/armor/generic = 800,
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_cheap_guns = 3000,
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design/nonlethal_ammo = 700,
+					/obj/item/weapon/computer_hardware/hard_drive/portable/design/ammo_magazines = 500,
 					/obj/item/weapon/electronics/circuitboard/autolathe = 700,
 					/obj/item/weapon/electronics/circuitboard/autolathe_disk_cloner = 1000,
 					/obj/item/weapon/electronics/circuitboard/vending = 500,

--- a/code/game/objects/items/weapons/design_disks/frozen_star.dm
+++ b/code/game/objects/items/weapons/design_disks/frozen_star.dm
@@ -1,27 +1,16 @@
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nonlethal_ammo
-	disk_name = "Frozen Star Nonlethal Magazines Pack"
+	disk_name = "Frozen Star Less-than-lethal Rounds Pack"
 	icon_state = "frozenstar"
 	spawn_tags = SPAWN_TAG_DESING_ADVANCED_COMMON
 	rarity_value = 20
 	license = 20
 	designs = list(
-		//please, maintain general order (pistol>speedloaders>smg>other>shells)+(smaller/less damaging caliber>bigger/more damaging caliber)
-		//pistol mags
-		/datum/design/autolathe/ammo/magazine_pistol/rubber,
-		/datum/design/autolathe/ammo/mg_magnum/rubber,
-		/datum/design/autolathe/ammo/cspistol/rubber,
-		//speed loaders
-		/datum/design/autolathe/ammo/sl_pistol/rubber,
-		/datum/design/autolathe/ammo/sl_magnum/rubber,
-		//smg mags
-		/datum/design/autolathe/ammo/smg/rubber,
-		//magnum smg mags
-		/datum/design/autolathe/ammo/msmg/rubber,
-		//rifles
-		/datum/design/autolathe/ammo/srifle/rubber,
-		/datum/design/autolathe/ammo/ihclrifle/rubber,
-		/datum/design/autolathe/ammo/lrifle/rubber,
+		/datum/design/autolathe/ammo/pistol_ammobox/rubber = 4,
+		/datum/design/autolathe/ammo/sl_magnum/rubber = 4,
+		/datum/design/autolathe/ammo/clrifle_ammobox_small/rubber = 4,
+		/datum/design/autolathe/ammo/srifle_ammobox_small/rubber = 4,
+		/datum/design/autolathe/ammo/lrifle_ammobox_small/rubber = 4,
 		//shells
 		/datum/design/autolathe/ammo/shotgun_blanks,
 		/datum/design/autolathe/ammo/shotgun_beanbag,
@@ -29,31 +18,49 @@
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/lethal_ammo
-	disk_name = "Frozen Star Lethal Magazines Pack"
+	disk_name = "Frozen Star Lethal Rounds Pack"
 	icon_state = "frozenstar"
 	spawn_tags = SPAWN_TAG_DESING_ADVANCED_COMMON
 	license = 20
 	designs = list(
 		//please, maintain general order (pistol>speedloaders>smg>other>shells)+(smaller/less damaging caliber>bigger/more damaging caliber)
 		//pistol mags
-		/datum/design/autolathe/ammo/magazine_pistol,
-		/datum/design/autolathe/ammo/mg_magnum,
-		/datum/design/autolathe/ammo/cspistol,
-		//speed loaders
-		/datum/design/autolathe/ammo/sl_pistol,
-		/datum/design/autolathe/ammo/sl_magnum,
-		//smg mags
-		/datum/design/autolathe/ammo/smg,
-		//magnum smg mags
-		/datum/design/autolathe/ammo/msmg,
-		//rifles
-		/datum/design/autolathe/ammo/srifle,
-		/datum/design/autolathe/ammo/ihclrifle,
-		/datum/design/autolathe/ammo/lrifle,
+		/datum/design/autolathe/ammo/pistol_ammobox = 4,
+		/datum/design/autolathe/ammo/sl_magnum = 4,
+		/datum/design/autolathe/ammo/clrifle_ammobox_small = 4,
+		/datum/design/autolathe/ammo/srifle_ammobox_small = 4,
+		/datum/design/autolathe/ammo/lrifle_ammobox_small = 4,
 		//shells
 		/datum/design/autolathe/ammo/shotgun_pellet,
 		/datum/design/autolathe/ammo/shotgun,
 	)
+
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/ammo_magazines
+	disk_name = "Frozen Star Magazines Pack"
+	icon_state = "frozenstar"
+	spawn_tags = SPAWN_TAG_DESING_ADVANCED_COMMON
+	rarity_value = 20
+	license = 20
+	designs = list(
+		//please, maintain general order (pistol>speedloaders>smg>other>shells)+(smaller/less damaging caliber>bigger/more damaging caliber)
+		//Pistols
+		/datum/design/autolathe/ammo/magazine_pistol/empty,
+		/datum/design/autolathe/ammo/magazine_hpistol/empty,
+		/datum/design/autolathe/ammo/mg_magnum/empty,
+		//Speedloaders
+		/datum/design/autolathe/ammo/sl_pistol/empty,
+		/datum/design/autolathe/ammo/sl_magnum/empty,
+		//SMG
+		/datum/design/autolathe/ammo/smg/empty,
+		/datum/design/autolathe/ammo/msmg/emtpy,
+		//Rifles
+		/datum/design/autolathe/ammo/srifle/empty,
+		/datum/design/autolathe/ammo/ihclrifle/empty,
+		/datum/design/autolathe/ammo/lrifle/empty,
+		//Shotgun
+		/datum/design/autolathe/ammo/m12/empty
+	)
+
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/ammo_boxes_smallarms
 	disk_name = "Frozen Star .35 and .40 Ammunition"
@@ -265,9 +272,9 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/bojevic = 3, // "SA SG \"Bojevic\""
-		/datum/design/autolathe/ammo/m12beanbag, // Never add tazershells, for love of god
-		/datum/design/autolathe/ammo/m12pellet,
-		/datum/design/autolathe/ammo/m12slug,
+		/datum/design/autolathe/ammo/m12/beanbag, // Never add tazershells, for love of god
+		/datum/design/autolathe/ammo/m12/pellet,
+		/datum/design/autolathe/ammo/m12/slug,
 		)
 
 // SMGs

--- a/code/game/objects/items/weapons/design_disks/frozen_star.dm
+++ b/code/game/objects/items/weapons/design_disks/frozen_star.dm
@@ -7,7 +7,7 @@
 	license = 20
 	designs = list(
 		/datum/design/autolathe/ammo/pistol_ammobox/rubber = 4,
-		/datum/design/autolathe/ammo/sl_magnum/rubber = 4,
+		/datum/design/autolathe/ammo/magnum_ammobox/rubber = 4,
 		/datum/design/autolathe/ammo/clrifle_ammobox_small/rubber = 4,
 		/datum/design/autolathe/ammo/srifle_ammobox_small/rubber = 4,
 		/datum/design/autolathe/ammo/lrifle_ammobox_small/rubber = 4,
@@ -26,7 +26,7 @@
 		//please, maintain general order (pistol>speedloaders>smg>other>shells)+(smaller/less damaging caliber>bigger/more damaging caliber)
 		//pistol mags
 		/datum/design/autolathe/ammo/pistol_ammobox = 4,
-		/datum/design/autolathe/ammo/sl_magnum = 4,
+		/datum/design/autolathe/ammo/magnum_ammobox = 4,
 		/datum/design/autolathe/ammo/clrifle_ammobox_small = 4,
 		/datum/design/autolathe/ammo/srifle_ammobox_small = 4,
 		/datum/design/autolathe/ammo/lrifle_ammobox_small = 4,

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -126,7 +126,7 @@
 	ammo_type = /obj/item/ammo_casing/srifle/hv
 
 /obj/item/ammo_magazine/ammobox/srifle_small/rubber
-	name = "ammunition packet (.20 Rifle high-velocity)"
+	name = "ammunition packet (.20 Rifle rubber)"
 	icon_state = "srifle_r"
 	ammo_type = /obj/item/ammo_casing/srifle/rubber
 

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -401,7 +401,7 @@
 	rarity_value = 6.66
 
 /obj/item/ammo_magazine/slpistol/empty
-	icon_state = "slpistol"
+	icon_state = "slpistol_l"
 	initial_ammo = 0
 
 /obj/item/ammo_magazine/slpistol/practice
@@ -436,7 +436,7 @@
 	rarity_value = 5
 
 /obj/item/ammo_magazine/slmagnum/empty
-	icon_state = "slmagnum"
+	icon_state = "slmagnum_l"
 	initial_ammo = 0
 
 /obj/item/ammo_magazine/slmagnum/practice


### PR DESCRIPTION
## About The Pull Request

Makes ammo disks give ammo boxes/strips, rather than magazines

Magazines are now printed on a seperate disk

## Why It's Good For The Game

Substantially better bullet economy

Magazines are now worth something to players, and don't have misleading names

## Changelog
:cl:
add: Adds a generic magazine autolathe disk
tweak: Lethal and nonlethal disks no longer print magazines, instead they print boxes of ammunition
/:cl: