### PR TITLE
Fixes infinite handcuff exploit and minor resist improvements.

### DIFF
--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -48,6 +48,11 @@ Freeing yourself is much harder than freeing someone else. Calling for help is a
 
 	if (!user)
 		return //No user, or too far away
+	
+	if(iscarbon(user)) //check if mob is carbon as handcuffed only applies to carbon mobs
+		var/mob/living/carbon/C = user //set carbon to user
+		if(C.handcuffed)
+			return//you instantly fail if you are handcuffed and trapped, this way you will loose the handcuffs first instead of repeatedly snapping your torso in half
 
 	//How hard will this be? The chance of failure
 	var/difficulty = base_difficulty

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -135,12 +135,10 @@
 	if(istype(H) && H.gloves && istype(H.gloves,/obj/item/clothing/gloves/rig))
 		breakouttime /= 2
 
-	visible_message(
-		SPAN_DANGER("\The [src] attempts to remove \the [HC]!"),
-		SPAN_WARNING("You attempt to remove \the [HC]. (This will take around [breakouttime / 10] seconds and you need to stand still)")
-		)
-
 	if(do_after(src, breakouttime, incapacitation_flags = INCAPACITATION_DEFAULT & ~INCAPACITATION_RESTRAINED))
+		visible_message(
+		SPAN_DANGER("\The [src] attempts to remove \the [HC]!"),
+		SPAN_WARNING("You attempt to remove \the [HC]. (This will take around [breakouttime / 10] seconds and you need to stand still)"))
 		if(!handcuffed || buckled)
 			return
 		visible_message(
@@ -148,6 +146,21 @@
 			SPAN_NOTICE("You successfully remove \the [handcuffed].")
 			)
 		drop_from_inventory(handcuffed)
+
+	if(istype(buckled, /obj/item/weapon/beartrap))
+		breakouttime /= 2
+		visible_message(
+		SPAN_DANGER("\The [src] attempts to remove \the [HC] using the trap!"),
+		SPAN_WARNING("You attempt to remove \the [HC] using the trap. (This will take around [breakouttime / 10] seconds and you need to stand still)")
+		)
+		if(do_after(src, breakouttime, incapacitation_flags = INCAPACITATION_UNCONSCIOUS))
+			if(!handcuffed)
+				return
+			visible_message(
+			SPAN_DANGER("\The [src] manages to remove \the [handcuffed]!"),
+			SPAN_NOTICE("You successfully remove \the [handcuffed].")
+			)
+			drop_from_inventory(handcuffed)
 
 /mob/living/carbon/proc/escape_legcuffs()
 	if(!can_click())


### PR DESCRIPTION
## About The Pull Request

Being beartrapped and cuffed no longer means you are stuck forever until you kill yourself with failed breakout attempts (the attempts don't actually happen you just get snapped). You also use the trap to break out faster now, note you still need to break out of the trap after.

## Why It's Good For The Game

Prevents players from being cuffed and left for upwards of 20 minutes (time to dispose of yourself depends on armour).

## Changelog
:cl:
tweak: tweaked resist code so the visible message does not display unless you are actually attempting to break out
balance: you now use the trap to break out of your cuffs faster (basically the total time to completely break out evens out)
fix: fixed infinite handcuff in trap exploit
/:cl:
