### PR TITLE
NT scourge bug fix

### DIFF
--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -83,10 +83,10 @@
 
 /obj/item/weapon/tool/sword/nt/scourge/proc/unextend()
 	extended = FALSE
-	force = initial(force)
-	armor_penetration = initial(armor_penetration)
-	slot_flags = initial(slot_flags)
 	w_class = initial(w_class)
+	slot_flags = initial(slot_flags)
+	armor_penetration = initial(armor_penetration)
+	refresh_upgrades() //it's also sets all to default
 	update_icon()
 
 /obj/item/weapon/tool/sword/nt/scourge/update_icon()

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -83,8 +83,10 @@
 
 /obj/item/weapon/tool/sword/nt/scourge/proc/unextend()
 	extended = FALSE
+	force = initial(force)
+	armor_penetration = initial(armor_penetration)
+	slot_flags = initial(slot_flags)
 	w_class = initial(w_class)
-	refresh_upgrades() //it's also sets all to default
 	update_icon()
 
 /obj/item/weapon/tool/sword/nt/scourge/update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes a bug where every time you extend the NT scourge, it would get extra damage and stop fitting in your belt slot, but refuse to reset these values upon unextending, resulting in a sword with infinite armor penetration after a while. and no way of fitting it in slots.

## Why It's Good For The Game


## Changelog
:cl:
fix: fixed some NT scourge related bugs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
