### PR TITLE
Add chemical reaction for gold slime extract

### DIFF
--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -1020,10 +1020,16 @@
 //Gold - removed
 /datum/chemical_reaction/slime/crit
 	result = null
-	required_reagents = list("plasma" = 1)
+	required_reagents = list("blood" = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/gold
-	mix_message = "The slime core fizzles disappointingly."
+	mix_message = "The slime extract begins to vibrate violently!"
+
+/datum/chemical_reaction/slime/crit/on_reaction(var/datum/reagents/holder)
+	for(var/i = 1 to 3)
+		var/roachcube = pick(subtypesof(/obj/item/weapon/reagent_containers/food/snacks/roachcube))
+		new roachcube(get_turf(holder.my_atom))
+	..()
 
 //Silver
 /datum/chemical_reaction/slime/bork


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Discord suggestion of Obamba.

Since the gold slime extract has no purpose and on other servers it is used to make animals, make it so that if you inject it with blood you get 3 random roach cubes.

## Why It's Good For The Game

Small reward for creating golden slimes since their extract has currently no use.

## Changelog
:cl: Hyperio
add: Inject gold slime extract with blood to get roach cubes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
