### PR TITLE
Judgement is now illegal

### DIFF
--- a/code/modules/paperwork/paper_premade.dm
+++ b/code/modules/paperwork/paper_premade.dm
@@ -3,6 +3,7 @@
  */
 /obj/item/weapon/paper/court
 	name = "Judgement"
+	spawn_blacklisted = TRUE
 	info = {"For crimes against the station, the offender is sentenced to:
 	\[br\]
 	\[br\]"}


### PR DESCRIPTION
## About The Pull Request

Blacklists the Paper "Judgement" from spawning in maint.

## Why It's Good For The Game

It barely had any text (literally two sentences) and would generally be just a waste of a spot for other useful items (aka everything, even scrap metal has more use).

## Changelog
:cl:
del: Removed a premade paper titled "Judgement" from spawning in maint
/:cl: