### PR TITLE
Shellshock rework

### DIFF
--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/energy/shrapnel
 	name = "OR SDF \"Shellshock\" energy shotgun"
-	desc = "An Oberth Republic Self Defence Force design, this mat-fab shotgun tends to burn through cells with use. The matter contained in empty cells can be converted directly into ammunition, as well."
+	desc = "An Oberth Republic Self Defence Force design, this mat-fab shotgun tends to burn through cells with use. The matter contained in empty cells can be converted directly into ammunition as well, if the safety bolts are loosened."
 	icon = 'icons/obj/guns/energy/shrapnel.dmi'
 	icon_state = "eshotgun"
 	item_charge_meter = TRUE
@@ -42,6 +42,14 @@
 	else
 		return new projectile_type(src)
 
+/obj/item/weapon/gun/energy/shrapnel/attacky(obj/item/I, mob/user)
+	..()
+	if(I.has_quality(QUALITY_BOLT_TURNING))
+		if(I.use_tool(user, src, WORKTIME_NEAR_INSTANT, QUALITY_BOLT_TURNING, FAILCHANCE_VERY_EASY, required_stat = STAT_MEC))
+			if(consume_cell)
+				consume_cell = FALSE
+			else
+				consume_cell = TRUE
 
 
 /obj/item/weapon/gun/energy/shrapnel/mounted

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -50,7 +50,7 @@
 		if(I.use_tool(user, src, WORKTIME_NEAR_INSTANT, QUALITY_BOLT_TURNING, FAILCHANCE_VERY_EASY, required_stat = STAT_MEC))
 			if(consume_cell)
 				consume_cell = FALSE
-				to_chat(user, SPAN_NOTICE("You secure the safety bolts."))
+				to_chat(user, SPAN_NOTICE("You secure the safety bolts, preventing the weapon from destroying empty cells for use as ammuniton."))
 			else
 				consume_cell = TRUE
 				to_chat(user, SPAN_NOTICE("You loosen the safety bolts, allowing the weapon to destroy empty cells for use as ammunition."))

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -11,7 +11,7 @@
 	flags = CONDUCT
 	slot_flags = SLOT_BACK
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2, TECH_ENGINEERING = 4)
-	charge_cost = 24
+	charge_cost = 25
 	suitable_cell = /obj/item/weapon/cell/small
 	cell_type = /obj/item/weapon/cell/small
 	projectile_type = /obj/item/projectile/bullet/shotgun
@@ -19,8 +19,8 @@
 	fire_delay = 12 //Equivalent to a pump then fire time
 	fire_sound = 'sound/weapons/guns/fire/energy_shotgun.ogg'
 	init_firemodes = list(
-		list(mode_name="Buckshot", mode_desc="Fires a buckshot synth-shell", projectile_type=/obj/item/projectile/bullet/pellet/shotgun, charge_cost=25, icon="kill"),
-		list(mode_name="Hurt", mode_desc="Fires a frag synth-shell", projectile_type=/obj/item/projectile/bullet/grenade/frag/weak, charge_cost=1000, icon="stun"),
+		list(mode_name="Buckshot", mode_desc="Fires a buckshot synth-shell", projectile_type=/obj/item/projectile/bullet/pellet/shotgun, charge_cost=50, icon="kill"),
+		list(mode_name="Hurt", mode_desc="Fires a frag synth-shell", projectile_type=/obj/item/projectile/bullet/grenade/frag/weak, charge_cost=1000, icon="grenade"),
 		list(mode_name="Blast", mode_desc="Fires a slug synth-shell", projectile_type=/obj/item/projectile/bullet/shotgun, charge_cost=null, icon="destroy"),
 	)
 	var/consume_cell = TRUE
@@ -30,8 +30,8 @@
 	twohanded = TRUE
 
 /obj/item/weapon/gun/energy/shrapnel/consume_next_projectile()
-	.=..()
-	if(!cell) return
+	if(!cell) return null
+	if(!ispath(projectile_type)) return null
 	if(consume_cell && !cell.checked_use(charge_cost))
 		visible_message(SPAN_WARNING("\The [cell] of \the [src] burns out!"))
 		qdel(cell)
@@ -39,7 +39,8 @@
 		playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 		new /obj/effect/decal/cleanable/ash(get_turf(src))
 		return new projectile_type(src)
-	return
+	else
+		return new projectile_type(src)
 
 
 

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -20,7 +20,7 @@
 	fire_sound = 'sound/weapons/guns/fire/energy_shotgun.ogg'
 	init_firemodes = list(
 		list(mode_name="Buckshot", mode_desc="Fires a buckshot synth-shell", projectile_type=/obj/item/projectile/bullet/pellet/shotgun, charge_cost=50, icon="kill"),
-		list(mode_name="Hurt", mode_desc="Fires a frag synth-shell", projectile_type=/obj/item/projectile/bullet/grenade/frag/weak, charge_cost=1000, icon="grenade"),
+		list(mode_name="Hurt", mode_desc="Fires a frag synth-shell", projectile_type=/obj/item/projectile/bullet/grenade/frag/weak, charge_cost=10000, icon="grenade"),
 		list(mode_name="Blast", mode_desc="Fires a slug synth-shell", projectile_type=/obj/item/projectile/bullet/shotgun, charge_cost=null, icon="destroy"),
 	)
 	var/consume_cell = TRUE

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/energy/shrapnel
 	name = "OR SDF \"Shellshock\" energy shotgun"
-	desc = "An Oberth Republic Self Defence Force design, this mat-fab shotgun tends to burn through cells with use."
+	desc = "An Oberth Republic Self Defence Force design, this mat-fab shotgun tends to burn through cells with use. The matter contained in empty cells can be converted directly into ammunition, as well."
 	icon = 'icons/obj/guns/energy/shrapnel.dmi'
 	icon_state = "eshotgun"
 	item_charge_meter = TRUE
@@ -11,7 +11,7 @@
 	flags = CONDUCT
 	slot_flags = SLOT_BACK
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2, TECH_ENGINEERING = 4)
-	charge_cost = 50
+	charge_cost = 49
 	suitable_cell = /obj/item/weapon/cell/small
 	cell_type = /obj/item/weapon/cell/small
 	projectile_type = /obj/item/projectile/bullet/shotgun
@@ -20,22 +20,25 @@
 	fire_sound = 'sound/weapons/guns/fire/energy_shotgun.ogg'
 	init_firemodes = list(
 		list(mode_name="Buckshot", mode_desc="Fires a buckshot synth-shell", projectile_type=/obj/item/projectile/bullet/pellet/shotgun, charge_cost=100, icon="kill"),
-		list(mode_name="Beanbag", mode_desc="Fires a beanbag synth-shell", projectile_type=/obj/item/projectile/bullet/shotgun/beanbag, charge_cost=25, icon="stun"),
+		list(mode_name="Hurt", mode_desc="Fires a Baton synth-shell", projectile_type=/obj/item/projectile/bullet/batonround, charge_cost= 1000, icon="stun"),
 		list(mode_name="Blast", mode_desc="Fires a slug synth-shell", projectile_type=/obj/item/projectile/bullet/shotgun, charge_cost=null, icon="destroy"),
 	)
-	var/consume_cell = FALSE
+	var/consume_cell = TRUE
 	price_tag = 2500
 	rarity_value = 20
 	spawn_tags = SPAWN_TAG_GUN_SHOTGUN_ENERGY
+	twohanded = TRUE
 
 /obj/item/weapon/gun/energy/shrapnel/consume_next_projectile()
 	.=..()
-	if(. && consume_cell && cell.is_empty())
+	if(!cell) return
+	if(. && consume_cell && !cell.checked_use(charge_cost))
 		visible_message(SPAN_WARNING("\The [cell] of \the [src] burns out!"))
 		qdel(cell)
 		cell = null
 		playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 		new /obj/effect/decal/cleanable/ash(get_turf(src))
+		return new projectile_type(src)
 	return .
 
 

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -39,17 +39,21 @@
 		playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 		new /obj/effect/decal/cleanable/ash(get_turf(src))
 		return new projectile_type(src)
+	else if(!consume_cell && !cell.checked_use(charge_cost))
+		return null
 	else
 		return new projectile_type(src)
 
-/obj/item/weapon/gun/energy/shrapnel/attacky(obj/item/I, mob/user)
+/obj/item/weapon/gun/energy/shrapnel/attackby(obj/item/I, mob/user)
 	..()
 	if(I.has_quality(QUALITY_BOLT_TURNING))
 		if(I.use_tool(user, src, WORKTIME_NEAR_INSTANT, QUALITY_BOLT_TURNING, FAILCHANCE_VERY_EASY, required_stat = STAT_MEC))
 			if(consume_cell)
 				consume_cell = FALSE
+				to_chat(user, SPAN_NOTICE("You secure the safety bolts."))
 			else
 				consume_cell = TRUE
+				to_chat(user, SPAN_NOTICE("You loosen the safety bolts."))
 
 
 /obj/item/weapon/gun/energy/shrapnel/mounted

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -53,7 +53,7 @@
 				to_chat(user, SPAN_NOTICE("You secure the safety bolts."))
 			else
 				consume_cell = TRUE
-				to_chat(user, SPAN_NOTICE("You loosen the safety bolts."))
+				to_chat(user, SPAN_NOTICE("You loosen the safety bolts, allowing the weapon to destroy empty cells for use as ammunition."))
 
 
 /obj/item/weapon/gun/energy/shrapnel/mounted
@@ -74,4 +74,3 @@
 		list(mode_name="Beanbag", mode_desc="Fires a beanbag synth-shell", projectile_type=/obj/item/projectile/bullet/shotgun/beanbag, charge_cost=25, icon="stun"),
 		list(mode_name="Blast", mode_desc="Fires a slug synth-shell", projectile_type=/obj/item/projectile/bullet/shotgun, charge_cost=null, icon="destroy"),
 	)
-

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -20,7 +20,7 @@
 	fire_sound = 'sound/weapons/guns/fire/energy_shotgun.ogg'
 	init_firemodes = list(
 		list(mode_name="Buckshot", mode_desc="Fires a buckshot synth-shell", projectile_type=/obj/item/projectile/bullet/pellet/shotgun, charge_cost=50, icon="kill"),
-		list(mode_name="Hurt", mode_desc="Fires a frag synth-shell", projectile_type=/obj/item/projectile/bullet/grenade/frag/weak, charge_cost=10000, icon="grenade"),
+		list(mode_name="Grenade", mode_desc="Fires a frag synth-shell", projectile_type=/obj/item/projectile/bullet/grenade/frag/weak, charge_cost=10000, icon="grenade"),
 		list(mode_name="Blast", mode_desc="Fires a slug synth-shell", projectile_type=/obj/item/projectile/bullet/shotgun, charge_cost=null, icon="destroy"),
 	)
 	var/consume_cell = TRUE

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -11,7 +11,7 @@
 	flags = CONDUCT
 	slot_flags = SLOT_BACK
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2, TECH_ENGINEERING = 4)
-	charge_cost = 49
+	charge_cost = 24
 	suitable_cell = /obj/item/weapon/cell/small
 	cell_type = /obj/item/weapon/cell/small
 	projectile_type = /obj/item/projectile/bullet/shotgun
@@ -19,8 +19,8 @@
 	fire_delay = 12 //Equivalent to a pump then fire time
 	fire_sound = 'sound/weapons/guns/fire/energy_shotgun.ogg'
 	init_firemodes = list(
-		list(mode_name="Buckshot", mode_desc="Fires a buckshot synth-shell", projectile_type=/obj/item/projectile/bullet/pellet/shotgun, charge_cost=100, icon="kill"),
-		list(mode_name="Hurt", mode_desc="Fires a Baton synth-shell", projectile_type=/obj/item/projectile/bullet/batonround, charge_cost= 1000, icon="stun"),
+		list(mode_name="Buckshot", mode_desc="Fires a buckshot synth-shell", projectile_type=/obj/item/projectile/bullet/pellet/shotgun, charge_cost=25, icon="kill"),
+		list(mode_name="Hurt", mode_desc="Fires a frag synth-shell", projectile_type=/obj/item/projectile/bullet/grenade/frag/weak, charge_cost=1000, icon="stun"),
 		list(mode_name="Blast", mode_desc="Fires a slug synth-shell", projectile_type=/obj/item/projectile/bullet/shotgun, charge_cost=null, icon="destroy"),
 	)
 	var/consume_cell = TRUE
@@ -32,14 +32,14 @@
 /obj/item/weapon/gun/energy/shrapnel/consume_next_projectile()
 	.=..()
 	if(!cell) return
-	if(. && consume_cell && !cell.checked_use(charge_cost))
+	if(consume_cell && !cell.checked_use(charge_cost))
 		visible_message(SPAN_WARNING("\The [cell] of \the [src] burns out!"))
 		qdel(cell)
 		cell = null
 		playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 		new /obj/effect/decal/cleanable/ash(get_turf(src))
 		return new projectile_type(src)
-	return .
+	return
 
 
 
@@ -54,4 +54,11 @@
 	consume_cell = FALSE
 	cell_type = /obj/item/weapon/cell/small/high //Two shots
 	spawn_blacklisted = TRUE
+	charge_cost = 50
+	twohanded = FALSE
+	init_firemodes = list(
+		list(mode_name="Buckshot", mode_desc="Fires a buckshot synth-shell", projectile_type=/obj/item/projectile/bullet/pellet/shotgun, charge_cost=100, icon="kill"),
+		list(mode_name="Beanbag", mode_desc="Fires a beanbag synth-shell", projectile_type=/obj/item/projectile/bullet/shotgun/beanbag, charge_cost=25, icon="stun"),
+		list(mode_name="Blast", mode_desc="Fires a slug synth-shell", projectile_type=/obj/item/projectile/bullet/shotgun, charge_cost=null, icon="destroy"),
+	)
 

--- a/code/modules/projectiles/projectile/projectilegrenades.dm
+++ b/code/modules/projectiles/projectile/projectilegrenades.dm
@@ -50,11 +50,11 @@
 /obj/item/projectile/bullet/grenade/frag/weak
 	name = "frag shell"
 	range = 7
-	f_type = /obj/item/projectile/bullet/pellet/fragment/weak
+	f_type = /obj/item/projectile/bullet/pellet/fragment/strong
 	f_amount = 100
 	f_damage = 2
-	f_step = 2
-	same_turf_hit_chance = 15
+	f_step = 1
+	same_turf_hit_chance = 10
 
 /obj/item/projectile/bullet/grenade/frag/grenade_effect(target)
 	fragment_explosion(target, range, f_type, f_amount, f_damage, f_step, same_turf_hit_chance)

--- a/code/modules/projectiles/projectile/projectilegrenades.dm
+++ b/code/modules/projectiles/projectile/projectilegrenades.dm
@@ -47,6 +47,15 @@
 	var/f_step = 2
 	var/same_turf_hit_chance = 15
 
+/obj/item/projectile/bullet/grenade/frag/weak
+	name = "frag shell"
+	range = 7
+	f_type = /obj/item/projectile/bullet/pellet/fragment/weak
+	f_amount = 100
+	f_damage = 2
+	f_step = 2
+	same_turf_hit_chance = 15
+
 /obj/item/projectile/bullet/grenade/frag/grenade_effect(target)
 	fragment_explosion(target, range, f_type, f_amount, f_damage, f_step, same_turf_hit_chance)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Hand-held version of the Shellshock loses it's ability to fire beanbags, and gains a mode that can fire a weaker version of the projectile frag grenades the china lake uses. It usually deals between 35 and 50 damage on a direct hit to an unarmored human, but rarely it can deal as much or as few damage as 20 or 60 due to chance-based same-turf hits.

The hand-held version also gains the ability to shoot once more if its cell is out of charge, which consumes the cell. The charge cost for the grenade launcher is so high that it will always consume the cell. Additionally, the hand-held shellshock must now be wielded, to increase the time to reload

This configuration encourages using one of the shotgun firemodes until the cell is empty, and then using up the cell with a grenade or another slug/buckshot. if you want to, you can also use the grenade mode immediately, but you'll get nowhere near as much mileage out of your cells this way. Or you can use high-quality cells instead for a high amount of shots, but need to be careful not to accidentally burn out your precious cell.

The Blitzshell version remains unaltered.

## Why It's Good For The Game

It's cooler than trash

## Changelog
:cl:
tweak: reworked the shellshock to be able to shoot grenades, as well as being able to trade an emty cell for another shot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
