### PR TITLE
You can now put pills into drinks unnoticed if you have fast fingers

### DIFF
--- a/code/datums/perks/oddity.dm
+++ b/code/datums/perks/oddity.dm
@@ -122,7 +122,7 @@
 /datum/perk/oddity/fast_fingers
 	name = "Fast Fingers"
 	desc = "Nothing is safe around your hands. You are a true kleptomaniac. \
-			Taking items off others is without sound and prompts, it's also quicker."
+			Taking items off others is without sound and prompts, it's also quicker, and you can slip pills into drinks unnoticed."
 	icon_state = "robber_hand" // https://game-icons.net/1x1/darkzaitzev/robber-hand.html
 
 /datum/perk/oddity/quiet_as_mouse

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -48,7 +48,8 @@
 
 		reagents.trans_to(target, reagents.total_volume)
 		for(var/mob/O in viewers(2, user))
-			O.show_message(SPAN_WARNING("[user] puts something in \the [target]."), 1)
+			if(!user.stats.getPerk(PERK_FAST_FINGERS))
+				O.show_message(SPAN_WARNING("[user] puts something in \the [target]."), 1)
 
 		qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

having the fast fingers perk allows you to slip pills into drinks unnoticed.

nanoforge

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: you can now put pills into drinks unnoticed if you have the fast fingers perk.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
