### PR TITLE
buckshot/slug bandaid bug fix

### DIFF
--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -185,7 +185,7 @@ There are important things regarding this file:
 	icon_state = "slug"
 	damage_types = list(BRUTE = 54)
 	armor_penetration = 15
-	knockback = 1
+	knockback = 2
 	step_delay = 1.1
 
 /obj/item/projectile/bullet/shotgun/beanbag
@@ -230,7 +230,7 @@ There are important things regarding this file:
 	pellets = 8
 	range_step = 1
 	spread_step = 10
-	knockback = 1
+	knockback = 2
 
 /obj/item/projectile/bullet/pellet/shotgun/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
buckshot and slug now knockbacks two tiles instead of one
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
allows the projectile to process properly before hitting a mob and prevents 20+ hits for buckshot or double hit for slug in theory
in practice the result is still somewhat janky depending on the angle of the shooter and the victim, but overall hits are lowered, you'll still get punted across the hallway but you won't get hit that much compared to before
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

balance: Slug and Buckshot now has more knockback

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
