### PR TITLE
Refactors and fixes malf AI emergency forcefield , buffs emergency forcefield

### DIFF
--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
@@ -3,7 +3,7 @@
 // Abilities in this tree allow the AI to physically manipulate systems around the station.
 // T1 - Electrical Pulse - Sends out pulse that breaks some lights and sometimes even APCs. This can actually break the AI's APC so be careful!
 // T2 - Hack Camera - Allows the AI to hack a camera. Deactivated areas may be reactivated, and functional cameras can be upgraded.
-// T3 - Emergency Forcefield - Allows the AI to project 1 tile forcefield that blocks movement and air flow. Forcefield´dissipates over time. It is also very susceptible to energetic weaponry.
+// T3 - Emergency Forcefield - Allows the AI to project 1 tile forcefield that blocks movement and air flow. Forcefieldï¿½dissipates over time. It is also very susceptible to energetic weaponry.
 // T4 - Machine Overload - Detonates machine of choice in a minor explosion. Two of these are usually enough to kill or K/O someone.
 
 
@@ -111,19 +111,20 @@
 				return
 
 
-/datum/game_mode/malfunction/verb/emergency_forcefield(var/turf/T in turfs)
+/datum/game_mode/malfunction/verb/emergency_forcefield()
 	set name = "Emergency Forcefield"
-	set desc = "275 CPU - Uses station's emergency shielding system to create temporary barrier which lasts for few minutes, but won't resist gunfire."
+	set desc = "275 CPU - Uses station's emergency shielding system to create temporary barrier which lasts indefinetly, but won't resist EMP pulses."
 	set category = "Software"
 	var/price = 275
 	var/mob/living/silicon/ai/user = usr
-	if(!T || !istype(T))
-		return
 	if(!ability_prechecks(user, price) || !ability_pay(user, price))
+		return
+	var/turf/target_turf = get_turf(user.client.virtual_eye)
+	if(!target_turf)
 		return
 
 	to_chat(user, "Emergency forcefield projection completed.")
-	new/obj/machinery/shield/malfai(T)
+	new/obj/machinery/shield/malfai(target_turf)
 	user.hacking = 1
 	spawn(20)
 		user.hacking = 0

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
@@ -113,7 +113,7 @@
 
 /datum/game_mode/malfunction/verb/emergency_forcefield()
 	set name = "Emergency Forcefield"
-	set desc = "275 CPU - Uses station's emergency shielding system to create temporary barrier which lasts indefinetly, but won't resist EMP pulses."
+	set desc = "275 CPU - Uses station's emergency shielding system to create temporary barrier which lasts indefinetely, but won't resist EMP pulses."
 	set category = "Software"
 	var/price = 275
 	var/mob/living/silicon/ai/user = usr

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -16,7 +16,7 @@
 /obj/machinery/shield/malfai
 	name = "emergency forcefield"
 	desc = "A powerfull forcefield which seems to be projected by the station's emergency atmosphere containment field"
-	health = 600
+	health = 400
 
 /obj/machinery/shield/proc/check_failure()
 	if (health <= 0)

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -15,7 +15,7 @@
 
 /obj/machinery/shield/malfai
 	name = "emergency forcefield"
-	desc = "A powerfull forcefield which seems to be projected by the station's emergency atmosphere containment field"
+	desc = "A powerful forcefield which seems to be projected by the station's emergency atmosphere containment field"
 	health = 400
 
 /obj/machinery/shield/proc/check_failure()

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -15,21 +15,17 @@
 
 /obj/machinery/shield/malfai
 	name = "emergency forcefield"
-	desc = "A weak forcefield which seems to be projected by the station's emergency atmosphere containment field"
-	health = max_health/2 // Half health, it's not suposed to resist much.
-
-/obj/machinery/shield/malfai/Process()
-	health -= 0.5 // Slowly lose integrity over time
-	check_failure()
+	desc = "A powerfull forcefield which seems to be projected by the station's emergency atmosphere containment field"
+	health = 600
 
 /obj/machinery/shield/proc/check_failure()
-	if (src.health <= 0)
+	if (health <= 0)
 		visible_message(SPAN_NOTICE("\The [src] dissipates!"))
 		qdel(src)
 		return
 
 /obj/machinery/shield/New()
-	src.set_dir(pick(1,2,3,4))
+	set_dir(pick(1,2,3,4))
 	..()
 	update_nearby_tiles(need_rebuild=1)
 
@@ -102,10 +98,10 @@
 	else
 		tforce = AM:throwforce
 
-	src.health -= tforce
+	health -= tforce
 
 	//This seemed to be the best sound for hitting a force field.
-	playsound(src.loc, 'sound/effects/EMPulse.ogg', 100, 1)
+	playsound(loc, 'sound/effects/EMPulse.ogg', 100, 1)
 
 	check_failure()
 

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -15,7 +15,7 @@
 
 /obj/machinery/shield/malfai
 	name = "emergency forcefield"
-	desc = "A powerful forcefield which seems to be projected by the station's emergency atmosphere containment field"
+	desc = "A powerful forcefield which seems to be projected by the vessel's emergency atmosphere containment field."
 	health = 400
 
 /obj/machinery/shield/proc/check_failure()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the malf AI emergency forcefield , it now spawns at the AI eye.  Quadruples its health so it holds somewhat well against current weapon damage values(Values weren't adjusted in 5 years) , The shields no longer dissipate (they cost 275 CPU , a hefty investment)

## Why It's Good For The Game
Lets the ability work , lets AI's do something more than hide and blow station , lets them create jail cells for their new slaves using power ,etc.
## Changelog
:cl:
balance: AI Emergency forcefield health quadruped (100 > 400)
balance: AI Emergency forcefield no longer dissipates 
fix: Fixed AI Emergency forcefield not being useable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
