### PR TITLE
Few more itmes in carrion uplink

### DIFF
--- a/code/datums/uplink/announcements.dm
+++ b/code/datums/uplink/announcements.dm
@@ -14,6 +14,7 @@
 	name = "Shipwide Announcement"
 	item_cost = 2
 	desc = "Broadcasts a message anonymously to the entire vessel. Triggers immediately after supplying additional data."
+	antag_roles |= ROLE_CARRION
 
 /datum/uplink_item/abstract/announcements/announce/get_goods(var/obj/item/device/uplink/U, var/loc, var/mob/user, var/list/args)
 	var/message = input(user, "What would you like the text of the announcement to be? Write as much as you like, The title will appear as Unknown Broadcast", "False Announcement") as text|null

--- a/code/datums/uplink/announcements.dm
+++ b/code/datums/uplink/announcements.dm
@@ -9,12 +9,11 @@
 	if(.)
 		log_and_message_admins("has triggered a falsified [src]", user)
 
-/datum/uplink_item/abstract/announcements/announce/New()
-	..()
+/datum/uplink_item/abstract/announcements/announce
 	name = "Shipwide Announcement"
 	item_cost = 2
 	desc = "Broadcasts a message anonymously to the entire vessel. Triggers immediately after supplying additional data."
-	antag_roles |= ROLE_CARRION
+	antag_roles = list(ROLE_TRAITOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 
 /datum/uplink_item/abstract/announcements/announce/get_goods(var/obj/item/device/uplink/U, var/loc, var/mob/user, var/list/args)
 	var/message = input(user, "What would you like the text of the announcement to be? Write as much as you like, The title will appear as Unknown Broadcast", "False Announcement") as text|null
@@ -106,7 +105,7 @@
 	item_cost = 8
 
 /datum/uplink_item/abstract/announcements/fake_serb/get_goods(var/obj/item/device/uplink/U, var/loc)
-	var/datum/shuttle/autodock/multi/antag/mercenary/merc = new /datum/shuttle/autodock/multi/antag/mercenary
-	command_announcement.Announce(merc.arrival_message, merc.announcer || "[boss_name]")
+	var/datum/shuttle/autodock/multi/antag/mercenary/merc = /datum/shuttle/autodock/multi/antag/mercenary
+	command_announcement.Announce(initial(merc.arrival_message), initial(merc.announcer) || "[boss_name]")
 	qdel(merc)
 	return 1

--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -13,10 +13,7 @@
 	name = "Surgery kit"
 	item_cost = 5
 	path = /obj/item/weapon/storage/firstaid/surgery/traitor
-
-/datum/uplink_item/item/medical/surgery/New()
-	..()
-	antag_roles |= ROLE_CARRION
+	antag_roles = list(ROLE_TRAITOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 
 /datum/uplink_item/item/medical/combat
 	name = "Combat medical kit"

--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -14,6 +14,10 @@
 	item_cost = 5
 	path = /obj/item/weapon/storage/firstaid/surgery/traitor
 
+/datum/uplink_item/item/medical/surgery/New()
+	..()
+	antag_roles |= ROLE_CARRION
+
 /datum/uplink_item/item/medical/combat
 	name = "Combat medical kit"
 	item_cost = 5

--- a/code/datums/uplink/stealth and camouflage items.dm
+++ b/code/datums/uplink/stealth and camouflage items.dm
@@ -25,6 +25,10 @@
 	item_cost = 5
 	path = /obj/item/weapon/storage/box/syndie_kit/chameleon
 
+/datum/uplink_item/item/stealth_items/chameleon_kit/New()
+	..()
+	antag_roles |= ROLE_CARRION
+
 /datum/uplink_item/item/stealth_items/voice
 	name = "Voice Changer"
 	item_cost = 5

--- a/code/datums/uplink/stealth and camouflage items.dm
+++ b/code/datums/uplink/stealth and camouflage items.dm
@@ -24,10 +24,7 @@
 	name = "Chameleon Kit"
 	item_cost = 5
 	path = /obj/item/weapon/storage/box/syndie_kit/chameleon
-
-/datum/uplink_item/item/stealth_items/chameleon_kit/New()
-	..()
-	antag_roles |= ROLE_CARRION
+	antag_roles = list(ROLE_TRAITOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 
 /datum/uplink_item/item/stealth_items/voice
 	name = "Voice Changer"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the surgery kit, shipwide announcement and the chameleon kit to the carrrion uplink. 

## Why It's Good For The Game

Carrions get to use a few more fun and stealthy items if they don't want any more gene points, the surgery kit should also make organ extraction less painful.

## Changelog
:cl:
add: Added the surgery kit, the chameleon kit and the shipwide announcement to the carrion uplink.
/:cl:
