### PR TITLE
sanity boost aura for club personnel

### DIFF
--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -39,3 +39,4 @@
 //job perks
 #define PERK_ARTIST /datum/perk/job/artist
 #define PERK_SURVIVOR /datum/perk/survivor
+#define PERK_CLUB /datum/perk/job/club

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -190,3 +190,18 @@
 	name = "Sommelier"
 	desc = "You know how to handle even strongest alcohol in the universe."
 	icon_state = "inspiration"
+
+/datum/perk/job/club
+	name = "Raising the bar"
+	desc = "You know how to mix drinks and change lives. People near you recover sanity."
+	icon_state = "inspiration"
+
+/datum/perk/job/club/assign(mob/living/carbon/human/H)
+	..()
+	if(holder)
+		holder.sanity_damage -= 2
+
+/datum/perk/job/club/remove()
+	if(holder)
+		holder.sanity_damage += 2
+	..()

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -15,6 +15,7 @@
 	also_known_languages = list(LANGUAGE_CYRILLIC = 25, LANGUAGE_SERBIAN = 15, LANGUAGE_JIVE = 80)
 	access = list(access_bar, access_kitchen, access_maint_tunnels, access_change_club)
 	initial_balance = 3000
+	perks = list(/datum/perk/oddity/charming_personality)
 	wage = WAGE_NONE // Makes his own money
 	stat_modifiers = list(
 		STAT_ROB = 15,
@@ -50,6 +51,7 @@
 	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_JIVE = 60)
 	access = list(access_bar, access_kitchen)
 	initial_balance = 750
+	perks = list(/datum/perk/oddity/charming_personality)
 	wage = WAGE_NONE //They should get paid by the club owner, otherwise you know what to do.
 	stat_modifiers = list(
 		STAT_ROB = 10,

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -51,7 +51,7 @@
 	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_JIVE = 60)
 	access = list(access_bar, access_kitchen)
 	initial_balance = 750
-	perks = list(/datum/perk/job/club)
+	perks = list(PERK_CLUB)
 	wage = WAGE_NONE //They should get paid by the club owner, otherwise you know what to do.
 	stat_modifiers = list(
 		STAT_ROB = 10,
@@ -76,5 +76,4 @@
 	name = "Club Worker"
 	icon_state = "player-grey"
 	join_tag = /datum/job/clubworker
-
 

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -15,7 +15,7 @@
 	also_known_languages = list(LANGUAGE_CYRILLIC = 25, LANGUAGE_SERBIAN = 15, LANGUAGE_JIVE = 80)
 	access = list(access_bar, access_kitchen, access_maint_tunnels, access_change_club)
 	initial_balance = 3000
-	perks = list(/datum/perk/job/club)
+	perks = list(PERK_CLUB)
 	wage = WAGE_NONE // Makes his own money
 	stat_modifiers = list(
 		STAT_ROB = 15,
@@ -76,6 +76,5 @@
 	name = "Club Worker"
 	icon_state = "player-grey"
 	join_tag = /datum/job/clubworker
-
 
 

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -15,7 +15,7 @@
 	also_known_languages = list(LANGUAGE_CYRILLIC = 25, LANGUAGE_SERBIAN = 15, LANGUAGE_JIVE = 80)
 	access = list(access_bar, access_kitchen, access_maint_tunnels, access_change_club)
 	initial_balance = 3000
-	perks = list(/datum/perk/oddity/charming_personality)
+	perks = list(/datum/perk/job/club)
 	wage = WAGE_NONE // Makes his own money
 	stat_modifiers = list(
 		STAT_ROB = 15,
@@ -51,7 +51,7 @@
 	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_JIVE = 60)
 	access = list(access_bar, access_kitchen)
 	initial_balance = 750
-	perks = list(/datum/perk/oddity/charming_personality)
+	perks = list(/datum/perk/job/club)
 	wage = WAGE_NONE //They should get paid by the club owner, otherwise you know what to do.
 	stat_modifiers = list(
 		STAT_ROB = 10,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Club personnel now starts with a trait thta has the same characteristics as the "charming personality" trait.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: club personnel now starts with a sanity-recovering aura trait
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
