### PR TITLE
Enables stock profiler for devs

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -736,7 +736,7 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 					config.start_location = "space ruins"
 
 				if("profiler_permission")
-					profiler_permission = text2num(value)
+					config.profiler_permission = text2num(value)
 
 				if("generate_loot_data")
 					config.generate_loot_data = TRUE
@@ -859,4 +859,3 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 
 	if(!ic_filter_regex && GLOB.in_character_filter.len)
 		ic_filter_regex = regex("\\b([jointext(GLOB.in_character_filter, "|")])\\b", "i")
-

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -227,6 +227,8 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 
 	var/generate_loot_data = FALSE //for loot rework
 
+	var/profiler_permission = R_DEBUG | R_SERVER
+
 /datum/configuration/New()
 	fill_storyevents_list()
 
@@ -732,6 +734,9 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 
 				if("ruins_start")
 					config.start_location = "space ruins"
+
+				if("profiler_permission")
+					profiler_permission = text2num(value)
 
 				if("generate_loot_data")
 					config.generate_loot_data = TRUE

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -28,9 +28,13 @@ var/list/admin_verbs = list("default" = list(), "hideable" = list())
 			if(text2num(text_right) & holder.rights)
 				verbs += admin_verbs[text_right]
 
+		if(check_rights(config.profiler_permission))
+			control_freak = 0 // enable profiler
+
 /client/proc/remove_admin_verbs()
 	for(var/right in admin_verbs)
 		verbs.Remove(admin_verbs[right])
+	control_freak = initial(control_freak)
 
 ADMIN_VERB_ADD(/client/proc/hide_most_verbs, null, FALSE)
 //hides all our hideable adminverbs

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -28,9 +28,6 @@
 		////////////
 		//SECURITY//
 		////////////
-	// comment out the line below when debugging locally to enable the options & messages menu
-	//control_freak = 1
-
 	var/received_irc_pm = -99999
 	var/irc_admin			//IRC admin that spoke with them last.
 	var/mute_irc = 0


### PR DESCRIPTION
## Changelog
:cl:
admin: Stock byond's optimized client-side profiler for devs, that not cause dream seeker and daemon lag as shit, required rights can be set through config. Current R_DEBUG | R_SERVER.
/:cl:
