### PR TITLE
removes floor stun from disarm

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -266,11 +266,6 @@
 
 			var/randn = rand(1, 100)
 			randn = max(1, randn - H.stats.getStat(STAT_ROB))
-			if(!(species.flags & NO_SLIP) && randn <= 20)
-				apply_effect(3, WEAKEN, getarmor(affecting, ARMOR_MELEE))
-				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-				visible_message(SPAN_DANGER("[M] has pushed [src]!"))
-				return
 
 			if(randn <= 50)
 				//See about breaking grips or pulls


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the floor stun from disarm intent.

## Why It's Good For The Game

You will notice these days that whenever a fight happens, even with guns, and one party decides to use their fists it will always be on disarm intent. The reason for this is this floor stun, its simply the strongest move, if you stun someone for three seconds on the floor they can't do anything and might as well be dead because thats 3 seconds to unload into them, decap, grab etc. In my opinion floor stuns are a leftover from old SS13 and has long outlived its place on Eris where we place emphasis on fast and fun combat, getting stunned on the floor and being unable to do anything is the exact opposite. 

## Changelog
:cl:
del: Removed floor stun from disarm intent 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
