### PR TITLE
Tweaked gun vendor prices

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1025,26 +1025,24 @@
 					/obj/item/weapon/storage/box/smokes = 3)
 
 	prices = list(
-					/obj/item/weapon/gun/projectile/automatic/slaught_o_matic = 90,
-					/obj/item/ammo_magazine/ammobox/pistol/rubber = 400,
-					/obj/item/ammo_magazine/ammobox/pistol/rubber = 500,
-					/obj/item/ammo_magazine/slpistol/rubber = 300,
-					/obj/item/ammo_magazine/pistol/rubber = 200,
-					/obj/item/ammo_magazine/hpistol = 400,
-					/obj/item/ammo_magazine/hpistol/rubber = 300,
+					/obj/item/ammo_magazine/ammobox/pistol/rubber = 200,
+					/obj/item/ammo_magazine/slpistol/rubber = 100,
+					/obj/item/ammo_magazine/pistol/rubber = 150,
+					/obj/item/ammo_magazine/hpistol = 300,
+					/obj/item/ammo_magazine/hpistol/rubber = 200,
 					/obj/item/weapon/storage/box/shotgunammo/beanbags = 300,
 					/obj/item/weapon/storage/box/shotgunammo/flashshells = 300,
 					/obj/item/weapon/storage/box/shotgunammo/blanks = 50,
-					/obj/item/ammo_magazine/sllrifle = 400,
-					/obj/item/ammo_magazine/slpistol = 500,
-					/obj/item/ammo_magazine/smg/rubber = 300,
+					/obj/item/ammo_magazine/sllrifle = 300,
+					/obj/item/ammo_magazine/slpistol = 100,
+					/obj/item/ammo_magazine/smg/rubber = 200,
 					/obj/item/ammo_magazine/smg = 400,
-					/obj/item/ammo_magazine/ammobox/pistol = 700,
-					/obj/item/weapon/storage/box/shotgunammo/slug = 900,
-					/obj/item/weapon/storage/box/shotgunammo/buckshot = 900,
-					/obj/item/weapon/tool/knife/tacknife = 600,
+					/obj/item/ammo_magazine/ammobox/pistol = 500,
+					/obj/item/weapon/storage/box/shotgunammo/slug = 600,
+					/obj/item/weapon/storage/box/shotgunammo/buckshot = 600,
+					/obj/item/weapon/tool/knife/tacknife = 300,
 					/obj/item/weapon/storage/box/smokes = 200,
-					/obj/item/ammo_magazine/pistol = 600,)
+					/obj/item/ammo_magazine/pistol = 300,)
 
 //This one's from bay12
 /obj/machinery/vending/cart

--- a/code/modules/projectiles/guns/energy/egun.dm
+++ b/code/modules/projectiles/guns/energy/egun.dm
@@ -42,7 +42,7 @@
 	charge_cost = 50
 	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 1)
 	matter = list(MATERIAL_PLASTEEL = 8, MATERIAL_PLASTIC = 4, MATERIAL_SILVER = 2)
-	price_tag = 1000
+	price_tag = 800
 	modifystate = null
 	suitable_cell = /obj/item/weapon/cell/small
 	cell_type = /obj/item/weapon/cell/small

--- a/code/modules/projectiles/guns/projectile/automatic/atreides.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/atreides.dm
@@ -16,7 +16,7 @@
 	mag_well = MAG_WELL_SMG
 	magazine_type = /obj/item/ammo_magazine/smg
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 13, MATERIAL_PLASTIC = 2)
-	price_tag = 1200
+	price_tag = 800
 	damage_multiplier = 0.8
 	recoil_buildup = 1.2
 	one_hand_penalty = 5 //smg level

--- a/code/modules/projectiles/guns/projectile/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun.dm
@@ -22,7 +22,7 @@
 	fire_sound = 'sound/weapons/guns/fire/sniper_fire.ogg'
 	reload_sound = 'sound/weapons/guns/interact/rifle_load.ogg'
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_PLASTIC = 10)
-	price_tag = 1600
+	price_tag = 900
 	one_hand_penalty = 20 //full sized rifle with bayonet is hard to keep on target
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut") // Considering attached bayonet
 	sharp = TRUE

--- a/code/modules/projectiles/guns/projectile/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun.dm
@@ -22,7 +22,7 @@
 	fire_sound = 'sound/weapons/guns/fire/sniper_fire.ogg'
 	reload_sound = 'sound/weapons/guns/interact/rifle_load.ogg'
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_PLASTIC = 10)
-	price_tag = 900
+	price_tag = 1000
 	one_hand_penalty = 20 //full sized rifle with bayonet is hard to keep on target
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut") // Considering attached bayonet
 	sharp = TRUE

--- a/code/modules/projectiles/guns/projectile/pistol/giskard.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/giskard.dm
@@ -15,7 +15,7 @@
 	mag_well = MAG_WELL_PISTOL
 	magazine_type = /obj/item/ammo_magazine/pistol
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_WOOD = 4)
-	price_tag = 600
+	price_tag = 400
 	damage_multiplier = 1.3
 	penetration_multiplier = 0.8
 	recoil_buildup = 2

--- a/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
@@ -12,7 +12,7 @@
 	mag_well = MAG_WELL_PISTOL|MAG_WELL_H_PISTOL
 	magazine_type = /obj/item/ammo_magazine/pistol
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
-	price_tag = 800
+	price_tag = 600
 	damage_multiplier = 1.2
 	penetration_multiplier = 1.2
 	recoil_buildup = 6

--- a/code/modules/projectiles/guns/projectile/revolver/havelock.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/havelock.dm
@@ -12,7 +12,7 @@
 	ammo_type = /obj/item/ammo_casing/pistol
 	magazine_type = /obj/item/ammo_magazine/slpistol
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
-	price_tag = 900
+	price_tag = 700
 	damage_multiplier = 1.4 //because pistol round
 	penetration_multiplier = 1.4
 	recoil_buildup = 8

--- a/code/modules/projectiles/guns/projectile/shotgun/gladstone.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/gladstone.dm
@@ -14,5 +14,5 @@
 	one_hand_penalty = 15 //full sized shotgun level
 	damage_multiplier = 0.8
 
-	price_tag = 2000
+	price_tag = 1800
 	spawn_tags = SPANW_TAG_FS_SHOTGUN

--- a/code/modules/projectiles/guns/projectile/shotgun/pump.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/pump.dm
@@ -17,7 +17,7 @@
 	fire_sound = 'sound/weapons/guns/fire/shotgunp_fire.ogg'
 	bulletinsert_sound = 'sound/weapons/guns/interact/shotgun_insert.ogg'
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 10)
-	price_tag = 1000
+	price_tag = 800
 	recoil_buildup = 12
 	one_hand_penalty = 15 //full sized shotgun level
 	spawn_tags = SPANW_TAG_FS_SHOTGUN


### PR DESCRIPTION
## About The Pull Request

I reduced almost all the prices in the gun vendors with items that relate to guns (guns, magazines and ammo) as almost all of these are early to mid tier items and have fallen into disuse. Many people regard these prices as not worth it as they often find better guns and ammo in maint a lot faster than they attain the credits to buy these.

## Why It's Good For The Game

In short this is a effort to make these weapons see a bit more use and be more affordable for the average eris role. Open to more suggestions on the prices as i more or less just willy nilly reduced them by 200-600 creds except for special cases.

## Changelog
:cl:
tweak: reduced gun vendor prices (and prices on guns themselves).
/:cl:

