### PR TITLE
Hotfix: remove redeclaration of effect/damagedfloor

### DIFF
--- a/maps/submaps/planetary_ruins/marooned/marooned.dm
+++ b/maps/submaps/planetary_ruins/marooned/marooned.dm
@@ -44,16 +44,6 @@
 	name = "\improper Crashed Dropship"
 	icon_state = "blue"
 
-/obj/effect/damagedfloor
-	name = "fire"
-
-/obj/effect/damagedfloor/Initialize()
-	..()
-	var/turf/simulated/T = get_turf(src)
-	if(istype(T))
-		T.fire_act(exposed_temperature = T0C + 3000)
-	return INITIALIZE_HINT_QDEL
-
 /obj/item/weapon/paper/marooned/
 	name = "diary page"
 	spawn_blacklisted = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix compilation issue.
For some reason effect/damagedfloor was declared twice and the compiler never complained since planetary exploration was ported. Except now it complains. Nothing to understand, really...

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Hyperio
fix: Remove redeclaration of effect/damagedfloor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
