### PR TITLE
More acolytes and all dedicated NTs speak latin now

### DIFF
--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -9,7 +9,7 @@
 	spawn_positions = 1
 	supervisors = "the NeoTheology Church"
 	selection_color = "#ecd37d"
-	also_known_languages = list(LANGUAGE_CYRILLIC = 25, LANGUAGE_SERBIAN = 25, LANGUAGE_LATIN = 45)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 25, LANGUAGE_SERBIAN = 25, LANGUAGE_LATIN = 100)
 
 	cruciform_access = list(
 		access_morgue, access_chapel_office, access_crematorium, access_hydroponics, access_janitor, access_maint_tunnels
@@ -74,11 +74,11 @@
 	department = DEPARTMENT_CHURCH
 	department_flag = CHURCH
 	faction = "CEV Eris"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 4
+	spawn_positions = 4
 	supervisors = "the NeoTheology Preacher"
 	selection_color = "#ecd37d"
-	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_LATIN = 20)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_LATIN = 1000)
 	cruciform_access = list(access_morgue, access_crematorium, access_maint_tunnels, access_hydroponics)
 	wage = WAGE_PROFESSIONAL // The money of the soul is faith, and cold hard cash
 	outfit_type = /decl/hierarchy/outfit/job/church/acolyte
@@ -121,7 +121,7 @@
 	supervisors = "the NeoTheology Preacher"
 	selection_color = "#ecd37d"
 	//alt_titles = list("Hydroponicist")
-	also_known_languages = list(LANGUAGE_CYRILLIC = 15, LANGUAGE_JIVE = 80, LANGUAGE_LATIN = 20)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 15, LANGUAGE_JIVE = 80, LANGUAGE_LATIN = 100)
 	cruciform_access = list(access_hydroponics, access_morgue, access_crematorium, access_maint_tunnels)
 	wage = WAGE_PROFESSIONAL // The money of the soul is faith, and cold hard cash
 
@@ -166,7 +166,7 @@
 	supervisors = "the NeoTheology Preacher"
 	selection_color = "#ecd37d"
 	//alt_titles = list("Custodian","Sanitation Technician")
-	also_known_languages = list(LANGUAGE_CYRILLIC = 15, LANGUAGE_JIVE = 80, LANGUAGE_LATIN = 20)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 15, LANGUAGE_JIVE = 80, LANGUAGE_LATIN = 100)
 	cruciform_access = list(access_janitor, access_maint_tunnels, access_morgue, access_crematorium)
 	wage = WAGE_PROFESSIONAL // The money of the soul is faith, and cold hard cash
 	outfit_type = /decl/hierarchy/outfit/job/church/janitor

--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -78,7 +78,7 @@
 	spawn_positions = 4
 	supervisors = "the NeoTheology Preacher"
 	selection_color = "#ecd37d"
-	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_LATIN = 1000)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_LATIN = 100)
 	cruciform_access = list(access_morgue, access_crematorium, access_maint_tunnels, access_hydroponics)
 	wage = WAGE_PROFESSIONAL // The money of the soul is faith, and cold hard cash
 	outfit_type = /decl/hierarchy/outfit/job/church/acolyte

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -25269,6 +25269,7 @@
 /obj/machinery/camera/network/third_section{
 	dir = 4
 	},
+/obj/structure/closet/acolyte,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/neotheology/storage)
 "bhD" = (
@@ -26442,6 +26443,7 @@
 	dir = 4;
 	pixel_x = -26
 	},
+/obj/structure/closet/acolyte,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/neotheology/storage)
 "bke" = (
@@ -44816,6 +44818,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/landmark/join/start/acolyte,
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/storage)
 "cau" = (
@@ -44937,6 +44940,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/weapon/storage/toolbox/electrical,
 /obj/item/weapon/storage/toolbox/electrical,
 /obj/item/weapon/storage/toolbox/electrical,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -45111,6 +45116,8 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/neotheology/storage)
 "cbk" = (
@@ -105115,6 +105122,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/chemistry)
+"wFh" = (
+/obj/landmark/join/start/acolyte,
+/turf/simulated/floor/tiled/dark/golden,
+/area/eris/neotheology/storage)
 "wOW" = (
 /obj/structure/closet/secure_closet/medicine,
 /obj/structure/catwalk,
@@ -118904,7 +118915,7 @@ alg
 asn
 avN
 axY
-bZO
+wFh
 cat
 btS
 axw


### PR DESCRIPTION
## About The Pull Request

Added 2 more acolyte slots as well as closets and their spawn essentials. All NTs speak latin now

## Why It's Good For The Game

I've always found it odd how every other faction has a backbone role except for NT. Mobi has scientists, technomancers have technomancers and IH has operatives but NT was always capped. This PR aims to make the acolyte the backbone of NT as i can understand that not everyone wants to be a janitor or a botanist just to play a dedicated NT role. Also all NTs know latin now just like all technos know russian.

## Changelog
:cl:
add: 2 more NT acolyte closets
add: 2 more toolboxes of each type
add: 2 more NT acolyte slots and spawn points
tweak: upped NT acolyte cap by 2
tweak: All NTs know latin now
/:cl:
