### PR TITLE
Fix the coolant tanks

### DIFF
--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -388,6 +388,7 @@
 	..()
 	M.add_chemical_effect(CE_PULSE, 2)
 
+#define COOLANT_LATENT_HEAT 19000 //Twice as good at cooling than water is, but may cool below 20c. It'll cause freezing that atmos will have to deal with..
 /datum/reagent/other/coolant
 	name = "Coolant"
 	id = "coolant"
@@ -396,6 +397,27 @@
 	taste_mult = 1.1
 	reagent_state = LIQUID
 	color = "#C8A5DC"
+
+/datum/reagent/coolant/touch_turf(var/turf/simulated/T)
+	if(!istype(T))
+		return
+
+	var/datum/gas_mixture/environment = T.return_air()
+	var/min_temperature = 0 // Room temperature + some variance. An actual diminishing return would be better, but this is *like* that. In a way. . This has the potential for weird behavior, but I says fuck it. Water grenades for everyone.
+
+	var/hotspot = (locate(/obj/fire) in T)
+	if(hotspot && !istype(T, /turf/space))
+		var/datum/gas_mixture/lowertemp = T.remove_air(T:air:total_moles)
+		lowertemp.temperature = max(min(lowertemp.temperature-2000, lowertemp.temperature / 2), 0)
+		lowertemp.react()
+		T.assume_air(lowertemp)
+		qdel(hotspot)
+
+	if (environment && environment.temperature > min_temperature) // Abstracted as steam or something
+		var/removed_heat = between(0, volume * COOLANT_LATENT_HEAT, -environment.get_thermal_energy_change(min_temperature))
+		environment.add_thermal_energy(-removed_heat)
+		if (prob(5) && environment && environment.temperature > T100C)
+			T.visible_message("<span class='warning'>The water sizzles as it lands on \the [T]!</span>")
 
 /datum/reagent/other/ultraglue
 	name = "Ultra Glue"

--- a/code/modules/research/xenoarchaeology/machinery/coolant.dm
+++ b/code/modules/research/xenoarchaeology/machinery/coolant.dm
@@ -5,14 +5,13 @@
 	icon_state = "coolanttank"
 	amount_per_transfer_from_this = 10
 
-/obj/structure/reagent_dispensers/coolanttank/Initialize(mapload, ...)
+/obj/structure/reagent_dispensers/coolanttank/New()
 	. = ..()
 	reagents.add_reagent("coolant",1000)
 
 /obj/structure/reagent_dispensers/coolanttank/bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.get_structure_damage())
-		if(!istype(Proj ,/obj/item/projectile/beam/lastertag) && !istype(Proj ,/obj/item/projectile/beam/practice) )
-			explode()
+		explode()
 
 /obj/structure/reagent_dispensers/coolanttank/ex_act()
 	explode()
@@ -28,12 +27,7 @@
 
 	var/datum/gas_mixture/env = src.loc.return_air()
 	if(env)
-		if (reagents.total_volume > 750)
-			env.temperature = 0
-		else if (reagents.total_volume > 500)
-			env.temperature -= 100
-		else
-			env.temperature -= 50
+		env.add_thermal_energy(reagents.total_volume * -5000)
 
 	sleep(10)
 	if(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR basically ports over current Baystation 12 coolant behaviour with a minor tweak.

## Why It's Good For The Game

Bruh you can chill entire deepmaint with a single coolant tank because it sets the atmosphere to zero no matter how much there air to cool.
Proofs of it working:

First section outside of FO office:

https://user-images.githubusercontent.com/57810301/115128474-a9808a00-9fe6-11eb-803c-16236e0e101b.mp4

Brig lobby:

https://user-images.githubusercontent.com/57810301/115128482-b8ffd300-9fe6-11eb-8c6b-935b093eaa8a.mp4

Head Staff meeting room:

https://user-images.githubusercontent.com/57810301/115128487-be5d1d80-9fe6-11eb-876b-3e6511278d1c.mp4

And, of course, deepmaint:

https://user-images.githubusercontent.com/57810301/115128457-92419c80-9fe6-11eb-8876-f02d2b92e991.mp4

Sorry for the delays in videos, I needed to give ZAS a moment to process atmos changes.


Do note that the behaviour in very small spaces will be mostly the same, since there are not much air to cool. Open a window or something I dunno.

## Changelog
:cl:
tweak: Coolant tanks and coolant behaviour was changed not to cool down entire ship at once.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
