### PR TITLE
Ghosts can occupy borers whenever

### DIFF
--- a/code/game/antagonist/alien/borer.dm
+++ b/code/game/antagonist/alien/borer.dm
@@ -17,7 +17,6 @@
 	outer = FALSE
 	mob_path = /mob/living/simple_animal/borer
 
-
 /datum/antagonist/borer/create_objectives(var/survive = FALSE)
 	new /datum/objective/borer_survive (src)
 	new /datum/objective/borer_reproduce (src)

--- a/code/game/antagonist/alien/borer.dm
+++ b/code/game/antagonist/alien/borer.dm
@@ -11,10 +11,12 @@
 	outer = TRUE
 	only_human = FALSE
 
-/datum/antagonist/borer/reproduced	//This antag datum will prevent all borers be rounstart
+/datum/antagonist/borer/reproduced	//This antag datum will prevent all borers be roundstart
 	id = ROLE_BORER_REPRODUCED
 	selectable = FALSE
+	outer = FALSE
 	mob_path = /mob/living/simple_animal/borer
+
 
 /datum/antagonist/borer/create_objectives(var/survive = FALSE)
 	new /datum/objective/borer_survive (src)

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -97,6 +97,24 @@
 	truename = "[pick("Primary","Secondary","Tertiary","Quaternary")] [rand(1000,9999)]"
 	if(!roundstart) request_player()
 
+/mob/living/simple_animal/borer/proc/ghost_enter(mob/user)
+	if(stat|| key)
+		return 0
+	var/confirmation = alert("Become a borer?", "You Monster", "Yes", "No")
+	if(confirmation == "No" || !src || QDELETED(src))
+		return 1
+	if(key)
+		to_chat(user, "<span class='warning'>Someone is already occupying this body.</span>")
+		return 1
+	key = user.key
+	return 1
+
+/mob/living/simple_animal/borer/attack_ghost(mob/user)
+	.=..()
+	if(.)
+		return
+	ghost_enter(user)
+
 /mob/living/simple_animal/borer/proc/update_abilities(force_host=FALSE)
 	// Remove all abilities
 	verbs -= abilities_standalone

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -95,26 +95,26 @@
 	update_abilities()
 
 	truename = "[pick("Primary","Secondary","Tertiary","Quaternary")] [rand(1000,9999)]"
+
 	if(!roundstart) request_player()
 
 /mob/living/simple_animal/borer/proc/ghost_enter(mob/user)
-	if(stat|| key)
-		return 0
-	var/confirmation = alert("Would you like to occupy the [src]?", "", "Yes", "No")
-	if(confirmation == "No" || !src || QDELETED(src))
-		return 1
+	if(stat || key)
+		return FALSE
+	var/confirmation = alert("Would you like to occupy \the [src]?", "", "Yes", "No")
+	if(confirmation == "No" || QDELETED(src))
+		return TRUE
 	if(key)
-		to_chat(user, "<span class='warning'>Someone is already occupying this body.</span>")
-		return 1
-	roundstart = 1 //Outer variable in /datum/antagonist/borer causes borer to teleport when mind is switched.
+		to_chat(user, SPAN_WARNING("Someone is already occupying this body."))
+		return TRUE
 	key = user.key
-	return 1
+	return TRUE
 
 /mob/living/simple_animal/borer/attack_ghost(mob/user)
-	.=..()
-	if(.)
-		return
-	ghost_enter(user)
+	. = ..()
+	if(!.)
+		. = ghost_enter(user)
+
 
 /mob/living/simple_animal/borer/proc/update_abilities(force_host=FALSE)
 	// Remove all abilities

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -95,17 +95,19 @@
 	update_abilities()
 
 	truename = "[pick("Primary","Secondary","Tertiary","Quaternary")] [rand(1000,9999)]"
+
 	if(!roundstart) request_player()
 
 /mob/living/simple_animal/borer/proc/ghost_enter(mob/user)
 	if(stat|| key)
 		return 0
-	var/confirmation = alert("Become a borer?", "You Monster", "Yes", "No")
+	var/confirmation = alert("Would you like to occupy [src]?", "", "Yes", "No")
 	if(confirmation == "No" || !src || QDELETED(src))
 		return 1
 	if(key)
 		to_chat(user, "<span class='warning'>Someone is already occupying this body.</span>")
 		return 1
+	roundstart = 1 //Outer variable in /datum/antagonist/borer causes borer to teleport when mind is switched.
 	key = user.key
 	return 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows unoccupied borers to be taken over whenever. There appears to be an issue where maybe multiple borers being made at once only allows one or maybe none to be occupied, so you end up with dumb borers just sitting around until someone stomps them to death despite there being plenty of ghosts. Mostly just stolen old spider code.

## Why It's Good For The Game

Allows ghost to occupy unoccupied borers.

## Changelog
:cl:
add: Ghosts can now occupy borers whenever.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
