### PR TITLE
Fixes monkey cubes

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1742,15 +1742,12 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/proc/Expand()
 	src.visible_message(SPAN_NOTICE("\The [src] expands!"))
-	var/mob/living/carbon/human/H = new(get_turf(src))
-	H.set_species(monkey_type)
-	H.real_name = H.species.get_random_name()
-	H.name = H.real_name
-	if(ismob(loc))
-		var/mob/M = loc
-		M.unEquip(src)
+	var/turf/T = get_turf(src)
+	if(T)
+		var/mob/living/carbon/human/monkey/M = new /mob/living/carbon/human/monkey
+		M.loc = T
 	qdel(src)
-	return 1
+	return TRUE
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/proc/Unwrap(mob/user as mob)
 	icon_state = "monkeycube"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1744,7 +1744,7 @@
 	src.visible_message(SPAN_NOTICE("\The [src] expands!"))
 	var/turf/T = get_turf(src)
 	if(istype(T))
-		var/mob/living/carbon/human/monkey/M = new /mob/living/carbon/human/monkey(T)
+		new /mob/living/carbon/human/monkey(T)
 	qdel(src)
 	return TRUE
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1743,9 +1743,8 @@
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/proc/Expand()
 	src.visible_message(SPAN_NOTICE("\The [src] expands!"))
 	var/turf/T = get_turf(src)
-	if(T)
-		var/mob/living/carbon/human/monkey/M = new /mob/living/carbon/human/monkey
-		M.loc = T
+	if(istype(T))
+		var/mob/living/carbon/human/monkey/M = new /mob/living/carbon/human/monkey(T)
 	qdel(src)
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Previously monkey cubes created a human, then set that human's species to a monkey. I'm not sure how current organs work but  set_species seemed to carry over any organs from the previous species. Now it just spawns a monkey on the turf it's expanded on, I'm not sure if there was any reason why it did it the way it did, but I encountered no issues while testing.
https://imgur.com/69TgtvA
Fixes #5976 

## Why It's Good For The Game

This made xenobiology a tiny bit more difficult, as some monkey's would die before the slime could completely eat them. It's also just weird for monkey's to have 2 sets of organs.

## Changelog
:cl:
fix: Fixed monkey cubes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
