### PR TITLE
Makes maintshrooms drawable

### DIFF
--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -28,6 +28,7 @@
 	layer = 3
 	pass_flags = PASSTABLE
 	mouse_opacity = 1
+	reagent_flags = DRAINABLE
 
 	var/health = 5
 	var/max_health = 60
@@ -315,8 +316,3 @@ var/list/global/cutoff_plant_icons = list()
 			to_chat(usr, SPAN_NOTICE("It looks juicy."))
 		else
 			to_chat(usr, SPAN_NOTICE("It looks a bit dry."))
-
-/obj/effect/plant/is_drawable(allowmobs)
-	. = ..()
-	return TRUE
-

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -319,3 +319,4 @@ var/list/global/cutoff_plant_icons = list()
 /obj/effect/plant/is_drawable(allowmobs)
 	. = ..()
 	return TRUE
+

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -319,3 +319,4 @@ var/list/global/cutoff_plant_icons = list()
 /obj/effect/plant/is_drawable(allowmobs)
 	. = ..()
 	return TRUE
+	

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -315,3 +315,7 @@ var/list/global/cutoff_plant_icons = list()
 			to_chat(usr, SPAN_NOTICE("It looks juicy."))
 		else
 			to_chat(usr, SPAN_NOTICE("It looks a bit dry."))
+
+/obj/effect/plant/is_drawable(allowmobs)
+	. = ..()
+	return TRUE

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -319,4 +319,3 @@ var/list/global/cutoff_plant_icons = list()
 /obj/effect/plant/is_drawable(allowmobs)
 	. = ..()
 	return TRUE
-	


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

you can now draw reagents from maintshrooms directly by using a syringe

## Why It's Good For The Game

dying in maint? just inject yourself with some shroom-grown inaprovaline (radium)

## Changelog
:cl:
tweak: maintshrooms are now syringe-drawable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
