### PR TITLE
Syndicate proffessional killer scope

### DIFF
--- a/code/datums/uplink/stealth and camouflage items.dm
+++ b/code/datums/uplink/stealth and camouflage items.dm
@@ -47,6 +47,6 @@
     path = /obj/item/weapon/gun_upgrade/muzzle/silencer
 
 /datum/uplink_item/item/stealth_items/killer
-    name = "Syndicate \"Proffesional Killer\" scope"
+    name = "Syndicate \"Profesional Killer\" scope"
     item_cost = 2
     path = /obj/item/weapon/gun_upgrade/scope/killer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR removes one extra `f` from proffessional word that is used in uplink 

## Why It's Good For The Game

Makes us look like we know english

## Changelog
:cl:
spellcheck: "Syndicate "Proffesional Killer" scope" now contains one less 'f', resulting in  "Syndicate "Profesional Killer" scope"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
