### PR TITLE
Tune stats of NT jobs to be consistent with NT documentation

### DIFF
--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -25,7 +25,7 @@
 
 	stat_modifiers = list(
 		STAT_TGH = 10,
-		STAT_BIO = 15,
+		STAT_ROB = 20,
 		STAT_VIG = 15,
 		STAT_COG = 10,
 	)
@@ -82,10 +82,9 @@
 	outfit_type = /decl/hierarchy/outfit/job/church/acolyte
 
 	stat_modifiers = list(
-	STAT_BIO = 10,
-	STAT_VIG = 20,
+	STAT_VIG = 15,
 	STAT_TGH = 15,
-	STAT_ROB = 5
+	STAT_ROB = 20
 	)
 
 	core_upgrades = list(
@@ -126,8 +125,8 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/church/gardener
 	stat_modifiers = list(
-		STAT_BIO = 15,
-		STAT_TGH = 15,
+		STAT_BIO = 20,
+		STAT_TGH = 10,
 		STAT_ROB = 10,
 	)
 
@@ -166,7 +165,7 @@
 
 	stat_modifiers = list(
 		STAT_ROB = 15,
-		STAT_BIO = 10,
+		STAT_TGH = 10,
 		STAT_VIG = 15
 	)
 

--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -84,7 +84,7 @@
 	stat_modifiers = list(
 	STAT_VIG = 15,
 	STAT_TGH = 15,
-	STAT_ROB = 20
+	STAT_ROB = 15
 	)
 
 	core_upgrades = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tune stats of NT jobs according to what's written in the NT rework documentation
It was asked for on discord in miner channel so here it is.

```
Custodian
Remove BIO, because he doesn’t need it, and move it all into TGH, it’s useful in fights.

Agrolyte
Take 5 TGH and move those points to BIO, this will help with them being medic.

Acolyte
Again, he has no use for bio as he is no farmer, nor healer. Make ROB 15, helps with killing roaches. Maybe 5 points could be taken from VIG and again put into the ROB again because NT is melee oriented.

Preacher
Give 15-20 to ROB as all church members complete a melee training course.
(At the cost of BIO?)
P.S.-I’m moving bio points into other skills because they are more useful there. Again, those roles don’t grow or heal and the possibility of printing healing kits doesn’t justify the BIO.
```


## Changelog
:cl: Hyperio
balance: Tune stats of Neotheology jobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
