### PR TITLE
Lascannon nerf

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -114,17 +114,15 @@
 	w_class = ITEM_SIZE_HUGE
 	slot_flags = SLOT_BELT|SLOT_BACK
 	projectile_type = /obj/item/projectile/beam/heavylaser
-	charge_cost = 50
+	charge_cost = 100
 	fire_delay = 20
 	zoom_factor = 0
 	damage_multiplier = 1
 	matter = list(MATERIAL_STEEL = 25, MATERIAL_SILVER = 4, MATERIAL_URANIUM = 1)
 	price_tag = 3000
 	init_firemodes = list(
-		WEAPON_NORMAL,
-		WEAPON_CHARGE
+		WEAPON_NORMAL
 		)
-	one_hand_penalty = 5
 	twohanded = TRUE
 
 /obj/item/weapon/gun/energy/lasercannon/mounted


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The las cannon no longer has a charge mode, and it's power cost per shot has been doubled
also removes it's one hand penalty, you can only fire it when it's wielded, anyways.

## Why It's Good For The Game

moe mad

## Changelog
:cl:
tweak: the laser cannon is now less deadly - its charge mode was removed and energy per shot increased(100 instead of 50).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
