### PR TITLE
buckshot and slug rework kinda

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -119,6 +119,9 @@
 	if(P.knockback && hit_dir)
 		throw_at(get_edge_target_turf(src, hit_dir), P.knockback, P.knockback)
 
+	if(P.proj_falloff > 0)
+		P.calculate_falloff()
+
 	//Armor and damage
 	if(!P.nodamage)
 		hit_impact(P.get_structure_damage(), hit_dir)

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -329,7 +329,7 @@
 	desc = "A .50 shell."
 	icon_state = "s-shell_l"
 	spent_icon = "s-shell_l-spent"
-	projectile_type = /obj/item/projectile/bullet/pellet/shotgun
+	projectile_type = /obj/item/projectile/bullet/shotgun/buckshot
 	matter = list(MATERIAL_STEEL = 1)
 
 /obj/item/ammo_casing/shotgun/pellet/prespawned
@@ -340,7 +340,7 @@
 	desc = "An older .50 shell."
 	icon_state = "s-shell_ss"
 	spent_icon = "s-shell_ss-spent"
-	projectile_type = /obj/item/projectile/bullet/pellet/shotgun/scrap
+	projectile_type = /obj/item/projectile/bullet/shotgun/buckshot/scrap
 
 /obj/item/ammo_casing/shotgun/pellet/scrap/prespawned
 	amount = 5

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -296,6 +296,7 @@
 			var/obj/item/projectile/P = projectile
 			P.adjust_damages(proj_damage_adjust)
 			P.adjust_ricochet(noricochet)
+			P.calculate_falloff()
 
 		if(pointblank)
 			process_point_blank(projectile, user, target)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -296,7 +296,6 @@
 			var/obj/item/projectile/P = projectile
 			P.adjust_damages(proj_damage_adjust)
 			P.adjust_ricochet(noricochet)
-			P.calculate_falloff()
 
 		if(pointblank)
 			process_point_blank(projectile, user, target)

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -70,7 +70,7 @@
 	charge_cost = 50
 	twohanded = FALSE
 	init_firemodes = list(
-		list(mode_name="Buckshot", mode_desc="Fires a buckshot synth-shell", projectile_type=/obj/item/projectile/bullet/pellet/shotgun, charge_cost=100, icon="kill"),
+		list(mode_name="Buckshot", mode_desc="Fires a buckshot synth-shell", projectile_type=/obj/item/projectile/bullet/shotgun/buckshot, charge_cost=100, icon="kill"),
 		list(mode_name="Beanbag", mode_desc="Fires a beanbag synth-shell", projectile_type=/obj/item/projectile/bullet/shotgun/beanbag, charge_cost=25, icon="stun"),
 		list(mode_name="Blast", mode_desc="Fires a slug synth-shell", projectile_type=/obj/item/projectile/bullet/shotgun, charge_cost=null, icon="destroy"),
 	)

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -19,7 +19,7 @@
 	fire_delay = 12 //Equivalent to a pump then fire time
 	fire_sound = 'sound/weapons/guns/fire/energy_shotgun.ogg'
 	init_firemodes = list(
-		list(mode_name="Buckshot", mode_desc="Fires a buckshot synth-shell", projectile_type=/obj/item/projectile/bullet/pellet/shotgun, charge_cost=50, icon="kill"),
+		list(mode_name="Buckshot", mode_desc="Fires a buckshot synth-shell", projectile_type=/obj/item/projectile/bullet/shotgun/buckshot, charge_cost=50, icon="kill"),
 		list(mode_name="Grenade", mode_desc="Fires a frag synth-shell", projectile_type=/obj/item/projectile/bullet/grenade/frag/weak, charge_cost=10000, icon="grenade"),
 		list(mode_name="Blast", mode_desc="Fires a slug synth-shell", projectile_type=/obj/item/projectile/bullet/shotgun, charge_cost=null, icon="destroy"),
 	)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -47,7 +47,7 @@
 	var/projectile_type = /obj/item/projectile
 	var/penetrating = 0 //If greater than zero, the projectile will pass through dense objects as specified by on_penetrate()
 	var/kill_count = 50 //This will de-increment every process(). When 0, it will delete the projectile.
-	var/falloff = 0 // the amount of damage this projectile will lose per tile travelled after the 2-tile range
+	var/proj_falloff = 0 // the amount of damage this projectile will lose per tile travelled after the 2-tile range
 
 	//Effects
 	var/stun = 0
@@ -124,12 +124,12 @@
 		can_ricochet = FALSE
 		return
 
-/obj/item/projectile/proc/calculate_falloff(var/distance, var/falloff)
-	falloff = 0
+/obj/item/projectile/proc/calculate_falloff(proj_falloff)
+	var/distance = get_dist(loc, starting)
+	var/damage_lost = 0
 	if(distance > 2)
-		falloff = (distance - 2) * falloff
-		for(falloff)
-			damage_types[BRUTE] -= falloff[BRUTE]
+		damage_lost = (distance - 2) * proj_falloff
+		damage_types[BRUTE] -= damage_lost[BRUTE]
 
 /obj/item/projectile/proc/on_hit(atom/target, def_zone = null)
 	if(!isliving(target))	return 0

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -125,11 +125,11 @@
 		return
 
 /obj/item/projectile/proc/calculate_falloff(proj_falloff)
-	var/distance = get_dist(loc, starting)
-	var/damage_lost = 0
-	if(distance > 2)
-		damage_lost = (distance - 2) * proj_falloff
-		damage_types[BRUTE] -= damage_lost[BRUTE]
+	var/distance=get_dist(loc, starting)
+	if(distance>2)
+		var/damage_lost = get_tiles_passed(distance)
+		damage_types[BRUTE]-=damage_lost
+
 
 /obj/item/projectile/proc/on_hit(atom/target, def_zone = null)
 	if(!isliving(target))	return 0

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -124,11 +124,11 @@
 		can_ricochet = FALSE
 		return
 
-/obj/item/projectile/proc/calculate_falloff(proj_falloff)
+/obj/item/projectile/proc/calculate_falloff()
 	var/distance=get_dist(loc, starting)
 	if(distance>2)
-		var/damage_lost = get_tiles_passed(distance)
-		damage_types[BRUTE]-=damage_lost
+		var/damage_lost=(distance-2)
+		damage_types[BRUTE] = round(damage_types[BRUTE]-damage_lost)
 
 
 /obj/item/projectile/proc/on_hit(atom/target, def_zone = null)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -127,7 +127,7 @@
 /obj/item/projectile/proc/calculate_falloff()
 	var/distance=get_dist(loc, starting)
 	if(distance>2)
-		var/damage_lost=(distance-2)
+		var/damage_lost=(distance-2)*proj_falloff
 		damage_types[BRUTE] = round(damage_types[BRUTE]-damage_lost)
 
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -47,6 +47,7 @@
 	var/projectile_type = /obj/item/projectile
 	var/penetrating = 0 //If greater than zero, the projectile will pass through dense objects as specified by on_penetrate()
 	var/kill_count = 50 //This will de-increment every process(). When 0, it will delete the projectile.
+	var/falloff = 0 // the amount of damage this projectile will lose per tile travelled after the 2-tile range
 
 	//Effects
 	var/stun = 0
@@ -122,6 +123,13 @@
 	if(noricochet)
 		can_ricochet = FALSE
 		return
+
+/obj/item/projectile/proc/calculate_falloff(var/distance, var/falloff)
+	falloff = 0
+	if(distance > 2)
+		falloff = (distance - 2) * falloff
+		for(falloff)
+			damage_types[BRUTE] -= falloff[BRUTE]
 
 /obj/item/projectile/proc/on_hit(atom/target, def_zone = null)
 	if(!isliving(target))	return 0

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -201,13 +201,13 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/shotgun
 	name = "slug"
 	icon_state = "slug"
-	damage_types = list(BRUTE = 50)
-	armor_penetration = 10
+	damage_types = list(BRUTE = 45)
+	armor_penetration = 20
 	knockback = 1
 	step_delay = 1.1
 
 /obj/item/projectile/bullet/shotgun/scrap
-	damage_types = list(BRUTE = 48)
+	damage_types = list(BRUTE = 40)
 
 /obj/item/projectile/bullet/shotgun/beanbag
 	name = "beanbag"
@@ -250,18 +250,18 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/shotgun/buckshot
 	name = "shrapnel"
 	icon_state = "birdshot-1"
-	damage_types = list(BRUTE = 37)
-	armor_penetration = 40
+	damage_types = list(BRUTE = 65)
+	armor_penetration = 0
 	step_delay = 0.8
 	knockback = 0
-	proj_falloff = 3
+	proj_falloff = 2
 
 /obj/item/projectile/bullet/shotgun/buckshot/Initialize()
 	. = ..()
 	icon_state = "birdshot-[rand(1,4)]"
 
 /obj/item/projectile/bullet/shotgun/buckshot/scrap
-	damage_types = list(BRUTE = 33)
+	damage_types = list(BRUTE = 54)
 
 //Miscellaneous
 /obj/item/projectile/bullet/blank

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -201,13 +201,13 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/shotgun
 	name = "slug"
 	icon_state = "slug"
-	damage_types = list(BRUTE = 45)
+	damage_types = list(BRUTE = 47)
 	armor_penetration = 20
 	knockback = 1
 	step_delay = 1.1
 
 /obj/item/projectile/bullet/shotgun/scrap
-	damage_types = list(BRUTE = 40)
+	damage_types = list(BRUTE = 42)
 
 /obj/item/projectile/bullet/shotgun/beanbag
 	name = "beanbag"

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -254,7 +254,7 @@ There are important things regarding this file:
 	armor_penetration = 40
 	step_delay = 5
 	knockback = 0
-	falloff = 3
+	proj_falloff = 3
 
 /obj/item/projectile/bullet/shotgun/buckshot/Initialize()
 	. = ..()

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -246,23 +246,26 @@ There are important things regarding this file:
 		M.adjust_fire_stacks(fire_stacks)
 		M.IgniteMob()
 
-//Should do about 80 damage at 1 tile distance (adjacent), and 50 damage at 3 tiles distance.
-//Overall less damage than slugs in exchange for more damage at very close range and more embedding
-/obj/item/projectile/bullet/pellet/shotgun
+
+/obj/item/projectile/bullet/shotgun/buckshot
 	name = "shrapnel"
 	icon_state = "birdshot-1"
-	damage_types = list(BRUTE = 10)
-	pellets = 8
-	range_step = 1
-	spread_step = 10
-	knockback = 1
+	damage_types = list(BRUTE = 38 - damage_falloff)
+	armor_penetration = 40
+	step_delay = 5
+	knockback = 0
 
-/obj/item/projectile/bullet/pellet/shotgun/Initialize()
+/obj/item/projectile/bullet/shotgun/buckshot/Initialize()
 	. = ..()
 	icon_state = "birdshot-[rand(1,4)]"
 
-/obj/item/projectile/bullet/pellet/shotgun/scrap
-	damage_types = list(BRUTE = 9)
+/obj/item/projectile/bullet/shotgun/buckshot/scrap
+	damage_types = list(BRUTE = 34)
+
+/obj/item/projectile/bullet/shotgun/buckshot/proc/get_damage(var/distance)
+	var/damage_falloff = round((distance - 1)*3)
+	if(distance > 1)
+		to_chat(world,
 
 //Miscellaneous
 /obj/item/projectile/bullet/blank

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -252,7 +252,7 @@ There are important things regarding this file:
 	icon_state = "birdshot-1"
 	damage_types = list(BRUTE = 38)
 	armor_penetration = 40
-	step_delay = 5
+	step_delay = 0.8
 	knockback = 0
 	proj_falloff = 3
 

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -252,7 +252,7 @@ There are important things regarding this file:
 	icon_state = "birdshot-1"
 	damage_types = list(BRUTE = 65)
 	armor_penetration = 0
-	step_delay = 0.8
+	step_delay = 0.9
 	knockback = 0
 	proj_falloff = 2
 

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -201,8 +201,8 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/shotgun
 	name = "slug"
 	icon_state = "slug"
-	damage_types = list(BRUTE = 54)
-	armor_penetration = 15
+	damage_types = list(BRUTE = 50)
+	armor_penetration = 10
 	knockback = 1
 	step_delay = 1.1
 

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -254,6 +254,7 @@ There are important things regarding this file:
 	armor_penetration = 40
 	step_delay = 5
 	knockback = 0
+	falloff = 3
 
 /obj/item/projectile/bullet/shotgun/buckshot/Initialize()
 	. = ..()
@@ -261,12 +262,6 @@ There are important things regarding this file:
 
 /obj/item/projectile/bullet/shotgun/buckshot/scrap
 	damage_types = list(BRUTE = 34)
-
-/obj/item/projectile/bullet/shotgun/buckshot/proc/calculate_falloff(var/distance)
-	var/distance
-	if(distance > 1)
-		to_chat(world, "<b>AREAS WITHOUT AN APC:</b>")
-	damage_types[BRUTE] -= distance[BRUTE]
 
 //Miscellaneous
 /obj/item/projectile/bullet/blank

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -250,7 +250,7 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/shotgun/buckshot
 	name = "shrapnel"
 	icon_state = "birdshot-1"
-	damage_types = list(BRUTE = 38 - damage_falloff)
+	damage_types = list(BRUTE = 38)
 	armor_penetration = 40
 	step_delay = 5
 	knockback = 0
@@ -262,10 +262,11 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/shotgun/buckshot/scrap
 	damage_types = list(BRUTE = 34)
 
-/obj/item/projectile/bullet/shotgun/buckshot/proc/get_damage(var/distance)
-	var/damage_falloff = round((distance - 1)*3)
+/obj/item/projectile/bullet/shotgun/buckshot/proc/calculate_falloff(var/distance)
+	var/distance
 	if(distance > 1)
-		to_chat(world,
+		to_chat(world, "<b>AREAS WITHOUT AN APC:</b>")
+	damage_types[BRUTE] -= distance[BRUTE]
 
 //Miscellaneous
 /obj/item/projectile/bullet/blank

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -250,8 +250,8 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/shotgun/buckshot
 	name = "shrapnel"
 	icon_state = "birdshot-1"
-	damage_types = list(BRUTE = 65)
-	armor_penetration = 0
+	damage_types = list(BRUTE = 60)
+	armor_penetration = 5
 	step_delay = 0.9
 	knockback = 0
 	proj_falloff = 2

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -250,7 +250,7 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/shotgun/buckshot
 	name = "shrapnel"
 	icon_state = "birdshot-1"
-	damage_types = list(BRUTE = 38)
+	damage_types = list(BRUTE = 37)
 	armor_penetration = 40
 	step_delay = 0.8
 	knockback = 0
@@ -261,7 +261,7 @@ There are important things regarding this file:
 	icon_state = "birdshot-[rand(1,4)]"
 
 /obj/item/projectile/bullet/shotgun/buckshot/scrap
-	damage_types = list(BRUTE = 34)
+	damage_types = list(BRUTE = 33)
 
 //Miscellaneous
 /obj/item/projectile/bullet/blank


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buckshot no longer uses janky pellet code, it is now a projectile like any other.
Previously, buckshot did a lot of damage at close range, enough to kill an unarmored person in 2 PB shots, while being useless against armor (if it was not for the jank). This is not fun for anyone foolish enough not to run around in full plate, and also limits buckshot to being used in the small niche of killing unarmored people quickly.

Now, buckshot deal 65 damage and have a slightly higher velocity than most bullets. It also loses 2 points of damage for each passed tile after the 2-tile range and gains 5 AP. This makes buckshot powerful at close range but for longer-ranged combat and against armored folks, slugs are superior. 

Slugs also had their damage nerfed from 54 to 47 and their AP buffed to 25 to make slugs more anti-armor- specialized.

## Why It's Good For The Game

NOOOOOOOOO YOU CAN'T JUST HIT SOMEONE 100 TIMES WITH ONE PROJECTILE NOOOOOO

## Changelog
:cl:
fix: buckshot should be much less janky now
balance: buckshot deals a bit less damage but has less damage falloff at range and flies slightly faster than other bullets.
balance: nerfed slugs damage and increased their AP
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
