### PR TITLE
Makes it so the mindswapper uses a list

### DIFF
--- a/code/game/machinery/mindswapper.dm
+++ b/code/game/machinery/mindswapper.dm
@@ -13,6 +13,13 @@
 	var/operating = FALSE  // Is it on?
 	var/swap_time = 200  // Time from starting until minds are swapped
 	var/swap_range = 1
+	var/swappable_mobs = list(
+	/mob/living/carbon/human,
+	/mob/living/silicon/robot,
+	/mob/living/simple_animal/borer,
+	/mob/living/simple_animal/mouse,
+	/mob/living/carbon/slime,
+	/mob/living/simple_animal/cow)
 
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
@@ -78,11 +85,11 @@
 	// Get all candidates in range for the mind swapping
 	var/list/swapBoddies = list()
 	var/list/swapMinds = list()
-	for(var/mob/living/carbon/C in range(swap_range,src))
-		if (C.stat != DEAD)  // candidates should not be dead
+	for(var/mob/living/C in range(swap_range,src))
+		if (C.stat != DEAD && C.type in swappable_mobs)  // candidates should not be dead
 			swapBoddies += C
 			swapMinds += C.ghostize(0)
-	
+
 	// Shuffle the list containing the candidates' boddies
 	swapBoddies = shuffle(swapBoddies)
 
@@ -98,7 +105,7 @@
 		i += 1
 
 	// Knock out all candidates
-	for(var/mob/living/carbon/C in swapBoddies)
+	for(var/mob/living/C in swapBoddies)
 		C.Stun(2)
 		C.Weaken(10)
 

--- a/code/game/machinery/mindswapper.dm
+++ b/code/game/machinery/mindswapper.dm
@@ -15,6 +15,7 @@
 	var/swap_range = 1
 	var/swappable_mobs = list(
 	/mob/living/carbon/human,
+	/mob/living/carbon/human/monkey,
 	/mob/living/silicon/robot,
 	/mob/living/simple_animal/borer,
 	/mob/living/simple_animal/mouse,

--- a/code/game/machinery/mindswapper.dm
+++ b/code/game/machinery/mindswapper.dm
@@ -89,7 +89,6 @@
 		if (C.stat != DEAD && C.type in swappable_mobs)  // candidates should not be dead
 			swapBoddies += C
 			swapMinds += C.ghostize(0)
-
 	// Shuffle the list containing the candidates' boddies
 	swapBoddies = shuffle(swapBoddies)
 

--- a/code/game/machinery/mindswapper.dm
+++ b/code/game/machinery/mindswapper.dm
@@ -87,7 +87,7 @@
 	var/list/swapBoddies = list()
 	var/list/swapMinds = list()
 	for(var/mob/living/C in range(swap_range,src))
-		if (C.stat != DEAD && C.type in swappable_mobs)  // candidates should not be dead
+		if (C.stat != DEAD && (C.type in swappable_mobs))  // candidates should not be dead
 			swapBoddies += C
 			swapMinds += C.ghostize(0)
 	// Shuffle the list containing the candidates' boddies


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so the mindswapper uses a list of mobs that can be swapped, rather than every type of carbon mob, which let players swap into mobs that just don't work well with actual players occupying them(Mob A.I taking over). 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds a few new types of mobs that the mindswapper works on, players can now swap into robots for example. Something I felt was missing. I wanted to also allow this for AI, and PAI but it didn't seem to work well.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Changes the mindswapper to use a list for swappable mobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
