### PR TITLE
Even more Hivemind balance changes and tweaks

### DIFF
--- a/code/modules/hivemind/machines.dm
+++ b/code/modules/hivemind/machines.dm
@@ -566,7 +566,7 @@
 	icon_state = "head"
 	max_health = 100
 	evo_level_required = 3
-	cooldown_time = 20 SECONDS
+	cooldown_time = 25 SECONDS
 	spawn_weight  =	35
 
 
@@ -595,13 +595,13 @@
 
 	var/mob/living/carbon/human/H = target
 	if(istype(H))
-		if(prob(100 - H.stats.getStat(STAT_VIG)))
-			H.Weaken(5)
+		if(prob(90 - H.stats.getStat(STAT_VIG)))
+			H.Weaken(6)
 			to_chat(H, SPAN_WARNING("A terrible howl tears through your mind, the voice senseless, soulless."))
 		else
 			to_chat(H, SPAN_NOTICE("A terrible howl tears through your mind, but you refuse to listen to it!"))
 	else
-		target.Weaken(5)
+		target.Weaken(6)
 		to_chat(target, SPAN_WARNING("A terrible howl tears through your mind, the voice senseless, soulless."))
 
 

--- a/code/modules/hivemind/machines.dm
+++ b/code/modules/hivemind/machines.dm
@@ -281,11 +281,11 @@
 /obj/machinery/hivemind_machine/emp_act(severity)
 	switch(severity)
 		if(1)
-			take_damage(30)
-			stun(10)
+			take_damage(60)
+			stun(20)
 		if(2)
-			take_damage(10)
-			stun(5)
+			take_damage(30)
+			stun(8)
 	..()
 
 

--- a/code/modules/hivemind/mobs.dm
+++ b/code/modules/hivemind/mobs.dm
@@ -71,7 +71,7 @@
 //It's second proc, result of our malfunction
 /mob/living/simple_animal/hostile/hivemind/proc/malfunction_result()
 	if(prob(malfunction_chance))
-		apply_damage(rand(5, 15), BURN)
+		apply_damage(rand(5, 30), BURN)
 
 
 //sometimes, players use closets, to staff mobs into it
@@ -136,11 +136,11 @@
 	switch(severity)
 		if(1)
 			if(malfunction_chance < 15)
-				malfunction_chance = 15
+				malfunction_chance = 25
 		if(2)
 			if(malfunction_chance < 25)
-				malfunction_chance = 25
-	health -= 20*severity
+				malfunction_chance = 45
+	health -= 30*severity
 
 
 /mob/living/simple_animal/hostile/hivemind/death()
@@ -159,6 +159,7 @@
 /mob/living/simple_animal/hostile/hivemind/resurrected
 	name = "marionette"
 	malfunction_chance = 10
+	bad_type = /mob/living/simple_animal/hostile/hivemind/resurrected
 
 
 //careful with this proc, it's used to 'transform' corpses into our mobs.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

EMP is even better against hivemind, increasing the malfunction chance increase and damage dealt to mobs/machines
Malfunction is also now capable of dealing more damage
Tormentor (head on a tendril) has now a longer cooldown, and a slightly stronger stun, while also the chance to resist the stun being larger
Bans a mob (marionette) from spawning from assemblers (as it was never meant to)

## Why It's Good For The Game

-Makes EMP actually strong and useful against hivemind
-Malfunction had a long cooldown, it now is capable of dealing more damage in order to balance the 1 minute cooldown
-Tormentor stuns have always been weird balance-wise, think it's better if the chance to resist/ignore the stun is higher than before, also longer cooldown
-Marionette was never intended to spawn from assemblers

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Tweaked malfunction proc damage on Hivemind mobs and tweaked EMP damage against Hivemind
balance: Tormentor has a slightly longer stun, chance to resist said stun is bigger and Tormentor has longer cooldown
fix: Marionette no longer spawns from Hivemind Assemblers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
