### PR TITLE
The hacking tool's speed now scales off cog

### DIFF
--- a/code/game/objects/items/devices/hacktool.dm
+++ b/code/game/objects/items/devices/hacktool.dm
@@ -58,8 +58,8 @@
 
 	to_chat(user, SPAN_NOTICE("You begin hacking \the [target]..."))
 	is_hacking = 1
-	// On average hackin takes ~30 seconds. Fairly small random span to avoid people simply aborting and trying again
-	var/hack_result = do_after(user, (20 SECONDS + rand(0, 10 SECONDS) + rand(0, 10 SECONDS)), progress = 0)
+	// without any cog, hacking takes 30 seconds. every point of cog lowers the time needed to hack by 0,5 seconds, up to a maximum reduction of 20 seconds.
+	var/hack_result = do_after(user, (30 SECONDS - min(20 SECONDS, user.stats.getStat(STAT_COG) / 2 SECONDS)) , progress = 0)
 	is_hacking = 0
 
 	if(hack_result && in_hack_mode)

--- a/code/game/objects/items/devices/hacktool.dm
+++ b/code/game/objects/items/devices/hacktool.dm
@@ -59,7 +59,7 @@
 	to_chat(user, SPAN_NOTICE("You begin hacking \the [target]..."))
 	is_hacking = 1
 	// without any cog, hacking takes 30 seconds. every point of cog lowers the time needed to hack by 0,5 seconds, up to a maximum reduction of 20 seconds.
-	var/hack_result = do_after(user, (30 SECONDS - min(20 SECONDS, user.stats.getStat(STAT_COG) / 2 SECONDS)) , progress = 0)
+	var/hack_result = do_after(user, min(60 SECONDS, 30 SECONDS - min(20 SECONDS, user.stats.getStat(STAT_COG) / 2 SECONDS)) , progress = 0)
 	is_hacking = 0
 
 	if(hack_result && in_hack_mode)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

the hacktool's hacking speed is now affected by the COG stat of it's user. default time is 30 seconds, every point of COG removes 0.5 seconds up to a maximum of 20 seconds. negative cog will affect it in the same way, but there is no maximum amount of extra time you can get from having terrible COG

## Why It's Good For The Game

Cognition OP, pls nerf

## Changelog
:cl:
tweak: The hacking tool now uses COG to determine the hacking speed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
