### PR TITLE
Refactors intercom code to not process , adds signals for area power changes and area apc deletion , removes .src from fire alarm code

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -92,6 +92,8 @@
 
 //machinery
 #define COMSIG_AREA_APC_OPERATING "area_operating"  //from apc process()
+#define COMSIG_AREA_APC_DELETED "area_apc_gone"
+#define COMSIG_AREA_APC_POWER_CHANGE "area_apc_power_change"
 #define COMSING_DESTRUCTIVE_ANALIZER "destructive_analizer"
 #define COMSIG_TURRENT "create_turrent"
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -205,6 +205,7 @@
 /area/proc/power_change()
 	for(var/obj/machinery/M in src)	// for each machine in the area
 		M.power_change()			// reverify power status (to update icons etc.)
+	SEND_SIGNAL(src, COMSIG_AREA_APC_POWER_CHANGE)
 	if (fire || eject || party)
 		updateicon()
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1084,15 +1084,15 @@ FIRE ALARM
 	if(stat & (NOPOWER|BROKEN))
 		return
 
-	if(src.timing)
-		if(src.time > 0)
-			src.time = src.time - ((world.timeofday - last_process)/10)
+	if(timing)
+		if(time > 0)
+			time = time - ((world.timeofday - last_process)/10)
 		else
-			src.alarm()
-			src.time = 0
-			src.timing = 0
+			alarm()
+			time = 0
+			timing = 0
 			STOP_PROCESSING(SSmachines, src)
-		src.updateDialog()
+		updateDialog()
 	last_process = world.timeofday
 
 	if(locate(/obj/fire) in loc)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -9,7 +9,7 @@
 	canhear_range = 2
 	flags = CONDUCT | NOBLOODY
 	var/number = 0
-	var/last_tick //used to delay the powercheck
+	var/area/linked_area = null
 
 /obj/item/device/radio/intercom/custom
 	name = "station intercom (Custom)"
@@ -39,7 +39,7 @@
 
 /obj/item/device/radio/intercom/New()
 	..()
-	START_PROCESSING(SSobj, src)
+	loop_area_check()
 
 /obj/item/device/radio/intercom/department/medbay/New()
 	..()
@@ -63,10 +63,6 @@
 /obj/item/device/radio/intercom/syndicate/New()
 	..()
 	internal_channels[num2text(SYND_FREQ)] = list(access_syndicate)
-
-/obj/item/device/radio/intercom/Destroy()
-	STOP_PROCESSING(SSobj, src)
-	. = ..()
 
 /obj/item/device/radio/intercom/attack_ai(mob/user as mob)
 	src.add_fingerprint(user)
@@ -93,23 +89,28 @@
 
 	return canhear_range
 
-/obj/item/device/radio/intercom/Process()
-	if(((world.timeofday - last_tick) > 30) || ((world.timeofday - last_tick) < 0))
-		last_tick = world.timeofday
+/obj/item/device/radio/intercom/proc/change_status()
+	on = linked_area.powered(EQUIP)
+	icon_state = on ? "intercom" : "intercom-p"
 
-		if(!src.loc)
-			on = FALSE
-		else
-			var/area/A = get_area(src)
-			if(!A)
-				on = FALSE
-			else
-				on = A.powered(EQUIP) // set "on" to the power status
+/obj/item/device/radio/intercom/proc/loop_area_check()
+	var/area/target_area = get_area(src)
+	if(!target_area)
+		addtimer(CALLBACK(src, .proc/loop_area_check), 30 SECONDS)
+		return FALSE
+	if(!(target_area.apc))
+		addtimer(CALLBACK(src, .proc/loop_area_check), 30 SECONDS) // We don't proces if there is no APC , no point in doing so is there ?
+		return FALSE
+	linked_area = target_area
+	RegisterSignal(target_area, COMSIG_AREA_APC_DELETED, .proc/on_apc_removal)
+	RegisterSignal(target_area, COMSIG_AREA_APC_POWER_CHANGE, .proc/change_status)
 
-		if(!on)
-			icon_state = "intercom-p"
-		else
-			icon_state = "intercom"
+/obj/item/device/radio/intercom/proc/on_apc_removal()
+	UnregisterSignal(linked_area , COMSIG_AREA_APC_DELETED)
+	UnregisterSignal(linked_area, COMSIG_AREA_APC_POWER_CHANGE)
+	linked_area = null
+	on = FALSE
+	addtimer(CALLBACK(src, .proc/loop_area_check), 30 SECONDS)
 
 /obj/item/device/radio/intercom/broadcasting
 	broadcasting = 1

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -95,10 +95,7 @@
 
 /obj/item/device/radio/intercom/proc/loop_area_check()
 	var/area/target_area = get_area(src)
-	if(!target_area)
-		addtimer(CALLBACK(src, .proc/loop_area_check), 30 SECONDS)
-		return FALSE
-	if(!(target_area.apc))
+	if(!target_area?.apc)
 		addtimer(CALLBACK(src, .proc/loop_area_check), 30 SECONDS) // We don't proces if there is no APC , no point in doing so is there ?
 		return FALSE
 	linked_area = target_area
@@ -110,6 +107,7 @@
 	UnregisterSignal(linked_area, COMSIG_AREA_APC_POWER_CHANGE)
 	linked_area = null
 	on = FALSE
+	icon_state = "intercom-p"
 	addtimer(CALLBACK(src, .proc/loop_area_check), 30 SECONDS)
 
 /obj/item/device/radio/intercom/broadcasting

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -9,7 +9,7 @@
 	canhear_range = 2
 	flags = CONDUCT | NOBLOODY
 	var/number = 0
-	var/area/linked_area = null
+	var/area/linked_area
 
 /obj/item/device/radio/intercom/custom
 	name = "station intercom (Custom)"

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -188,6 +188,7 @@
 /obj/machinery/power/apc/Destroy()
 	update()
 	area.apc = null
+	SEND_SIGNAL(area, COMSIG_AREA_APC_DELETED)
 	area.power_light = 0
 	area.power_equip = 0
 	area.power_environ = 0


### PR DESCRIPTION
## About The Pull Request
Removes process() from intercoms , now they work based on signals , add a signal for when the APC of an area is deleted, and for when a power change on an area is called, firealarms no longer do src.time which  would result in src.src.time on compile
adresses #4537 by a bit.

## Why It's Good For The Game
190 less objects to process overall , bad code removal , signals good.

## Changelog
:cl:
code: added signals for APC power change, and APC deletion for areas.
refactor: refactored intercom code to not process and instead use signals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
