### PR TITLE
Fix shuttle landing area not having any mineral ressources

### DIFF
--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -43,7 +43,7 @@
 
 	for(var/i=0,i<chunk_size,i++)
 		for(var/j=0,j<chunk_size,j++)
-			var/turf/simulated/mineral/T = locate(tx+j, ty+i, origin_z)
+			var/turf/simulated/T = locate(tx+j, ty+i, origin_z)
 			if(!istype(T) || !T.has_resources)
 				continue
 			if(!priority_process) sleep(-1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Revert a change made during the Planetary port that caused shuttle landing area to have no mineral ressources in the ground.

## Why It's Good For The Game

Makes miners happy.

## Changelog
:cl: Hyperio
fix: Fix shuttle landing area not having any mineral ressource
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
