### PR TITLE
Gives Bluespace Technicians 99s in every stat, and knowledge of all languages

### DIFF
--- a/code/modules/admin/bluespacetech.dm
+++ b/code/modules/admin/bluespacetech.dm
@@ -28,11 +28,11 @@ ADMIN_VERB_ADD(/client/proc/cmd_dev_bst, R_ADMIN|R_DEBUG, TRUE)
 	bst.h_style = "Crewcut"
 	var/list/stat_modifiers = list(
 		STAT_ROB = 99,
-        STAT_TGH = 99,
-        STAT_BIO = 99,
-        STAT_MEC = 99,
-        STAT_VIG = 99,
-        STAT_COG = 99
+		STAT_TGH = 99,
+		STAT_BIO = 99,
+		STAT_MEC = 99,
+		STAT_VIG = 99,
+		STAT_COG = 99
 	)
 	for(var/stat in stat_modifiers)
 		bst.stats.changeStat(stat, stat_modifiers[stat])

--- a/code/modules/admin/bluespacetech.dm
+++ b/code/modules/admin/bluespacetech.dm
@@ -26,6 +26,16 @@ ADMIN_VERB_ADD(/client/proc/cmd_dev_bst, R_ADMIN|R_DEBUG, TRUE)
 	bst.real_name = "Bluespace Technician"
 	bst.voice_name = "Bluespace Technician"
 	bst.h_style = "Crewcut"
+	var/list/stat_modifiers = list(
+		STAT_ROB = 99,
+        STAT_TGH = 99,
+        STAT_BIO = 99,
+        STAT_MEC = 99,
+        STAT_VIG = 99,
+        STAT_COG = 99
+	)
+	for(var/stat in stat_modifiers)
+		bst.stats.changeStat(stat, stat_modifiers[stat])
 
 	//Items
 	bst.equip_to_slot_or_del(new /obj/item/clothing/under/assistantformal/bst(bst), slot_w_uniform)
@@ -62,11 +72,19 @@ ADMIN_VERB_ADD(/client/proc/cmd_dev_bst, R_ADMIN|R_DEBUG, TRUE)
 	bst.add_language(LANGUAGE_CYRILLIC)
 	bst.add_language(LANGUAGE_SERBIAN)
 	bst.add_language(LANGUAGE_MONKEY)
+	bst.add_language(LANGUAGE_JIVE)
+	bst.add_language(LANGUAGE_GERMAN)
+	bst.add_language(LANGUAGE_NEOHONGO)
+	bst.add_language(LANGUAGE_LATIN)
+	// Robot languages
+	bst.add_language(LANGUAGE_ROBOT)
+	bst.add_language(LANGUAGE_DRONE)
 	// Antagonist languages
 	bst.add_language(LANGUAGE_HIVEMIND)
 	bst.add_language(LANGUAGE_CORTICAL)
 	bst.add_language(LANGUAGE_CULT)
 	bst.add_language(LANGUAGE_OCCULT)
+	bst.add_language(LANGUAGE_BLITZ)
 
 	spawn(10)
 		bst_post_spawn(bst)
@@ -292,7 +310,7 @@ ADMIN_VERB_ADD(/client/proc/cmd_dev_bst, R_ADMIN|R_DEBUG, TRUE)
 
 /obj/item/weapon/card/id/bst
 	icon_state = "centcom"
-	desc = "An ID straight from Central Command. This one looks highly classified."
+	desc = "An ID straight from Hansa. This one looks as though its very existence is a trade secret."
 	spawn_frequency = 0
 
 /obj/item/weapon/card/id/bst/Initialize(mapload)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The admin "test dummies", Bluespace Technicians, didn't have any specific stat modifiers set at spawn, which made doing any sort of stat check very slow, and annoying for doing actual testing. I set all of their stats to 99 when they spawn.
Additionally, they don't know any of the newer languages, so I added every missing language (including robot and drone, even if humans can't speak them) to the BSTs as well.
Finally, the BSTs' ID cards refer to "Central Command" and "classified information" in their descriptions, so I changed that to be more in line with the times.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Certain kinds of testing are now a lot faster, since BSTs no longer have to wait very long at all to do any stat-based actions.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Bluespace Technicians now spawn with 99 in each stat, know every language, and have a small change to their ID cards' descriptions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
