### PR TITLE
Oddities no longer lose their perks when being used to level up

### DIFF
--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -263,8 +263,7 @@
 			to_chat(owner, SPAN_NOTICE("Your [stat] stat goes up by [stat_up]"))
 			owner.stats.changeStat(stat, stat_up)
 		if(I.perk)
-			if(owner.stats.addPerk(I.perk))
-				I.perk = null
+			owner.stats.addPerk(I.perk)
 		for(var/mob/living/carbon/human/H in viewers(owner))
 			SEND_SIGNAL(H, COMSIG_HUMAN_ODDITY_LEVEL_UP, owner, O)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request


Oddities no longer lose their perk when being used to level up

## Why It's Good For The Game

Oddities losing their perks upon use serves no purpose other than hindering free trade of oddities, and thus player interaction. Since you can't get a perk twice, Vagabond Mcpowergame just continues to use an oddity with a good perk once and then switches to whatever oddity gives the most stats, and it does not matter to him whether or not the oddity is purged because he isn't looking to sell it or pass it on anyways. If you are actually trying to interact with players through selling, renting or gifting oddities, having their perks removed upon use is just another hindrance. 


## Changelog
:cl:
tweak: Oddities no longer lose their perk when being used to level up
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
