### PR TITLE
Completes a partial revert of the craftmenu subtype code

### DIFF
--- a/code/datums/craft/menu.dm
+++ b/code/datums/craft/menu.dm
@@ -62,9 +62,9 @@
 		)
 	var/list/items = list()
 	for(var/datum/craft_recipe/recipe in SScraft.categories[curr_category])
-		if((recipe.avaliableToEveryone || (recipe.type in user.mind.knownCraftRecipes)) && (recipe.variation_type == CRAFT_REFERENCE))
+		if((recipe.avaliableToEveryone || (recipe.type in user.mind.knownCraftRecipes)))
 			items += list(list(
-				"name" = capitalize(recipe.name_craft_menu ? recipe.name_craft_menu : recipe.name), // Display subtype name if the item is the reference of a subtype of items
+				"name" = capitalize(recipe.name),
 				"ref" = "\ref[recipe]"
 			))
 	data["items"] = items

--- a/code/datums/craft/recipe.dm
+++ b/code/datums/craft/recipe.dm
@@ -14,10 +14,6 @@
 	// set it to CRAFT_DEFAULT_DIR to spawn the result in its default direction (stored in dir_default)
 	var/dir_default = 2  // south is default for recipes with dir_type = CRAFT_DEFAULT_DIR
 
-	var/variation_type = CRAFT_REFERENCE  // if the object is the reference of a subtype
-	// set it to CRAFT_VARIATION if the object is a variation of the reference
-	var/name_craft_menu  // name of the subtype formed by a reference and its variations
-
 /datum/craft_recipe/New()
 	var/step_definations = steps
 	steps = new

--- a/code/datums/craft/recipes/airlocks.dm
+++ b/code/datums/craft/recipes/airlocks.dm
@@ -10,57 +10,56 @@
 /datum/craft_recipe/airlock/assembly
 	name = "standard airlock assembly"
 	result = /obj/structure/door_assembly
-	name_craft_menu = "Airlock assemblies"
 
 /datum/craft_recipe/airlock/assembly/command
 	name = "command airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_com
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/airlock/assembly/security
 	name = "security airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_sec
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/airlock/assembly/engineering
 	name = "engineering airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_eng
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/airlock/assembly/mining
 	name = "mining airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_min
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/airlock/assembly/atmospherics
 	name = "atmospherics airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_atmo
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/airlock/assembly/research
 	name = "research airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_research
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/airlock/assembly/medical
 	name = "medical airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_med
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/airlock/assembly/maintenance
 	name = "maintenance airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_mai
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/airlock/assembly/external
 	name = "external airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_ext
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/airlock/assembly/freezer
 	name = "freezer airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_fre
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/airlock/hatch/airtight
 	name = "airtight hatch assembly"
@@ -73,7 +72,7 @@
 /datum/craft_recipe/airlock/assembly/high_security
 	name = "high security airlock assembly"
 	result = /obj/structure/door_assembly/door_assembly_highsecurity
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/airlock/shutter/emergency_shutter
 	name = "emergency shutter"
@@ -85,4 +84,4 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 20, MATERIAL_STEEL),
 	)
-	variation_type = CRAFT_VARIATION
+

--- a/code/datums/craft/recipes/floor.dm
+++ b/code/datums/craft/recipes/floor.dm
@@ -13,7 +13,6 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_WOOD)
 	)
-	name_craft_menu = "Classic tiles"
 
 /datum/craft_recipe/floor/classic/cafe
 	name = "cafe floor tile"
@@ -21,7 +20,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTIC)
 	)
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/classic/techmaint
 	name = "maint floor tile"
@@ -29,7 +28,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_STEEL)
 	)
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/classic/techmaint_perforated
 	name = "perforated maint floor tile"
@@ -37,7 +36,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_STEEL)
 	)
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/classic/techmaint_panels
 	name = "panels maint floor tile"
@@ -45,7 +44,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_STEEL)
 	)
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/classic/techmaint_cargo
 	name = "cargo maint floor tile"
@@ -53,102 +52,101 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_STEEL)
 	)
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel
 	name = "regular steel floor tile"
 	result = /obj/item/stack/tile/floor/steel
-	name_craft_menu = "Steel tiles"
 
 /datum/craft_recipe/floor/steel/panels
 	name = "steel panel tile"
 	result = /obj/item/stack/tile/floor/steel/panels
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel/techfloor
 	name = "steel techfloor tile"
 	result = /obj/item/stack/tile/floor/steel/techfloor
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel/techfloor_grid
 	name = "steel techfloor tile with vents"
 	result = /obj/item/stack/tile/floor/steel/techfloor_grid
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel/brown_perforated
 	name = "steel brown perforated tile"
 	result = /obj/item/stack/tile/floor/steel/brown_perforated
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel/gray_perforated
 	name = "steel gray perforated tile"
 	result = /obj/item/stack/tile/floor/steel/gray_perforated
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel/cargo
 	name = "steel cargo tile"
 	result = /obj/item/stack/tile/floor/steel/cargo
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel/brown_platform
 	name = "steel brown platform tile"
 	result = /obj/item/stack/tile/floor/steel/brown_platform
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel/gray_platform
 	name = "steel gray platform tile"
 	result = /obj/item/stack/tile/floor/steel/gray_platform
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel/danger
 	name = "steel danger tile"
 	result = /obj/item/stack/tile/floor/steel/danger
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel/golden
 	name = "steel golden tile"
 	result = /obj/item/stack/tile/floor/steel/golden
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel/bluecorner
 	name = "steel blue corner tile"
 	result = /obj/item/stack/tile/floor/steel/bluecorner
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel/orangecorner
 	name = "steel orange corner tile"
 	result = /obj/item/stack/tile/floor/steel/orangecorner
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel/cyancorner
 	name = "steel cyan corner tile"
 	result = /obj/item/stack/tile/floor/steel/cyancorner
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel/violetcorener
 	name = "steel violet corener tile"
 	result = /obj/item/stack/tile/floor/steel/violetcorener
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel/monofloor
 	name = "steel monofloor tile"
 	result = /obj/item/stack/tile/floor/steel/monofloor
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel/bar_flat
 	name = "steel bar flat tile"
 	result = /obj/item/stack/tile/floor/steel/bar_flat
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel/bar_dance
 	name = "steel bar dance tile"
 	result = /obj/item/stack/tile/floor/steel/bar_dance
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/steel/bar_light
 	name = "steel bar light tile"
 	result = /obj/item/stack/tile/floor/steel/bar_light
-	variation_type = CRAFT_VARIATION
+
 
 
 
@@ -158,82 +156,66 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTIC)
 	)
-	name_craft_menu = "White tiles"
 
 /datum/craft_recipe/floor/white/panels
 	name = "white panel tile"
 	result = /obj/item/stack/tile/floor/white/panels
-	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/techfloor
 	name = "white techfloor tile"
 	result = /obj/item/stack/tile/floor/white/techfloor
-	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/techfloor_grid
 	name = "white techfloor tile with vents"
 	result = /obj/item/stack/tile/floor/white/techfloor_grid
-	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/brown_perforated
 	name = "white brown perforated tile"
 	result = /obj/item/stack/tile/floor/white/brown_perforated
-	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/gray_perforated
 	name = "white gray perforated tile"
 	result = /obj/item/stack/tile/floor/white/gray_perforated
-	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/cargo
 	name = "white cargo tile"
 	result = /obj/item/stack/tile/floor/white/cargo
-	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/brown_platform
 	name = "white brown platform tile"
 	result = /obj/item/stack/tile/floor/white/brown_platform
-	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/gray_platform
 	name = "white gray platform tile"
 	result = /obj/item/stack/tile/floor/white/gray_platform
-	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/danger
 	name = "white danger tile"
 	result = /obj/item/stack/tile/floor/white/danger
-	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/golden
 	name = "white golden tile"
 	result = /obj/item/stack/tile/floor/white/golden
-	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/bluecorner
 	name = "white blue corner tile"
 	result = /obj/item/stack/tile/floor/white/bluecorner
-	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/orangecorner
 	name = "white orange corner tile"
 	result = /obj/item/stack/tile/floor/white/orangecorner
-	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/cyancorner
 	name = "white cyan corner tile"
 	result = /obj/item/stack/tile/floor/white/cyancorner
-	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/violetcorener
 	name = "white violet corener tile"
 	result = /obj/item/stack/tile/floor/white/violetcorener
-	variation_type = CRAFT_VARIATION
 
 /datum/craft_recipe/floor/white/monofloor
 	name = "white monofloor tile"
 	result = /obj/item/stack/tile/floor/white/monofloor
-	variation_type = CRAFT_VARIATION
 
 
 
@@ -242,82 +224,81 @@
 /datum/craft_recipe/floor/dark
 	name = "regular dark floor tile"
 	result = /obj/item/stack/tile/floor/dark
-	name_craft_menu = "Dark tiles"
 
 /datum/craft_recipe/floor/dark/panels
 	name = "dark panel tile"
 	result = /obj/item/stack/tile/floor/dark/panels
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/dark/techfloor
 	name = "dark techfloor tile"
 	result = /obj/item/stack/tile/floor/dark/techfloor
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/dark/techfloor_grid
 	name = "dark techfloor tile with vents"
 	result = /obj/item/stack/tile/floor/dark/techfloor_grid
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/dark/brown_perforated
 	name = "dark brown perforated tile"
 	result = /obj/item/stack/tile/floor/dark/brown_perforated
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/dark/gray_perforated
 	name = "dark gray perforated tile"
 	result = /obj/item/stack/tile/floor/dark/gray_perforated
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/dark/cargo
 	name = "dark cargo tile"
 	result = /obj/item/stack/tile/floor/dark/cargo
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/dark/brown_platform
 	name = "dark brown platform tile"
 	result = /obj/item/stack/tile/floor/dark/brown_platform
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/dark/gray_platform
 	name = "dark gray platform tile"
 	result = /obj/item/stack/tile/floor/dark/gray_platform
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/dark/danger
 	name = "dark danger tile"
 	result = /obj/item/stack/tile/floor/dark/danger
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/dark/golden
 	name = "dark golden tile"
 	result = /obj/item/stack/tile/floor/dark/golden
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/dark/bluecorner
 	name = "dark blue corner tile"
 	result = /obj/item/stack/tile/floor/dark/bluecorner
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/dark/orangecorner
 	name = "dark orange corner tile"
 	result = /obj/item/stack/tile/floor/dark/orangecorner
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/dark/cyancorner
 	name = "dark cyan corner tile"
 	result = /obj/item/stack/tile/floor/dark/cyancorner
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/dark/violetcorener
 	name = "dark violet corener tile"
 	result = /obj/item/stack/tile/floor/dark/violetcorener
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/dark/monofloor
 	name = "dark monofloor tile"
 	result = /obj/item/stack/tile/floor/dark/monofloor
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/floor/lighttile
 	name = "light tile"

--- a/code/datums/craft/recipes/furniture.dm
+++ b/code/datums/craft/recipes/furniture.dm
@@ -143,12 +143,11 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 5, MATERIAL_STEEL),
 	)
-	name_craft_menu = "Office chairs"
 
 /datum/craft_recipe/furniture/office_chair/light
 	name = "light office chair"
 	result = /obj/structure/bed/chair/office/light
-	variation_type = CRAFT_VARIATION
+
 
 // Wheelchairs
 /datum/craft_recipe/furniture/wheelchair
@@ -165,44 +164,42 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 5, MATERIAL_STEEL),
 	)
-	name_craft_menu = "Comfy chairs"
 
 /datum/craft_recipe/furniture/comfy_chair/black
 	name = "black comfy chair"
 	result = /obj/structure/bed/chair/comfy/black
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/furniture/comfy_chair/brown
 	name = "brown comfy chair"
 	result = /obj/structure/bed/chair/comfy/brown
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/furniture/comfy_chair/lime
 	name = "lime comfy chair"
 	result = /obj/structure/bed/chair/comfy/lime
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/furniture/comfy_chair/teal
 	name = "teal comfy chair"
 	result = /obj/structure/bed/chair/comfy/teal
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/furniture/comfy_chair/red
 	name = "red comfy chair"
 	result = /obj/structure/bed/chair/comfy/red
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/furniture/comfy_chair/blue
 	name = "blue comfy chair"
 	result = /obj/structure/bed/chair/comfy/blue
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/furniture/comfy_chair/purple
 	name = "purple comfy chair"
 	result = /obj/structure/bed/chair/comfy/purp
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/furniture/comfy_chair/green
 	name = "green comfy chair"
 	result = /obj/structure/bed/chair/comfy/green
-	variation_type = CRAFT_VARIATION

--- a/code/datums/craft/recipes/misc.dm
+++ b/code/datums/craft/recipes/misc.dm
@@ -121,27 +121,26 @@
 		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
 	)
 	related_stats = list(STAT_COG)
-	name_craft_menu = "Folders"
 
 /datum/craft_recipe/folder/blue
 	name = "blue folder"
 	result = /obj/item/weapon/folder/blue
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/folder/red
 	name = "red folder"
 	result = /obj/item/weapon/folder/red
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/folder/cyan
 	name = "cyan folder"
 	result = /obj/item/weapon/folder/cyan
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/folder/yellow
 	name = "yellow folder"
 	result = /obj/item/weapon/folder/yellow
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/bandage
 	name = "bandages"
@@ -229,8 +228,6 @@
 	)
 	related_stats = list(STAT_MEC)
 
-	name_craft_menu = "exosuit drill heads"
-
 /datum/craft_recipe/drill_head/plasteel
 	name = "plasteel drill head"
 	result = /obj/item/weapon/material/drill_head/plasteel
@@ -238,7 +235,7 @@
 		list(CRAFT_MATERIAL, 6, MATERIAL_PLASTEEL, "time" = 30),
 		list(QUALITY_WELDING, 10, 60)
 	)
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/drill_head/diamond
 	name = "diamond drill head"
@@ -247,7 +244,7 @@
 		list(CRAFT_MATERIAL, 6, MATERIAL_DIAMOND, "time" = 30),
 		list(QUALITY_WELDING, 10, 60)
 	)
-	variation_type = CRAFT_VARIATION
+
 
 /datum/craft_recipe/pipe
 	name = "Smoking pipe"


### PR DESCRIPTION
## About The Pull Request

I deleted some code in the makeshift prosthetics PR, not realizing that the jank was not just skin-deep

## Why It's Good For The Game

Technos can possibly replace my broken medbay doors with medbay doors now, rather than the default airlock

## Changelog
:cl:
fix: The crafting subtypes of doors, tiles, and chairs are now available again.
/:cl: