### PR TITLE
Big Cog Renaissance ( I am very proud of that name)

### DIFF
--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -55,13 +55,13 @@
 #define SEMI_AUTO_NODELAY	list(mode_name = "semiauto",  mode_desc = "Fire as fast as you can pull the trigger", burst=1, fire_delay=0, move_delay=null, icon="semi")
 
 //Cog firemode
-#define BURST_2_ROUND		list(mode_name="2-beam bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, move_delay=4, icon="burst", damage_mult_add = -0.1)
+#define BURST_2_ROUND		list(mode_name="2-beam bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, move_delay=2, icon="burst", damage_mult_add = -0.1)
 
 #define BURST_3_ROUND		list(mode_name="3-round bursts", mode_desc = "Short, controlled bursts", burst=3, fire_delay=null, move_delay=4, icon="burst", damage_mult_add = -0.1)
 #define BURST_5_ROUND		list(mode_name="5-round bursts", mode_desc = "Short, controlled bursts", burst=5, fire_delay=null, move_delay=6, icon="burst", damage_mult_add = -0.1)
 #define BURST_8_ROUND		list(mode_name="8-round bursts", mode_desc = "Short, uncontrolled bursts", burst=8, fire_delay=null, move_delay=8, icon="burst", damage_mult_add = -0.1)
 
-#define WEAPON_NORMAL		list(mode_name="standard", icon="semi")
+#define WEAPON_NORMAL		list(mode_name="standard", burst =1, icon="semi")
 #define WEAPON_CHARGE		list(mode_name="charge mode", mode_desc="Hold down the trigger, and let loose a more powerful shot", mode_type = /datum/firemode/charge, icon="charge")
 
 #define STUNBOLT			list(mode_name="stun", mode_desc="Stun bolt until they're eating the floortiles", projectile_type=/obj/item/projectile/beam/stun, modifystate="energystun", item_modifystate="stun", fire_sound='sound/weapons/Taser.ogg', icon="stun")

--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -54,6 +54,9 @@
 
 #define SEMI_AUTO_NODELAY	list(mode_name = "semiauto",  mode_desc = "Fire as fast as you can pull the trigger", burst=1, fire_delay=0, move_delay=null, icon="semi")
 
+//Cog firemode
+#define BURST_2_ROUND		list(mode_name="2-beam bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, move_delay=4, icon="burst", damage_mult_add = -0.1)
+
 #define BURST_3_ROUND		list(mode_name="3-round bursts", mode_desc = "Short, controlled bursts", burst=3, fire_delay=null, move_delay=4, icon="burst", damage_mult_add = -0.1)
 #define BURST_5_ROUND		list(mode_name="5-round bursts", mode_desc = "Short, controlled bursts", burst=5, fire_delay=null, move_delay=6, icon="burst", damage_mult_add = -0.1)
 #define BURST_8_ROUND		list(mode_name="8-round bursts", mode_desc = "Short, uncontrolled bursts", burst=8, fire_delay=null, move_delay=8, icon="burst", damage_mult_add = -0.1)

--- a/code/datums/autolathe/guns.dm
+++ b/code/datums/autolathe/guns.dm
@@ -210,6 +210,10 @@
 	name = "NT LG \"Lightfall\""
 	build_path = /obj/item/weapon/gun/energy/laser
 
+/datum/design/autolathe/gun/retro
+	name = "OS LG \"Cog\""
+	build_path = /obj/item/weapon/gun/energy/retro
+
 /datum/design/autolathe/gun/ionrifle
 	name = "NT IR \"Halicon\""
 	build_path = /obj/item/weapon/gun/energy/ionrifle

--- a/code/game/objects/items/weapons/design_disks/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/design_disks/autolathe_disks.dm
@@ -166,6 +166,7 @@
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/retro = 3, //"OS LG \"Cog\""
+		/datum/design/autolathe/cell/medium/high,
 	)
 
 // ARMOR

--- a/code/game/objects/items/weapons/design_disks/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/design_disks/autolathe_disks.dm
@@ -158,6 +158,15 @@
 		/datum/design/autolathe/ammo/c10x24,
 	)
 
+//The Cog
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/retro
+	disk_name = "OS LG \"Cog\""
+	icon_state = "onestar"
+	rarity_value = 5.5
+	license = 12
+	designs = list(
+		/datum/design/autolathe/gun/retro = 3, //"OS LG \"Cog\""
+	)
 
 // ARMOR
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/armor

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -62,17 +62,17 @@
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_NORMAL
 	can_dual = TRUE
-	matter = list(MATERIAL_STEEL = 12)
+	matter = list(MATERIAL_STEEL = 10, MATERIAL_PLASTIC = 15, MATERIAL_GLASS = 5)
 	projectile_type = /obj/item/projectile/beam
 	fire_delay = 10 //old technology
 	zoom_factor = 0
 	damage_multiplier = 1
 	charge_cost = 100
 	price_tag = 2000
-	rarity_value = 10
+	rarity_value = 48
 	init_firemodes = list(
 		WEAPON_NORMAL,
-		WEAPON_CHARGE
+		BURST_2_ROUND
 	)
 	twohanded = TRUE
 


### PR DESCRIPTION

## About The Pull Request
Adds Cog design disk with enough license points to print 4 off one. Adds 2 burst firing mode to Cog, instead of charge mode. Changes material cost from 12 steel to 10 steel, 15 plastic and 5 glass. Adjusted rarity values of both gun itself and design disk to mirror these of Novakovic.

## Why It's Good For The Game

![garro](https://user-images.githubusercontent.com/59981504/106159995-aa431600-6185-11eb-8bc0-4375fb8b557b.png)

To add to that: Cog has always been embarrassing gun to shoot by any means, and it has largely remained such: it still fires beams of 30 burn damage wih 0AP, it still is woefully uneconomical to shoot with charge cost of 100 per shot. But I hope it will now have at least any reason at all to be considered and become different from upcoming makeshift laser gun, which would otherwise be very same thing.

## Changelog
:cl:
add: 2 burst  firemode
del: Charge mode on cog
add: cog's design disk 
tweak: cog's matter list
add: burst = 1 to WEAPON_NORMAL firemode
/:cl:

