### PR TITLE
QoL: Cyborg tile stack can copy steel tiles by clicking on them

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -198,7 +198,7 @@
 		var/obj/item/stack/tile/floor/cyborg/C = I
 		C.stacktype = src.type
 		C.build_type = src.type
-		to_chat(usr, SPAN_NOTICE("You will now build [C.build_type]"))
+		to_chat(usr, SPAN_NOTICE("You will now build [C.name]"))
 	else
 		..()
 

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -191,6 +191,17 @@
 /*
  * Steel
  */
+
+ // Cyborg tile stack can copy steel tiles by clicking on them (for easy reconstruction)
+/obj/item/stack/tile/floor/steel/attackby(obj/item/I, mob/living/user)
+	if(istype(I, /obj/item/stack/tile/floor/cyborg))
+		var/obj/item/stack/tile/floor/cyborg/C = I
+		C.stacktype = src.type
+		C.build_type = src.type
+		to_chat(usr, SPAN_NOTICE("You will now build [C.build_type]"))
+	else
+		..()
+
 /obj/item/stack/tile/floor/steel
 	name = "steel floor tile"
 	singular_name = "steel floor tile"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cyborg tile stack (the one owned by maintenance drones and engi borgs) can copy steel tiles by clicking on them.

## Why It's Good For The Game

It makes reconstruction way easier and prettier for cyborgs because right now you have to chose the type you want to build with a limited list without any previsualization capability. Now when a floor is damaged, you just crowbar a nearby intact tile, click on it to copy it then put down the tile on the damaged spot. And because it's the same type they will merge cleanly instead of an ugly spot because you could not find the exact right type.

## Changelog
:cl: Hyperio
add: Cyborg tile stack can copy steel tiles by clicking on them for easy reconstruction of damaged areas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
