### PR TITLE
Deletes the prob(66) from excel implant

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/excelsior.dm
+++ b/code/game/objects/items/weapons/implant/implants/excelsior.dm
@@ -100,12 +100,7 @@
 		if(A.id == antag_id)
 			A.remove_antagonist()
 	wearer.visible_message(SPAN_DANGER("As \the [src] is removed from \the [wearer]..."))
-	if(prob(66))
-		wearer.visible_message(SPAN_DANGER("\The [wearer]'s [part.name] violently explodes from within!"))
-		wearer.adjustBrainLoss(200)
-		part.droplimb(FALSE, DROPLIMB_BLUNT)
-	else
-		wearer.visible_message(SPAN_NOTICE("Something fizzles in \the [wearer]'s [part.name], but nothing interesting happens."))
+	wearer.visible_message(SPAN_NOTICE("Something fizzles in \the [wearer]'s [part.name], but nothing interesting happens."))
 
 //The leader version of the implant is the one given to antags spawned by the storyteller.
 //It has no special gameplay properties and is not attainable in normal gameplay, it just exists to


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

 If you want to deconvert someone - you should be able to.

## Changelog
:cl:
balance: excel implants now don't explode anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
