### PR TITLE
fire slug buff

### DIFF
--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -232,10 +232,7 @@ There are important things regarding this file:
 	knockback = 0
 
 /obj/item/projectile/bullet/shotgun/incendiary
-	damage_types = list(BRUTE = 10)
-	agony = 5
-	armor_penetration = 0
-	embed = FALSE
+	damage_types = list(BRUTE = 45)
 	knockback = 0
 	var/fire_stacks = 4
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

incendiary shotgun slugs now deal 45 damage and have the same amount of AP as normal slugs, but they still don't knock you back. they also no longer cause agony.

## Why It's Good For The Game

Fire deals very low damage and can be easily extinguished. Incendiary slugs also require plasma and research to be fabricated.

## Changelog
:cl:
balance: buffed the damage of incendiary slugs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
