### PR TITLE
Adds RIG tab and bunch of related crates to Guild Console

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1335,34 +1335,6 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	crate_name = "Industrial Hardsuit Control Module Crate"
 	group = "Resource Integration Gear"
 
-/datum/supply_pack/minerpack
-	name = "Hardsuit Mining Utilities Package"
-	contains = list(/obj/item/rig_module/device/drill,
-					/obj/item/rig_module/device/orescanner,
-					/obj/item/rig_module/vision/meson,
-					/obj/item/rig_module/maneuvering_jets)
-	cost = 1920
-	crate_name = "Hardsuit Mining Utilities Package"
-	group = "Resource Integration Gear"
-
-/datum/supply_pack/medicpack
-	name = "Hardsuit Medical Utilities Package"
-	contains = list(/obj/item/rig_module/device/healthscanner,
-					/obj/item/rig_module/vision/medhud)
-	cost = 720
-	crate_name = "Hardsuit Medical Utilities Package"
-	group = "Resource Integration Gear"
-
-/datum/supply_pack/secpack
-	name = "Hardsuit Security Utilities Package"
-	contains = list(/obj/item/rig_module/mounted/egun,
-					/obj/item/rig_module/mounted/taser,
-					/obj/item/rig_module/device/flash,
-					/obj/item/rig_module/vision/sechud)
-	cost = 2880
-	crate_name = "Hardsuit Security Utilities Package"
-	group = "Resource Integration Gear"
-
 /datum/supply_pack/flash
 	name = "Mounted Flash Module Crate"
 	contains = list(/obj/item/rig_module/device/flash)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1385,7 +1385,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	group = "Resource Integration Gear"
 
 /datum/supply_pack/storage
-	name = "Internal Hardsuit Storage Comparment Crate"
+	name = "Internal Hardsuit Storage Compartment Crate"
 	contains = list(/obj/item/rig_module/storage)
 	cost = 1200
 	crate_name = "Internal Hardsuit Storage Compartment Crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1388,7 +1388,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	name = "Internal Hardsuit Storage Comparment Crate"
 	contains = list(/obj/item/rig_module/storage)
 	cost = 1200
-	crate_name = "Internal Hardsuit Storage Comparment Crate"
+	crate_name = "Internal Hardsuit Storage Compartment Crate"
 	group = "Resource Integration Gear"
 
 /datum/supply_pack/meson

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1327,6 +1327,13 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	cost = 1100
 	crate_name = "Hazard Hardsuit Control Module Crate"
 	group = "Resource Integration Gear"
+	
+/datum/supply_pack/industrial
+	name = "Industrial Hardsuit Control Module Crate"
+	contains = list(/obj/item/weapon/rig/industrial)
+	cost = 3000
+	crate_name = "Industrial Hardsuit Control Module Crate"
+	group = "Resource Integration Gear"
 
 /datum/supply_pack/minerpack
 	name = "Hardsuit Mining Utilities Package"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1352,7 +1352,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 					/obj/item/rig_module/mounted/taser,
 					/obj/item/rig_module/device/flash,
 					/obj/item/rig_module/vision/sechud)
-	cost = 2160
+	cost = 2880
 	crate_name = "Hardsuit Security Utilities Package"
 	group = "Resource Integration Gear"
 
@@ -1366,7 +1366,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 /datum/supply_pack/egun
 	name = "Mouned Energy Gun Module Crate"
 	contains = list(/obj/item/rig_module/mounted/egun)
-	cost = 1200
+	cost = 2100
 	crate_name = "Mouned Energy Gun Module Crate"
 	group = "Resource Integration Gear"
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -5,7 +5,7 @@
 //BIG NOTE: Don't add living things to crates, that's bad, it will break the shuttle.
 //NEW NOTE: Do NOT set the price of any crates below 7 points. Doing so allows infinite points.
 
-var/list/all_supply_groups = list("Operations","Security","Hospitality","Engineering","Medical / Science","Hydroponics","Mining","Supply","Miscellaneous")
+var/list/all_supply_groups = list("Operations","Security","Hospitality","Engineering","Medical / Science","Hydroponics","Mining","Supply","Resource Integration Gear","Miscellaneous")
 
 /datum/supply_pack
 	var/name = "Crate"
@@ -1310,6 +1310,135 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	crate_name = "Empty box crate"
 	group = "Supply"
 
+//----------------------------------------------
+//-----------------R.I.G------------------------
+//----------------------------------------------
+
+/datum/supply_pack/eva
+	name = "EVA Suit Control Module Crate"
+	contains = list(/obj/item/weapon/rig/eva)
+	cost = 600
+	crate_name = "EVA Suit Control Module Crate"
+	group = "Resource Integration Gear"
+
+/datum/supply_pack/hazard
+	name = "Hazard Hardsuit Control Module Crate"
+	contains = list(/obj/item/weapon/rig/hazard)
+	cost = 1100
+	crate_name = "Hazard Hardsuit Control Module Crate"
+	group = "Resource Integration Gear"
+
+/datum/supply_pack/minerpack
+	name = "Hardsuit Mining Utilities Package"
+	contains = list(/obj/item/rig_module/device/drill,
+					/obj/item/rig_module/device/orescanner,
+					/obj/item/rig_module/vision/meson,
+					/obj/item/rig_module/maneuvering_jets)
+	cost = 1920
+	crate_name = "Hardsuit Mining Utilities Package"
+	group = "Resource Integration Gear"
+
+/datum/supply_pack/medicpack
+	name = "Hardsuit Medical Utilities Package"
+	contains = list(/obj/item/rig_module/device/healthscanner,
+					/obj/item/rig_module/vision/medhud)
+	cost = 720
+	crate_name = "Hardsuit Medical Utilities Package"
+	group = "Resource Integration Gear"
+
+/datum/supply_pack/secpack
+	name = "Hardsuit Security Utilities Package"
+	contains = list(/obj/item/rig_module/mounted/egun,
+					/obj/item/rig_module/mounted/taser,
+					/obj/item/rig_module/device/flash,
+					/obj/item/rig_module/vision/sechud)
+	cost = 2160
+	crate_name = "Hardsuit Security Utilities Package"
+	group = "Resource Integration Gear"
+
+/datum/supply_pack/flash
+	name = "Mouned Flash Module Crate"
+	contains = list(/obj/item/rig_module/device/flash)
+	cost = 300
+	crate_name = "Mouned Flash Module Crate"
+	group = "Resource Integration Gear"
+
+/datum/supply_pack/egun
+	name = "Mouned Energy Gun Module Crate"
+	contains = list(/obj/item/rig_module/mounted/egun)
+	cost = 1200
+	crate_name = "Mouned Energy Gun Module Crate"
+	group = "Resource Integration Gear"
+
+/datum/supply_pack/taser
+	name = "Mouned Taser Gun Module Crate"
+	contains = list(/obj/item/rig_module/mounted/taser)
+	cost = 900
+	crate_name = "Mouned Taser Gun Module Crate"
+	group = "Resource Integration Gear"
+
+/datum/supply_pack/drill
+	name = "Hardsuit Mounted Drill Crate"
+	contains = list(/obj/item/rig_module/device/drill)
+	cost = 600
+	crate_name = "Hardsuit Mounted Drill Crate"
+	group = "Resource Integration Gear"
+
+/datum/supply_pack/orescanner
+	name = "Hardsuit Mounted Ore Scanner Crate"
+	contains = list(/obj/item/rig_module/device/orescanner)
+	cost = 300
+	crate_name = "Hardsuit Mounted Ore Scanner Crate"
+	group = "Resource Integration Gear"
+
+/datum/supply_pack/healthscanner
+	name = "Hardsuit Mounted Health Scanner Crate"
+	contains = list(/obj/item/rig_module/device/healthscanner)
+	cost = 300
+	crate_name = "Hardsuit Mounted Health Scanner Crate"
+	group = "Resource Integration Gear"
+
+/datum/supply_pack/maneuverjet
+	name = "Hardsuit Maneuvering Jet Crate"
+	contains = list(/obj/item/rig_module/maneuvering_jets)
+	cost = 1200
+	crate_name = "Hardsuit Maneuvering Jet Crate"
+	group = "Resource Integration Gear"
+
+/datum/supply_pack/storage
+	name = "Internal Hardsuit Storage Comparment Crate"
+	contains = list(/obj/item/rig_module/storage)
+	cost = 1200
+	crate_name = "Internal Hardsuit Storage Comparment Crate"
+	group = "Resource Integration Gear"
+
+/datum/supply_pack/meson
+	name = "Hardsut Meson Scanner Crate"
+	contains = list(/obj/item/rig_module/vision/meson)
+	cost = 300
+	crate_name = "Hardsut Meson Scanner Crate"
+	group = "Resource Integration Gear"
+
+/datum/supply_pack/medhud
+	name = "Hardsuit Medical Hud Crate"
+	contains = list(/obj/item/rig_module/vision/medhud)
+	cost = 300
+	crate_name = "Hardsuit Medical Hud Crate"
+	group = "Resource Integration Gear"
+
+/datum/supply_pack/sechud
+	name = "Hardsuit Security Hud Crate"
+	contains = list(/obj/item/rig_module/vision/sechud)
+	cost = 300
+	crate_name = "Hardsuit Security Hud Crate"
+	group = "Resource Integration Gear"
+
+/datum/supply_pack/nvgrig
+	name = "Hardsuit Night vision Interface Crate"
+	contains = list(/obj/item/rig_module/vision/nvg)
+	cost = 1800
+	crate_name = "Hardsuit Night vision Interface Crate"
+	group = "Resource Integration Gear"
 //----------------------------------------------
 //--------------MISCELLANEOUS-------------------
 //----------------------------------------------

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1357,21 +1357,21 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	group = "Resource Integration Gear"
 
 /datum/supply_pack/flash
-	name = "Mouned Flash Module Crate"
+	name = "Mounted Flash Module Crate"
 	contains = list(/obj/item/rig_module/device/flash)
 	cost = 300
 	crate_name = "Mouned Flash Module Crate"
 	group = "Resource Integration Gear"
 
 /datum/supply_pack/egun
-	name = "Mouned Energy Gun Module Crate"
+	name = "Mounted Energy Gun Module Crate"
 	contains = list(/obj/item/rig_module/mounted/egun)
 	cost = 2100
 	crate_name = "Mouned Energy Gun Module Crate"
 	group = "Resource Integration Gear"
 
 /datum/supply_pack/taser
-	name = "Mouned Taser Gun Module Crate"
+	name = "Mounted Taser Gun Module Crate"
 	contains = list(/obj/item/rig_module/mounted/taser)
 	cost = 900
 	crate_name = "Mouned Taser Gun Module Crate"


### PR DESCRIPTION
## About The Pull Request

Adds Resource Integration Gear to Cargo Console, along with multiple crates: Generic EVA, Hazard and Industrial RIGs, crates with some modules (mostly generic ones, except for basic mounted egun, Internal Storage, and NVG, autodocs and chem injectors are still moebius exclusive).

## Why It's Good For The Game

Most common complaints I hear about RIGs and one I raised myself very often, is that there is not really any way to get most modules, however essential they are. It's all junk, uplink, and maybe robbing armory hoping they got something cool. And what better place to make soruce of them, than Guild?

## Changelog
:cl:
add: Resoruce Integration Gear Tab in Cargo Console
add: Some RIG crates to Cargo console
/:cl:


