### PR TITLE
Tones down the explosive potential of water/pot bombs

### DIFF
--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -602,7 +602,7 @@
 
 /datum/chemical_reaction/explosion_potassium/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/datum/effect/effect/system/reagents_explosion/e = new()
-	e.set_up(round (created_volume/10, 1), holder.my_atom, 0, 0)
+	e.set_up(round (created_volume/45, 1), holder.my_atom, 0, 0) // 600/45 = 13.3 , 13/3 = 4-3 light-range , slightly weaker than a cracker.
 	if(isliving(holder.my_atom))
 		e.amount *= 0.5
 		var/mob/living/L = holder.my_atom


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Water/Pot reaction explosions now get divided by 45 instead of 10 , at 600 reaction amount (bluespace beakers) resulting in a explosion slightly weaker than a cracker.

## Why It's Good For The Game
Griefing shouldn't be this easy , being  able to force a round to end shouldn't be done with a few simple clicks, unlike water/pot , glycerol requires some effort. If people want to end the round they should work for it.  Oversized water/pot explosions also have never proven to be fun for anyone , they force the round to end everytime they're used.
## Changelog
:cl:
balance: Water/Pot bombs have been extremly toned down.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
