### PR TITLE
Small melee balance changes

### DIFF
--- a/code/game/objects/items/weapons/tools/knives.dm
+++ b/code/game/objects/items/weapons/tools/knives.dm
@@ -96,7 +96,7 @@
 	icon_state = "dagger"
 	item_state = "dagger"
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 2)
-	force = 13
+	force = WEAPON_FORCE_NORMAL * 1.3
 	armor_penetration = ARMOR_PEN_HALF
 	rarity_value = 15
 

--- a/code/game/objects/items/weapons/tools/knives.dm
+++ b/code/game/objects/items/weapons/tools/knives.dm
@@ -196,7 +196,7 @@
 	matter = list(MATERIAL_PLASTEEL = 4, MATERIAL_STEEL =6)
 	switched_on_qualities = list(QUALITY_CUTTING = 20, QUALITY_WIRE_CUTTING = 10, QUALITY_SCREW_DRIVING = 5)
 	w_class = ITEM_SIZE_TINY
-	var/switched_on_w_class
+	var/switched_on_w_class = ITEM_SIZE_SMALL
 	tool_qualities = list()
 	toggleable = TRUE
 	rarity_value = 25
@@ -243,6 +243,8 @@
 	sharp = FALSE
 	force = WEAPON_FORCE_WEAK
 	switched_on_force = WEAPON_FORCE_PAINFUL
+	w_class = ITEM_SIZE_TINY
+	var/switched_on_w_class = ITEM_SIZE_SMALL
 	matter = list(MATERIAL_PLASTEEL = 4, MATERIAL_STEEL = 6, MATERIAL_GOLD= 0.5)
 	switched_on_qualities = list(QUALITY_CUTTING = 20, QUALITY_WIRE_CUTTING = 10, QUALITY_SCREW_DRIVING = 5)
 	tool_qualities = list()
@@ -262,6 +264,7 @@
 	tool_qualities = switched_on_qualities
 	if (!isnull(switched_on_force))
 		force = switched_on_force
+	w_class = switched_on_w_class
 	update_icon()
 	update_wear_icon()
 
@@ -275,5 +278,6 @@
 	switched_on = FALSE
 	tool_qualities = switched_off_qualities
 	force = initial(force)
+	w_class = initial(w_class)
 	update_icon()
 	update_wear_icon()

--- a/code/game/objects/items/weapons/tools/knives.dm
+++ b/code/game/objects/items/weapons/tools/knives.dm
@@ -86,6 +86,7 @@
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 2)
 	force = WEAPON_FORCE_PAINFUL
 	armor_penetration = ARMOR_PEN_MODERATE
+	embed_mult = 0.3
 	max_upgrades = 3
 
 /obj/item/weapon/tool/knife/dagger
@@ -95,8 +96,8 @@
 	icon_state = "dagger"
 	item_state = "dagger"
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 2)
-	force = WEAPON_FORCE_NORMAL
-	armor_penetration = ARMOR_PEN_DEEP
+	force = 13
+	armor_penetration = ARMOR_PEN_HALF
 	rarity_value = 15
 
 /obj/item/weapon/tool/knife/dagger/ceremonial
@@ -105,6 +106,9 @@
 	icon_state = "fancydagger"
 	item_state = "fancydagger"
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 2, MATERIAL_GOLD = 1, MATERIAL_SILVER = 1)
+	armor_penetration = ARMOR_PEN_HALF
+	embed_mult = 0.3
+	max_upgrades = 4
 	spawn_blacklisted = TRUE
 
 /obj/item/weapon/tool/knife/dagger/bluespace
@@ -191,6 +195,8 @@
 	switched_on_force = WEAPON_FORCE_PAINFUL
 	matter = list(MATERIAL_PLASTEEL = 4, MATERIAL_STEEL =6)
 	switched_on_qualities = list(QUALITY_CUTTING = 20, QUALITY_WIRE_CUTTING = 10, QUALITY_SCREW_DRIVING = 5)
+	w_class = ITEM_SIZE_TINY
+	var/switched_on_w_class
 	tool_qualities = list()
 	toggleable = TRUE
 	rarity_value = 25
@@ -206,6 +212,7 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	switched_on = TRUE
 	tool_qualities = switched_on_qualities
+	w_class = switched_on_w_class
 	if (!isnull(switched_on_force))
 		force = switched_on_force
 	update_icon()
@@ -221,6 +228,7 @@
 	switched_on = FALSE
 	tool_qualities = switched_off_qualities
 	force = initial(force)
+	w_class = initial(w_class)
 	update_icon()
 	update_wear_icon()
 

--- a/code/game/objects/items/weapons/tools/pickaxe.dm
+++ b/code/game/objects/items/weapons/tools/pickaxe.dm
@@ -135,7 +135,7 @@
 	desc = "Yours is the drill that will pierce the heavens!"
 	icon_state = "diamonddrill"
 	item_state = "jackhammer"
-	force = 23
+	force = WEAPON_FORCE_DANGEROUS * 1.15
 	tool_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 20)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 20)
 	switched_on_qualities = list(QUALITY_DIGGING = 50, QUALITY_DRILLING = 20)

--- a/code/game/objects/items/weapons/tools/pickaxe.dm
+++ b/code/game/objects/items/weapons/tools/pickaxe.dm
@@ -135,7 +135,7 @@
 	desc = "Yours is the drill that will pierce the heavens!"
 	icon_state = "diamonddrill"
 	item_state = "jackhammer"
-	force = WEAPON_FORCE_DANGEROUS * 1.15
+	force = 23
 	tool_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 20)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 20)
 	switched_on_qualities = list(QUALITY_DIGGING = 50, QUALITY_DRILLING = 20)

--- a/code/game/objects/items/weapons/tools/saws.dm
+++ b/code/game/objects/items/weapons/tools/saws.dm
@@ -31,7 +31,7 @@
 	icon_state = "saw"
 	hitsound = WORKSOUND_CIRCULAR_SAW
 	worksound = WORKSOUND_CIRCULAR_SAW
-	force = WEAPON_FORCE_ROBUST
+	force = 23
 	armor_penetration = ARMOR_PEN_MODERATE
 	matter = list(MATERIAL_STEEL = 5, MATERIAL_PLASTIC = 2)
 	tool_qualities = list(QUALITY_SAWING = 40, QUALITY_CUTTING = 30, QUALITY_WIRE_CUTTING = 30)

--- a/code/game/objects/items/weapons/tools/saws.dm
+++ b/code/game/objects/items/weapons/tools/saws.dm
@@ -31,7 +31,7 @@
 	icon_state = "saw"
 	hitsound = WORKSOUND_CIRCULAR_SAW
 	worksound = WORKSOUND_CIRCULAR_SAW
-	force = 23
+	force = WEAPON_FORCE_DANGEROUS * 1.15
 	armor_penetration = ARMOR_PEN_MODERATE
 	matter = list(MATERIAL_STEEL = 5, MATERIAL_PLASTIC = 2)
 	tool_qualities = list(QUALITY_SAWING = 40, QUALITY_CUTTING = 30, QUALITY_WIRE_CUTTING = 30)
@@ -44,6 +44,7 @@
 	name = "advanced circular saw"
 	desc = "You think you can cut anything with it."
 	icon_state = "advanced_saw"
+	force = WEAPON_FORCE_ROBUST
 	armor_penetration = ARMOR_PEN_DEEP
 	matter = list(MATERIAL_STEEL = 6, MATERIAL_PLASTEEL = 1, MATERIAL_PLASTIC = 2)
 	tool_qualities = list(QUALITY_SAWING = 50, QUALITY_CUTTING = 40, QUALITY_WIRE_CUTTING = 40)

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -141,7 +141,7 @@
 	icon_state = "katana"
 	item_state = "katana"
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_STEEL = 5, MATERIAL_DIAMOND = 1) //sharpened using diamond dust or whatever
-	force = 30
+	force = WEAPON_FORCE_DANGEROUS * 1.5
 	armor_penetration = ARMOR_PEN_MODERATE
 	rarity_value = 35
 

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -141,7 +141,7 @@
 	icon_state = "katana"
 	item_state = "katana"
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_STEEL = 5, MATERIAL_DIAMOND = 1) //sharpened using diamond dust or whatever
-	force = WEAPON_FORCE_BRUTAL
+	force = 30
 	armor_penetration = ARMOR_PEN_MODERATE
 	rarity_value = 35
 
@@ -151,6 +151,7 @@
 	icon_state = "eutactic_katana"
 	item_state = "eutactic_katana"
 	toggleable = TRUE
+	max_upgrades = 1
 
 	suitable_cell = /obj/item/weapon/cell/small
 
@@ -159,7 +160,7 @@
 
 	switched_on_qualities = list(QUALITY_CUTTING = 25)
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 6)
-	switched_on_force = WEAPON_FORCE_LETHAL
+	switched_on_force = WEAPON_FORCE_BRUTAL
 	rarity_value = 60
 	spawn_blacklisted = TRUE
 

--- a/code/game/objects/items/weapons/tools/wrenches.dm
+++ b/code/game/objects/items/weapons/tools/wrenches.dm
@@ -31,7 +31,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	tool_qualities = list(QUALITY_BOLT_TURNING = 40,QUALITY_HAMMERING = 15)
 	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLASTEEL = 1)
-	force = 18
+	force = WEAPON_FORCE_PAINFUL * 1.2
 	structure_damage_factor = STRUCTURE_DAMAGE_HEAVY
 	throwforce = WEAPON_FORCE_PAINFUL
 	degradation = 0.7

--- a/code/game/objects/items/weapons/tools/wrenches.dm
+++ b/code/game/objects/items/weapons/tools/wrenches.dm
@@ -31,7 +31,8 @@
 	w_class = ITEM_SIZE_NORMAL
 	tool_qualities = list(QUALITY_BOLT_TURNING = 40,QUALITY_HAMMERING = 15)
 	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLASTEEL = 1)
-	force = WEAPON_FORCE_PAINFUL
+	force = 18
+	structure_damage_factor = STRUCTURE_DAMAGE_HEAVY
 	throwforce = WEAPON_FORCE_PAINFUL
 	degradation = 0.7
 	max_upgrades = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR mostly tries to make knives a bit more distinct and interesting and rebalances some melee weapons along the way.

- The tactical knife now has a lower chance to embed than other knives because tacticool

- The damage and the armor penetration of the dagger have been increased to from 10 to 13 and from 20 to 50, respectively, to make the dagger an actual dedicated anti-armor knife instead of being a crowbar minus

- The switchblade and butterfly knife are now tiny items when folded in.

- The ceremonial knife gets all of the above benefits with the exception of folding in, of course. The cap should get a robust knife.

- The katana has been nerfed to deal 30 damage instead of 33 in order to make it less superior to the claymore and other non-powered melee weapons

- The muramasa has been nerfed to deal 30 damage when turned off and 33 damage when turned on (instead of 40 damage when turned on), for obvious reasons.

- The circular saw has been nerfed to deal 23 damage instead of 26 damage because it is a very common tool and easy to store as well so it should not be as powerful as it is right now.

- The big wrench now deals 18 damage instead of 15 and is a bit better at smashing structures, too., for authentic techno melee combat.


## Why It's Good For The Game

perfectly balanced... Oh who am I kidding

## Changelog
:cl:
balance: buffed most knives
balance: nerfed katanas
balance: buffed the big wrench 
balance: nerfed the circular saw
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
