### PR TITLE
Fixes/tweaks Hivemind mobs speed

### DIFF
--- a/code/modules/hivemind/mobs.dm
+++ b/code/modules/hivemind/mobs.dm
@@ -228,6 +228,7 @@
 //Special ability: none
 //Just another boring mob without any cool abilities
 //Low chance of malfunction
+//Faster than average, to the point it could possibly catch up to someone
 //Default speaking chance
 //Appears from dead small mobs or from hive spawner
 //////////////////////////////////////////////////////////////////////////////
@@ -246,7 +247,7 @@
 	malfunction_chance = 5
 	mob_size = MOB_SMALL
 	pass_flags = PASSTABLE
-	speed = 5
+	move_to_delay = 2
 
 	speak = list(
 				"A stitch in time saves nine!",
@@ -275,6 +276,7 @@
 //Special ability: none
 //Explode in contact with target
 //Extremely low chance of malfunction
+//Very slow
 //Default speaking chance
 //Appears from dead small mobs or from hive spawner
 //////////////////////////////////////////////////////////////////////////////
@@ -290,7 +292,7 @@
 	malfunction_chance = 1 //1% chance of it exploding, for no reason at all
 	mob_size = MOB_SMALL
 	pass_flags = PASSTABLE
-	speed = 2 //explosive, slow, don't ignore it. it can catch up to you
+	move_to_delay = 10 //explosive, slow, don't ignore it. it can catch up to you
 	rarity_value = 25
 	speak = list(
 				"WE COME IN PEACE.",
@@ -327,7 +329,6 @@
 //Special ability: Can fire 3 projectiles at once for 10 seconds, then overheats
 //Deals no melee damage, but fires projectiles
 //Starts with 10 malfunction chance, malfunction also triggered when overheating
-//Higher speed than normal
 //Slighly higher speaking chance
 //Appears from hive spawner and Mechiver
 //Appears rarely than bomber or stinger
@@ -355,7 +356,6 @@
 	rarity_value = 50
 	mob_size = MOB_SMALL
 	pass_flags = PASSTABLE
-	speed = 8
 	ability_cooldown = 60 SECONDS
 	speak = list(
 				"No more leaks, no more pain!",
@@ -421,6 +421,7 @@
 //							  Splash attack, that slash everything around!
 //Decent chance of malfunction
 //Default speaking chance
+//Slower than average
 //Appears from dead cyborgs and assemblers
 //////////////////////////////////////////////////////////////////////////////
 
@@ -434,7 +435,7 @@
 	melee_damage_lower = 25
 	melee_damage_upper = 30 //Claws man, they hurt
 	attacktext = "clawed"
-	speed = 7
+	move_to_delay = 6
 	malfunction_chance = 10 //although it is a complex machine, it is all metal and wires rather than a combination of machinery and flesh
 	mob_size = MOB_MEDIUM
 	rarity_value = 75
@@ -494,6 +495,7 @@
 //Special ability: Shriek, that stuns victims
 //Can fool his enemies and pretend to be dead
 //A little bit higher chance of malfunction than others
+//Slower than average, faster than Hiborg
 //Default speaking chance
 //Appears from dead human corpses
 //////////////////////////////////////////////////////////////////////////////
@@ -510,7 +512,7 @@
 	attacktext = "slashed"
 	malfunction_chance = 20 //a combination of metal and flesh in a weird and confusing way. I would assume the body is trying to reject the implants/cybernetics.
 	mob_size = MOB_MEDIUM
-	speed = 8
+	move_to_delay = 5
 	ability_cooldown = 20 SECONDS
 	rarity_value = 75
 	//internals
@@ -636,6 +638,7 @@
 //Can picking up corpses too, rebuild them to living hive mobs, like it wires do
 //Default malfunction chance
 //Increased speaking chance, can take pilot and speak with him
+//Dummy thick, slow as fuck
 //Rarely can appear from infested machinery (with a circuit board, like an Autholate)
 //////////////////////////////////////////////////////////////////////////////
 
@@ -645,16 +648,16 @@
 	icon = 'icons/mob/hivemind.dmi'
 	icon_state = "mechiver-closed"
 	icon_dead = "mechiver-dead"
-	health = 550
-	maxHealth = 550
-	resistance = RESISTANCE_AVERAGE
+	health = 600
+	maxHealth = 600
+	resistance = RESISTANCE_ARMOURED 
 	melee_damage_lower = 25
 	melee_damage_upper = 35
 	mob_size = MOB_LARGE
 	attacktext = "crushed"
 	ability_cooldown = 1 MINUTES
 	speak_chance = 8
-	speed = 8
+	move_to_delay = 10
 	rarity_value = 125
 	//internals
 	var/pilot						//Yes, there's no pilot, so we just use var


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I finally figured out how to properly set the speed of Hivemind mobs, no more fucky balance

Stinger is fast now, to the point it could possibly catch up

Bomber is slow, you can easily outrun it or kite it

Lobber has "normal" movement speed

Similary with Mechiver, however the mechiver has now way better armour and a bigger HP pool as to compensate for it's slowness

Hiborg and Himan are slower than average, with the Himan being faster than Hiborg

Marionette movement speed is unchanged

## Why It's Good For The Game

Before this PR all the hivemind mobs had the same speed
This was obviously awful and not what i wanted, given the fact that a suicide bomb and a armoured walking tank had the same speed.

This PR effectively fixes that by making the mobs slower (or faster for the Stinger).

Also the Mechiver being so slow deserves better Armour and HP.

Tl;Dr - Having the mobs be slower is, I believe, way better than before when the mobs speed was exactly the same.
## Changelog
:cl:
balance: Hivemind Mobs now have their movement speed fixed, in order from slowest to fastest: Mechiver < Bomber < Hiborg < Himan < Lobber < Stinger.  Also makes the Mechiver have higher HP and Armour as to compensate for the slowness.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
