### PR TITLE
Adds IH AK to IH

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -18214,14 +18214,14 @@
 /area/eris/engineering/atmos/storage)
 "aSw" = (
 /obj/structure/table/rack,
-/obj/item/weapon/storage/box/shotgunammo/slug,
-/obj/item/weapon/storage/box/shotgunammo/slug,
-/obj/item/weapon/storage/box/shotgunammo/slug,
-/obj/item/weapon/storage/box/shotgunammo/slug,
 /obj/machinery/door/blast/shutters/glass{
 	id = "Armoury";
 	name = "Armoury showcase"
 	},
+/obj/item/weapon/gun/projectile/automatic/ak47/fs/ih,
+/obj/item/weapon/gun/projectile/automatic/ak47/fs/ih,
+/obj/item/weapon/gun/projectile/automatic/ak47/fs/ih,
+/obj/item/weapon/gun/projectile/automatic/ak47/fs/ih,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/security/warden)
 "aSx" = (
@@ -21423,6 +21423,19 @@
 /obj/item/ammo_magazine/lrifle/pk,
 /obj/item/ammo_magazine/ammobox/lrifle,
 /obj/item/ammo_magazine/ammobox/lrifle,
+/obj/item/weapon/storage/box/shotgunammo/slug,
+/obj/item/weapon/storage/box/shotgunammo/slug,
+/obj/item/weapon/storage/box/shotgunammo/slug,
+/obj/item/weapon/storage/box/shotgunammo/slug,
+/obj/item/ammo_magazine/lrifle,
+/obj/item/ammo_magazine/lrifle,
+/obj/item/ammo_magazine/lrifle,
+/obj/item/ammo_magazine/lrifle,
+/obj/item/ammo_magazine/lrifle,
+/obj/item/ammo_magazine/lrifle,
+/obj/item/ammo_magazine/lrifle,
+/obj/item/ammo_magazine/lrifle,
+/obj/item/ammo_magazine/lrifle,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/security/warden)
 "aZC" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds 4 IH AKs to IH and 9 mags (2 for each gun and one extra). Moved slugs to crate and the mags are in there too.
![image](https://user-images.githubusercontent.com/51462035/115971690-29a87180-a54a-11eb-97dc-cbcde53d0f9d.png)


## Why It's Good For The Game

Surprise surprise its me with yet another IH PR, i know i know my bias is showing! Just adds another gun thats a nice middle between sol and takeshi. Besides this gun quite literally has IH print on it, its destiny.

## Changelog
:cl:
add: Added IH AK and mags to IH.
tweak: Moved slugs to crate in armoury.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
