### PR TITLE
Neotheo wage alternative

### DIFF
--- a/code/game/jobs/department.dm
+++ b/code/game/jobs/department.dm
@@ -105,7 +105,8 @@
 /datum/department/church
 	name = "Church of NeoTheology"
 	id = DEPARTMENT_CHURCH
-	funding_type = FUNDING_EXTERNAL
+	account_budget = 4500 //each Neotheo has a wage of 900, this is enough to pay 5 paychecks before needing more cash
+	funding_type = FUNDING_NONE //The church on eris has no external funding. This further reinforces the theory that everyone on the CEV Eris is a reject of their factions
 	funding_source = "Church of NeoTheology"
 
 

--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -19,7 +19,7 @@
 		access_RC_announce, access_keycard_auth, access_heads, access_sec_doors, access_change_nt
 	)
 
-	wage = WAGE_NONE // The money of the soul is faith
+	wage = WAGE_PROFESSIONAL // The money of the soul is faith, and cold hard cash
 	department_account_access = TRUE
 	outfit_type = /decl/hierarchy/outfit/job/church/chaplain
 
@@ -80,7 +80,7 @@
 	selection_color = "#ecd37d"
 	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_LATIN = 20)
 	cruciform_access = list(access_morgue, access_crematorium, access_maint_tunnels, access_hydroponics)
-	wage = WAGE_NONE // The money of the soul is faith
+	wage = WAGE_PROFESSIONAL // The money of the soul is faith, and cold hard cash
 	outfit_type = /decl/hierarchy/outfit/job/church/acolyte
 
 	stat_modifiers = list(
@@ -123,7 +123,7 @@
 	//alt_titles = list("Hydroponicist")
 	also_known_languages = list(LANGUAGE_CYRILLIC = 15, LANGUAGE_JIVE = 80, LANGUAGE_LATIN = 20)
 	cruciform_access = list(access_hydroponics, access_morgue, access_crematorium, access_maint_tunnels)
-	wage = WAGE_NONE // The money of the soul is faith
+	wage = WAGE_PROFESSIONAL // The money of the soul is faith, and cold hard cash
 
 	outfit_type = /decl/hierarchy/outfit/job/church/gardener
 	stat_modifiers = list(
@@ -168,7 +168,7 @@
 	//alt_titles = list("Custodian","Sanitation Technician")
 	also_known_languages = list(LANGUAGE_CYRILLIC = 15, LANGUAGE_JIVE = 80, LANGUAGE_LATIN = 20)
 	cruciform_access = list(access_janitor, access_maint_tunnels, access_morgue, access_crematorium)
-	wage = WAGE_NONE // The money of the soul is faith
+	wage = WAGE_PROFESSIONAL // The money of the soul is faith, and cold hard cash
 	outfit_type = /decl/hierarchy/outfit/job/church/janitor
 
 	stat_modifiers = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reverses what PR number 6039 did (#6039).... Kinda

this PR also removes the Neotheology source of funding, forcing them to use their department account

the starting money is also increased by 1000 (from 3500 to 4500) which should last for 5 paychecks

Will close this PR if the other one (https://github.com/discordia-space/CEV-Eris/pull/6050) is merged, and vice versa

## Why It's Good For The Game

This doesn't remove starting money from the Neotheology, while also forcing them to """"""""""interact"""""""""" with the rest of the crew as to maintain a steady balance

## Changelog
:cl:
balance: Neotheos now have a wage and starting money, however no external funding so they have to use their department account for wages, it should last enough for five paychecks though.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
