### PR TITLE
Adds emergency self-surgery

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -201,3 +201,10 @@
 #define RANDOM_BLOOD_TYPE pick(4;"O-", 36;"O+", 3;"A-", 28;"A+", 1;"B-", 20;"B+", 1;"AB-", 5;"AB+")
 
 #define NECROZTIME 	(5 MINUTES)
+
+
+
+//Surgery operation defines
+#define CAN_OPERATE_ALL 1 //All possible surgery types are available
+#define CAN_OPERATE_STANDING -1 //Only limited surgery types are available (gouging out shrapnel, for instance)
+

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -80,7 +80,8 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /mob/living/attackby(obj/item/I, mob/living/user, var/params)
 	if(!ismob(user))
 		return FALSE
-	if(can_operate(src, user) && do_surgery(src, user, I)) //Surgery
+	var/surgery_check = can_operate(src, user)
+	if(surgery_check && do_surgery(src, user, I, surgery_check)) //Surgery
 		return TRUE
 	return I.attack(src, user, user.targeted_organ)
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -194,8 +194,8 @@
 						to_chat(user, SPAN_WARNING("\The [src] is used up, but there are more wounds to treat on \the [affecting.name]."))
 				use(used)
 		else
-			if (can_operate(H, user))        //Checks if mob is lying down on table for surgery
-				if (do_surgery(H,user,src))
+			if (can_operate(H, user) == CAN_OPERATE_ALL)        //Checks if mob is lying down on table for surgery
+				if (do_surgery(H,user,src, TRUE))
 					return
 			else
 				to_chat(user, SPAN_NOTICE("The [affecting.name] is cut open, you'll need more than a bandage!"))
@@ -263,8 +263,8 @@
 						else
 							to_chat(user, "<span class='[pain > 50 ? "danger" : "warning"]'>Your amateur actions caused you [pain > 50 ? "a lot of " : ""]pain.</span>")
 		else
-			if (can_operate(H, user))        //Checks if mob is lying down on table for surgery
-				if (do_surgery(H,user,src))
+			if (can_operate(H, user) == CAN_OPERATE_ALL)        //Checks if mob is lying down on table for surgery
+				if (do_surgery(H,user,src, TRUE))
 					return
 			else
 				to_chat(user, SPAN_NOTICE("The [affecting.name] is cut open, you'll need more than a [src]!"))
@@ -364,8 +364,8 @@
 			use(used)
 			update_icon()
 	else
-		if (can_operate(H, user))        //Checks if mob is lying down on table for surgery
-			if (do_surgery(H,user,src))
+		if (can_operate(H, user) == CAN_OPERATE_ALL)        //Checks if mob is lying down on table for surgery
+			if (do_surgery(H,user,src, TRUE))
 				return
 		else
 			to_chat(user, SPAN_NOTICE("The [affecting.name] is cut open, you'll need more than a bandage!"))
@@ -432,8 +432,8 @@
 						else
 							to_chat(user, "<span class='[pain > 50 ? "danger" : "warning"]'>Your amateur actions caused you [pain > 50 ? "a lot of " : ""]pain.</span>")
 		else
-			if (can_operate(H, user))        //Checks if mob is lying down on table for surgery
-				if (do_surgery(H,user,src))
+			if (can_operate(H, user) == CAN_OPERATE_ALL)        //Checks if mob is lying down on table for surgery
+				if (do_surgery(H,user,src, TRUE))
 					return
 			else
 				to_chat(user, SPAN_NOTICE("The [affecting.name] is cut open, you'll need more than a bandage!"))

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -49,8 +49,8 @@
 					)
 				else
 					to_chat(user, SPAN_NOTICE("Nothing to fix here."))
-			if (can_operate(H, user))        //Checks if mob is lying down on table for surgery
-				if (do_surgery(H,user,src))
+			if (can_operate(H, user) == CAN_OPERATE_ALL)        //Checks if mob is lying down on table for surgery
+				if (do_surgery(H,user,src, TRUE))
 					return
 			else
 				to_chat(user, SPAN_NOTICE("Nothing to fix in here.")) //back to the original

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -180,7 +180,7 @@
 	if(!istype(M))
 		return
 
-	if(!can_operate(M, user))
+	if(!can_operate(M, user) == CAN_OPERATE_ALL)
 		to_chat(user, SPAN_WARNING("You need to lay the cadaver down on a table first!"))
 		return
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -55,7 +55,7 @@
 
 	switch(M.a_intent)
 		if(I_HELP)
-			if(can_operate(src, M) && do_surgery(src, M, null))
+			if(can_operate(src, M) == CAN_OPERATE_ALL && do_surgery(src, M, null, TRUE))
 				return 1
 			else if(istype(H) && health < HEALTH_THRESHOLD_CRIT && health > HEALTH_THRESHOLD_DEAD)
 				if(!H.check_has_mouth())

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -14,6 +14,8 @@
 		to_chat(user, SPAN_WARNING("You find [E.get_wounds_desc()]"))
 	else
 		to_chat(user, SPAN_NOTICE("You find no visible wounds."))
+	if(locate(/obj/item/weapon/material/shard/shrapnel) in E.implants)
+		to_chat(user, SPAN_WARNING("There is what appears to be shrapnel embedded within [affecting]'s [E.name]."))
 
 	to_chat(user, SPAN_NOTICE("Checking bones now..."))
 	if(!do_mob(user, H, 20))

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -931,9 +931,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 		return english_list(descriptors)
 
-	. = ""
-	if((status & ORGAN_CUT_AWAY) && !is_stump() && !(parent && parent.status & ORGAN_CUT_AWAY))
-		. += "tear at [amputation_point] so severe that it hangs by a scrap of flesh"
 	//Normal organic organ damage
 	var/list/wound_descriptors = list()
 	if(open > 1)

--- a/code/modules/organs/surgery_helpers.dm
+++ b/code/modules/organs/surgery_helpers.dm
@@ -109,5 +109,6 @@
 
 // Handling of attacks in organ-centric surgery - called from attackby and attack_hand
 // To be overridden in subtypes
-/obj/item/organ/proc/do_surgery(mob/living/user, obj/item/tool)
+/obj/item/organ/proc/do_surgery(mob/living/user, obj/item/tool, var/surgery_status = CAN_OPERATE_ALL)
 	return FALSE
+

--- a/code/modules/surgery/organic.dm
+++ b/code/modules/surgery/organic.dm
@@ -388,3 +388,70 @@
 	)
 	organ.take_damage(30, 0, sharp=TRUE, edge=TRUE)
 	organ.fracture()
+
+
+//removing shrapnel from yourself, using a knife
+/datum/surgery_step/remove_shrapnel
+	required_tool_quality = QUALITY_CUTTING
+
+	duration = 8 SECONDS
+	blood_level = 1
+
+/datum/surgery_step/remove_shrapnel/can_use(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
+	return organ.owner && !organ.open && (locate(/obj/item/weapon/material/shard/shrapnel) in organ.implants)
+
+/datum/surgery_step/remove_shrapnel/begin_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
+	user.visible_message(
+		SPAN_NOTICE("[user] is beginning to attempt to remove shrapnel from [organ.get_surgery_name()] with \the [tool]."),
+		SPAN_NOTICE("You are beginning to remove shrapnel from [organ.get_surgery_name()] with \the [tool].")
+	)
+	organ.owner_custom_pain("Your [organ.name] is being torn apart!", 1)
+
+/datum/surgery_step/remove_shrapnel/end_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
+	user.visible_message(
+		SPAN_NOTICE("[user] removes shrapnel from [organ.get_surgery_name()] with \the [tool]."),
+		SPAN_NOTICE("You remove shrapnel from [organ.get_surgery_name()] with \the [tool].")
+	)
+	var/obj/item/shrapnel = locate(/obj/item/weapon/material/shard/shrapnel) in organ.implants
+	organ.remove_item(shrapnel, user, FALSE)
+	organ.take_damage(max(tool.force/5, tool.force/(user.stats.getStat(STAT_BIO)/STAT_LEVEL_BASIC)), 0, sharp=TRUE, edge=TRUE) //So it's a bad idea to remove shrapnel with a chainsaw
+
+/datum/surgery_step/remove_shrapnel/fail_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
+	user.visible_message(
+		SPAN_WARNING("[user]'s hand slips, catching inside [organ.get_surgery_name()] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, sawing through the flesh in [organ.get_surgery_name()] with \the [tool]!")
+	)
+	organ.take_damage(tool.force*1.5, 0, sharp=TRUE, edge=TRUE)
+
+//Cauterizing a wound to stop bleeding
+/datum/surgery_step/close_wounds
+	required_tool_quality = QUALITY_CAUTERIZING
+
+	duration = 4 SECONDS
+	blood_level = 0
+
+/datum/surgery_step/close_wounds/can_use(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
+	return organ.owner && !organ.open && organ.status & ORGAN_BLEEDING
+
+/datum/surgery_step/close_wounds/begin_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
+	user.visible_message(
+		SPAN_NOTICE("[user] is beginning to close the wounds on [organ.get_surgery_name()] with \the [tool]."),
+		SPAN_NOTICE("You are beginning to close the wounds on [organ.get_surgery_name()] with \the [tool].")
+	)
+	organ.owner_custom_pain("It burns!", 1)
+
+/datum/surgery_step/close_wounds/end_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
+	user.visible_message(
+		SPAN_NOTICE("[user] closes the wounds on [organ.get_surgery_name()] with \the [tool]."),
+		SPAN_NOTICE("You close the wounds on [organ.get_surgery_name()] with \the [tool].")
+	)
+	organ.stopBleeding()
+	organ.take_damage(0, max(tool.force/5, tool.force/(user.stats.getStat(STAT_BIO)/STAT_LEVEL_BASIC)), sharp=TRUE, edge=TRUE) //So it's a bad idea to remove shrapnel with a chainsaw
+
+/datum/surgery_step/close_wounds/fail_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
+	user.visible_message(
+		SPAN_WARNING("[user]'s hand slips, burning across [organ.get_surgery_name()] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, char-grilling the flesh in [organ.get_surgery_name()] with \the [tool]!")
+	)
+	organ.take_damage(0, tool.force*1.5, sharp=TRUE, edge=TRUE)
+

--- a/code/modules/surgery/organic.dm
+++ b/code/modules/surgery/organic.dm
@@ -446,12 +446,12 @@
 		SPAN_NOTICE("You close the wounds on [organ.get_surgery_name()] with \the [tool].")
 	)
 	organ.stopBleeding()
-	organ.take_damage(0, max(tool.force/5, tool.force/(user.stats.getStat(STAT_BIO)/STAT_LEVEL_BASIC)), sharp=TRUE, edge=TRUE) //So it's a bad idea to remove shrapnel with a chainsaw
+	organ.take_damage(0, max(tool.force/5, tool.force/(user.stats.getStat(STAT_BIO)/STAT_LEVEL_BASIC))) //So it's a bad idea to remove shrapnel with a chainsaw
 
 /datum/surgery_step/close_wounds/fail_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
 	user.visible_message(
 		SPAN_WARNING("[user]'s hand slips, burning across [organ.get_surgery_name()] with \the [tool]!"),
 		SPAN_WARNING("Your hand slips, char-grilling the flesh in [organ.get_surgery_name()] with \the [tool]!")
 	)
-	organ.take_damage(0, tool.force*1.5, sharp=TRUE, edge=TRUE)
+	organ.take_damage(0, tool.force*1.5)
 


### PR DESCRIPTION
## About The Pull Request

Adds self shrapnel removal surgery (Needs a sharp item), and being able to close your own wounds using a cauterizable item (Welding torch, for instance)

Removes some text from get_wound_desc that was never used, as it was never returned properly.

Adds surgery checks to see if you're standing and trying to operate on yourself, or sitting and trying to operate on yourself, to prevent conflicts with regular surgery and emergency surgery.

Adds being able to see shrapnel in somebodies limb by using the grab-examine inspect organ

## Why It's Good For The Game
Requested feature, as shrapnel is a death sentence for solo antagonists.

## Changelog
:cl:
add: Adds emergency self surgery. 
add: Stand still, and use a sharp item on the limb with shrapnel in it to remove shrapnel from yourself.
add: Stand still, and use a hot item to cauterize any open wounds on yourself. Useful if you're out of bandages.
/:cl:
