### PR TITLE
Maintchem and vomit! 

### DIFF
--- a/code/game/objects/random/food.dm
+++ b/code/game/objects/random/food.dm
@@ -2,11 +2,12 @@
 	name = "random preserved rations"
 	icon_state = "food-green"
 	tags_to_spawn = list(SPAWN_RATIONS)
+	spawn_nothing_percentage = 90
 
 /obj/spawner/rations/low_chance
 	name = "low chance preserved rations"
 	icon_state = "food-green-low"
-	spawn_nothing_percentage = 60
+	spawn_nothing_percentage = 95
 
 
 /obj/spawner/junkfood
@@ -14,11 +15,12 @@
 	icon_state = "food-red"
 	has_postspawn = FALSE
 	tags_to_spawn = list(SPAWN_JUNKFOOD)
+	spawn_nothing_percentage = 90
 
 /obj/spawner/junkfood/low_chance
 	name = "low chance junkfood"
 	icon_state = "food-red-low"
-	spawn_nothing_percentage = 60
+	spawn_nothing_percentage = 95
 
 /obj/spawner/junkfood/rotten
 	name = "random spoiled food"
@@ -28,7 +30,7 @@
 /obj/spawner/junkfood/rotten/low_chance
 	name = "low chance spoiled food"
 	icon_state = "food-red-low"
-	spawn_nothing_percentage = 60
+	spawn_nothing_percentage = 80
 
 /obj/spawner/junkfood/rotten/post_spawn(list/spawns)
 	for(var/obj/item/weapon/reagent_containers/food in spawns)
@@ -36,7 +38,9 @@
 			return
 		if(prob(80))
 			food.reagents.add_reagent("toxin", 25)
-		if(prob(30)) // So sometimes the rot is visible.
+		if(prob(90))
+			food.reagents.add_reagent("vomitol", 25)
+		if(prob(50)) // So sometimes the rot is visible.
 			food.make_old()
 	return spawns
 
@@ -44,11 +48,12 @@
 	name = "random pizza"
 	icon_state = "food-red"
 	tags_to_spawn = list(SPAWN_PIZZA)
+	spawn_nothing_percentage = 85
 
 /obj/spawner/pizza/low_chance
 	name = "low chance pizza"
 	icon_state = "food-red-low"
-	spawn_nothing_percentage = 60
+	spawn_nothing_percentage = 90
 
 /obj/spawner/soda
 	name = "random soda"

--- a/code/game/objects/random/food.dm
+++ b/code/game/objects/random/food.dm
@@ -2,12 +2,11 @@
 	name = "random preserved rations"
 	icon_state = "food-green"
 	tags_to_spawn = list(SPAWN_RATIONS)
-	spawn_nothing_percentage = 90
 
 /obj/spawner/rations/low_chance
 	name = "low chance preserved rations"
 	icon_state = "food-green-low"
-	spawn_nothing_percentage = 95
+	spawn_nothing_percentage = 70
 
 
 /obj/spawner/junkfood
@@ -15,12 +14,11 @@
 	icon_state = "food-red"
 	has_postspawn = FALSE
 	tags_to_spawn = list(SPAWN_JUNKFOOD)
-	spawn_nothing_percentage = 90
 
 /obj/spawner/junkfood/low_chance
 	name = "low chance junkfood"
 	icon_state = "food-red-low"
-	spawn_nothing_percentage = 95
+	spawn_nothing_percentage = 70
 
 /obj/spawner/junkfood/rotten
 	name = "random spoiled food"
@@ -30,16 +28,38 @@
 /obj/spawner/junkfood/rotten/low_chance
 	name = "low chance spoiled food"
 	icon_state = "food-red-low"
-	spawn_nothing_percentage = 80
+	spawn_nothing_percentage = 60
 
 /obj/spawner/junkfood/rotten/post_spawn(list/spawns)
 	for(var/obj/item/weapon/reagent_containers/food in spawns)
 		if(!food.reagents)
 			return
-		if(prob(80))
-			food.reagents.add_reagent("toxin", 25)
-		if(prob(90))
-			food.reagents.add_reagent("vomitol", 25)
+		var/list/random_reagent_list = list(
+			list("hydrazine" = 20) = 2,
+			list("lithium" = 20) = 2,
+			list("carbon" = 20) = 2,
+			list("ammonia" = 20) = 2,
+			list("acetone" = 20) = 2,
+			list("sodium" = 20) = 2,
+			list("aluminum" = 20) = 2,
+			list("silicon" = 20) = 2,
+			list("phosphorus" = 20) = 2,
+			list("sulfur" = 20) = 2,
+			list("hclacid" = 20) = 2,
+			list("potassium" = 20) = 2,
+			list("iron" = 20) = 2,
+			list("copper" = 20) = 2,
+			list("mercury" = 20) = 2,
+			list("radium" = 20) = 2,
+			list("water" = 20) = 2,
+			list("ethanol" = 20) = 2,
+			list("sugar" = 20) = 2,
+			list("sacid" = 20) = 2,
+			list("tungsten" = 20) = 2,
+			list("vomitol" = 20) = 10)
+		var/list/picked_reagents = pickweight(random_reagent_list)
+		for(var/reagent in picked_reagents)
+			reagents.add_reagent(reagent, picked_reagents[reagent])
 		if(prob(50)) // So sometimes the rot is visible.
 			food.make_old()
 	return spawns
@@ -48,12 +68,11 @@
 	name = "random pizza"
 	icon_state = "food-red"
 	tags_to_spawn = list(SPAWN_PIZZA)
-	spawn_nothing_percentage = 85
 
 /obj/spawner/pizza/low_chance
 	name = "low chance pizza"
 	icon_state = "food-red-low"
-	spawn_nothing_percentage = 90
+	spawn_nothing_percentage = 60
 
 /obj/spawner/soda
 	name = "random soda"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3427,10 +3427,9 @@
 	center_of_mass = list("x"=16, "y"=15)
 	nutriment_desc = list("chalk" = 6)
 	nutriment_amt = 20
-	preloaded_reagents = list("iron" = 3)
 	junk_food = TRUE
 	spawn_tags = SPAWN_TAG_JUNKFOOD_RATIONS
-	rarity_value = 5
+	rarity_value = 70
 	taste_tag = list(BLAND_FOOD,UMAMI_FOOD)
 
 /obj/item/weapon/reagent_containers/food/snacks/tastybread

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3426,6 +3426,7 @@
 	bitesize = 4
 	center_of_mass = list("x"=16, "y"=15)
 	nutriment_desc = list("chalk" = 6)
+	preloaded_reagents = list("iron" = 3)
 	nutriment_amt = 20
 	junk_food = TRUE
 	spawn_tags = SPAWN_TAG_JUNKFOOD_RATIONS

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -790,7 +790,7 @@
 /datum/reagent/medicine/vomitol
 	name = "Vomitol"
 	id = "vomitol"
-	description = "Forces patient to vomit - results in total cleaning of his stomach. Has extremely unpleasant taste."
+	description = "Forces patient to vomit - results in total cleaning of his stomach. Has extremely unpleasant taste and seems to collect on food in mushroom rich enviroments."
 	taste_description = "worst thing in the world"
 	reagent_state = LIQUID
 	color = "#a6b85b"

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -29925,8 +29925,8 @@
 /area/eris/maintenance/section3deck1central)
 "bsl" = (
 /obj/structure/table/rack/shelf,
-/obj/spawner/rations,
-/obj/spawner/rations,
+/obj/spawner/junkfood/rotten,
+/obj/spawner/junkfood/rotten,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/eris/maintenance/section3deck1central)
 "bsm" = (
@@ -49550,14 +49550,10 @@
 "clG" = (
 /obj/structure/catwalk,
 /obj/structure/closet/crate,
-/obj/spawner/junkfood,
-/obj/spawner/junkfood,
-/obj/spawner/junkfood,
-/obj/spawner/junkfood,
-/obj/spawner/rations,
-/obj/spawner/rations,
-/obj/spawner/rations,
-/obj/spawner/rations,
+/obj/spawner/rations/low_chance,
+/obj/spawner/rations/low_chance,
+/obj/spawner/junkfood/low_chance,
+/obj/spawner/junkfood/low_chance,
 /turf/simulated/open,
 /area/eris/quartermaster/storage)
 "clH" = (
@@ -56716,9 +56712,8 @@
 /obj/spawner/rations,
 /obj/spawner/rations,
 /obj/spawner/rations,
-/obj/spawner/rations/low_chance,
-/obj/spawner/rations/low_chance,
-/obj/spawner/rations/low_chance,
+/obj/spawner/rations,
+/obj/spawner/rations,
 /turf/simulated/floor/tiled/cafe,
 /area/eris/crew_quarters/kitchen)
 "cCE" = (
@@ -88302,9 +88297,9 @@
 /area/eris/maintenance/section3deck3starboard)
 "dZA" = (
 /obj/structure/table/standard,
-/obj/spawner/rations,
-/obj/spawner/rations,
-/obj/spawner/rations,
+/obj/spawner/junkfood/rotten,
+/obj/spawner/junkfood/rotten,
+/obj/spawner/junkfood/rotten,
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/maintenance/section3deck3starboard)
 "dZB" = (
@@ -88881,7 +88876,7 @@
 /area/eris/maintenance/section3deck3starboard)
 "eaM" = (
 /obj/structure/table/standard,
-/obj/spawner/rations,
+/obj/spawner/junkfood/rotten,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/eris/maintenance/section3deck3starboard)
 "eaN" = (
@@ -96935,10 +96930,10 @@
 /area/eris/maintenance/section3deck1central)
 "etY" = (
 /obj/structure/table/standard,
-/obj/spawner/rations,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/spawner/junkfood/low_chance,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/hallway/main/section2)
 "etZ" = (
@@ -104639,15 +104634,14 @@
 /obj/spawner/rations,
 /obj/spawner/rations,
 /obj/spawner/rations,
-/obj/spawner/rations/low_chance,
-/obj/spawner/rations/low_chance,
-/obj/spawner/rations/low_chance,
 /obj/machinery/button/remote/blast_door{
 	id = "kitchen_hatch";
 	name = "Kitchen Hatch Control";
 	pixel_y = -24;
 	req_access = null
 	},
+/obj/spawner/rations,
+/obj/spawner/rations,
 /turf/simulated/floor/tiled/cafe,
 /area/eris/crew_quarters/kitchen)
 "sJL" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a variety of chemicals (vomitol most common) to maint food and makes food spawns rarer.

## Why It's Good For The Game

Maintchem is now a bit more possible and maint food is overall more dangerous/rare.

## Changelog
:cl:
add: Maint food now contains a variety of chemicals.
tweak: Maint food is rarer. 
map: Replaced some normal food spawns with low_chance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
