### PR TITLE
Minor junk kit fixes

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_kits.dm
+++ b/code/modules/projectiles/ammunition/ammo_kits.dm
@@ -1,7 +1,7 @@
 
 //// .35 ////
 /obj/item/ammo_kit
-	name = "Scrap Ammo Kit"
+	name = "scrap ammo kit"
 	desc = "A somewhat jank looking crafting kit. It has a can of single-use tools, cheap pliers and a box of bullet making materials."
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "ammo_kit-1"
@@ -61,7 +61,10 @@
 		if("slug")
 			spawn_shotgun(dice_roll,user,3)
 	if(choice)
+		user.visible_message("[user] makes some [choice] rounds out of [src], using up all the materials in it.")
 		qdel(src)	//All used up
+	else
+		to_chat(user, "You reconsider the path of gunsmith.")
 
 //////////////////////////////////////////////////////////////////////////////////////
 

--- a/code/modules/projectiles/ammunition/ammo_kits.dm
+++ b/code/modules/projectiles/ammunition/ammo_kits.dm
@@ -60,8 +60,8 @@
 			spawn_shotgun(dice_roll,user,2)
 		if("slug")
 			spawn_shotgun(dice_roll,user,3)
-
-	qdel(src)	//All used up
+	if(choice)
+		qdel(src)	//All used up
 
 //////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes sure you won't waste junk ammo kit if you close the window without choosing any ammo. Also makes its name lowercase and adds some feedback.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Laws of thermodynamics should usually be respected.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Firefox13, Shazbot
fix: Junk ammo craft kit won't delete itself if you leave the ammo selection menu. Also added some feedback to it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
