### PR TITLE
Examining cruciforms tells you if they've been activated or not

### DIFF
--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -100,6 +100,21 @@ var/list/disciples = list()
 		eotp.addObservation(50)
 	return TRUE
 
+/obj/item/weapon/implant/core_implant/cruciform/examine(mob/user) 
+	..()
+	var/datum/core_module/cruciform/cloning/data = get_module(CRUCIFORM_CLONING)
+	if(data?.mind) // if there is cloning data and it has a mind
+		to_chat(user, SPAN_NOTICE("This cruciform has been activated."))
+		if(isghost(user) || (user in disciples))
+			var/datum/mind/MN = data.mind
+			if(MN.name) // if there is a mind and it also has a name
+				to_chat(user, SPAN_NOTICE("It contains <b>[MN.name]</b>'s soul."))
+			else
+				to_chat(user, SPAN_DANGER("Something terrible has happened with this soul. Please notify somebody in charge."))
+	else // no cloning data
+		to_chat(user, "This cruciform has not yet been activated.")
+
+
 
 /obj/item/weapon/implant/core_implant/cruciform/deactivate()
 	if(!active || !wearer)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This adds an `examine()` to cruciforms that informs the user whether or not a cruciform has been activated (read: has a soul), and that also tells NT members and ghosts the soul's name, if present.
![Demonstration](https://i.imgur.com/pFTiVt3.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Clearly tells apart a cruciform that belongs to someone from one that's brand-new. You don't need someone to tell you in LOOC that they shouldn't sell the cruciform he/she found lying around maintenance anymore.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added an examine message that states whether or not a cruciform has been activated, and that additionally tells NT members and ghosts whose soul it is.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
