### PR TITLE
Spear Banishment

### DIFF
--- a/code/game/objects/items/weapons/improvised_components.dm
+++ b/code/game/objects/items/weapons/improvised_components.dm
@@ -37,11 +37,7 @@
 /obj/item/weapon/material/wirerod/attackby(var/obj/item/I, mob/user)
 	..()
 	var/obj/item/finished
-	if(istype(I, /obj/item/weapon/material/shard))
-		var/obj/item/weapon/material/tmp_shard = I
-		finished = new /obj/item/weapon/material/spear(get_turf(user), tmp_shard.material.name)
-		to_chat(user, SPAN_NOTICE("You fasten \the [I] to the top of the rod with the cable."))
-	else if((QUALITY_CUTTING in I.tool_qualities) || (QUALITY_WIRE_CUTTING in I.tool_qualities))
+	if((QUALITY_CUTTING in I.tool_qualities) || (QUALITY_WIRE_CUTTING in I.tool_qualities))
 		finished = new /obj/item/weapon/melee/baton/cattleprod(get_turf(user))
 		to_chat(user, SPAN_NOTICE("You fasten the wirecutters to the top of the rod with the cable, prongs outward."))
 	if(finished)

--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -8,27 +8,3 @@
 	armor_penetration = ARMOR_PEN_MODERATE
 	force_divisor = 0.3 // 18 with hardness 60 (steel)
 	attack_verb = list("jabbed","stabbed","ripped")
-
-/obj/item/weapon/material/spear
-	icon_state = "spearglass0"
-	wielded_icon = "spearglass1"
-	name = "spear"
-	desc = "A haphazardly-constructed yet still deadly weapon of ancient design."
-	armor_penetration = ARMOR_PEN_MODERATE // It's a SPEAR!
-	structure_damage_factor = STRUCTURE_DAMAGE_WEAK
-	w_class = ITEM_SIZE_HUGE
-	slot_flags = SLOT_BACK
-	force_divisor = 0.5         // 15 when unwielded 22.5 when wielded with hardness 30 (glass)
-	thrown_force_divisor = 1.5 // 22 when thrown with weight 15 (glass)
-	throw_speed = 3
-	edge = TRUE
-	sharp = TRUE
-	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "poked", "jabbed", "torn", "gored")
-	default_material = MATERIAL_GLASS
-	embed_mult = 1.5
-
-/obj/item/weapon/material/spear/update_force()
-	..()
-	force_unwielded = force
-	force_wielded = force * 1.5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Banishes the spear for all eternity, being a wonky bay leftover that used material hardness and before the bandaid fix could do a whopping 75 damage per hit

## Why It's Good For The Game

despite spears being, well funky spears, their damage output and usage of material hardness resulted in real wonky business
![image](https://user-images.githubusercontent.com/59490776/115957310-d01c5480-a501-11eb-9ac7-ed20b027eb98.png)
![image](https://user-images.githubusercontent.com/59490776/115957314-df9b9d80-a501-11eb-8516-714129e8f6a1.png)


## Changelog
:cl:
del: Banishes spears to the eternal realm of the TeeGee github, where it will suffer for all eternity for using bay code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
