### PR TITLE
Blacklists chameleon projector

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -16,6 +16,7 @@ GLOBAL_LIST_INIT(champroj_whitelist, list())
 	w_class = ITEM_SIZE_SMALL
 	origin_tech = list(TECH_COVERT = 4, TECH_MAGNET = 4)
 	suitable_cell = /obj/item/weapon/cell/small
+	spawn_blacklisted = TRUE
 	var/can_use = 1
 	var/obj/effect/dummy/chameleon/active_dummy
 	var/saved_item


### PR DESCRIPTION

## About The Pull Request

Title.

Blacklists the chameleon projector from spawning.

## Why It's Good For The Game

A, quite frankly strong, traitor item being able to spawn in maint doesn't seem like a good idea

## Changelog
:cl:
tweak: Chameleon Projector is now blacklisted from maint.
/:cl: