### PR TITLE
Players with godlike strength(robustness) can tear apart handcuffs

### DIFF
--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -148,14 +148,6 @@
 			SPAN_NOTICE("You successfully remove \the [handcuffed].")
 			)
 		drop_from_inventory(handcuffed)
-	if(src.stats.getStat(STAT_ROB) > 50)
-		if(!handcuffed || buckled)
-			return
-		visible_message(
-			SPAN_DANGER("\The [src] manages to rip their [handcuffed] apart!"),
-			SPAN_NOTICE("You successfully tear your handcuffs off.")
-			)
-		drop_from_inventory(handcuffed)
 
 /mob/living/carbon/proc/escape_legcuffs()
 	if(!can_click())

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -201,14 +201,13 @@
 			return
 
 		visible_message(
-			SPAN_DANGER("[src] manages to break \the [handcuffed]!"),
+			SPAN_DANGER("<big>[src] manages to destroy \the [handcuffed]!</big>"),
 			SPAN_WARNING("You successfully break your [handcuffed.name].")
 			)
 
 		if(HULK in mutations)
-			say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" )) //Hulks like bragging.
-		else
-			say(pick("RAAAAAAAARGH!", "HNNNNNNNNNGGGGGGH!", "GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", "AAAAAAARRRGH!" ))
+			say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", ";NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
+
 
 		qdel(handcuffed)
 		handcuffed = null
@@ -225,14 +224,12 @@
 			return
 
 		visible_message(
-			SPAN_DANGER("[src] manages to break the legcuffs!"),
+			SPAN_DANGER("<big>[src] manages to destroy the legcuffs!</big>"),
 			SPAN_WARNING("You successfully break your legcuffs.")
 			)
 
 		if(HULK in mutations)
-			say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
-		else
-			say(pick("RAAAAAAAARGH!", "HNNNNNNNNNGGGGGGH!", "GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", "AAAAAAARRRGH!" ))
+			say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", ";NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
 
 		qdel(legcuffed)
 		legcuffed = null

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -141,7 +141,7 @@
 		)
 
 	if(do_after(src, breakouttime, incapacitation_flags = INCAPACITATION_DEFAULT & ~INCAPACITATION_RESTRAINED))
-		if(!handcuffed || buckled || src.stats.getStat(STAT_ROB) < 50)
+		if(!handcuffed || buckled)
 			return
 		visible_message(
 			SPAN_DANGER("\The [src] manages to remove \the [handcuffed]!"),

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -141,11 +141,19 @@
 		)
 
 	if(do_after(src, breakouttime, incapacitation_flags = INCAPACITATION_DEFAULT & ~INCAPACITATION_RESTRAINED))
-		if(!handcuffed || buckled)
+		if(!handcuffed || buckled || src.stats.getStat(STAT_ROB) < 50)
 			return
 		visible_message(
 			SPAN_DANGER("\The [src] manages to remove \the [handcuffed]!"),
 			SPAN_NOTICE("You successfully remove \the [handcuffed].")
+			)
+		drop_from_inventory(handcuffed)
+	if(src.stats.getStat(STAT_ROB) > 50)
+		if(!handcuffed || buckled)
+			return
+		visible_message(
+			SPAN_DANGER("\The [src] manages to rip their [handcuffed] apart!"),
+			SPAN_NOTICE("You successfully tear your handcuffs off.")
 			)
 		drop_from_inventory(handcuffed)
 
@@ -187,6 +195,8 @@
 /mob/living/carbon/proc/can_break_cuffs()
 	if(HULK in mutations)
 		return 1
+	if(stats.getStat(STAT_ROB) >= STAT_LEVEL_GODLIKE)
+		return 1
 
 /mob/living/carbon/proc/break_handcuffs()
 	visible_message(
@@ -203,7 +213,10 @@
 			SPAN_WARNING("You successfully break your [handcuffed.name].")
 			)
 
-		say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
+		if(HULK in mutations)
+			say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" )) //Hulks like bragging.
+		else
+			say(pick("RAAAAAAAARGH!", "HNNNNNNNNNGGGGGGH!", "GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", "AAAAAAARRRGH!" ))
 
 		qdel(handcuffed)
 		handcuffed = null
@@ -224,7 +237,10 @@
 			SPAN_WARNING("You successfully break your legcuffs.")
 			)
 
-		say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
+		if(HULK in mutations)
+			say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
+		else
+			say(pick("RAAAAAAAARGH!", "HNNNNNNNNNGGGGGGH!", "GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", "AAAAAAARRRGH!" ))
 
 		qdel(legcuffed)
 		legcuffed = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As the title states it makes it so players with high enough robustness can tear handcuffs apart.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is already technically possible, it's just nicer. Beforehand you would need a robustness value of 120 to instantly break cuffs instantly, so players can break handcuffs easier than they could before. If players have robustness higher than 120, it also no longer gives negative values.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: If you have robustness of 80 or more you can break cuffs in 5 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
