### PR TITLE
Unfuck the junk .60

### DIFF
--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -259,4 +259,3 @@
 	ammo_type = /obj/item/ammo_casing/antim/scrap
 	max_ammo = 30
 	rarity_value = 1
-	spawn_tags = SPAWN_TAG_AMMO_COMMON


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR removes the `SPAWN_TAG_AMMO_COMMON` from old .60 box. It should make it refer to default `SPAWN_TAG_AMMO` which isn't frequent as shit in maints. 

## Why It's Good For The Game

![изображение](https://user-images.githubusercontent.com/57810301/106327501-4442b580-628f-11eb-9476-5d270b20b84b.png)


## Changelog
:cl:
tweak: Junk .60 ammoboxes should be less frequent now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
