### PR TITLE
Overdrive mod/upgrade cannot be installed on the Valkyrie anymore + mod blacklists.

### DIFF
--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -35,6 +35,7 @@
 	var/list/gun_loc_tag //Define(string). For checking if the gun already has something of this installed (No double trigger mods, for instance)
 	var/list/req_gun_tags = list() //Define(string). Must match all to be able to install it.
 	var/list/weapon_upgrades = list() //variable name(string) -> num
+	var/list/gun_blacklist = list() //Used to compare Gun used and whether the Mod can be installed on it or not.
 
 /datum/component/item_upgrade/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_IATTACK, .proc/attempt_install)
@@ -162,11 +163,10 @@
 				to_chat(user, SPAN_WARNING("There is already something attached to \the [G]'s [gun_loc_tag]!"))
 			return FALSE
 
-	for(var/I in req_gun_tags)
-		if(!G.gun_tags.Find(I))
-			if(user)
-				to_chat(user, SPAN_WARNING("\The [G] lacks the following property: [I]"))
-			return FALSE
+	if(G.type in gun_blacklist)
+		if(user)
+			to_chat(user, SPAN_WARNING("This mod can not be installed on the [G]!"))
+		return FALSE
 
 	if((req_fuel_cell & REQ_CELL) && !istype(G, /obj/item/weapon/gun/energy))
 		if(user)

--- a/code/modules/projectiles/guns/mods/research_mods.dm
+++ b/code/modules/projectiles/guns/mods/research_mods.dm
@@ -84,6 +84,7 @@
 	GUN_UPGRADE_FIRE_DELAY_MULT = 0.25)
 	I.req_fuel_cell = REQ_CELL
 	I.gun_loc_tag = GUN_MECHANISM
+	I.gun_blacklist = list(/obj/item/weapon/gun/energy/sniperrifle)
 
 // Add toxin damage to your weapon
 /obj/item/weapon/gun_upgrade/barrel/toxin_coater


### PR DESCRIPTION
The overdrive mod can't be installed on the Valkyrie anymore.
You can also blacklist other mods from installing from certain weapons using the similar method in this PR if ever needed in future.

