### PR TITLE
Glide size recursion removal

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -322,10 +322,10 @@
 	else
 		glide_size = max(min, glide_size_override)
 
-	for (var/atom/movable/AM in contents)
+/*	for (var/atom/movable/AM in contents)
 		AM.set_glide_size(glide_size, min, max)
 
-
+*/
 //This proc should never be overridden elsewhere at /atom/movable to keep directions sane.
 // Spoiler alert: it is, in moved.dm
 /atom/movable/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, var/glide_size_override = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes recursion in `set_glide_size` proc, lowering it's impact on performance substantially.

Profiler results (3 minutes each, 90 pk ammo boxes on a conveyor loop with 80 bullets each):
Before:
![glide1](https://user-images.githubusercontent.com/61743710/113684029-1f225700-96c5-11eb-9d3b-52f793a5ffba.png)
After:
![glide2](https://user-images.githubusercontent.com/61743710/113684137-319c9080-96c5-11eb-9e85-289e01ffed08.png)


## Why It's Good For The Game

Lag bad.

## Changelog
:cl:
code: `set_glide_size` had the recursion for all atom/movable in contents removed
/:cl:
