### PR TITLE
Remove the carrion part in reveal adversaries litany

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -86,15 +86,8 @@
 				was_triggired = TRUE
 				break
 	if (prob(80) && (locate(/obj/structure/wire_splicing) in view(7, H))) //Add more traps later
-		to_chat(H, SPAN_WARNING("Something wrong with this area. Tread carefully."))
+		to_chat(H, SPAN_WARNING("Something is wrong with this area. Tread carefully."))
 		was_triggired = TRUE
-	if (prob(20))
-		for(var/mob/living/carbon/human/target in range(14, H))
-			for(var/organ in target.organs)
-				if (organ in subtypesof(/obj/item/organ/internal/carrion))
-					to_chat(H, SPAN_DANGER("Something's ire is upon you! Twisted and evil mind touches you for a moment, leaving you in cold sweat."))
-					was_triggired = TRUE
-					break
 	if (!was_triggired)
 		to_chat(H, SPAN_NOTICE("There is nothing there. You feel safe."))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR removes the carrion part in the reveal adversaries litany and fixes a typo.

## Why It's Good For The Game

This was supposed to be removed when EOTP system was introduced with Miracle that would tell you the area Carrion is.

## Changelog
:cl:
del: Evil powers have affected NT religion! "Reveal Adversaries" is no longer able to detect Carrions. Rely on EOTP instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
