### PR TITLE
signaling spider for carrion

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -1039,6 +1039,7 @@
 #include "code\game\objects\items\weapons\implant\implants\carrion\infection_spider.dm"
 #include "code\game\objects\items\weapons\implant\implants\carrion\mindboil_spider.dm"
 #include "code\game\objects\items\weapons\implant\implants\carrion\observer_spider.dm"
+#include "code\game\objects\items\weapons\implant\implants\carrion\signal_spider.dm"
 #include "code\game\objects\items\weapons\implant\implants\carrion\toxic_spider.dm"
 #include "code\game\objects\items\weapons\material\ashtray.dm"
 #include "code\game\objects\items\weapons\material\bats.dm"

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -174,7 +174,7 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 
 				// Attach
 				else
-					if(istype(I, /obj/item/device/assembly/signaler))
+					if(istype(I, /obj/item/device/assembly/signaler) || istype(I, /obj/item/weapon/implant/carrion_spider/signal))
 						L.drop_item()
 						add_log_entry(L, "has attached [I] to the <font color='[colour]'>[capitalize(colour)]</font> wire")
 						Attach(colour, I)
@@ -273,17 +273,19 @@ var/const/POWER = 8
 	return null
 
 /datum/wires/proc/Attach(var/colour, var/obj/item/device/assembly/signaler/S)
-	if(colour && S)
-		if(!IsAttached(colour))
-			signallers[colour] = S
-			S.loc = holder
-			S.connected = src
-			return S
+    var/obj/item/weapon/implant/carrion_spider/signal/I = S
+    if(istype(S) || istype(I))
+        if(!IsAttached(colour))
+            signallers[colour] = S
+            S.loc = holder
+            S.connected = src
+            return S
 
 /datum/wires/proc/Detach(var/colour)
 	if(colour)
 		var/obj/item/device/assembly/signaler/S = GetAttached(colour)
-		if(S)
+		var/obj/item/weapon/implant/carrion_spider/signal/I = S
+		if(istype(S) || istype(I))
 			signallers -= colour
 			S.connected = null
 			S.loc = holder.loc
@@ -291,11 +293,12 @@ var/const/POWER = 8
 
 
 /datum/wires/proc/Pulse(var/obj/item/device/assembly/signaler/S)
-
-	for(var/colour in signallers)
-		if(S == signallers[colour])
-			PulseColour(colour)
-			break
+	var/obj/item/weapon/implant/carrion_spider/signal/I = S
+	if(istype(S) || istype(I))
+		for(var/colour in signallers)
+			if(S == signallers[colour])
+				PulseColour(colour)
+				break
 
 
 //

--- a/code/game/gamemodes/changeling/modularchangling.dm
+++ b/code/game/gamemodes/changeling/modularchangling.dm
@@ -74,6 +74,12 @@ var/list/datum/power/carrion/powerinstances = list()
 	genomecost = 3
 	spiderpath = /obj/item/weapon/implant/carrion_spider/identity
 
+/datum/power/carrion/signal_spider
+	name = "Electrocurrent spider"
+	desc = "Creates a spider that can pulse wires in machines."
+	genomecost = 2
+	spiderpath = /obj/item/weapon/implant/carrion_spider/signal
+
 /datum/power/carrion/maw
 	name = "Carrion Maw"
 	desc = "Unlocks and expands your jaw, giving you the ability to spit acid and call upon spiders."

--- a/code/game/objects/items/weapons/implant/implants/carrion/signal_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/signal_spider.dm
@@ -1,0 +1,14 @@
+/obj/item/weapon/implant/carrion_spider/signal
+	name = "electrocurrent spider"
+	icon_state = "spiderling_identity"
+	spider_price = 5
+	var/datum/wires/connected
+
+/obj/item/weapon/implant/carrion_spider/signal/activate()
+	..()
+	if(src.connected)
+		connected.Pulse(src)
+	else
+		to_chat(owner_mob, SPAN_WARNING("[src] is not attached to a pulseable wire"))
+
+		


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'll probably merge this with the  spark spider if showns PR ever gets merged
shown also helped me circumvent shitcoding through advanced shitcoding.

Carrions get a cheap spider that can be attached to wires like a signaler and pulsed via activation. can't be used for grenades and assemblies, though.

## Why It's Good For The Game

1000 IQ plans instead of hand grenade spiders

## Changelog
:cl:
add: signaler spider for the carrion, works like a signaling device
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
