### PR TITLE
Remove salary of NT jobs

### DIFF
--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -19,7 +19,7 @@
 		access_RC_announce, access_keycard_auth, access_heads, access_sec_doors, access_change_nt
 	)
 
-	wage = WAGE_PROFESSIONAL //The church has deep pockets
+	wage = WAGE_NONE // The money of the soul is faith
 	department_account_access = TRUE
 	outfit_type = /decl/hierarchy/outfit/job/church/chaplain
 
@@ -80,7 +80,7 @@
 	selection_color = "#ecd37d"
 	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_LATIN = 20)
 	cruciform_access = list(access_morgue, access_crematorium, access_maint_tunnels, access_hydroponics)
-	wage = WAGE_PROFESSIONAL
+	wage = WAGE_NONE // The money of the soul is faith
 	outfit_type = /decl/hierarchy/outfit/job/church/acolyte
 
 	stat_modifiers = list(
@@ -123,7 +123,7 @@
 	//alt_titles = list("Hydroponicist")
 	also_known_languages = list(LANGUAGE_CYRILLIC = 15, LANGUAGE_JIVE = 80, LANGUAGE_LATIN = 20)
 	cruciform_access = list(access_hydroponics, access_morgue, access_crematorium, access_maint_tunnels)
-	wage = WAGE_PROFESSIONAL
+	wage = WAGE_NONE // The money of the soul is faith
 
 	outfit_type = /decl/hierarchy/outfit/job/church/gardener
 	stat_modifiers = list(
@@ -168,7 +168,7 @@
 	//alt_titles = list("Custodian","Sanitation Technician")
 	also_known_languages = list(LANGUAGE_CYRILLIC = 15, LANGUAGE_JIVE = 80, LANGUAGE_LATIN = 20)
 	cruciform_access = list(access_janitor, access_maint_tunnels, access_morgue, access_crematorium)
-	wage = WAGE_PROFESSIONAL
+	wage = WAGE_NONE // The money of the soul is faith
 	outfit_type = /decl/hierarchy/outfit/job/church/janitor
 
 	stat_modifiers = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I was asked to do this PR. Remove salary of all Neotheology jobs. They can earn money by placing obelisks for other departments, selling food, chems, biomatter, weapons, medkits and other stuff that they can print such as pouches.

## Why It's Good For The Game

* Incentive for NT people to perform church related activities and increase interactions with the rest of the crew.
* NT people only needs the faith, feeling of a well-done job and recognition of their believers as a salary, don't they? 🙏 

## Changelog
:cl: Hyperio
balance: Remove salary of NT jobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
