### PR TITLE
Removes the accidental .25 slowdown players started with

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -336,7 +336,7 @@
 
 	var/muscle_eff = owner.get_specific_organ_efficiency(OP_MUSCLE, organ_tag)
 	muscle_eff = muscle_eff - (muscle_eff/(owner.get_specific_organ_efficiency(OP_NERVE, organ_tag)/100)) //Need more nerves to control those new muscles
-	. += max(-(muscle_eff/ 100 - 1)/4, MAX_MUSCLE_SPEED)
+	. += max(-(muscle_eff/ 100)/4, MAX_MUSCLE_SPEED)
 
 	. += tally
 


### PR DESCRIPTION
## About The Pull Request
My math was off.


## Why It's Good For The Game

Navigation of the ship is an important part of the game.
## Changelog
:cl:
fix: Players now walk at the pre muscle speed nerf speed again
/:cl: