### PR TITLE
Psyionic to psionic

### DIFF
--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -205,7 +205,7 @@
 	name = "Oborin Syndrome"
 	icon_state = "prism" //https://game-icons.net/1x1/delapouite/prism.html
 	desc = "A condition manifested at some recent point in human history. \
-			It’s origin and prevalence are unknown, but it is speculated to be a psyionic phenomenom.\
+			It’s origin and prevalence are unknown, but it is speculated to be a psionic phenomenom.\
 			Your sanity pool is higher than that of others at the cost of the colors of the world."
 
 /datum/perk/fate/oborin_syndrome/assign(mob/living/carbon/human/H)

--- a/code/datums/setup_option/backgrounds/fate.dm
+++ b/code/datums/setup_option/backgrounds/fate.dm
@@ -93,7 +93,7 @@
 /datum/category_item/setup_option/background/fate/oborin_syndrome
 	name = "Oborin Syndrome"
 	desc = "A condition manifested at some recent point in human history. \
-			It’s origin and prevalence are unknown, but it is speculated to be a psyionic phenomenom.\
+			It’s origin and prevalence are unknown, but it is speculated to be a psionic phenomenom.\
 			You are affected by this so called Oborin Syndrome and are unable to see the colors of the world. You see what lies beyond them."
 
 	perks = list(PERK_OBORIN_SYNDROME)


### PR DESCRIPTION
## About The Pull Request

Basic typo fix from psyionic to psionic for the oborin syndrome perk description.

## Why It's Good For The Game
Basic typo fix

## Changelog
:cl: Xoxeyos
spellcheck: Psyionic is now psionic
/:cl:
