### PR TITLE
Buffs internal storage module for RIG's

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/storage.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/storage.dm
@@ -14,8 +14,8 @@
 	//These vars will be passed onto the storage
 	var/list/can_hold = new/list() //List of objects which this item can store (if set, it can't store anything else)
 	var/list/cant_hold = new/list(/obj/item/weapon/rig) //List of objects which this item can't store (in effect only if can_hold isn't set)
-	var/max_w_class = ITEM_SIZE_NORMAL //Max size of objects that this object can store (in effect only if can_hold isn't set)
-	var/max_storage_space = 16 //This is 2/3rds of what a satchel holds
+	var/max_w_class = ITEM_SIZE_BULKY //Max size of objects that this object can store (in effect only if can_hold isn't set)
+	var/max_storage_space = 24 //This is a entire satchel of storage
 	var/storage_slots = null //The number of storage slots in this container.
 
 //Create the internal storage and pass on various parameters


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This essentially brings the internal storage module for RIG's in line with satchels
## Why It's Good For The Game

Not a lot of people use rigs, even after Omni added a way to easily get modules, maybe this will make using rigs less cbt and more fun

## Changelog
:cl: 

balance: internal storage for RIGs is now satchel sized

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
