### PR TITLE
Reduces the recoil of pistols/revolvers by a lot

### DIFF
--- a/code/modules/projectiles/guns/projectile/pistol/avasarala.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/avasarala.dm
@@ -17,7 +17,7 @@
 	can_dual = TRUE
 	damage_multiplier = 1.45
 	penetration_multiplier = 1.35
-	recoil_buildup = 33
+	recoil_buildup = 5
 
 	fire_sound = 'sound/weapons/guns/fire/hpistol_fire.ogg'
 	unload_sound = 'sound/weapons/guns/interact/hpistol_magout.ogg'

--- a/code/modules/projectiles/guns/projectile/pistol/colt.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/colt.dm
@@ -13,7 +13,7 @@
 	mag_well = MAG_WELL_PISTOL|MAG_WELL_H_PISTOL
 	magazine_type = /obj/item/ammo_magazine/pistol
 	damage_multiplier = 1.5
-	recoil_buildup = 17
+	recoil_buildup = 4
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
 
 

--- a/code/modules/projectiles/guns/projectile/pistol/handmade.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/handmade.dm
@@ -12,7 +12,7 @@
 	max_shells = 1
 	ammo_type = /obj/item/ammo_casing/magnum
 	damage_multiplier = 1.36
-	recoil_buildup = 45
+	recoil_buildup = 15
 	spawn_frequency = 0
 	var/chamber_open = FALSE
 	var/jammed = FALSE

--- a/code/modules/projectiles/guns/projectile/pistol/lamia.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/lamia.dm
@@ -21,7 +21,7 @@
 	cocked_sound = 'sound/weapons/guns/interact/hpistol_cock.ogg'
 	damage_multiplier = 1.4
 	penetration_multiplier = 1.4
-	recoil_buildup = 21
+	recoil_buildup = 5
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
 

--- a/code/modules/projectiles/guns/projectile/pistol/mandella.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mandella.dm
@@ -20,7 +20,7 @@
 	magazine_type = /obj/item/ammo_magazine/cspistol
 	damage_multiplier = 1.2
 	penetration_multiplier = 1.7
-	recoil_buildup = 19
+	recoil_buildup = 2
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
 

--- a/code/modules/projectiles/guns/projectile/pistol/paco.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/paco.dm
@@ -20,7 +20,7 @@
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
 	damage_multiplier = 1.5
 	penetration_multiplier = 0.9
-	recoil_buildup = 10
+	recoil_buildup = 3
 	gun_tags = list(GUN_SILENCABLE)
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE

--- a/code/modules/projectiles/guns/projectile/pistol/selfload.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/selfload.dm
@@ -19,7 +19,7 @@
 	magazine_type = /obj/item/ammo_magazine/pistol
 
 	damage_multiplier = 1
-	recoil_buildup = 19
+	recoil_buildup = 2
 	silenced = 0
 	can_dual = 1
 
@@ -63,7 +63,7 @@
 	icon = 'icons/obj/guns/projectile/makarov.dmi'
 	icon_state = "makarov"
 	damage_multiplier = 1.2
-	recoil_buildup = 21
+	recoil_buildup = 3
 	price_tag = 1400
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2, TECH_COVERT = 3)
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/revolver/consul.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/consul.dm
@@ -13,5 +13,5 @@
 	price_tag = 1700
 	damage_multiplier = 1.35
 	penetration_multiplier = 1.5
-	recoil_buildup = 35
+	recoil_buildup = 6
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE

--- a/code/modules/projectiles/guns/projectile/revolver/deckard.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/deckard.dm
@@ -11,5 +11,5 @@
 	price_tag = 3100 //one of most robust revolvers here
 	damage_multiplier = 1.45
 	penetration_multiplier = 1.65
-	recoil_buildup = 40
+	recoil_buildup = 6
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE

--- a/code/modules/projectiles/guns/projectile/revolver/handmade.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/handmade.dm
@@ -9,5 +9,5 @@
 	matter = list(MATERIAL_PLASTIC = 10, MATERIAL_STEEL = 15)
 	price_tag = 250 //one of the cheapest revolvers here
 	damage_multiplier = 1.3
-	recoil_buildup = 60
+	recoil_buildup = 7
 	spawn_blacklisted = TRUE

--- a/code/modules/projectiles/guns/projectile/revolver/havelock.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/havelock.dm
@@ -15,6 +15,6 @@
 	price_tag = 900
 	damage_multiplier = 1.4 //because pistol round
 	penetration_multiplier = 1.4
-	recoil_buildup = 18
+	recoil_buildup = 8
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE

--- a/code/modules/projectiles/guns/projectile/revolver/mateba.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/mateba.dm
@@ -8,6 +8,6 @@
 	price_tag = 3000 //more op and rare than miller, hits harder, but have fun with hittin anything
 	damage_multiplier = 1.35
 	penetration_multiplier = 1.5
-	recoil_buildup = 38
+	recoil_buildup = 6
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE

--- a/code/modules/projectiles/guns/projectile/revolver/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/revolver.dm
@@ -21,7 +21,7 @@
 	fire_delay = 3 //all revolvers can fire faster, but have huge recoil
 	damage_multiplier = 1.75
 	armor_penetration = 0.65 // Insanely powerful handcannon, but worthless against heavy armor
-	recoil_buildup = 50
+	recoil_buildup = 8
 	var/drawChargeMeter = TRUE
 	var/chamber_offset = 0 //how many empty chambers in the cylinder until you hit a round
 

--- a/code/modules/projectiles/guns/projectile/revolver/sky_driver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/sky_driver.dm
@@ -17,7 +17,7 @@
 	damage_multiplier = 1.1
 	penetration_multiplier = 20
 	pierce_multiplier = 5
-	recoil_buildup = 50
+	recoil_buildup = 6
 	spawn_frequency = 0
 	spawn_blacklisted = TRUE
 	noricochet = TRUE


### PR DESCRIPTION
## About The Pull Request
Cuts down a lot of recoil from most of the pistols to make them viable.
## Why It's Good For The Game
3 Shots and the rest can't be aimed , even with very high stats. A pistol shouldn't have a lot of recoil , especially one that is rare ,  obtainable through stashes or the traitor uplink  , and that already has a low mag capacity.
Pistols also in general use barely powerfull calibers most of the time and lack the ability for full auto.

## Changelog
:cl:
balance: Reduced recoil of the mandella from 19 to 2
balance: Reduced recoil of the avarsala from  33 to 5
balance: Reduced recoil of the lamia from 21 to 5
balance: Reduced recoil from the paco from 10 to 3
balance: Reduced recoil from clarrisa from 19 to 2
balance: Reduced recoil from the makarov from 21 to 3
balance: Reduced recoil fron the consul from 35 to 6
balance: Reduced recoil from the deckard from 40 to 6
balance: Reduced recoil of the handmade revolver from 60 to 7
balance: Reduced recoil from the havelock from 18 to 8
balance: Reduced recoil from the mateba from 38 to 6
balance: Reduced recoil from miller from 50 to 8
balance: Reduced recoil from the skydriver from 50 to 6
/:cl:
