### PR TITLE
Remove the disk inflation

### DIFF
--- a/code/modules/trade/datums/trade_stations_presets/zarya.dm
+++ b/code/modules/trade/datums/trade_stations_presets/zarya.dm
@@ -38,8 +38,7 @@
 			/obj/item/clothing/head/welding,
 			/obj/item/weapon/tool/omnitool,
 			/obj/structure/reagent_dispensers/fueltank,
-			/obj/machinery/floodlight,
-			/obj/spawner/lathe_disk
+			/obj/machinery/floodlight
 		)
 	)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Guild can buy a fuckton of disks in Zarya station because the spawner they use cost 30. This removes the disk. Go junk.

## Why It's Good For The Game
![изображение](https://user-images.githubusercontent.com/57810301/115916712-d36dfc80-a47d-11eb-8216-b2a979a20dc4.png)
![изображение](https://user-images.githubusercontent.com/57810301/115916801-f4cee880-a47d-11eb-966c-5dcb596dafdb.png)
Most of the disks are junk but the fact that you can get a fuckton of disks some of them are basically appear once every five round combined with our broken export creates interesting amount of disks spam-bought by guild.

## Changelog
:cl:
del: Random disk in 'Zarya' station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
