### PR TITLE
Carrion organ eating buff

### DIFF
--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -9,7 +9,7 @@
 	Your body is ever changing. You should start out by evolving a chemical vessel to use your powers. A carrion maw can be a good way to earn evolution points. <br>\
 	You can do contracts to grow stronger until the ship becomes your stage and your master plan is ready. A slow and methodical approach is recommended. <br>\
 	You won't find many friends here, but spiders are one of them. If you ever feel alone, you can always give birth to your own children, or search ship in attempt to find your brothers and sisters. <br>\
-	Your enemies are many, and your biology can be easily discerned in the health scanner. You should be wary of other carrions too, as your organs are a sought-after delicacy "
+	Your enemies are many, and your biology can be easily discerned in the health scanner. You should be wary of other carrions too, as your organs are sought-after for their taste and genetic material "
 
 	antaghud_indicator = "hudchangeling"
 

--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -9,7 +9,7 @@
 	Your body is ever changing. You should start out by evolving a chemical vessel to use your powers. A carrion maw can be a good way to earn evolution points. <br>\
 	You can do contracts to grow stronger until the ship becomes your stage and your master plan is ready. A slow and methodical approach is recommended. <br>\
 	You won't find many friends here, but spiders are one of them. If you ever feel alone, you can always give birth to your own children, or search ship in attempt to find your brothers and sisters. <br>\
-	Your enemies are many, and your biology can be easily discerned in the health scanner. You should be wary."
+	Your enemies are many, and your biology can be easily discerned in the health scanner. You should be wary of other carrions too, as your organs are a sought-after delicacy "
 
 	antaghud_indicator = "hudchangeling"
 

--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -9,7 +9,7 @@
 	Your body is ever changing. You should start out by evolving a chemical vessel to use your powers. A carrion maw can be a good way to earn evolution points. <br>\
 	You can do contracts to grow stronger until the ship becomes your stage and your master plan is ready. A slow and methodical approach is recommended. <br>\
 	You won't find many friends here, but spiders are one of them. If you ever feel alone, you can always give birth to your own children, or search ship in attempt to find your brothers and sisters. <br>\
-	Your enemies are many, and your biology can be easily discerned in the health scanner. You should be wary of other carrions too, as your organs are sought-after for their taste and genetic material "
+	Your enemies are many, and your biology can be easily discerned in the health scanner. You should be wary of other carrions too, as your organs are sought-after for their taste and genetic material."
 
 	antaghud_indicator = "hudchangeling"
 

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -233,7 +233,7 @@
 	var/obj/item/organ/internal/carrion/maw/H = owner.random_organ_by_process(OP_MAW)
 	if(!H)
 		geneticpoints_lost +=4
-		to_chat(owner, SPAN_NOTICE("your missing maw caused a leak of genetic material."))
+		to_chat(owner, SPAN_NOTICE("Your missing maw caused a leak of genetic material."))
 	owner.status_flags |= FAKEDEATH
 	owner.update_lying_buckled_and_verb_status()
 	owner.emote("gasp")

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -228,7 +228,7 @@
 	if(!(owner.check_ability(20)))
 		return
 
-	to_chat(owner, SPAN_NOTICE("you will attempt to regenerate your form."))
+	to_chat(owner, SPAN_NOTICE("You will attempt to regenerate your form."))
 	var/geneticpoints_lost = 0
 	var/obj/item/organ/internal/carrion/maw/H = owner.random_organ_by_process(OP_MAW)
 	if(!H)

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -222,18 +222,23 @@
 	set category = "Carrion"
 	set name = "Regenerative Stasis (20)"
 
-	if(!owner.stat && alert("Are we sure we wish to fake our death?",,"Yes","No") == "No")
+	if(!owner.stat && alert("Are you sure you wish to fake our death?",,"Yes","No") == "No")
 		return
 
 	if(!(owner.check_ability(20)))
 		return
 
-	to_chat(owner, SPAN_NOTICE("We will attempt to regenerate our form."))
-
+	to_chat(owner, SPAN_NOTICE("you will attempt to regenerate your form."))
+	var/geneticpoints_lost = 0
+	var/obj/item/organ/internal/carrion/maw/H = owner.random_organ_by_process(OP_MAW)
+	if(!H)
+		geneticpoints_lost +=4
+		to_chat(owner, SPAN_NOTICE("your missing maw caused a leak of genetic material."))
 	owner.status_flags |= FAKEDEATH
 	owner.update_lying_buckled_and_verb_status()
 	owner.emote("gasp")
 	owner.timeofdeath = world.time
+	src.geneticpoints -= geneticpoints_lost
 	var/last_owner = owner
 
 	spawn(rand(1 MINUTES, 3 MINUTES))

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -288,6 +288,11 @@
 			if(BP_IS_ROBOTIC(O))
 				to_chat(owner, SPAN_WARNING("This organ is robotic, you can't eat it."))
 				return
+			else if(istype(O, /obj/item/organ/internal/carrion))
+				owner.carrion_hunger += 3
+				geneticpointgain = 4
+				chemgain = 50
+				taste_description = "carrion organs taste heavenly, you need more!"
 			else if(istype(O, /obj/item/organ/internal))
 				geneticpointgain = 3
 				chemgain = 20


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Carrion internal organs (maw, chem vessel, spinneret) now add 4 genome points while only lowering your hunger by one point. They also completely refill your chemicals. regenerating without a maw will now deduct 4 gene points so you can't infinitely regenerate and eat and regenerate your own maw (you need your chemvessel to regenerate, and the spinneret costs 7 points to evolve, so those can't be eaten for a profit)

## Why It's Good For The Game

This gives carrions an incentive for screwing each other over, leading to funfunfun paranoia. Also makes spamming infection spiders riskier, as mass-converting will certainly lead to you being backstabbed by others. You can't farm gene points by converting because new convertees will only develop their organs once they're certain you won't/can't harm them, so converting someone without releasing them in order to eat their organs will not work because these people won't develop their organs if they're not granted freedom

## Changelog
:cl:
add: carrion organs are now extra tasty, and give 4 gene points while only satisfying you once.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
