### PR TITLE
Removes Hivemind ability to upgrade the supermatter

### DIFF
--- a/code/modules/hivemind/core.dm
+++ b/code/modules/hivemind/core.dm
@@ -27,7 +27,7 @@ var/datum/hivemind/hive_mind_ai
 						/obj/machinery/floor_light,		/obj/machinery/flasher,
 						/obj/machinery/filler_object,		/obj/machinery/hivemind_machine,
 						/obj/machinery/cryopod,			/obj/machinery/portable_atmospherics/hydroponics/soil,
-						/obj/machinery/portable_atmospherics/canister)
+						/obj/machinery/power/supermatter,	/obj/machinery/portable_atmospherics/canister)
 
 	var/list/global_abilities_cooldown = list()
 	var/list/EP_price_list = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the Hivemind from being able to corrupt the supermatter

## Why It's Good For The Game

Wacky things would happen with the SM, that and because it makes no sense for it to somehow upgrade a funky death crystal

## Changelog
:cl:
tweak: Hivemind can't upgrade the supermatter now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
