### PR TITLE
Players can toss objects a z-level above

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -296,7 +296,7 @@
 	if(item && src.unEquip(item, loc))
 		if((target.z > src.z) && istype(get_turf(GetAbove(src)), /turf/simulated/open))
 			var/obj/item/I = item
-			src.visible_message(SPAN_DANGER("[src] is beginning to throw \the [item] high!"))
+			src.visible_message(SPAN_DANGER("[src] is trying to toss \the [item] into the air!"))
 			if((I.w_class < ITEM_SIZE_GARGANTUAN) && do_after(src, (5 * I.w_class))) //Tiny = 5, giant = 30
 				item.throwing = 1
 				item.forceMove(get_turf(GetAbove(src)))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -305,6 +305,9 @@
 			if((I.w_class < ITEM_SIZE_GARGANTUAN) && do_after(src, (5 * I.w_class))) //Tiny = 5, giant = 30
 				item.throwing = 1
 				item.forceMove(get_turf(GetAbove(src)))
+			else
+				to_chat(usr, SPAN_WARNING("You were interrupted!"))
+				return
 		src.visible_message(SPAN_DANGER("[src] has thrown [item]."))
 		if(incorporeal_move)
 			inertia_dir = 0

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -299,6 +299,7 @@
 			src.visible_message(SPAN_DANGER("[src] is trying to toss \the [item] into the air!"))
 			if((I.w_class < ITEM_SIZE_GARGANTUAN) && do_after(src, (5 * I.w_class))) //Tiny = 5, giant = 30
 				item.throwing = 1
+				src.unEquip(item, loc)
 				item.forceMove(get_turf(GetAbove(src)))
 			else
 				to_chat(usr, SPAN_WARNING("You were interrupted!"))
@@ -310,6 +311,7 @@
 			src.inertia_dir = get_dir(target, src)
 			step(src, inertia_dir)
 
+		src.unEquip(item, loc)
 		item.throw_at(target, item.throw_range, item.throw_speed, src)
 		item.throwing = 0
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -273,6 +273,11 @@
 
 	if(!item) return
 
+	if(GetAbove(target) && !istype(item, /obj/item/weapon/grab))
+		var/turf/target = GetAbove(get_turf(target))
+		item.throw_at(target, item.throw_range, item.throw_speed, src)
+		return
+
 	if (istype(item, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/G = item
 		item = G.throw_held() //throw the person instead of the grab
@@ -294,7 +299,13 @@
 
 	//Grab processing has a chance of returning null
 	if(item && src.unEquip(item, loc))
-		src.visible_message("\red [src] has thrown [item].")
+		if((target.z > src.z) && istype(get_turf(GetAbove(src)), /turf/simulated/open))
+			var/obj/item/I = item
+			src.visible_message(SPAN_DANGER("[src] is beginning to throw \the [item] high!"))
+			if((I.w_class < ITEM_SIZE_GARGANTUAN) && do_after(src, (5 * I.w_class))) //Tiny = 5, giant = 30
+				item.throwing = 1
+				item.forceMove(get_turf(GetAbove(src)))
+		src.visible_message(SPAN_DANGER("[src] has thrown [item]."))
 		if(incorporeal_move)
 			inertia_dir = 0
 		else if(!check_gravity() && !src.allow_spacemove()) // spacemove would return one with magboots, -1 with adjacent tiles
@@ -302,6 +313,7 @@
 			step(src, inertia_dir)
 
 		item.throw_at(target, item.throw_range, item.throw_speed, src)
+		item.throwing = 0
 
 /mob/living/carbon/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -273,11 +273,6 @@
 
 	if(!item) return
 
-	if(GetAbove(target) && !istype(item, /obj/item/weapon/grab))
-		var/turf/target = GetAbove(get_turf(target))
-		item.throw_at(target, item.throw_range, item.throw_speed, src)
-		return
-
 	if (istype(item, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/G = item
 		item = G.throw_held() //throw the person instead of the grab


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lets players toss an item a z-level above, if it's below a certain weight. I'm not sure if this is hacky or not, but it seems like a decent way of going about it. To summarize, it first checks to see if the turf above the player is an open space, then it checks to see if the item is below a certain weight class and if enough time has passed(Calculated by a default of 5 * weight_class), enables the throwing variable on it(So it doesn't fall), moves it to the z-level above, then throws it normally. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
It's one of those things that should already be there in my opinion, when a player looks up and tries to throw something, it should just work.
![Vid](https://user-images.githubusercontent.com/81935588/116672034-333e3900-a991-11eb-8fbb-7674e4aaf04a.gif)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Players can toss objects a floor above themselves, but heavy objects can take a while to throw.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
