### PR TITLE
Yet another awful hivemind mobs update, including Tyrant

### DIFF
--- a/code/modules/hivemind/mobs.dm
+++ b/code/modules/hivemind/mobs.dm
@@ -312,7 +312,7 @@
 /mob/living/simple_animal/hostile/hivemind/bomber/death()
 	..()
 	gibs(loc, null, /obj/effect/gibspawner/robot)
-	explosion(get_turf(src), 0, 0, 3) //explosion almost equal to a full welding fuel tank, deadly
+	explosion(get_turf(src), 0, 0, 2) //explosion almost equal to a full welding fuel tank, deadly
 	qdel(src)
 
 
@@ -426,8 +426,8 @@
 	desc = "A cyborg covered with something... something alive."
 	icon_state = "hiborg"
 	icon_dead = "hiborg-dead"
-	health = 400
-	maxHealth = 400 //can take a lot of hits before being obliterated
+	health = 350
+	maxHealth = 350 //can take a lot of hits before being obliterated
 	melee_damage_lower = 25
 	melee_damage_upper = 30 //Claws man, they hurt
 	attacktext = "clawed"
@@ -638,12 +638,13 @@
 
 /mob/living/simple_animal/hostile/hivemind/mechiver
 	name = "Mechiver"
-	desc = "Once an exosuit, this hulking amalgamation of flesh and machine drips fresh blood out of the pilot's hatch."
+	desc = "Once an exosuit, this hulking amalgamation of armoured flesh and machine drips fresh blood out of the pilot's hatch."
 	icon = 'icons/mob/hivemind.dmi'
 	icon_state = "mechiver-closed"
 	icon_dead = "mechiver-dead"
-	health = 700
-	maxHealth = 700
+	health = 550
+	maxHealth = 550
+	resistance = RESISTANCE_AVERAGE
 	melee_damage_lower = 25
 	melee_damage_upper = 35
 	mob_size = MOB_LARGE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hivetechboss.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hivetechboss.dm
@@ -11,8 +11,8 @@
 	pixel_x = -16
 	ranged = TRUE
 
-	health = 2250
-	maxHealth = 2250 //Only way for it to show up right now is via adminbus OR Champion call (which gives it 150hp). For comparison Kaiser has 2000hp
+	health = 1650
+	maxHealth = 1650 //Only way for it to show up right now is via adminbus OR Champion call (which gives it 150hp). For comparison Kaiser has 2000hp
 	break_stuff_probability = 95
 
 	melee_damage_lower = 30
@@ -21,22 +21,11 @@
 	megafauna_max_cooldown = 80
 
 
-	var/health_marker_1 = 0//1700
-	var/health_marker_2 = 0//900
-	var/health_marker_3 = 0//100
-
 	projectiletype = /obj/item/projectile/goo
 
 /mob/living/simple_animal/hostile/megafauna/hivemind_tyrant/death()
 	..()
 	delhivetech()
-
-/mob/living/simple_animal/hostile/megafauna/hivemind_tyrant/proc/telenode()
-	var/list/atom/NODES = list()
-	for(var/obj/machinery/hivemind_machine/node/NODE in world)
-		NODES.Add(NODE.loc)
-	if(length(NODES) > 0)
-		forceMove(pick(NODES))
 
 /mob/living/simple_animal/hostile/megafauna/hivemind_tyrant/proc/delhivetech()
 	var/othertyrant = 0
@@ -55,18 +44,6 @@
 		return 0
 	if(client)
 		return 0
-
-	if(!health_marker_1 && health < 1700)
-		health_marker_1 = !health_marker_1
-		telenode()
-
-	if(!health_marker_2 && health < 900)
-		health_marker_2 = !health_marker_2
-		telenode()
-
-	if(!health_marker_3 && health < 100)
-		health_marker_3 = !health_marker_3
-		telenode()
 
 /mob/living/simple_animal/hostile/megafauna/hivemind_tyrant/OpenFire()
 	anger_modifier = CLAMP(((maxHealth - health)/50),0,20)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hivetechboss.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hivetechboss.dm
@@ -11,8 +11,8 @@
 	pixel_x = -16
 	ranged = TRUE
 
-	health = 1650
-	maxHealth = 1650 //Only way for it to show up right now is via adminbus OR Champion call (which gives it 150hp). For comparison Kaiser has 2000hp
+	health = 1850
+	maxHealth = 1850 //Only way for it to show up right now is via adminbus OR Champion call (which gives it 150hp). For comparison Kaiser has 2000hp
 	break_stuff_probability = 95
 
 	melee_damage_lower = 30


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes Bomber explosion being 5x5 instead of 3x3
Hiborg and Mechiver have now reduced HP
Mechiver has a small Resistance, reducing damage taken
Tyrant can no longer teleport

## Why It's Good For The Game

5x5 explosion was ridiclously broken
Hiborg was a bit too tanky in personal
Mechiver similary so, however I also gave it a small amount of resistance so it can shrug off very basic attacks

Tyrant teleporting around is absolutely awful, given the fact that it can teleport to ANY core in game, not to mention often failing at that and teleporting into maint and other unintended areas. Also reduced HP by a bit, as to help the crew a bit.

## Changelog
:cl:
tweak: Hiborg and Mechiver have reduced HP. Mechiver now has some flat damage resistance.
balance: Removed Hivemind Tyrant's ability to teleport around.
fix: Fixed Hivemind Bomber's explosion being 5x5 instead of 3x3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
