### PR TITLE
armblades no longer spawn in maint

### DIFF
--- a/code/game/objects/items/devices/organ_module/active/armblades.dm
+++ b/code/game/objects/items/devices/organ_module/active/armblades.dm
@@ -12,6 +12,7 @@
 	attack_verb = list("stabbed", "chopped", "cut")
 	armor_penetration = ARMOR_PEN_MODERATE
 	tool_qualities = list(QUALITY_CUTTING = 20)
+	spawn_blacklisted = TRUE
 
 /obj/item/organ_module/active/simple/armblade
 	name = "embedded armblade"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

the armblade item that looks like it's the upgrade, but actually is the real armblade can no longer spawn in maint

## Why It's Good For The Game

less confusion

## Changelog
:cl:
tweak: armblades no longer spawn in maint
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
