### PR TITLE
Hivemind Machine Damage Text

### DIFF
--- a/code/modules/hivemind/machines.dm
+++ b/code/modules/hivemind/machines.dm
@@ -45,6 +45,20 @@
 		icon_state = initial(icon_state)
 
 
+/obj/machinery/hivemind_machine/examine(mob/user)
+	..()
+	if (health < max_health * 0.1)
+		to_chat(user, SPAN_DANGER("It's almost nothing but scrap!"))
+	else if (health < max_health * 0.25)
+		to_chat(user, SPAN_DANGER("It's seriously fucked up!"))
+	else if (health < max_health * 0.50)
+		to_chat(user, SPAN_DANGER("It's very damaged, you can almost see the components inside!"))
+	else if (health < max_health * 0.75)
+		to_chat(user, SPAN_WARNING("It has numerous dents and deep scratches."))
+	else if (health < max_health)
+		to_chat(user, SPAN_WARNING("It's a bit scratched and has dents."))
+
+
 /obj/machinery/hivemind_machine/Process()
 	if(wireweeds_required && !locate(/obj/effect/plant/hivemind) in loc)
 		take_damage(5, on_damage_react = FALSE)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

##About Pull Request

You can (rougly) tell how much a hivemind machine is damaged now when examining it.
That's it
![image](https://user-images.githubusercontent.com/59490776/110212999-69ce6a80-7e9e-11eb-885c-82acd31c4b75.png)


## Why It's Good For The Game

Players being able to tell if they are actually dealing any damage to the machine is important, along with being able to know how much HP the machine still has.
Also helps in debugging.

## Changelog
:cl:
add: You can now examine Hivemind machines to rougly check their health
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
