### PR TITLE
Remove ladder cheese with slipping items, traps and mines

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1333,7 +1333,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /obj/item/device/pda/clown/Crossed(AM as mob|obj) //Clown PDA is slippery.
 	if (isliving(AM))
 		var/mob/living/M = AM
-		if(locate(/obj/structure/multiz/ladder) in get_turf(loc))
+		if(locate(/obj/structure/multiz/stairs) in get_turf(loc) || locate(/obj/structure/multiz/ladder) in get_turf(loc))
 			visible_message(SPAN_DANGER("\The [M] carefully avoids stepping down on \the [src]."))
 			return
 		if(M.slip("the PDA",8) && M.real_name != src.owner && istype(src.cartridge, /obj/item/weapon/cartridge/clown))

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1333,7 +1333,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /obj/item/device/pda/clown/Crossed(AM as mob|obj) //Clown PDA is slippery.
 	if (isliving(AM))
 		var/mob/living/M = AM
-
+		if(locate(/obj/structure/multiz/ladder) in get_turf(loc))
+			visible_message(SPAN_DANGER("\The [M] carefully avoids stepping down on \the [src]."))
+			return
 		if(M.slip("the PDA",8) && M.real_name != src.owner && istype(src.cartridge, /obj/item/weapon/cartridge/clown))
 			if(src.cartridge.charges < 5)
 				src.cartridge.charges++

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -11,7 +11,7 @@
 /obj/item/weapon/bananapeel/Crossed(AM as mob|obj)
 	if (isliving(AM))
 		var/mob/living/M = AM
-		if(locate(/obj/structure/multiz/ladder) in get_turf(loc))
+		if(locate(/obj/structure/multiz/stairs) in get_turf(loc) || locate(/obj/structure/multiz/ladder) in get_turf(loc))
 			visible_message(SPAN_DANGER("\The [M] carefully avoids stepping down on \the [src]."))
 			return
 		M.slip("the [src.name]",4)
@@ -43,7 +43,7 @@
 /obj/item/weapon/soap/Crossed(AM as mob|obj)
 	if (isliving(AM))
 		var/mob/living/M = AM
-		if(locate(/obj/structure/multiz/ladder) in get_turf(loc))
+		if(locate(/obj/structure/multiz/stairs) in get_turf(loc) || locate(/obj/structure/multiz/ladder) in get_turf(loc))
 			visible_message(SPAN_DANGER("\The [M] carefully avoids stepping down on \the [src]."))
 			return
 		M.slip("the [src.name]",3)

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -11,6 +11,9 @@
 /obj/item/weapon/bananapeel/Crossed(AM as mob|obj)
 	if (isliving(AM))
 		var/mob/living/M = AM
+		if(locate(/obj/structure/multiz/ladder) in get_turf(loc))
+			visible_message(SPAN_DANGER("\The [M] carefully avoids stepping down on \the [src]."))
+			return
 		M.slip("the [src.name]",4)
 /*
  * Soap
@@ -40,6 +43,9 @@
 /obj/item/weapon/soap/Crossed(AM as mob|obj)
 	if (isliving(AM))
 		var/mob/living/M = AM
+		if(locate(/obj/structure/multiz/ladder) in get_turf(loc))
+			visible_message(SPAN_DANGER("\The [M] carefully avoids stepping down on \the [src]."))
+			return
 		M.slip("the [src.name]",3)
 
 /obj/item/weapon/soap/afterattack(atom/target, mob/user as mob, proximity)

--- a/code/game/objects/items/weapons/implant/implants/carrion/smooth_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/smooth_spider.dm
@@ -16,7 +16,7 @@
 /obj/item/weapon/implant/carrion_spider/smooth/Crossed(AM as mob|obj)
 	if (isliving(AM))
 		var/mob/living/M = AM
-		if(locate(/obj/structure/multiz/ladder) in get_turf(loc))
+		if(locate(/obj/structure/multiz/stairs) in get_turf(loc) || locate(/obj/structure/multiz/ladder) in get_turf(loc))
 			visible_message(SPAN_DANGER("\The [M] carefully avoids stepping down on \the [src]."))
 			return
 		M.slip("the [src.name]",3)

--- a/code/game/objects/items/weapons/implant/implants/carrion/smooth_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/smooth_spider.dm
@@ -16,4 +16,7 @@
 /obj/item/weapon/implant/carrion_spider/smooth/Crossed(AM as mob|obj)
 	if (isliving(AM))
 		var/mob/living/M = AM
+		if(locate(/obj/structure/multiz/ladder) in get_turf(loc))
+			visible_message(SPAN_DANGER("\The [M] carefully avoids stepping down on \the [src]."))
+			return
 		M.slip("the [src.name]",3)

--- a/code/game/objects/items/weapons/mine.dm
+++ b/code/game/objects/items/weapons/mine.dm
@@ -47,6 +47,9 @@
 	if(locate(/obj/structure/multiz/ladder) in get_turf(user))
 		to_chat(user, SPAN_NOTICE("You cannot place \the [src] here, there is a ladder."))
 		return
+	if(locate(/obj/structure/multiz/stairs) in get_turf(user))
+		to_chat(user, SPAN_NOTICE("You cannot place \the [src] here, it needs a flat surface."))
+		return
 	if(!armed)
 		user.visible_message(
 			SPAN_DANGER("[user] starts to deploy \the [src]."),
@@ -124,6 +127,9 @@
 		if(locate(/obj/structure/multiz/ladder) in get_turf(loc))
 			visible_message(SPAN_DANGER("\The [src]'s triggering mechanism is disrupted by the ladder and does not go off."))
 			return
+		if(locate(/obj/structure/multiz/stairs) in get_turf(loc))
+			visible_message(SPAN_DANGER("\The [src]'s triggering mechanism is disrupted by the slope and does not go off."))
+			return ..()
 		if (isliving(AM))
 			for(var/datum/antagonist/A in AM.mind.antagonist)
 				if(A.id == ROLE_EXCELSIOR_REV)

--- a/code/game/objects/items/weapons/mine.dm
+++ b/code/game/objects/items/weapons/mine.dm
@@ -80,13 +80,13 @@
 			return
 	if (deployed)
 		user.visible_message(
-				SPAN_DANGER("[user] extends its hand to reach the [src]!"),
+				SPAN_DANGER("[user] extends its hand to reach \the [src]!"),
 				SPAN_DANGER("you extend your arms to pick it up, knowing that it will likely blow up when you touch it!")
 				)
 		if (do_after(user, 5))
 			user.visible_message(
-				SPAN_DANGER("[user] attempts to pick up the [src] only to hear a beep as it explodes in your hands!"),
-				SPAN_DANGER("you attempts to pick up the [src] only to hear a beep as it explodes in your hands!")
+				SPAN_DANGER("[user] attempts to pick up \the [src] only to hear a beep as it explodes in your hands!"),
+				SPAN_DANGER("you attempts to pick up \the [src] only to hear a beep as it explodes in your hands!")
 				)
 			explode()
 			return
@@ -113,14 +113,17 @@
 	else
 		if (deployed)   //now touching it with stuff that don't pulse will also be a bad idea
 			user.visible_message(
-				SPAN_DANGER("the [src] is hit with [I] and it explodes!"),
-				SPAN_DANGER("You hit the [src] with [I] and it explodes!"))
+				SPAN_DANGER("\The [src] is hit with [I] and it explodes!"),
+				SPAN_DANGER("You hit \the [src] with [I] and it explodes!"))
 			explode()
 		return
 
 
 /obj/item/weapon/mine/Crossed(mob/AM)
 	if (armed)
+		if(locate(/obj/structure/multiz/ladder) in get_turf(loc))
+			visible_message(SPAN_DANGER("\The [src]'s triggering mechanism is disrupted by the ladder and does not go off."))
+			return
 		if (isliving(AM))
 			for(var/datum/antagonist/A in AM.mind.antagonist)
 				if(A.id == ROLE_EXCELSIOR_REV)

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -323,6 +323,9 @@ Very rarely it might escape
 
 /obj/item/weapon/beartrap/Crossed(AM as mob|obj)
 	if(deployed && isliving(AM))
+		if(locate(/obj/structure/multiz/ladder) in get_turf(loc))
+			visible_message(SPAN_DANGER("\The [src]'s triggering mechanism is disrupted by the ladder and does not go off."))
+			return ..()
 		var/mob/living/L = AM
 		var/true_prob_catch = prob_catch - L.skill_to_evade_traps()
 		if("\ref[L]" in aware_mobs)

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -206,6 +206,9 @@ Freeing yourself is much harder than freeing someone else. Calling for help is a
 	if(locate(/obj/structure/multiz/ladder) in get_turf(user))
 		to_chat(user, SPAN_NOTICE("You cannot place \the [src] here, there is a ladder."))
 		return
+	if(locate(/obj/structure/multiz/stairs) in get_turf(user))
+		to_chat(user, SPAN_NOTICE("You cannot place \the [src] here, it needs a flat surface."))
+		return
 	if(!deployed && can_use(user))
 		user.visible_message(
 			SPAN_DANGER("[user] starts to deploy \the [src]."),
@@ -325,6 +328,9 @@ Very rarely it might escape
 	if(deployed && isliving(AM))
 		if(locate(/obj/structure/multiz/ladder) in get_turf(loc))
 			visible_message(SPAN_DANGER("\The [src]'s triggering mechanism is disrupted by the ladder and does not go off."))
+			return ..()
+		if(locate(/obj/structure/multiz/stairs) in get_turf(loc))
+			visible_message(SPAN_DANGER("\The [src]'s triggering mechanism is disrupted by the slope and does not go off."))
 			return ..()
 		var/mob/living/L = AM
 		var/true_prob_catch = prob_catch - L.skill_to_evade_traps()

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -95,6 +95,12 @@
 					floor_type = "icy"
 					slip_stun = 4
 
+			if(locate(/obj/structure/multiz/ladder) in get_turf(M.loc))  // Avoid slipping on ladder tiles
+				visible_message(SPAN_DANGER("\The [M] supports themself with the ladder to avoid slipping."))
+				return ..()
+			if(locate(/obj/structure/multiz/stairs) in get_turf(M.loc))  // Avoid slipping on stairs tiles
+				visible_message(SPAN_DANGER("\The [M] supports themself with the handrail to avoid slipping."))
+				return ..()
 			if(M.slip("the [floor_type] floor",slip_stun))
 				for(var/i = 0;i<slip_dist;i++)
 					step(M, M.dir)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Avoid triggering soaps, excel mines, beartraps, banana peels, carrion smooth spiders, clown PDA and wet floors on ladder/stairs tiles.

## Why It's Good For The Game

To avoid ladder cheesing with slipping objects since you cannot interact with them if you're on another zlevel. You can basically get an easy killzone / interdiction tool if a ladder is the only way to get into an area. Just have to carry a soap with you and if someone follow you then you just can drop a soap on the ladder, nobody can move up/down anymore without getting slipped.
And some of the ship areas only have a single ladder leading to them (especially in maints), or two but super far away from each other, so you cannot avoid it.

Technically beartraps and mines cannot be armed on ladder tile but better be safe than sorry so I've included them in the package in case some bored people find an exploit.

**Same for stairs.**

Also removed slipping from wet/lubed floors on ladder/stairs tiles.

## Changelog
:cl: Hyperio
balance: Remove ladder and stairs cheese with slipping items, traps, mines and wet floors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
