### PR TITLE
[Hotfix] Fix shuttles not being able to move back to Eris

### DIFF
--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -55,6 +55,11 @@
 			for(var/obj/effect/shuttle_landmark/LZ in S.get_waypoints(src.name))
 				if(LZ.is_valid(src))
 					res["[S.name_stages[1]] - [LZ.name]"] = LZ
+
+	for(var/obj/effect/overmap/ship/eris/S in map)
+		for(var/obj/effect/shuttle_landmark/LZ in S.get_waypoints(src.name))
+			if(LZ.is_valid(src))
+				res["[S.name_stages[1]] - [LZ.name]"] = LZ
 	return res
 
 /datum/shuttle/autodock/overmap/proc/get_location_name()

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -91,7 +91,7 @@
 		if (S.z in map_z)
 			S.linked = src
 
-/obj/effect/overmap/sector/proc/get_waypoints(var/shuttle_name)
+/obj/effect/overmap/proc/get_waypoints(var/shuttle_name)
 	. = generic_waypoints.Copy()
 	if(shuttle_name in restricted_waypoints)
 		. += restricted_waypoints[shuttle_name]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Due to shuttles now being able to move far away from Eris, the code was not made to detect the docking ports if Eris was not on an overmap sector like asteroid or space ruins.

## Why It's Good For The Game

Shuttles can now go back to Eris after their planetary exploration.

## Changelog
:cl: Hyperio
fix: Fix shuttles not being able to move back to Eris
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
