### PR TITLE
crucifrom energy fixes

### DIFF
--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -27,7 +27,7 @@ var/list/disciples = list()
 	true_power_regen += max(round(wearer.stats.getStat(STAT_COG) / 4), 0) * (0.1 / 1 MINUTES)
 	true_power_regen +=  power_regen * 1.5 * righteous_life / max_righteous_life
 	if(wearer && wearer.stats?.getPerk(/datum/perk/channeling))
-		true_power_regen += disciples.len / 2.5  // Proportional to the number of cruciformed people on board
+		true_power_regen += power_regen * disciples.len / 2.5  // Proportional to the number of cruciformed people on board
 
 	restore_power(true_power_regen)
 

--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -16,17 +16,19 @@ var/list/disciples = list()
 	price_tag = 500
 	var/obj/item/weapon/cruciform_upgrade/upgrade
 
-	var/channeling_boost = 0  // used for the power regen boost if the wearer has the channeling perk
-
 	var/righteous_life = 0
 	var/max_righteous_life = 100
 
 /obj/item/weapon/implant/core_implant/cruciform/auto_restore_power()
 	if(power >= max_power)
 		return
+
 	var/true_power_regen = power_regen
 	true_power_regen += max(round(wearer.stats.getStat(STAT_COG) / 4), 0) * (0.1 / 1 MINUTES)
 	true_power_regen +=  power_regen * 1.5 * righteous_life / max_righteous_life
+	if(wearer && wearer.stats?.getPerk(/datum/perk/channeling))
+		true_power_regen += disciples.len / 2.5  // Proportional to the number of cruciformed people on board
+
 	restore_power(true_power_regen)
 
 /obj/item/weapon/implant/core_implant/cruciform/proc/register_wearer()
@@ -98,7 +100,7 @@ var/list/disciples = list()
 		eotp.addObservation(50)
 	return TRUE
 
-/obj/item/weapon/implant/core_implant/cruciform/examine(mob/user) 
+/obj/item/weapon/implant/core_implant/cruciform/examine(mob/user)
 	..()
 	var/datum/core_module/cruciform/cloning/data = get_module(CRUCIFORM_CLONING)
 	if(data?.mind) // if there is cloning data and it has a mind
@@ -129,10 +131,6 @@ var/list/disciples = list()
 	if(wearer)
 		if(wearer.stat == DEAD)
 			deactivate()
-		else if(wearer.stats?.getPerk(/datum/perk/channeling) && round(world.time) % 5 == 0)
-			power_regen -= channeling_boost  // Removing the previous channeling boost since the number of disciples may have changed
-			channeling_boost = power_regen * disciples.len / 2.5  // Proportional to the number of cruciformed people on board
-			power_regen += channeling_boost  // Applying the new power regeneration boost
 
 /obj/item/weapon/implant/core_implant/cruciform/proc/transfer_soul()
 	if(!wearer || !activated)

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -188,7 +188,10 @@ var/global/obj/machinery/power/eotp/eotp
 		for(var/mob/living/carbon/human/H in disciples)
 			var/obj/item/weapon/implant/core_implant/cruciform/C = H.get_core_implant(/obj/item/weapon/implant/core_implant/cruciform)
 			C.power_regen += initial(C.power_regen) * 0.5
+			for(var/mob/living/carbon/human/disciple in disciples)
+				to_chat(disciple, SPAN_NOTICE("Your cruciform vibrates."))
 
 	for(var/disciple in disciples)
 		to_chat(disciple, SPAN_NOTICE("A miracle has occured at the [src]! May the Angels live forever!"))
+
 	GLOB.miracle_points++

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -298,7 +298,6 @@
 				true_offerings.Add(I)
 
 		if(num_item < req_num)
-			var/obj/item = path
 			break
 		else
 			num_check++


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. the miracle that increases the regeneration of energy gives a little warning to the members of the church.
2. the perk Channeling is applied when calculating passive energy regeneration instead of running on an external proc. This should not make any changes to avoid strange situations when interacting with the rest of the nt update code.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

improve the criciform and EOTP code.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: now the miracle of regeneration gives an alert to all the members of the church.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
