### PR TITLE
Death fix

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -54,7 +54,7 @@
 			if(!B.ckey && ckey && B.controlling)
 				B.ckey = ckey
 				B.controlling = 0
-			if(B.host_brain.ckey)
+			if(B.host_brain?.ckey)
 				ckey = B.host_brain.ckey
 				B.host_brain.ckey = null
 				B.host_brain.name = "host brain"


### PR DESCRIPTION
## About The Pull Request

Fixes good borers preventing somebody from dying, ever

## Why It's Good For The Game

A man was exploded by 10 explosion spiders, but because his borer was a good boy and never tried to take control of him, a runtime in human/death.dm prevented him from dying, ever.

## Changelog
:cl:
fix: Fixes good borers who never take control of people from preventing the death of their host through a runtime error.
/:cl: