### PR TITLE
Biomatter now properly checks bio armor

### DIFF
--- a/code/modules/biomatter_manipulation/toxic_biomass.dm
+++ b/code/modules/biomatter_manipulation/toxic_biomass.dm
@@ -4,9 +4,8 @@
 //toxin attack proc, it's used for attacking people with checking their armor
 /proc/toxin_attack(mob/living/victim, var/damage = rand(2, 4))
 	if(istype(victim))
-		var/hazard_protection = victim.getarmor(null, ARMOR_BIO)
-		if(!hazard_protection)
-			victim.apply_damage(damage * victim.reagent_permeability(), TOX)
+		var/hazard_protection = 100 - victim.getarmor(null, ARMOR_BIO)
+		victim.apply_damage(max(0, damage * hazard_protection / 100 * victim.reagent_permeability()), TOX)
 
 
 //this proc spill some biomass on the floor


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Previously, if you had any amount of bio protection, no matter the amount, you were completely safe from Biomatter. Now, bio protection reduces the toxin damage percentage-based

Rosa, please mention this change boldly in your news post, we at least want to pretend we care about NTards who are going to die like flies after this change.
## Why It's Good For The Game

So scientists in bare jumpsuuits can no longer steamroll street shitting NT

## Changelog
:cl:
fix: biomatter now deals damage based on the amount of bio protection you have, instead of just not dealing damage if you had even a very tiny amount of bio resist.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
