### PR TITLE
(Probably) better fix for the byond bug that plagues borers.

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -124,7 +124,7 @@
 
 	// Borer gets host abilities before actually getting inside the host
 	// Workaround for a BYOND bug: http://www.byond.com/forum/post/1833666
-	if(force_host)
+	/*if(force_host)
 		if(ishuman(host))
 			verbs += abilities_in_host
 			return
@@ -132,22 +132,17 @@
 			if(istype(ability, /mob/living/carbon/human))
 				continue
 			verbs += ability
-		return
+		return*/
 
 	// Re-grant some of the abilities, depending on the situation
 	if(!host)
 		verbs += abilities_standalone
 	else if(!controlling)
-		if(ishuman(host))
+		if(host)
 			verbs += abilities_in_host
 			Stat()
 			return
-		for(var/ability in abilities_in_host)
-			if(istype(ability, /mob/living/carbon/human))
-				continue
-			verbs += ability
 	else
-
 		host.verbs += abilities_in_control
 	Stat()
 
@@ -340,7 +335,7 @@
 
 	update_abilities()
 
-	to_chat(src, SPAN_NOTICE("Congratulations! You've reached Evolution Level [level], new synthesis reagents and new abilities are now available."))
+	to_chat(get_borer_control(), SPAN_NOTICE("Congratulations! You've reached Evolution Level [level], new synthesis reagents and new abilities are now available."))
 	max_chemicals += (borer_level * 10)
 	max_chemicals_inhost = max_chemicals * 5
 

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -94,11 +94,9 @@
 			infestation_delay *= 3
 
 	// Borer gets host abilities before actually getting inside the host
-	// Workaround for a BYOND bug: http://www.byond.com/forum/post/1833666
-	update_abilities(force_host=TRUE)
+	// Workaround for a BYOND bug: http://www.byond.com/forum/post/1833666 << What the fuck were they thinking when they do the force move MUCH later.
 	if(!do_mob(src, M, infestation_delay))
 		to_chat(src, SPAN_DANGER("As [M] moves away, you are dislodged and fall to the ground."))
-		update_abilities()
 		return
 
 	to_chat(src, SPAN_NOTICE("You wiggle into [M]'s ear."))
@@ -116,6 +114,9 @@
 
 	host = M
 	host.status_flags |= PASSEMOTES
+	update_abilities()
+	var/random_turf = get_step(src, NORTH) // Bluespace fuckery i ain't got to explain shit.
+	move_to_turf(src , loc, random_turf)
 	forceMove(host)
 	//Update their traitor status.
 	/*if(host.mind && src.mind)
@@ -180,6 +181,7 @@
 	H.verbs |= /mob/living/carbon/human/proc/psychic_whisper
 	H.verbs |= /mob/living/carbon/proc/spawn_larvae
 	H.verbs |= /mob/living/carbon/proc/talk_host
+	H.verbs |= /mob/living/simple_animal/borer/proc/secrete_chemicals
 
 	if(H.client)
 		H.daemonize()

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -94,7 +94,7 @@
 			infestation_delay *= 3
 
 	// Borer gets host abilities before actually getting inside the host
-	// Workaround for a BYOND bug: http://www.byond.com/forum/post/1833666 << What the fuck were they thinking when they do the force move MUCH later.
+	// Workaround for a BYOND bug: http://www.byond.com/forum/post/1833666 << We fix this in a better way
 	if(!do_mob(src, M, infestation_delay))
 		to_chat(src, SPAN_DANGER("As [M] moves away, you are dislodged and fall to the ground."))
 		return
@@ -115,9 +115,8 @@
 	host = M
 	host.status_flags |= PASSEMOTES
 	update_abilities()
-	var/random_turf = get_step(src, NORTH) // Bluespace fuckery i ain't got to explain shit.
-	move_to_turf(src , loc, random_turf)
-	forceMove(host)
+	spawn(1) /// Wait for abilities to update THEN move them in due to the afore-mentioned bug.
+		forceMove(host)
 	//Update their traitor status.
 	/*if(host.mind && src.mind)
 		var/list/L = get_player_antags(src.mind, ROLE_BORER)
@@ -125,15 +124,15 @@
 		if(L.len)
 			borer = L[1]*/
 
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/I = H.random_organ_by_process(BP_BRAIN)
-		if(!I) // No brain organ, so the borer moves in and replaces it permanently.
-			replace_brain()
-		else
-			// If they're in normally, implant removal can get them out.
-			var/obj/item/organ/external/head = H.get_organ(BP_HEAD)
-			head.implants += src
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			var/obj/item/organ/I = H.random_organ_by_process(BP_BRAIN)
+			if(!I) // No brain organ, so the borer moves in and replaces it permanently.
+				replace_brain()
+			else
+				// If they're in normally, implant removal can get them out.
+				var/obj/item/organ/external/head = H.get_organ(BP_HEAD)
+				head.implants += src
 
 /*
 /mob/living/simple_animal/borer/verb/devour_brain()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes how borer ability giving and removal is handled , before it was  given host abilities before being inside , but could've still failed to get inside and be stuck with host abilities, now , it  will only give them IF they are confirmed to go inside said host.
## Why It's Good For The Game
Let borers bore.
## Changelog
:cl:
fix: Borer abilities buggging out
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
