### PR TITLE
Makes atmos fires less painful for engineers to deal with

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -15,7 +15,7 @@
 	desc = "Has a valve and pump attached to it"
 	use_power = NO_POWER_USE
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 7500			//7500 W ~ 10 HP
+	power_rating = 12000		//12000 W ~ 16 HP
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY //connects to regular and supply pipes
 
@@ -73,7 +73,7 @@
 
 /obj/machinery/atmospherics/unary/vent_pump/New()
 	..()
-	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP
+	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP * 2
 
 	initial_loc = get_area(loc)
 	area_uid = initial_loc.uid

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -9,7 +9,7 @@
 	desc = "Has a valve and pump attached to it"
 	use_power = NO_POWER_USE
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 7500			//7500 W ~ 10 HP
+	power_rating = 12000		//12000 W ~ 16 HP
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SCRUBBER //connects to regular and scrubber pipes
 
@@ -39,7 +39,7 @@
 
 /obj/machinery/atmospherics/unary/vent_scrubber/New()
 	..()
-	air_contents.volume = ATMOS_DEFAULT_VOLUME_FILTER
+	air_contents.volume = ATMOS_DEFAULT_VOLUME_FILTER * 2
 
 	initial_loc = get_area(loc)
 	area_uid = initial_loc.uid

--- a/code/__DEFINES/machinery.dm
+++ b/code/__DEFINES/machinery.dm
@@ -88,8 +88,8 @@ var/list/restricted_camera_networks = list(NETWORK_MERCENARY, "Secret")
 /*
  *	Atmospherics Machinery.
 */
-#define MAX_SIPHON_FLOWRATE   2500 // L/s. This can be used to balance how fast a room is siphoned. Anything higher than CELL_VOLUME has no effect.
-#define MAX_SCRUBBER_FLOWRATE 200  // L/s. Max flow rate when scrubbing from a turf.
+#define MAX_SIPHON_FLOWRATE   5000 // L/s. This can be used to balance how fast a room is siphoned. Anything higher than CELL_VOLUME has no effect.
+#define MAX_SCRUBBER_FLOWRATE 400  // L/s. Max flow rate when scrubbing from a turf.
 
 // These balance how easy or hard it is to create huge pressure gradients with pumps and filters.
 // Lower values means it takes longer to create large pressures differences.

--- a/code/__DEFINES/machinery.dm
+++ b/code/__DEFINES/machinery.dm
@@ -88,7 +88,7 @@ var/list/restricted_camera_networks = list(NETWORK_MERCENARY, "Secret")
 /*
  *	Atmospherics Machinery.
 */
-#define MAX_SIPHON_FLOWRATE   5000 // L/s. This can be used to balance how fast a room is siphoned. Anything higher than CELL_VOLUME has no effect.
+#define MAX_SIPHON_FLOWRATE   2500 // L/s. This can be used to balance how fast a room is siphoned. Anything higher than CELL_VOLUME has no effect.
 #define MAX_SCRUBBER_FLOWRATE 400  // L/s. Max flow rate when scrubbing from a turf.
 
 // These balance how easy or hard it is to create huge pressure gradients with pumps and filters.

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -122,6 +122,9 @@
 	if(buildstage == 2 && !master_is_operating())
 		elect_master()
 
+/obj/machinery/alarm/fire_act()
+	return
+
 /obj/machinery/alarm/Process()
 	if((stat & (NOPOWER|BROKEN)) || shorted || buildstage != 2)
 		return

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -692,6 +692,9 @@
 
 // attack with hand - remove cell (if cover open) or interact with the APC
 
+/obj/machinery/power/apc/fire_act()
+	return
+
 /obj/machinery/power/apc/emag_act(var/remaining_charges, var/mob/user)
 	if (!(emagged || hacker))		// trying to unlock with an emag card
 		if(opened)

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -106185,6 +106185,10 @@
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/reinforced,
 /area/eris/medical/chemstor)
+"sMx" = (
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/hull,
+/area/eris/engineering/atmos)
 "sRW" = (
 /obj/machinery/slotmachine,
 /turf/simulated/floor/tiled/steel/bar_light,
@@ -121226,7 +121230,7 @@ aGq
 aGS
 aFc
 aCW
-aad
+sMx
 aad
 aad
 aai


### PR DESCRIPTION
## About The Pull Request

This PR makes fires much easier to clean up, and also makes scrubbers and vents more efficient and powerful

## Why It's Good For The Game

I feel for a ship the size of Eris, standard ZAS configurations of some atmos machinery simply isnt enough to sustain a ship. If engineers are having to vent a room to space to clean it up faster than siphoning or scrubbers can, that is a major design issue.

## Changelog
:cl:

tweak: Max scrubber flow rate is now 400 Liters per second
tweak: vents and scrubbers now have a power rating of 12000 watts instead of 7500, this should make them able to move more moles of gas
tweak: scrubbers and vents now have more volume
tweak: APCs and air alarms (hopefully) no longer take fire damage and break, NT has now upgraded them
add; there is now a shield diffuser around the atmos waste vent, which will allow waste to leave atmos with the shields up
/:cl:

