### PR TITLE
Slime people changes

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1225,6 +1225,8 @@ var/list/rank_prefix = list(\
 			var/obj/item/I = organs_by_name[limb_tag]
 			if(I && I.type == OD.default_type)
 				continue
+			else if(I)
+				qdel(I)
 			OD.create_organ(src)
 
 		for(var/organ_tag in species.has_process)
@@ -1232,6 +1234,8 @@ var/list/rank_prefix = list(\
 			var/obj/item/I = random_organ_by_process(organ_tag)
 			if(I && I.type == organ_type)
 				continue
+			else if(I)
+				qdel(I)
 			new organ_type(src)
 
 		if(checkprefcruciform)

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -57,12 +57,19 @@
 /datum/unarmed_attack/slime_glomp
 	attack_verb = list("glomped")
 	attack_noun = list("body")
+	var/delay = 500 // more than 5 seconds thats for sure.
+	var/last_attack 
 	damage = 2
 
-/datum/unarmed_attack/slime_glomp/apply_effects()
-	//Todo, maybe have a chance of causing an electrical shock?
-	return
-
+/datum/unarmed_attack/slime_glomp/apply_effects(mob/living/carbon/human/user, mob/living/carbon/human/target, attack_damage, zone)
+	if(user.nutrition > 40 && (world.time > last_attack + delay) && !(user.stat) && istype(target))
+		zone = target.get_organ(zone) // Zone is passed as a string and not as a external organ.
+		if(!zone)
+			return
+		target.electrocute_act(25, "[user.name]'s", 1, zone)
+		user.adjustNutrition(-40)
+		last_attack = world.time
+		user.visible_message(SPAN_DANGER("[user] electrocutes \the [target] with their arms!"), SPAN_NOTICE("You electrocute \the [target] with your arm!"), SPAN_WARNING("You hear a splash of water and a sharp electric buzz!"), 5)
 /datum/unarmed_attack/stomp/weak
 	attack_verb = list("jumped on")
 

--- a/code/modules/mob/living/carbon/human/species/station/slime.dm
+++ b/code/modules/mob/living/carbon/human/species/station/slime.dm
@@ -8,7 +8,11 @@
 
 	language = null //todo?
 	unarmed_types = list(/datum/unarmed_attack/slime_glomp)
+	inherent_verbs = list(/mob/living/carbon/human/proc/regenerate_organs)
 	flags = NO_SCAN | NO_SLIP | NO_BREATHE | NO_MINOR_CUT
+	total_health = 200
+	brute_mod = 1
+	burn_mod = 0.7
 	spawn_flags = IS_RESTRICTED
 	siemens_coefficient = 3 //conductive
 	darksight = 3
@@ -44,3 +48,30 @@
 	spawn(1)
 		if(H)
 			H.gib()
+
+/mob/living/carbon/human/proc/regenerate_organs()
+	set name = "Regenerate missing limb"
+	set desc = "Regenerate a missing limb at the cost of nutrition"
+	set category = "Abilities"
+	var/mob/living/carbon/human/user = usr
+	var/missing_limb_tag
+	if(!user || !species)
+		return
+	if(user.stat)
+		return 
+	for(var/limb_tag in BP_ALL_LIMBS)
+		var/obj/item/organ/external/organ_to_check = organs_by_name[limb_tag]
+		if(!organ_to_check || istype(organ_to_check , /obj/item/organ/external/stump))
+			missing_limb_tag = limb_tag
+			break
+	if(!missing_limb_tag)
+		to_chat(user, "You don't have any limbs to replace!")
+		return
+	if(user.species.has_limbs.Find(missing_limb_tag))
+		var/stump_to_delete = organs_by_name[missing_limb_tag]
+		if(stump_to_delete)
+			qdel(stump_to_delete)
+		user.adjustNutrition(-50)
+		var/datum/organ_description/OD = species.has_limbs[missing_limb_tag]
+		OD.create_organ(src)
+		to_chat(user, "You regenerate your [missing_limb_tag]")

--- a/code/modules/mob/living/carbon/human/species/station/slime.dm
+++ b/code/modules/mob/living/carbon/human/species/station/slime.dm
@@ -11,7 +11,7 @@
 	inherent_verbs = list(/mob/living/carbon/human/proc/regenerate_organs)
 	flags = NO_SCAN | NO_SLIP | NO_BREATHE | NO_MINOR_CUT
 	total_health = 200
-	brute_mod = 1
+	brute_mod = 1.2
 	burn_mod = 0.7
 	spawn_flags = IS_RESTRICTED
 	siemens_coefficient = 3 //conductive

--- a/code/modules/organs/organ_description.dm
+++ b/code/modules/organs/organ_description.dm
@@ -155,23 +155,44 @@
 ////SLIME////
 /datum/organ_description/chest/slime
 	name = "upper body"
+	max_damage = 125
+	min_broken_damage = 120
+	max_volume = 5
 	default_type = /obj/item/organ/external/unbreakable
 
 /datum/organ_description/groin/slime
 	name = "fork"
+	max_damage = 100
+	min_broken_damage = 150
+	max_volume = 3
 	default_type = /obj/item/organ/external/unbreakable
 
 /datum/organ_description/head/slime
+	max_damage = 100
+	min_broken_damage = 150
+	max_volume = 4
 	default_type = /obj/item/organ/external/unbreakable
 
 /datum/organ_description/arm/left/slime
+	max_damage = 85
+	min_broken_damage = 15
+	max_volume = 3
 	default_type = /obj/item/organ/external/unbreakable
 
 /datum/organ_description/arm/right/slime
+	max_damage = 85
+	min_broken_damage = 15
+	max_volume = 3
 	default_type = /obj/item/organ/external/unbreakable
 
 /datum/organ_description/leg/left/slime
+	max_damage = 85
+	min_broken_damage = 15
+	max_volume = 3
 	default_type = /obj/item/organ/external/unbreakable
 
 /datum/organ_description/leg/right/slime
+	max_damage = 85
+	min_broken_damage = 15
+	max_volume = 3
 	default_type = /obj/item/organ/external/unbreakable

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -325,6 +325,9 @@
 	color = "#801E28"
 
 /datum/reagent/medicine/slimejelly/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	if(M.species.name == "Slime")
+		M.heal_organ_damage(1 * effect_multiplier, 1 * effect_multiplier)
+		return
 	if(prob(10))
 		to_chat(M, SPAN_DANGER("Your insides are burning!"))
 		M.adjustToxLoss(rand(10, 30) * effect_multiplier)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Slime people can now regenerate limbs at the cost of 50 nutrition
Slime people can now electrocute people at the cost of  40 nutrition by attacking them
Slime people now have 2x their health
Slime people now have 1.2x brute mod
Slime people now have 0.7x burn mod
Slime people now have more internal space in general
Slime people have their arms and legs more fragile , but the upper body , groin and head more resistant
Slime jelly now heals slimes 
## Why It's Good For The Game
Slime people are kinda meh and don't really have anything super different. Now people have a reason to lynch slime people as they are possibly very dangerous due to their very tough nature and ability to electrocute and regenerate limbs.

## Changelog
:cl:
balance : Slime people now have a 1.2x brute mod
balance : Slime people now have a 0.7x burn mod
balance : Slime jelly now heals slimes
balance : Slimes can now electrocute people at the cost of 40 nutrition with a considerable delay by punching
balance : Slimes can now regenerate limbs at the cost of 50 nutrition
balance : Slime people now have double the health of a normal human
balance : Slime people now have fragile arms/legs but tough groin , upper body and head.
balance : Slime people have more internal organ space.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
