### PR TITLE
Tweak decloner price

### DIFF
--- a/code/modules/projectiles/guns/energy/decloner.dm
+++ b/code/modules/projectiles/guns/energy/decloner.dm
@@ -9,5 +9,5 @@
 	can_dual = TRUE
 	projectile_type = /obj/item/projectile/energy/declone
 	charge_cost = 100
-	matter = list(MATERIAL_STEEL = 20)
-	price_tag = 2000
+	matter = list(MATERIAL_STEEL = 20, MATERIAL_PLASTIC = 10, MATERIAL_URANIUM = 8, MATERIAL_SILVER = 2)
+	price_tag = 1500


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR edits the price and material requirements to make a decloner

## Why It's Good For The Game

20 steel for:
1. tenfold increase in price
2. 150 irradiation projectiles 

is way too much

## Changelog
:cl:
balance: Due to recent [REDACTED] raid on Moebius science station the original blueprint for biological demolecularisor was lost. Replacements are already being researched, but the new resource cost will be higher.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
