### PR TITLE
readds menu based crafting for tiles

### DIFF
--- a/code/datums/craft/menu.dm
+++ b/code/datums/craft/menu.dm
@@ -103,5 +103,22 @@
 		set_category(href_list["category"], usr)
 		SSnano.update_uis(src)
 	else if(href_list["item"])
-		set_item(href_list["item"], usr)
+		var/list/subtypes_item = subtypesof(locate(href_list["item"]))
+		if (subtypes_item.len > 1)  // Check if the crafted item has variations
+			var/list/namelist = list()  // To store names of variations
+			var/obj/item/CR  // Temporary item
+			for (var/I in subtypes_item)  // Go through all variations of the reference item
+				CR = new I (null)
+				namelist += "[CR.name]"
+			var/variation_choices = input(usr, "Please chose variation") as null|anything in namelist  // Ask the user which variation he wants to craft
+			if(CanInteract(usr, GLOB.default_state))
+				if (!variation_choices)
+					return
+				var/usr_choice = variation_choices
+				for (var/I in subtypes_item)  // Retrieve the desired item by checking the name of all variations
+					CR = new I (null)
+					if (CR.name == usr_choice)
+						set_item("\ref[CR]", usr)  // Update UI with desired variation
+		else
+			set_item(href_list["item"], usr)
 		SSnano.update_uis(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

in the FBP PR, the code that allowed you to craft variations of floor tiles etc was removed, probably because it seemed like it was unused. But it isn't and without it you can't craft any variations of floor tiles anymore.

## Why It's Good For The Game

cyberpunk hideouts good

## Changelog
:cl:
fix: you can now craft all kinds of floor tiles again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
