### PR TITLE
Makes ablative vest into proper fullbody armor

### DIFF
--- a/code/datums/autolathe/clothing.dm
+++ b/code/datums/autolathe/clothing.dm
@@ -2,7 +2,7 @@
 /datum/design/autolathe/clothing/excelsior_armor
 	name = "excelsior armor"
 	build_path = /obj/item/clothing/suit/space/void/excelsior
-	
+
 // Standard
 
 /datum/design/autolathe/clothing/generic_helmet_basic
@@ -16,7 +16,7 @@
 /datum/design/autolathe/clothing/generic_vest
 	name = "armor vest"
 	build_path = /obj/item/clothing/suit/armor/vest
-	
+
 /datum/design/autolathe/clothing/generic_vest_full
 	name = "fullbody armor vest"
 	build_path = /obj/item/clothing/suit/armor/vest/full
@@ -30,7 +30,7 @@
 /datum/design/autolathe/clothing/bulletproof_vest_generic
 	name = "bulletproof vest"
 	build_path = /obj/item/clothing/suit/armor/bulletproof
-	
+
 /datum/design/autolathe/clothing/bulletproof_vest_generic_full
 	name = "fullbody bulletproof vest"
 	build_path = /obj/item/clothing/suit/armor/bulletproof/full
@@ -41,9 +41,9 @@
 
 // Ablative
 
-/datum/design/autolathe/clothing/ablative_vest
-	name = "ablative armor vest"
-	build_path = /obj/item/clothing/suit/armor/laserproof
+/datum/design/autolathe/clothing/ablative_vest_full
+	name = "full ablative armor vest"
+	build_path = /obj/item/clothing/suit/armor/laserproof/full
 
 /datum/design/autolathe/clothing/ablative_helmet
 	name = "ablative helmet"
@@ -62,7 +62,7 @@
 /datum/design/autolathe/clothing/ih_vest_basic
 	name = "operator armor"
 	build_path = /obj/item/clothing/suit/armor/vest/ironhammer
-	
+
 /datum/design/autolathe/clothing/ih_vest_basic_full
 	name = "fullbody operator armor"
 	build_path = /obj/item/clothing/suit/armor/vest/full/ironhammer

--- a/code/game/objects/items/weapons/design_disks/ironhammer.dm
+++ b/code/game/objects/items/weapons/design_disks/ironhammer.dm
@@ -48,7 +48,7 @@
 	rarity_value = 16 // slightly rarer than bulletproof gear
 	license = 4 // 4 pieces, or 2 sets
 	designs = list(
-		/datum/design/autolathe/clothing/ablative_vest,
+		/datum/design/autolathe/clothing/ablative_vest_full,
 		/datum/design/autolathe/clothing/ablative_helmet
 	)
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -255,11 +255,12 @@
 	name = "full tan platecarrier vest"
 	icon_state = "platecarrier_tan_fullbody"
 
-/obj/item/clothing/suit/armor/laserproof
-	name = "ablative armor vest"
+/obj/item/clothing/suit/armor/laserproof/full
+	name = "full ablative armor vest"
 	desc = "A vest that excels in protecting the wearer against energy projectiles."
 	icon_state = "ablative"
 	item_state = "ablative"
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	blood_overlay_type = "armor"
 	slowdown = 0.15
 	rarity_value = 45


### PR DESCRIPTION

## About The Pull Request

Extends coverage of ablative vest onto arms and legs

## Why It's Good For The Game

It was super confusing to find out that it only covers torso itself, despite the fact that sprite follows the format of all fulbody armors. It also made whole thing an absolute joke of an armor

## Changelog
:cl:
tweak: Extends coverage of ablative vest onto arms and legs
/:cl:
