### PR TITLE
Neohongo Ironhammer Conversion

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -10,7 +10,7 @@
 	supervisors = "the Moebius Expedition Overseer"
 	selection_color = "#94a87f"
 	req_admin_notify = 1
-	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_SERBIAN = 5, LANGUAGE_NEOHONGO = 40)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_SERBIAN = 5)
 	wage = WAGE_COMMAND
 	outfit_type = /decl/hierarchy/outfit/job/medical/cmo
 
@@ -70,7 +70,7 @@ Your second loyalty is to your career with Moebius corp, and to your coworkers i
 	supervisors = "the Moebius Biolab Officer"
 	selection_color = "#a8b69a"
 	wage = WAGE_PROFESSIONAL
-	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_NEOHONGO = 20)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 10)
 
 	outfit_type = /decl/hierarchy/outfit/job/medical/doctor
 
@@ -131,7 +131,7 @@ Your second loyalty is to your career with Moebius corp, and to your coworkers i
 	supervisors = "the Moebius Biolab Officer"
 	selection_color = "#a8b69a"
 	wage = WAGE_PROFESSIONAL
-	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_NEOHONGO = 20)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 10)
 
 	outfit_type = /decl/hierarchy/outfit/job/medical/chemist
 
@@ -184,7 +184,7 @@ Your second loyalty is to your career with Moebius corp, and to your coworkers i
 	wage = WAGE_PROFESSIONAL
 	supervisors = "the Moebius Biolab Officer"
 	selection_color = "#a8b69a"
-	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_NEOHONGO = 20)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 10)
 
 	outfit_type = /decl/hierarchy/outfit/job/medical/psychiatrist
 
@@ -222,7 +222,7 @@ Your second loyalty is to your career with Moebius corp, and to your coworkers i
 	supervisors = "the Moebius Biolab Officer"
 	selection_color = "#a8b69a"
 	wage = WAGE_LABOUR_HAZARD
-	also_known_languages = list(LANGUAGE_CYRILLIC = 20, LANGUAGE_SERBIAN = 15, LANGUAGE_NEOHONGO = 20)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 20, LANGUAGE_SERBIAN = 15)
 
 	outfit_type = /decl/hierarchy/outfit/job/medical/paramedic
 	access = list(

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -11,7 +11,7 @@
 	selection_color = "#b39aaf"
 	req_admin_notify = 1
 	wage = WAGE_COMMAND
-	also_known_languages = list(LANGUAGE_CYRILLIC = 25, LANGUAGE_SERBIAN = 25, LANGUAGE_NEOHONGO = 35)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 25, LANGUAGE_SERBIAN = 25)
 
 	outfit_type = /decl/hierarchy/outfit/job/science/rd
 
@@ -69,7 +69,7 @@ Your second loyalty is to moebius corp. In order to ensure it can continue its m
 	supervisors = "the Moebius Expedition Overseer"
 	selection_color = "#bdb1bb"
 	wage = WAGE_PROFESSIONAL
-	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_NEOHONGO = 20)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 10)
 
 	//alt_titles = list("Moebius Xenobiologist")
 	outfit_type = /decl/hierarchy/outfit/job/science/scientist
@@ -129,7 +129,7 @@ Your second loyalty is to moebius corp. In order to ensure it can continue its m
 	supervisors = "the Moebius Expedition Overseer"
 	selection_color = "#bdb1bb"
 	wage = WAGE_PROFESSIONAL
-	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_NEOHONGO = 20)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 10)
 
 	outfit_type = /decl/hierarchy/outfit/job/science/roboticist
 

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -11,7 +11,7 @@
 	selection_color = "#97b0be"
 	req_admin_notify = 1
 	wage = WAGE_COMMAND
-	also_known_languages = list(LANGUAGE_CYRILLIC = 60, LANGUAGE_SERBIAN = 60)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 60, LANGUAGE_SERBIAN = 60, LANGUAGE_NEOHONGO = 100)
 
 	outfit_type = /decl/hierarchy/outfit/job/security/ihc
 
@@ -71,7 +71,7 @@
 	selection_color = "#a7bbc6"
 	department_account_access = TRUE
 	wage = WAGE_LABOUR_HAZARD
-	also_known_languages = list(LANGUAGE_CYRILLIC = 25, LANGUAGE_SERBIAN = 25)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 25, LANGUAGE_SERBIAN = 25, LANGUAGE_NEOHONGO = 65)
 
 	outfit_type = /decl/hierarchy/outfit/job/security/gunserg
 
@@ -123,7 +123,7 @@
 	supervisors = "the Ironhammer Commander"
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
-	also_known_languages = list(LANGUAGE_CYRILLIC = 50, LANGUAGE_SERBIAN = 50)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 50, LANGUAGE_SERBIAN = 50, LANGUAGE_NEOHONGO = 80)
 
 	outfit_type = /decl/hierarchy/outfit/job/security/inspector
 
@@ -179,7 +179,7 @@
 	supervisors = "the Ironhammer Commander"
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
-	also_known_languages = list(LANGUAGE_CYRILLIC = 5)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 5, LANGUAGE_NEOHONGO = 35)
 
 	outfit_type = /decl/hierarchy/outfit/job/security/medspec
 
@@ -232,7 +232,7 @@
 	//alt_titles = list("Ironhammer Junior Operative")
 	selection_color = "#a7bbc6"
 	wage = WAGE_LABOUR_HAZARD
-	also_known_languages = list(LANGUAGE_CYRILLIC = 25, LANGUAGE_SERBIAN = 25)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 25, LANGUAGE_SERBIAN = 25, LANGUAGE_NEOHONGO = 45)
 
 	outfit_type = /decl/hierarchy/outfit/job/security/ihoper
 

--- a/code/modules/mob/language/neohongo.dm
+++ b/code/modules/mob/language/neohongo.dm
@@ -16,5 +16,7 @@
 	                 "shishutemu", "irai", "ichi", "kore", "sore", "are", "dore", "jido", "seishiki", "genzai", "miral", "ii", "yoi", \
 	                 "Jikko", "naze", "takai", "boruda", "garasu","kritikaru", "chan", "itsu","niichi", "ji", "mono", \
 	                 "daigaku", "ima", "ato", "mae", "sen", "heya", "namae", "chuu", "gai", "hoka no", "desu", "receive", \
-	                 "tsukuru", "manabu", "chikai", "daijoubu", "totemo", "shikashi", "mata", "dakara", "to", " node", "kashira")
+	                 "tsukuru", "manabu", "chikai", "daijoubu", "totemo", "shikashi", "mata", "dakara", "to", " node", "kashira", \
+	                 "dan'yaku", "guntai", "taiho", "Kogeki!", "bakudan", "tatakai", "gado", "koshi!", "heishi", "shori!", \
+	                 "shireikan", "misairu", "shuryuudan!", "buki", "sento", "teisen", "senso", "tairyohakaiheiki", "hohei!", "eiseitai!")
 

--- a/code/modules/mob/language/neohongo.dm
+++ b/code/modules/mob/language/neohongo.dm
@@ -17,6 +17,6 @@
 	                 "Jikko", "naze", "takai", "boruda", "garasu","kritikaru", "chan", "itsu","niichi", "ji", "mono", \
 	                 "daigaku", "ima", "ato", "mae", "sen", "heya", "namae", "chuu", "gai", "hoka no", "desu", "receive", \
 	                 "tsukuru", "manabu", "chikai", "daijoubu", "totemo", "shikashi", "mata", "dakara", "to", " node", "kashira", \
-	                 "dan'yaku", "guntai", "taiho", "Kogeki!", "bakudan", "tatakai", "gado", "koshi!", "heishi", "shori!", \
-	                 "shireikan", "misairu", "shuryuudan!", "buki", "sento", "teisen", "senso", "tairyohakaiheiki", "hohei!", "eiseitai!")
+	                 "dan'yaku", "guntai", "taiho", "Kogeki", "bakudan", "tatakai", "gado", "koshi", "heishi", "shori", \
+	                 "shireikan", "misairu", "shuryuudan", "buki", "sento", "teisen", "senso", "tairyohakaiheiki", "hohei", "eiseitai")
 


### PR DESCRIPTION
## About The Pull Request

Switches Neohongo over to the IH due to their affilitation with Frozen Star, also militarised the vocabulary to suit IH more. (Moebius no longer has Neohongo)

## Why It's Good For The Game

Neohongo suits IH better, because of their relationship with the Japanese company known as Frozen Star.

## Changelog
:cl:
tweak: Neohongo IH conversion.
/:cl: