### PR TITLE
Intercom code refactor , Signal for area power changes, src. cleanup on firealarm

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -92,6 +92,8 @@
 
 //machinery
 #define COMSIG_AREA_APC_OPERATING "area_operating"  //from apc process()
+#define COMSIG_AREA_APC_DELETED "area_apc_gone"
+#define COMSIG_AREA_APC_POWER_CHANGE "area_apc_power_change"
 #define COMSING_DESTRUCTIVE_ANALIZER "destructive_analizer"
 #define COMSIG_TURRENT "create_turrent"
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -205,6 +205,7 @@
 /area/proc/power_change()
 	for(var/obj/machinery/M in src)	// for each machine in the area
 		M.power_change()			// reverify power status (to update icons etc.)
+	SEND_SIGNAL(src, COMSIG_AREA_APC_POWER_CHANGE)
 	if (fire || eject || party)
 		updateicon()
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1084,15 +1084,15 @@ FIRE ALARM
 	if(stat & (NOPOWER|BROKEN))
 		return
 
-	if(src.timing)
-		if(src.time > 0)
-			src.time = src.time - ((world.timeofday - last_process)/10)
+	if(timing)
+		if(time > 0)
+			time = time - ((world.timeofday - last_process)/10)
 		else
-			src.alarm()
-			src.time = 0
-			src.timing = 0
+			alarm()
+			time = 0
+			timing = 0
 			STOP_PROCESSING(SSmachines, src)
-		src.updateDialog()
+		updateDialog()
 	last_process = world.timeofday
 
 	if(locate(/obj/fire) in loc)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -108,6 +108,7 @@
 	linked_area = target_area
 	RegisterSignal(target_area, COMSIG_AREA_APC_DELETED, .proc/on_apc_removal)
 	RegisterSignal(target_area, COMSIG_AREA_APC_POWER_CHANGE, .proc/change_status)
+	change_status()
 
 /obj/item/device/radio/intercom/proc/on_apc_removal()
 	UnregisterSignal(linked_area , COMSIG_AREA_APC_DELETED)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -9,7 +9,7 @@
 	canhear_range = 2
 	flags = CONDUCT | NOBLOODY
 	var/number = 0
-	var/last_tick //used to delay the powercheck
+	var/area/linked_area = null
 
 /obj/item/device/radio/intercom/custom
 	name = "station intercom (Custom)"
@@ -39,7 +39,7 @@
 
 /obj/item/device/radio/intercom/New()
 	..()
-	START_PROCESSING(SSobj, src)
+	loop_area_check()
 
 /obj/item/device/radio/intercom/department/medbay/New()
 	..()
@@ -93,23 +93,28 @@
 
 	return canhear_range
 
-/obj/item/device/radio/intercom/Process()
-	if(((world.timeofday - last_tick) > 30) || ((world.timeofday - last_tick) < 0))
-		last_tick = world.timeofday
+/obj/item/device/radio/intercom/proc/change_status()
+	on = linked_area.powered(EQUIP)
+	icon_state = on ? "intercom" : "intercom-p"
 
-		if(!src.loc)
-			on = FALSE
-		else
-			var/area/A = get_area(src)
-			if(!A)
-				on = FALSE
-			else
-				on = A.powered(EQUIP) // set "on" to the power status
+/obj/item/device/radio/intercom/proc/loop_area_check()
+	var/area/target_area = get_area(src)
+	if(!target_area)
+		addtimer(CALLBACK(src, .proc/loop_area_check), 30 SECONDS)
+		return FALSE
+	if(!(target_area.apc))
+		addtimer(CALLBACK(src, .proc/loop_area_check), 30 SECONDS) // We don't proces if there is no APC , no point in doing so is there ?
+		return FALSE
+	linked_area = target_area
+	RegisterSignal(target_area, COMSIG_AREA_APC_DELETED, .proc/on_apc_removal)
+	RegisterSignal(target_area, COMSIG_AREA_APC_POWER_CHANGE, .proc/change_status)
 
-		if(!on)
-			icon_state = "intercom-p"
-		else
-			icon_state = "intercom"
+/obj/item/device/radio/intercom/proc/on_apc_removal()
+	UnregisterSignal(linked_area , COMSIG_AREA_APC_DELETED)
+	UnregisterSignal(linked_area, COMSIG_AREA_APC_POWER_CHANGE)
+	linked_area = null
+	on = FALSE
+	addtimer(CALLBACK(src, .proc/loop_area_check), 30 SECONDS)
 
 /obj/item/device/radio/intercom/broadcasting
 	broadcasting = 1

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -187,6 +187,7 @@
 
 /obj/machinery/power/apc/Destroy()
 	update()
+	SEND_SIGNAL(area, COMSIG_AREA_APC_DELETED, src)
 	area.apc = null
 	area.power_light = 0
 	area.power_equip = 0

--- a/code/modules/projectiles/guns/projectile/pistol/avasarala.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/avasarala.dm
@@ -17,7 +17,7 @@
 	can_dual = TRUE
 	damage_multiplier = 1.45
 	penetration_multiplier = 1.35
-	recoil_buildup = 33
+	recoil_buildup = 5
 
 	fire_sound = 'sound/weapons/guns/fire/hpistol_fire.ogg'
 	unload_sound = 'sound/weapons/guns/interact/hpistol_magout.ogg'

--- a/code/modules/projectiles/guns/projectile/pistol/colt.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/colt.dm
@@ -13,7 +13,7 @@
 	mag_well = MAG_WELL_PISTOL|MAG_WELL_H_PISTOL
 	magazine_type = /obj/item/ammo_magazine/pistol
 	damage_multiplier = 1.5
-	recoil_buildup = 17
+	recoil_buildup = 4
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
 
 

--- a/code/modules/projectiles/guns/projectile/pistol/handmade.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/handmade.dm
@@ -12,7 +12,7 @@
 	max_shells = 1
 	ammo_type = /obj/item/ammo_casing/magnum
 	damage_multiplier = 1.36
-	recoil_buildup = 45
+	recoil_buildup = 15
 	spawn_frequency = 0
 	var/chamber_open = FALSE
 	var/jammed = FALSE

--- a/code/modules/projectiles/guns/projectile/pistol/lamia.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/lamia.dm
@@ -21,7 +21,7 @@
 	cocked_sound = 'sound/weapons/guns/interact/hpistol_cock.ogg'
 	damage_multiplier = 1.4
 	penetration_multiplier = 1.4
-	recoil_buildup = 21
+	recoil_buildup = 5
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
 

--- a/code/modules/projectiles/guns/projectile/pistol/mandella.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mandella.dm
@@ -20,7 +20,7 @@
 	magazine_type = /obj/item/ammo_magazine/cspistol
 	damage_multiplier = 1.2
 	penetration_multiplier = 1.7
-	recoil_buildup = 19
+	recoil_buildup = 2
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
 

--- a/code/modules/projectiles/guns/projectile/pistol/paco.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/paco.dm
@@ -20,7 +20,7 @@
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
 	damage_multiplier = 1.5
 	penetration_multiplier = 0.9
-	recoil_buildup = 10
+	recoil_buildup = 3
 	gun_tags = list(GUN_SILENCABLE)
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE

--- a/code/modules/projectiles/guns/projectile/pistol/selfload.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/selfload.dm
@@ -19,7 +19,7 @@
 	magazine_type = /obj/item/ammo_magazine/pistol
 
 	damage_multiplier = 1
-	recoil_buildup = 19
+	recoil_buildup = 2
 	silenced = 0
 	can_dual = 1
 
@@ -63,7 +63,7 @@
 	icon = 'icons/obj/guns/projectile/makarov.dmi'
 	icon_state = "makarov"
 	damage_multiplier = 1.2
-	recoil_buildup = 21
+	recoil_buildup = 3
 	price_tag = 1400
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2, TECH_COVERT = 3)
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/revolver/consul.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/consul.dm
@@ -13,5 +13,5 @@
 	price_tag = 1700
 	damage_multiplier = 1.35
 	penetration_multiplier = 1.5
-	recoil_buildup = 35
+	recoil_buildup = 6
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE

--- a/code/modules/projectiles/guns/projectile/revolver/deckard.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/deckard.dm
@@ -11,5 +11,5 @@
 	price_tag = 3100 //one of most robust revolvers here
 	damage_multiplier = 1.45
 	penetration_multiplier = 1.65
-	recoil_buildup = 40
+	recoil_buildup = 6
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE

--- a/code/modules/projectiles/guns/projectile/revolver/handmade.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/handmade.dm
@@ -9,5 +9,5 @@
 	matter = list(MATERIAL_PLASTIC = 10, MATERIAL_STEEL = 15)
 	price_tag = 250 //one of the cheapest revolvers here
 	damage_multiplier = 1.3
-	recoil_buildup = 60
+	recoil_buildup = 7
 	spawn_blacklisted = TRUE

--- a/code/modules/projectiles/guns/projectile/revolver/havelock.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/havelock.dm
@@ -15,6 +15,6 @@
 	price_tag = 900
 	damage_multiplier = 1.4 //because pistol round
 	penetration_multiplier = 1.4
-	recoil_buildup = 18
+	recoil_buildup = 8
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE

--- a/code/modules/projectiles/guns/projectile/revolver/mateba.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/mateba.dm
@@ -8,6 +8,6 @@
 	price_tag = 3000 //more op and rare than miller, hits harder, but have fun with hittin anything
 	damage_multiplier = 1.35
 	penetration_multiplier = 1.5
-	recoil_buildup = 38
+	recoil_buildup = 6
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE

--- a/code/modules/projectiles/guns/projectile/revolver/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/revolver.dm
@@ -21,7 +21,7 @@
 	fire_delay = 3 //all revolvers can fire faster, but have huge recoil
 	damage_multiplier = 1.75
 	armor_penetration = 0.65 // Insanely powerful handcannon, but worthless against heavy armor
-	recoil_buildup = 50
+	recoil_buildup = 8
 	var/drawChargeMeter = TRUE
 	var/chamber_offset = 0 //how many empty chambers in the cylinder until you hit a round
 

--- a/code/modules/projectiles/guns/projectile/revolver/sky_driver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/sky_driver.dm
@@ -17,7 +17,7 @@
 	damage_multiplier = 1.1
 	penetration_multiplier = 20
 	pierce_multiplier = 5
-	recoil_buildup = 50
+	recoil_buildup = 6
 	spawn_frequency = 0
 	spawn_blacklisted = TRUE
 	noricochet = TRUE


### PR DESCRIPTION

## About The Pull Request
Removes process() from intercoms , now they work based on signals , add a signal for when the APC of an area is deleted, and for when a power change on an area is called, firealarms no longer do src.time which  would result in src.src.time on compile

## Why It's Good For The Game
190 less objects to process overall , bad code removal , signals good.

## Changelog
:cl:
code: added signals for APC power change, and APC deletion for areas.
refactor: refactored intercom code to not process and instead use signals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
