### PR TITLE
Adds the ability to shoot people near ladders from below/above

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -32,6 +32,7 @@
 	nutrition = 400//Carbon
 
 	var/is_watching = TRUE  //used for remote viewing of multiz structures
+	var/can_multiz_pb = FALSE // used for point-blanking people that camp ladders.
 
 	var/obj/item/weapon/tank/internal //Human/Monkey
 

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -217,7 +217,8 @@
 						user.client.perspective = EYE_PERSPECTIVE
 						user.hud_used.updatePlaneMasters(user)
 						user.is_watching = TRUE
-						user.can_multiz_pb = TRUE
+						if(Adjacent(user))
+							user.can_multiz_pb = TRUE
 				return
 		else
 			to_chat(user, SPAN_NOTICE("You can't do it right now."))

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -211,11 +211,13 @@
 						user.client.perspective = MOB_PERSPECTIVE
 						user.hud_used.updatePlaneMasters(user)
 						user.is_watching = FALSE
+						user.can_multiz_pb = FALSE
 					else if(user.is_watching == FALSE)
 						user.client.eye = target
 						user.client.perspective = EYE_PERSPECTIVE
 						user.hud_used.updatePlaneMasters(user)
 						user.is_watching = TRUE
+						user.can_multiz_pb = TRUE
 				return
 		else
 			to_chat(user, SPAN_NOTICE("You can't do it right now."))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -269,10 +269,6 @@
 	else
 		return ..() //Pistolwhippin'
 
-
-
-
-
 /obj/item/weapon/gun/proc/Fire(atom/target, mob/living/user, clickparams, pointblank=0, reflex=0)
 	if(!user || !target) return
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -194,7 +194,14 @@
 		qdel(src)
 		return FALSE
 
-	loc = get_turf(user) //move the projectile out into the world
+	loc = get_turf(user)
+
+	if(iscarbon(user))
+		var/mob/living/carbon/human/blanker = user
+		if(blanker.can_multiz_pb && (!isturf(target)))
+			loc = get_turf(blanker.client.eye)
+			if(!(loc.Adjacent(target)))
+				loc = get_turf(blanker)
 
 	firer = user
 	shot_from = launcher.name


### PR DESCRIPTION

## About The Pull Request
Gives players the ability to shoot people on the other side of ladders as long as they are adjaecent to it, this it to counter ladder camping and give people a viable choice other than grenade spam

## Why It's Good For The Game
More robust combat for multi-z , more robust counters

## Changelog
:cl:
add: You can now shoot people adjacenet to ladders you look through from above/elow
/:cl:

