### PR TITLE
Low walls & tables no longer block Weakened mob/living, and airflow stun length nerfed

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -16,7 +16,7 @@ mob/proc/airflow_stun()
 		return 0
 	if(!lying)
 		to_chat(src, SPAN_WARNING("The sudden rush of air knocks you over!"))
-	Weaken(5)
+	Weaken(3) // Nerfed from 5
 	last_airflow_stun = world.time
 
 mob/living/silicon/airflow_stun()

--- a/code/game/objects/structures/low_wall.dm
+++ b/code/game/objects/structures/low_wall.dm
@@ -107,6 +107,10 @@
 		return 1
 	if(locate(/obj/structure/low_wall) in get_turf(mover))
 		return 1
+	if(isliving(mover))
+		var/mob/living/L = mover
+		if(L.weakened)
+			return 1
 	return ..()
 
 

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -10,7 +10,7 @@
 	//This armor only applies to legs
 	style = STYLE_NEG_LOW
 	spawn_blacklisted = TRUE
-	var/magpulse = 0
+	var/magpulse = FALSE
 	var/mag_slow = 3
 	var/icon_base = "magboots"
 
@@ -23,14 +23,14 @@
 /obj/item/clothing/shoes/magboots/attack_self(mob/user)
 	if(magpulse)
 		item_flags &= ~NOSLIP
-		magpulse = 0
+		magpulse = FALSE
 		set_slowdown()
 		force = WEAPON_FORCE_WEAK
 		if(icon_base) icon_state = "[icon_base]0"
 		to_chat(user, "You disable the mag-pulse traction system.")
 	else
 		item_flags |= NOSLIP
-		magpulse = 1
+		magpulse = TRUE
 		set_slowdown()
 		force = WEAPON_FORCE_PAINFUL
 		if(icon_base) icon_state = "[icon_base]1"

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -97,6 +97,13 @@ var/list/custom_table_appearance = list(
 		T.update_icon()
 	. = ..()
 
+/obj/structure/table/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	if(isliving(mover))
+		var/mob/living/L = mover
+		if(L.weakened)
+			return 1
+	return ..()	
+
 /obj/structure/table/examine(mob/user)
 	. = ..()
 	if(health < maxhealth)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![This PR in a GIF](https://files.catbox.moe/j1qoph.gif)
- Low walls and unflipped tables will no longer block `mob/living` that are `weakened`, allowing those mobs to pass through when atmos pushes them. This has the hilarious side effect of allowing you to defenestrate stunned people and/or throw them onto/over tables.
- No changes to shields, the modules will still work normally. Base shields won't prevent you from getting pulled out into space, humanoid blocking only will still pull you towards space but still block you at the shield, atmospheric containment will prevent the atmos from moving at all.
- Flipped tables will still block movement in their normal directions.
- The `Weaken(5)` from airflow stunning has been changed to `Weaken(3)`, so that you can't get spaced to a whole other sector on a laggy server with no ability to do anything about it.
- Changed the `magpulse` variable on magboots from `0` and `1` to `FALSE` and `TRUE` respectively, because why not.

Resolves #2861.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes combat in some areas more dynamic, gives more danger to being *on a space ship* (and without magboots), makes it so that you're not instafucked by getting spaced out a window or an airlock, places more significant emphasis on the ship's shielding capabilities. For the magboots code change, using `0` and `1` for `true` and `false` statements a shit.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Low walls (without a window) and unflipped tables will no longer block "living", "hard-stunned" creatures, meaning that, without any shielding, you can now break a window to space and get spaced if you don't have magboots.
balance: Airflow stun length has been nerfed from 5 to 3 ticks, so that you don't get back up from the stun in the middle of nowhere after getting spaced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
