### PR TITLE
Multiz throwing

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -296,7 +296,7 @@
 	if(item)
 		if((target.z > src.z) && istype(get_turf(GetAbove(src)), /turf/simulated/open))
 			var/obj/item/I = item
-			var/robust = usr.stats.getStat(STAT_ROB)
+			var/robust = stats.getStat(STAT_ROB)
 			var/timer = ((5 * I.w_class) - (robust * 0.1)) //(W_CLASS * 5) * (STR * 0.1)
 			visible_message(SPAN_DANGER("[src] is trying to toss \the [item] into the air!"))
 			if((I.w_class < ITEM_SIZE_GARGANTUAN) && do_after(src, timer))
@@ -304,7 +304,7 @@
 				unEquip(item, loc)
 				item.forceMove(get_turf(GetAbove(src)))
 			else
-				to_chat(usr, SPAN_WARNING("You were interrupted!"))
+				to_chat(src, SPAN_WARNING("You were interrupted!"))
 				return
 		visible_message(SPAN_DANGER("[src] has thrown [item]."))
 		if(incorporeal_move)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -297,7 +297,7 @@
 		if((target.z > src.z) && istype(get_turf(GetAbove(src)), /turf/simulated/open))
 			var/obj/item/I = item
 			var/robust = stats.getStat(STAT_ROB)
-			var/timer = ((5 * I.w_class) - (robust * 0.1)) //(W_CLASS * 5) * (STR * 0.1)
+			var/timer = ((5 * I.w_class) - (robust * 0.1)) //(W_CLASS * 5) - (STR * 0.1)
 			visible_message(SPAN_DANGER("[src] is trying to toss \the [item] into the air!"))
 			if((I.w_class < ITEM_SIZE_GARGANTUAN) && do_after(src, timer))
 				item.throwing = TRUE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -293,15 +293,29 @@
 				return
 
 	//Grab processing has a chance of returning null
-	if(item && src.unEquip(item, loc))
-		src.visible_message("\red [src] has thrown [item].")
+	if(item)
+		if((target.z > src.z) && istype(get_turf(GetAbove(src)), /turf/simulated/open))
+			var/obj/item/I = item
+			var/robust = usr.stats.getStat(STAT_ROB)
+			var/timer = ((5 * I.w_class) - (robust * 0.1)) //(W_CLASS * 5) * (STR * 0.1)
+			visible_message(SPAN_DANGER("[src] is trying to toss \the [item] into the air!"))
+			if((I.w_class < ITEM_SIZE_GARGANTUAN) && do_after(src, timer))
+				item.throwing = TRUE
+				unEquip(item, loc)
+				item.forceMove(get_turf(GetAbove(src)))
+			else
+				to_chat(usr, SPAN_WARNING("You were interrupted!"))
+				return
+		visible_message(SPAN_DANGER("[src] has thrown [item]."))
 		if(incorporeal_move)
 			inertia_dir = 0
 		else if(!check_gravity() && !src.allow_spacemove()) // spacemove would return one with magboots, -1 with adjacent tiles
-			src.inertia_dir = get_dir(target, src)
+			inertia_dir = get_dir(target, src)
 			step(src, inertia_dir)
 
+		unEquip(item, loc)
 		item.throw_at(target, item.throw_range, item.throw_speed, src)
+		item.throwing = FALSE
 
 /mob/living/carbon/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Try 2:
Being able to throw an item a floor above themselves is something a player would expect to be able to do. This is a pretty small change, and it's a tiny bit more polished than my previous pull. There is one math thing in it, which just multiplies an item's weight class by 5, then subtracts the result by the players robustness * 0.1, for a large object and pretty high strength this is a few seconds off
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
![Vid](https://user-images.githubusercontent.com/81935588/116672034-333e3900-a991-11eb-8fbb-7674e4aaf04a.gif)
Like stated above, players expect certain cause & effect reactions. If they attempt to toss an item a floor above, they expect it to work. If they try to shoot a floor above, they expect it to work(Although this isn't the case yet for guns). 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
## Changelog
:cl:
add: You can now toss items a floor above yourself! Heavier objects take longer to throw, slightly altered by your strength.
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
