### PR TITLE
Autolathe nerf

### DIFF
--- a/code/__DEFINES/gamemode.dm
+++ b/code/__DEFINES/gamemode.dm
@@ -65,6 +65,7 @@
 #define FACTION_EXCELSIOR "excelsior"
 #define FACTION_BORERS "borers"
 #define FACTION_SERBS	"serbians"
+#define FACTION_NEOTHEOLOGY	"neotheologists"
 
 #define ROLES_CONTRACT_VIEWONLY ROLE_MARSHAL
 #define ROLES_CONTRACT list(ROLE_TRAITOR,ROLE_CARRION,ROLE_BLITZ)

--- a/code/datums/autolathe/autolathe_datums.dm
+++ b/code/datums/autolathe/autolathe_datums.dm
@@ -158,12 +158,17 @@
 
 //Returns a new instance of the item for this design
 //This is to allow additional initialization to be performed, including possibly additional contructor arguments.
-/datum/design/proc/Fabricate(newloc, mat_efficiency, fabricator)
+/datum/design/proc/Fabricate(newloc, mat_efficiency, fabricator, low_quality_print)
 	if(!build_path)
 		return
 
 	var/atom/A = new build_path(newloc)
 	A.Created()
+
+	if(low_quality_print)
+		var/obj/O = A
+		if(istype(O))
+			O.make_old(TRUE)
 
 	if(mat_efficiency != 1 && adjust_materials)
 		for(var/obj/O in A.GetAllContents(includeSelf = TRUE))

--- a/code/datums/autolathe/autolathe_datums.dm
+++ b/code/datums/autolathe/autolathe_datums.dm
@@ -14,6 +14,7 @@
 	var/category 			//Primarily used for Mech Fabricators, but can be used for anything.
 	var/time = 0					//How many ticks it requires to build. If 0, calculated from the amount of materials used.
 	var/starts_unlocked = FALSE		//If the design starts unlocked.
+	var/list/factions = list()				//What faction the design is tied to, currently only used so the NT autolathe can print NT designs perfectly.
 
 	var/list/ui_data			//Pre-generated UI data, to be sent into NanoUI/TGUI interfaces.
 
@@ -158,23 +159,28 @@
 
 //Returns a new instance of the item for this design
 //This is to allow additional initialization to be performed, including possibly additional contructor arguments.
-/datum/design/proc/Fabricate(newloc, mat_efficiency, fabricator, low_quality_print)
+/datum/design/proc/Fabricate(newloc, mat_efficiency, var/obj/machinery/autolathe/fabricator)
 	if(!build_path)
 		return
 
 	var/atom/A = new build_path(newloc)
 	A.Created()
 
-	if(low_quality_print)
-		var/obj/O = A
-		if(istype(O))
-			O.make_old(TRUE)
-
 	if(mat_efficiency != 1 && adjust_materials)
 		for(var/obj/O in A.GetAllContents(includeSelf = TRUE))
 			if(length(O.matter))
 				for(var/i in O.matter)
 					O.matter[i] = round(O.matter[i] * mat_efficiency, 0.01)
+
+	if(fabricator && fabricator.low_quality_print)
+		for(var/design_faction in factions)
+			if(design_faction in fabricator.high_quality_faction_list)
+				return A
+
+		var/obj/O = A
+		if(istype(O))
+			O.make_old(TRUE)
+
 
 	return A
 

--- a/code/datums/autolathe/biomatter.dm
+++ b/code/datums/autolathe/biomatter.dm
@@ -1,6 +1,7 @@
 /datum/design/bioprinter
 	build_type = BIOPRINTER
 	materials = list(MATERIAL_BIOMATTER = 6)
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/bioprinter/meat
 	name = "Meat"
@@ -208,16 +209,22 @@
 	build_path = /obj/item/weapon/storage/bag/money
 
 //[/THINGS]
+/datum/design/autolathe/nt
+	factions = list(FACTION_NEOTHEOLOGY)
+
 /datum/design/autolathe/firstaid/nt
 	name = "NeoTheologian Medkit"
 	build_path = /obj/item/weapon/storage/firstaid/nt
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/excruciator
 	name = "NeoTheology \"EXCRUCIATOR\" giga lens"
 	build_path = /obj/item/weapon/gun_upgrade/barrel/excruciator
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/cruciform_upgrade
 	build_path = /obj/item/weapon/cruciform_upgrade
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/cruciform_upgrade/natures_blessing
 	name = "Natures blessing"
@@ -244,63 +251,64 @@
 	build_path = /obj/item/weapon/cruciform_upgrade/speed_of_the_chosen
 
 //[MELEE]
-/datum/design/autolathe/sword/nt_sword
+/datum/design/autolathe/nt/sword/nt_sword
 	name = "NT Shortsword"
 	build_path = /obj/item/weapon/tool/sword/nt
 
-/datum/design/autolathe/sword/nt_longsword
+/datum/design/autolathe/nt/sword/nt_longsword
 	name = "NT Longsword"
 	build_path = /obj/item/weapon/tool/sword/nt/longsword
 
-/datum/design/autolathe/sword/nt_dagger
+/datum/design/autolathe/nt/sword/nt_dagger
 	name = "NT Dagger"
 	build_path = /obj/item/weapon/tool/knife/dagger/nt
 
-/datum/design/autolathe/sword/nt_halberd
+/datum/design/autolathe/nt/sword/nt_halberd
 	name = "NT Halberd"
 	build_path = /obj/item/weapon/tool/sword/nt/halberd
 
-/datum/design/autolathe/sword/nt_scourge
+/datum/design/autolathe/nt/sword/nt_scourge
 	name = "NT Scourge"
 	build_path = /obj/item/weapon/tool/sword/nt/scourge
 
-/datum/design/autolathe/shield/nt_shield
+/datum/design/autolathe/nt/shield/nt_shield
 	name = "NT Shield"
 	build_path = /obj/item/weapon/shield/riot/nt
 
-/datum/design/autolathe/tool_upgrade/sanctifier
+/datum/design/autolathe/nt/tool_upgrade/sanctifier
 	name = "sanctifier"
 	build_path = /obj/item/weapon/tool_upgrade/augment/sanctifier
 
 //[GRENADES]
-/datum/design/autolathe/grenade/nt_smokebomb
+/datum/design/autolathe/nt/grenade/nt_smokebomb
 	name = "NT SG \"Holy Fog\""
 	build_path = /obj/item/weapon/grenade/smokebomb/nt
 
-/datum/design/autolathe/grenade/nt_frag
+/datum/design/autolathe/nt/grenade/nt_frag
 	name = "NT DFG \"Holy Thunder\""
 	build_path = /obj/item/weapon/grenade/frag/nt
 
-/datum/design/autolathe/grenade/nt_flashbang
+/datum/design/autolathe/nt/grenade/nt_flashbang
 	name = "NT FBG \"Holy Light\""
 	build_path = /obj/item/weapon/grenade/flashbang/nt
 
-/datum/design/autolathe/grenade/nt_explosive
+/datum/design/autolathe/nt/grenade/nt_explosive
 	name = "NT OBG \"Holy Grail\""
 	build_path = /obj/item/weapon/grenade/explosive/nt
 
 //[CRUSADE]
-/datum/design/autolathe/armor/crusader
+/datum/design/autolathe/nt/armor/crusader
 	name = "crusader armor"
 	build_path = /obj/item/clothing/suit/armor/crusader
 
-/datum/design/autolathe/helmet/crusader
+/datum/design/autolathe/nt/helmet/crusader
 	name = "crusader helmet"
 	build_path = /obj/item/clothing/head/armor/helmet/crusader
 
 /datum/design/autolathe/clothing/NTvoid
 	name = "neotheology voidsuit"
 	build_path = /obj/item/clothing/suit/space/void/NTvoid
+	factions = list(FACTION_NEOTHEOLOGY)
 
 //[MED]
 /datum/design/bioprinter/medical

--- a/code/datums/autolathe/circuits.dm
+++ b/code/datums/autolathe/circuits.dm
@@ -94,5 +94,5 @@
 	build_path = /obj/item/weapon/electronics/circuitboard/excelsior_turret
 
 /datum/design/autolathe/circuit/autolathe_excelsior
-	name = "excelsior autolathe"
+	name = "excelsior autoforge"
 	build_path = /obj/item/weapon/electronics/circuitboard/excelsiorautolathe

--- a/code/datums/autolathe/devices.dm
+++ b/code/datums/autolathe/devices.dm
@@ -69,10 +69,12 @@
 /datum/design/autolathe/device/grenade/nt_cleaner
 	name = "NT \"Cleanse Capsule\""
 	build_path = /obj/item/weapon/grenade/chem_grenade/cleaner/nt_cleaner
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/device/grenade/nt_weedkiller
 	name = "NT \"Kudzu Killer\""
 	build_path = /obj/item/weapon/grenade/chem_grenade/antiweed/nt_antiweed
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/device/floorpainter
 	name = "floor painter"

--- a/code/datums/autolathe/guns.dm
+++ b/code/datums/autolathe/guns.dm
@@ -26,10 +26,12 @@
 /datum/design/autolathe/gun/mk58
 	name = "NT HG .35 \"Mk58\""
 	build_path = /obj/item/weapon/gun/projectile/mk58
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/gun/mk58_wood
 	name = "NT HG .35 \"Mk58\""
 	build_path = /obj/item/weapon/gun/projectile/mk58/wood
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/gun/colt
 	name = "FS HG .35 Auto \"Colt M1911\""
@@ -78,6 +80,7 @@
 /datum/design/autolathe/gun/regulator
 	name = "NT SG \"Regulator 1000\""
 	build_path = /obj/item/weapon/gun/projectile/shotgun/pump/regulator
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/gun/gladstone
 	name = "FS SG \"Gladstone\""
@@ -165,6 +168,7 @@
 /datum/design/autolathe/gun/heavysniper
 	name = "NT AMR .60 \"Penetrator\""
 	build_path = /obj/item/weapon/gun/projectile/heavysniper
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/gun/mg_pk
 	name = "SA MG .30 \"Pulemyot Kalashnikova\""
@@ -173,6 +177,7 @@
 /datum/design/autolathe/gun/grenade_launcher
 	name = "NT GL \"Protector\""
 	build_path = /obj/item/weapon/gun/launcher/grenade
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/gun/grenade_launcher_lenar
 	name = "FS GL \"Lenar\""
@@ -183,6 +188,7 @@
 /datum/design/autolathe/gun/taser
 	name = "NT SP \"Counselor\""
 	build_path = /obj/item/weapon/gun/energy/taser
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/gun/energygun
 	name = "FS PDW E \"Spider Rose\""
@@ -195,20 +201,24 @@
 /datum/design/autolathe/gun/nt_svalinn
 	name = "NT LP \"Svalinn\""
 	build_path = /obj/item/weapon/gun/energy/nt_svalinn
+	factions = list(FACTION_NEOTHEOLOGY)
 
 // Energy general
 
 /datum/design/autolathe/gun/energy_crossbow
 	name = "NT EC \"Nemesis\""
 	build_path = /obj/item/weapon/gun/energy/crossbow
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/gun/large_energy_crossbow
 	name = "NT EC \"Themis\""
 	build_path = /obj/item/weapon/gun/energy/crossbow/largecrossbow
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/gun/laser
 	name = "NT LG \"Lightfall\""
 	build_path = /obj/item/weapon/gun/energy/laser
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/gun/retro
 	name = "OS LG \"Cog\""
@@ -217,24 +227,29 @@
 /datum/design/autolathe/gun/ionrifle
 	name = "NT IR \"Halicon\""
 	build_path = /obj/item/weapon/gun/energy/ionrifle
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/gun/sniperrifle
 	name = "NT MER \"Valkyrie\""
 	build_path = /obj/item/weapon/gun/energy/sniperrifle
+	factions = list(FACTION_NEOTHEOLOGY)
 
 // Plasma
 
 /datum/design/autolathe/gun/plasma/dominion
 	name = "NT PR \"Dominion\""
 	build_path = /obj/item/weapon/gun/energy/plasma
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/gun/plasma/destroyer
 	name = "NT PR \"Purger\""
 	build_path = /obj/item/weapon/gun/energy/plasma/destroyer
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/gun/plasma/cassad
 	name = "FS PR \"Cassad\""
 	build_path = /obj/item/weapon/gun/energy/plasma/cassad
+	factions = list(FACTION_NEOTHEOLOGY)
 
 // Special
 /datum/design/autolathe/gun/reclaimer
@@ -244,6 +259,7 @@
 /datum/design/autolathe/gun/nt_sprayer
 	name = "NT cleansing carbine"
 	build_path = /obj/item/weapon/gun/matter/launcher/nt_sprayer
+	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/gun/syringe_gun
 	name = "syringe gun"

--- a/code/game/machinery/autolathe/artist_bench.dm
+++ b/code/game/machinery/autolathe/artist_bench.dm
@@ -13,6 +13,7 @@
 	categories = list("Artwork")
 	use_oddities = TRUE
 	suitable_materials = list(MATERIAL_WOOD, MATERIAL_STEEL, MATERIAL_GLASS, MATERIAL_PLASTEEL, MATERIAL_PLASTIC)
+	low_quality_print = FALSE
 	var/min_mat = 20
 	var/min_insight = 40
 

--- a/code/game/machinery/autolathe/autolathe.dm
+++ b/code/game/machinery/autolathe/autolathe.dm
@@ -70,6 +70,9 @@
 	var/tmp/obj/effect/flicker_overlay/image_load
 	var/tmp/obj/effect/flicker_overlay/image_load_material
 
+	// If it prints high quality or bulky/deformed/debuffed items
+	var/low_quality_print = TRUE
+
 	//for nanoforge and artist bench
 	var/use_oddities = FALSE
 	var/datum/component/inspiration/inspiration
@@ -920,7 +923,7 @@
 
 /obj/machinery/autolathe/proc/fabricate_design(datum/design/design)
 	consume_materials(design)
-	design.Fabricate(drop_location(), mat_efficiency, src)
+	design.Fabricate(drop_location(), mat_efficiency, src, low_quality_print)
 
 	working = FALSE
 	current_file = null

--- a/code/game/machinery/autolathe/autolathe.dm
+++ b/code/game/machinery/autolathe/autolathe.dm
@@ -70,8 +70,9 @@
 	var/tmp/obj/effect/flicker_overlay/image_load
 	var/tmp/obj/effect/flicker_overlay/image_load_material
 
-	// If it prints high quality or bulky/deformed/debuffed items
+	// If it prints high quality or bulky/deformed/debuffed items, or if it prints good items for one faction only.
 	var/low_quality_print = TRUE
+	var/list/high_quality_faction_list = list()
 
 	//for nanoforge and artist bench
 	var/use_oddities = FALSE
@@ -923,7 +924,7 @@
 
 /obj/machinery/autolathe/proc/fabricate_design(datum/design/design)
 	consume_materials(design)
-	design.Fabricate(drop_location(), mat_efficiency, src, low_quality_print)
+	design.Fabricate(drop_location(), mat_efficiency, src)
 
 	working = FALSE
 	current_file = null

--- a/code/game/machinery/autolathe/mechfab.dm
+++ b/code/game/machinery/autolathe/mechfab.dm
@@ -13,6 +13,8 @@
 	have_reagents = FALSE
 	have_recycling = FALSE
 
+	low_quality_print = FALSE
+
 	special_actions = list(
 		list("action" = "sync", "name" = "Sync with R&D console", "icon" = "refresh")
 	)

--- a/code/game/machinery/autolathe/nanoforge.dm
+++ b/code/game/machinery/autolathe/nanoforge.dm
@@ -1,5 +1,5 @@
 /obj/machinery/autolathe/nanoforge
-	name = "matter nanoforge"
+	name = "matter auto-nanoforge"
 	desc = "It consumes items and produces compressed matter."
 	icon_state = "nanoforge"
 	icon = 'icons/obj/machines/autolathe.dmi'

--- a/code/game/machinery/autolathe/nanoforge.dm
+++ b/code/game/machinery/autolathe/nanoforge.dm
@@ -6,6 +6,7 @@
 	use_oddities = TRUE
 	use_license = FALSE
 	is_nanoforge = TRUE
+	low_quality_print = FALSE
 	circuit = /obj/item/weapon/electronics/circuitboard/nanoforge
 	var/list/nanoforge_designs = list()
 	var/list/tags_to_spawn = list(SPAWN_DESIGN)

--- a/code/game/machinery/bioprinter_nt.dm
+++ b/code/game/machinery/bioprinter_nt.dm
@@ -5,6 +5,7 @@
 	unsuitable_materials = list()
 
 	build_type = AUTOLATHE | BIOPRINTER
+	high_quality_faction_list = list(FACTION_NEOTHEOLOGY)
 
 /obj/machinery/autolathe/bioprinter/attackby(obj/item/I, mob/user)
 	//hacky way to forbid deconstruction but use ..()

--- a/code/game/machinery/excelsior/autolathe.dm
+++ b/code/game/machinery/excelsior/autolathe.dm
@@ -1,5 +1,5 @@
 /obj/machinery/autolathe/excelsior
-	name = "Excelsior autolathe"
+	name = "Excelsior autoforge"
 	desc = "It produces items using metal and glass."
 	icon = 'icons/obj/machines/excelsior/autolathe.dmi'
 	icon_state = "stanok"
@@ -8,6 +8,7 @@
 	build_type = AUTOLATHE | BIOPRINTER
 	speed = 4
 	storage_capacity = 240
+	low_quality_print = FALSE
 	unsuitable_materials = list()	// Can use biomatter too.
 
 /obj/machinery/autolathe/excelsior/Initialize()

--- a/code/game/objects/items/weapons/circuitboards/machinery/excelsior.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/excelsior.dm
@@ -13,7 +13,7 @@
 	spawn_blacklisted = TRUE
 
 /obj/item/weapon/electronics/circuitboard/excelsiorautolathe
-	name = T_BOARD("excelsior autolathe")
+	name = T_BOARD("excelsior autoforge")
 	build_path = /obj/machinery/autolathe/excelsior
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2, TECH_COVERT = 2)

--- a/code/game/objects/items/weapons/design_disks/NeoTheology.dm
+++ b/code/game/objects/items/weapons/design_disks/NeoTheology.dm
@@ -122,8 +122,8 @@
 	disk_name = "NeoTheology Armory - Crusader Armor"
 	icon_state = "neotheology"
 	designs = list(
-		/datum/design/autolathe/helmet/crusader,
-		/datum/design/autolathe/armor/crusader
+		/datum/design/autolathe/nt/helmet/crusader,
+		/datum/design/autolathe/nt/armor/crusader
 	)
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/void
 	disk_name = "NeoTheology Armory - Neotheology Voidsuit"
@@ -150,37 +150,37 @@
 	disk_name = "NeoTheology Armory - Basic Melee Weapons"
 	icon_state = "neotheology"
 	designs = list(
-		/datum/design/autolathe/sword/nt_sword,
-		/datum/design/autolathe/sword/nt_dagger,
+		/datum/design/autolathe/nt/sword/nt_sword,
+		/datum/design/autolathe/nt/sword/nt_dagger,
 		/datum/design/bioprinter/storage/sheath,
-		/datum/design/autolathe/tool_upgrade/sanctifier
+		/datum/design/autolathe/nt/tool_upgrade/sanctifier
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/longsword
 	disk_name = "NeoTheology Armory - NT Longsword"
 	icon_state = "neotheology"
 	designs = list(
-		/datum/design/autolathe/sword/nt_longsword,
+		/datum/design/autolathe/nt/sword/nt_longsword,
 		/datum/design/bioprinter/storage/sheath,
-		/datum/design/autolathe/tool_upgrade/sanctifier
+		/datum/design/autolathe/nt/tool_upgrade/sanctifier
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/scourge
 	disk_name = "NeoTheology Armory - NT Scourge"
 	icon_state = "neotheology"
 	designs = list(
-		/datum/design/autolathe/sword/nt_scourge,
+		/datum/design/autolathe/nt/sword/nt_scourge,
 		/datum/design/bioprinter/storage/sheath,
-		/datum/design/autolathe/tool_upgrade/sanctifier
+		/datum/design/autolathe/nt/tool_upgrade/sanctifier
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/halberd
 	disk_name = "NeoTheology Armory - NT Halberd"
 	icon_state = "neotheology"
 	designs = list(
-		/datum/design/autolathe/sword/nt_halberd,
+		/datum/design/autolathe/nt/sword/nt_halberd,
 		/datum/design/bioprinter/storage/sheath,
-		/datum/design/autolathe/tool_upgrade/sanctifier
+		/datum/design/autolathe/nt/tool_upgrade/sanctifier
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/shield
@@ -188,11 +188,11 @@
 	icon_state = "neotheology"
 	spawn_blacklisted = TRUE
 	designs = list(
-		/datum/design/autolathe/sword/nt_sword,
-		/datum/design/autolathe/sword/nt_dagger,
-		/datum/design/autolathe/shield/nt_shield,
+		/datum/design/autolathe/nt/sword/nt_sword,
+		/datum/design/autolathe/nt/sword/nt_dagger,
+		/datum/design/autolathe/nt/shield/nt_shield,
 		/datum/design/bioprinter/storage/sheath,
-		/datum/design/autolathe/tool_upgrade/sanctifier
+		/datum/design/autolathe/nt/tool_upgrade/sanctifier
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/firstaid
@@ -228,10 +228,10 @@
 	disk_name = "NeoTheology Armory - Grenades Pack"
 	icon_state = "neotheology"
 	designs = list(
-		/datum/design/autolathe/grenade/nt_explosive,
-		/datum/design/autolathe/grenade/nt_flashbang,
-		/datum/design/autolathe/grenade/nt_frag,
-		/datum/design/autolathe/grenade/nt_smokebomb
+		/datum/design/autolathe/nt/grenade/nt_explosive,
+		/datum/design/autolathe/nt/grenade/nt_flashbang,
+		/datum/design/autolathe/nt/grenade/nt_frag,
+		/datum/design/autolathe/nt/grenade/nt_smokebomb
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_nemesis

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -19,6 +19,7 @@
 	have_disk = FALSE
 	have_recycling = FALSE
 	have_design_selector = FALSE
+	low_quality_print = FALSE
 
 	var/obj/machinery/computer/rdconsole/linked_console
 

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -32,53 +32,63 @@
 		return TRUE
 	return FALSE
 
-/obj/proc/make_old()
+/obj/proc/make_old(low_quality_oldification)	//low_quality_oldification changes names and colors to fit with "bad prints" instead of "very old items" asthetic
 	GET_COMPONENT(oldified, /datum/component/oldficator)
 	if(oldified)
 		return FALSE
 	AddComponent(/datum/component/oldficator)
-	if(prob(80))
-		color = pick("#AA7744", "#774411", "#777777")
 	light_color = color
-	name = "[pick("old", "worn", "rusted", "weathered", "expired", "dirty", "frayed", "beaten", "ancient", "tarnished")] [name]"
-	desc += "\n "
-	desc += pick("Its warranty has expired.",
-	 "The inscriptions on this thing have been erased by time.",
-	  "Looks completely ruined.",
-	   "It is difficult to make out what this thing once was.",
-	    "A relic from a bygone age.")
+	if(!low_quality_oldification)
+		name = "[pick("old", "worn", "rusted", "weathered", "expired", "dirty", "frayed", "beaten", "ancient", "tarnished")] [name]"
+		desc += "\n "
+		desc += pick("Its warranty has expired.",
+		 "The inscriptions on this thing have been erased by time.",
+		  "Looks completely ruined.",
+		   "It is difficult to make out what this thing once was.",
+	 	   "A relic from a bygone age.")
+		germ_level = max(germ_level, pick(80,110,160))
 
-	germ_level = max(germ_level, pick(80,110,160))
+		if(prob(80))
+			color = pick("#AA7744", "#774411", "#777777")
+
+		//Deplete matter and matter_reagents
+		for(var/a in matter)
+			matter[a] *= RAND_DECIMAL(0.5, 1)
+
+		for(var/a in matter_reagents)
+			matter_reagents[a] *= RAND_DECIMAL(0.5, 1)
+
+	else
+		name = "[pick("bulky", "deformed", "misshapen", "warped", "unwieldy", "crooked", "distorted", "cracked", "layer-shifted", "fragile")] [name]"
+		desc += "\n "
+		desc += pick("Its shaped rather strangely.",
+			"The fine details on this thing have been erased.",
+			"Looks completely crooked.",
+	 		"Looks like it could break at any moment.")
+
 	price_tag *= RAND_DECIMAL(0.1, 0.6) //Tank the price of it
-
-	//Deplete matter and matter_reagents
-	for(var/a in matter)
-		matter[a] *= RAND_DECIMAL(0.5, 1)
-
-	for(var/a in matter_reagents)
-		matter_reagents[a] *= RAND_DECIMAL(0.5, 1)
 
 	for(var/obj/item/sub_item in contents)
 		if(prob(80))
-			sub_item.make_old()
+			sub_item.make_old(low_quality_oldification)
 	spawn(1)
 		update_icon()
 	return TRUE
 
 
-/obj/item/make_old()
+/obj/item/make_old(low_quality_oldification)
 	.=..()
 	if(.)
-		if(prob(75))
+		if(prob(75) && (!low_quality_oldification))
 			origin_tech = list()
 		siemens_coefficient += 0.3
 
-/obj/item/weapon/tool/make_old()
+/obj/item/weapon/tool/make_old(low_quality_oldification)
 	.=..()
 	if(.)
 		adjustToolHealth(-(rand(40, 150) * degradation))
 
-/obj/item/weapon/storage/make_old()
+/obj/item/weapon/storage/make_old(low_quality_oldification)
 	.=..()
 	if(.)
 		var/del_count = rand(0, contents.len)
@@ -93,47 +103,47 @@
 			max_storage_space = max_storage_space / 2
 
 //Old pill bottles get a name that disguises their contents
-/obj/item/weapon/storage/pill_bottle/make_old()
+/obj/item/weapon/storage/pill_bottle/make_old(low_quality_oldification)
 	GET_COMPONENT(oldified, /datum/component/oldficator)
-	if(!oldified && prob(85))
+	if(!oldified && prob(85) && (!low_quality_oldification))
 		name = "bottle of [pick("generic ", "unknown ", "")]pills"
 		desc = "Contains pills of some kind. The label has long since worn away"
 		for(var/obj/item/weapon/reagent_containers/pill/P in contents)
-			P.make_old()
+			P.make_old(low_quality_oldification)
 	.=..()
 
 //Make sure old pills always hide their contents too
-/obj/item/weapon/reagent_containers/pill/make_old()
+/obj/item/weapon/reagent_containers/pill/make_old(low_quality_oldification)
 	GET_COMPONENT(oldified, /datum/component/oldficator)
-	if(!oldified)
+	if(!oldified && (!low_quality_oldification))
 		name = "pill"
 		desc = "Some kind of pill. The imprints have worn away."
 	.=..()
 
-/obj/structure/reagent_dispensers/make_old()
+/obj/structure/reagent_dispensers/make_old(low_quality_oldification)
 	.=..()
 	if(. && reagents)
 		for(var/datum/reagent/R in reagents.reagent_list)
 			reagents.remove_reagent(R.id,rand(0, R.volume),TRUE)
 
-/obj/item/weapon/reagent_containers/make_old()
+/obj/item/weapon/reagent_containers/make_old(low_quality_oldification)
 	.=..()
-	if(.)
+	if(. && (!low_quality_oldification))
 		var/actual_volume = reagents.total_volume
 		for(var/datum/reagent/R in reagents.reagent_list)
 			reagents.remove_reagent(R.id,rand(0, R.volume),TRUE)
 		reagents.add_reagent("toxin", rand(0, actual_volume - reagents.total_volume))
 
-/obj/item/weapon/reagent_containers/food/snacks/make_old()
+/obj/item/weapon/reagent_containers/food/snacks/make_old(low_quality_oldification)
 	.=..()
 	if(.)
 		junk_food = TRUE
 
 //Sealed survival food, always edible
-/obj/item/weapon/reagent_containers/food/snacks/liquidfood/make_old()
+/obj/item/weapon/reagent_containers/food/snacks/liquidfood/make_old(low_quality_oldification)
 	return
 
-/obj/item/ammo_magazine/make_old()
+/obj/item/ammo_magazine/make_old(low_quality_oldification)
 	var/del_count = rand(0,contents.len)
 	for(var/i = 1 to del_count)
 		var/removed_item = pick(stored_ammo)
@@ -141,66 +151,68 @@
 		qdel(removed_item)
 	..()
 
-/obj/item/weapon/cell/make_old()
+/obj/item/weapon/cell/make_old(low_quality_oldification)
 	.=..()
 	if(.)
 		// It's silly to have old self-charging cells spawn partially discharged
-		autorecharging = FALSE
+		if(!low_quality_oldification)
+			autorecharging = FALSE
+
 		maxcharge = rand(maxcharge/2, maxcharge)
 		use(RAND_DECIMAL(0, maxcharge))
 		if(prob(10))
 			rigged = TRUE
 
-/obj/item/weapon/stock_parts/make_old()
+/obj/item/weapon/stock_parts/make_old(low_quality_oldification)
 	.=..()
 	if(.)
 		var/degrade = pick(0,1,1,1,2)
 		rating = max(rating - degrade, 1)
 
 
-/obj/item/stack/material/make_old()
+/obj/item/stack/material/make_old(low_quality_oldification)
 	return
 
-/obj/item/stack/rods/make_old()
+/obj/item/stack/rods/make_old(low_quality_oldification)
 	return
 
-/obj/item/weapon/ore/make_old()
+/obj/item/weapon/ore/make_old(low_quality_oldification)
 	return
 
-/obj/item/weapon/grenade/make_old()
+/obj/item/weapon/grenade/make_old(low_quality_oldification)
 	. =..()
 	if(.)
 		det_time = RAND_DECIMAL(0, det_time)
 
-/obj/item/weapon/tank/make_old()
+/obj/item/weapon/tank/make_old(low_quality_oldification)
 	.=..()
 	if(.)
 		air_contents.remove(pick(0.2, 0.4 ,0.6, 0.8))
 
-/obj/item/weapon/electronics/circuitboard/make_old()
+/obj/item/weapon/electronics/circuitboard/make_old(low_quality_oldification)
 	.=..()
-	if(. && prob(75))
+	if(. && prob(75) && (!low_quality_oldification))
 		name = T_BOARD("unknown")
 		build_path = pick(/obj/machinery/washing_machine, /obj/machinery/broken, /obj/machinery/shower, /obj/machinery/holoposter, /obj/machinery/holosign)
 
 
-/obj/item/weapon/electronics/ai_module/make_old()
+/obj/item/weapon/electronics/ai_module/make_old(low_quality_oldification)
 	GET_COMPONENT(oldified, /datum/component/oldficator)
 	if(!oldified && prob(75) && !istype(src, /obj/item/weapon/electronics/ai_module/broken))
 		var/obj/item/weapon/electronics/ai_module/brokenmodule = new /obj/item/weapon/electronics/ai_module/broken(loc)
 		brokenmodule.name = src.name
 		brokenmodule.desc = src.desc
-		brokenmodule.make_old()
+		brokenmodule.make_old(low_quality_oldification)
 		qdel(src)
 	else
 		.=..()
 
-/obj/item/clothing/suit/space/make_old()
+/obj/item/clothing/suit/space/make_old(low_quality_oldification)
 	.=..()
 	if(. && prob(50))
 		create_breaches(pick(BRUTE, BURN), rand(10, 50))
 
-/obj/item/clothing/make_old()
+/obj/item/clothing/make_old(low_quality_oldification)
 	.=..()
 	if(.)
 		if(prob(30))
@@ -215,10 +227,12 @@
 			heat_protection = rand(0, round(heat_protection * 0.5))
 		if(prob(40))
 			cold_protection = rand(0, round(cold_protection * 0.5))
-		if(prob(20))
-			contaminate()
-		if(prob(15))
-			add_blood()
+		
+		if(!low_quality_oldification)
+			if(prob(20))
+				contaminate()
+			if(prob(15))
+				add_blood()
 		if(prob(60)) // I mean, the thing is ew gross.
 			equip_delay += rand(0, 6 SECONDS)
 		style += STYLE_NEG_LOW
@@ -236,7 +250,7 @@
 	contents.Cut()
 	return ..()
 
-/obj/machinery/broken/make_old()
+/obj/machinery/broken/make_old(low_quality_oldification)
 	return
 
 /obj/item/weapon/electronics/ai_module/broken/transmitInstructions(mob/living/silicon/ai/target, mob/sender)
@@ -246,7 +260,7 @@
 	sender.drop_from_inventory(src)
 	qdel(src)
 
-/obj/item/weapon/dnainjector/make_old()
+/obj/item/weapon/dnainjector/make_old(low_quality_oldification)
 	.=..()
 	if(.)
 		if(prob(75))
@@ -257,7 +271,7 @@
 			block = pick(MONKEYBLOCK, HALLUCINATIONBLOCK, DEAFBLOCK, BLINDBLOCK, NERVOUSBLOCK, TWITCHBLOCK, CLUMSYBLOCK, COUGHBLOCK, HEADACHEBLOCK, GLASSESBLOCK)
 
 
-/obj/item/clothing/glasses/hud/make_old()
+/obj/item/clothing/glasses/hud/make_old(low_quality_oldification)
 	GET_COMPONENT(oldified, /datum/component/oldficator)
 	if(!oldified && prob(75) && !istype(src, /obj/item/clothing/glasses/hud/broken))
 		var/obj/item/clothing/glasses/hud/broken/brokenhud = new /obj/item/clothing/glasses/hud/broken(loc)
@@ -266,12 +280,12 @@
 		brokenhud.icon = src.icon
 		brokenhud.icon_state = src.icon_state
 		brokenhud.item_state = src.item_state
-		brokenhud.make_old()
+		brokenhud.make_old(low_quality_oldification)
 		qdel(src)
 	else
 		.=..()
 
-/obj/item/clothing/glasses/make_old()
+/obj/item/clothing/glasses/make_old(low_quality_oldification)
 	.=..()
 	if(.)
 		if(prob(75))
@@ -279,22 +293,22 @@
 		if(prob(75))
 			darkness_view = -1
 
-/obj/item/device/lighting/glowstick/make_old()
+/obj/item/device/lighting/glowstick/make_old(low_quality_oldification)
 	.=..()
 	if(. && prob(75))
 		fuel = rand(0, fuel)
 
-/obj/item/device/lighting/toggleable/make_old()
+/obj/item/device/lighting/toggleable/make_old(low_quality_oldification)
 	.=..()
 	if(. && prob(75))
 		brightness_on = brightness_on / 2
 
-/obj/machinery/floodlight/make_old()
+/obj/machinery/floodlight/make_old(low_quality_oldification)
 	.=..()
 	if(. && prob(75))
 		brightness_on = brightness_on / 2
 
-/obj/machinery/make_old()
+/obj/machinery/make_old(low_quality_oldification)
 	.=..()
 	if(.)
 		if(prob(60))
@@ -302,7 +316,7 @@
 		if(prob(60))
 			emagged = TRUE
 
-/obj/machinery/vending/make_old()
+/obj/machinery/vending/make_old(low_quality_oldification)
 	.=..()
 	if(.)
 		if(prob(60))
@@ -319,23 +333,23 @@
 		for(var/i in 1 to del_count)
 			product_records.Remove(pick(product_records))
 
-/obj/item/clothing/glasses/sunglasses/sechud/make_old()
+/obj/item/clothing/glasses/sunglasses/sechud/make_old(low_quality_oldification)
 	.=..()
 	if(. && hud && prob(75))
 		hud = new /obj/item/clothing/glasses/hud/broken
 /*
-/obj/effect/decal/mecha_wreckage/make_old()
+/obj/effect/decal/mecha_wreckage/make_old(low_quality_oldification)
 	.=..()
 	if (.)
 		salvage_num = max(1, salvage_num - pick(1, 2, 3))
 */
-/obj/item/part/gun/make_old()
+/obj/item/part/gun/make_old(low_quality_oldification)
 	return
 
 /mob/living/exosuit
 	var/oldified = FALSE//Todo: inprove it.
 
-/mob/living/exosuit/proc/make_old()
+/mob/living/exosuit/proc/make_old(low_quality_oldification)
 	if(oldified)
 		return FALSE
 	oldified = TRUE
@@ -345,11 +359,11 @@
 	adjustBruteLoss(rand(0, health))
 	/*
 	for(var/obj/item/mech_component/comp in list(arms, legs, head, body))
-		comp.make_old()
+		comp.make_old(low_quality_oldification)
 	updatehealth()
 	*/
 
-/obj/item/weapon/gun/make_old()
+/obj/item/weapon/gun/make_old(low_quality_oldification)
 	.=..()
 	if(. && prob(60))
 		var/list/trash_mods = TRASH_GUNMODS

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -145,6 +145,9 @@
 
 /obj/item/ammo_magazine/make_old(low_quality_oldification)
 	var/del_count = rand(0,contents.len)
+	if(low_quality_oldification)
+		del_count = rand(0, contents.len / 2)
+	
 	for(var/i = 1 to del_count)
 		var/removed_item = pick(stored_ammo)
 		stored_ammo -= removed_item


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Pretty simple, all autolathes print items with very similar effects to oldified items found in maints, with some effects removed to make sense in game. Machines spared from this effect are the moebius protolathe, exofab and the circuit imprinter, as they can only print specific designs, the clown bench and the nanoforge. (The normal, excelsior and NT autolates all have this effect). The only machine that can print disk designs with no side effects is the newly renamed technomancer (auto-)nanoforge.

## Why It's Good For The Game
As one disk can print up to 4 guns and the main (almost only) source of disks is maints this should be a nerf to vagabonds. This is mostly targeted to vagabonds but the guild and the NT lathe are also affected by this, so this may be changed. Also lore compliance.

## Changelog
:cl:
balance: items printed in an autolathe have various negative effects applied to them.
/:cl:
