### PR TITLE
adds smoke grenades to the Sectech and gun vendor

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1021,7 +1021,8 @@
 					/obj/item/ammo_magazine/ammobox/pistol = 5,
 					/obj/item/weapon/storage/box/shotgunammo/slug = 3,
 					/obj/item/weapon/storage/box/shotgunammo/buckshot = 3,
-					/obj/item/weapon/tool/knife/tacknife = 5)
+					/obj/item/weapon/tool/knife/tacknife = 5,
+					/obj/item/weapon/storage/box/smokes = 3)
 
 	prices = list(
 					/obj/item/weapon/gun/projectile/automatic/slaught_o_matic = 90,
@@ -1042,6 +1043,7 @@
 					/obj/item/weapon/storage/box/shotgunammo/slug = 900,
 					/obj/item/weapon/storage/box/shotgunammo/buckshot = 900,
 					/obj/item/weapon/tool/knife/tacknife = 600,
+					/obj/item/weapon/storage/box/smoke = 200,
 					/obj/item/ammo_magazine/pistol = 600,)
 
 //This one's from bay12
@@ -1210,6 +1212,7 @@
 					/obj/item/weapon/handcuffs/zipties = 8,
 					/obj/item/weapon/grenade/flashbang = 8,
 					/obj/item/weapon/grenade/chem_grenade/teargas = 8,
+					/obj/item/weapon/grenade/smokebomb = 8,
 					/obj/item/device/flash = 8,
 					/obj/item/weapon/reagent_containers/spray/pepper = 8,
 					/obj/item/ammo_magazine/ihclrifle/rubber = 8,

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1043,7 +1043,7 @@
 					/obj/item/weapon/storage/box/shotgunammo/slug = 900,
 					/obj/item/weapon/storage/box/shotgunammo/buckshot = 900,
 					/obj/item/weapon/tool/knife/tacknife = 600,
-					/obj/item/weapon/storage/box/smoke = 200,
+					/obj/item/weapon/storage/box/smokes = 200,
 					/obj/item/ammo_magazine/pistol = 600,)
 
 //This one's from bay12


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

see title

## Why It's Good For The Game

Smoke bombs are cool but under-used.

## Changelog
:cl:
tweak: added smoke bombs to the sec and gun vendors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
