### PR TITLE
Revert "Oddities no longer lose their perks when being used to level up"

### DIFF
--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -263,7 +263,8 @@
 			to_chat(owner, SPAN_NOTICE("Your [stat] stat goes up by [stat_up]"))
 			owner.stats.changeStat(stat, stat_up)
 		if(I.perk)
-			owner.stats.addPerk(I.perk)
+			if(owner.stats.addPerk(I.perk))
+				I.perk = null
 		for(var/mob/living/carbon/human/H in viewers(owner))
 			SEND_SIGNAL(H, COMSIG_HUMAN_ODDITY_LEVEL_UP, owner, O)
 


### PR DESCRIPTION
Reverts discordia-space/CEV-Eris#5891
After a bit of discussions with Nestor we've decided that it was a abad idea to merge akchually
:cl:
tweak: the changelog that says that oddities do not lose their perk is a lie.
/:cl: