### PR TITLE
Gun and Armour parts

### DIFF
--- a/code/datums/autolathe/biomatter.dm
+++ b/code/datums/autolathe/biomatter.dm
@@ -196,6 +196,10 @@
 	name= "Vial pouch"
 	build_path = /obj/item/weapon/storage/pouch/tubular/vial
 
+/datum/design/bioprinter/part
+	build_type = "Part pouch"
+	build_path = /obj/item/weapon/storage/pouch/gun_part
+
 //[/CLOTHES, ARMOR AND ACCESORIES]
 
 //[MISC]

--- a/code/datums/autolathe/biomatter.dm
+++ b/code/datums/autolathe/biomatter.dm
@@ -197,7 +197,7 @@
 	build_path = /obj/item/weapon/storage/pouch/tubular/vial
 
 /datum/design/bioprinter/part
-	build_type = "Part pouch"
+	name = "Part pouch"
 	build_path = /obj/item/weapon/storage/pouch/gun_part
 
 //[/CLOTHES, ARMOR AND ACCESORIES]

--- a/code/datums/craft/crafting_items.dm
+++ b/code/datums/craft/crafting_items.dm
@@ -23,14 +23,14 @@
 	desc = "Spare part for clothing."
 	icon_state = "armor_part"
 	spawn_tags = SPAWN_TAG_PART_ARMOR
-	matter = list(MATERIAL_PLASTIC = 1)
+	matter = list(MATERIAL_PLASTIC = 5, MATERIAL_WOOD = 5, MATERIAL_CARDBOARD = 5, MATERIAL_STEEL = 5)
 
 /obj/item/part/gun
 	name = "gun part"
 	desc = "Spare part of a gun."
 	icon_state = "gun_part_1"
-	spawn_tags = SPAWN_TAG_GUN_PART
-	matter = list(MATERIAL_PLASTEEL = 1)
+	w_class = ITEM_SIZE_SMALL
+	matter = list(MATERIAL_PLASTEEL = 6)
 
 /obj/item/part/gun/New()
 	. = ..()
@@ -57,7 +57,7 @@
 /obj/item/craft_frame/guns
 	name = "gun assembly"
 	desc = "Add some weapon parts to complete this, use your knowledge of mechanics and create a gun."
-	matter = list(MATERIAL_PLASTEEL = 5)
+	matter = list(MATERIAL_PLASTEEL = 6)
 	suitable_part = /obj/item/part/gun
 	spawn_frequency = 0
 	tags_to_spawn = list(SPAWN_GUN)

--- a/code/datums/craft/crafting_items.dm
+++ b/code/datums/craft/crafting_items.dm
@@ -58,7 +58,7 @@
 /obj/item/craft_frame/guns
 	name = "gun assembly"
 	desc = "Add some weapon parts to complete this, use your knowledge of mechanics and create a gun."
-	matter = list(MATERIAL_PLASTEEL = 6)
+	matter = list(MATERIAL_PLASTEEL = 5)
 	suitable_part = /obj/item/part/gun
 	spawn_frequency = 0
 	tags_to_spawn = list(SPAWN_GUN)

--- a/code/datums/craft/crafting_items.dm
+++ b/code/datums/craft/crafting_items.dm
@@ -29,6 +29,7 @@
 	name = "gun part"
 	desc = "Spare part of a gun."
 	icon_state = "gun_part_1"
+	spawn_tags = SPAWN_TAG_GUN_PART
 	w_class = ITEM_SIZE_SMALL
 	matter = list(MATERIAL_PLASTEEL = 6)
 

--- a/code/datums/craft/crafting_items.dm
+++ b/code/datums/craft/crafting_items.dm
@@ -31,7 +31,7 @@
 	icon_state = "gun_part_1"
 	spawn_tags = SPAWN_TAG_GUN_PART
 	w_class = ITEM_SIZE_SMALL
-	matter = list(MATERIAL_PLASTEEL = 6)
+	matter = list(MATERIAL_PLASTEEL = 1.2)
 
 /obj/item/part/gun/New()
 	. = ..()

--- a/code/game/objects/items/weapons/design_disks/NeoTheology.dm
+++ b/code/game/objects/items/weapons/design_disks/NeoTheology.dm
@@ -78,6 +78,7 @@
 		/datum/design/bioprinter/ammo,
 		/datum/design/bioprinter/tubular,
 		/datum/design/bioprinter/tubular/vial,
+		/datum/design/bioprinter/part,
 
    		/datum/design/autolathe/device/headset_church,
 		/datum/design/bioprinter/leather/cash_bag

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -305,5 +305,7 @@
 	max_w_class = ITEM_SIZE_NORMAL
 
 	can_hold = list(
-		/obj/item/part, /obj/item/weapon/stock_parts, /obj/item/weapon/electronics
+		/obj/item/part,
+		/obj/item/weapon/stock_parts,
+		/obj/item/weapon/electronics
 		)


### PR DESCRIPTION

## About The Pull Request

1. Increases the material from gun and armour parts (gun part is 1.2 plasteel, armour part is 5 wood, steel, cardboard and plastic)
reduces gun part size to small
2. allows NT to print parts pouch
3. also makes the part pouch list look nicer

## Why It's Good For The Game

1. having the parts give only 1 sheet in materials made them highly useless to those who didn't want to craft anything with them, also having the gun parts not be the same size as a crowbar is nice
2. consistency, NT can already print almost every pouch
3. doesn't affect gameplay, just looks better and more consistent with other pouches

## Changelog
:cl:
add: Added parts pouch to a NT disk (the one with pouches and clothes)
tweak: tweaked materials from gun and armour parts, gun part is smaller
/:cl:


