### PR TITLE
cruciform energy fixes V4

### DIFF
--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -24,7 +24,7 @@ var/list/disciples = list()
 		return
 
 	var/true_power_regen = power_regen
-	true_power_regen += max(round(wearer.stats.getStat(STAT_COG) / 4), 0) * (0.1 / (1 MINUTES))
+	true_power_regen += max(round(wearer.stats.getStat(STAT_COG) / 4), 0) * (1 / (1 MINUTES))
 	true_power_regen +=  power_regen * 1.5 * righteous_life / max_righteous_life
 	if(wearer && wearer.stats?.getPerk(/datum/perk/channeling))
 		true_power_regen += power_regen * disciples.len / 2.5  // Proportional to the number of cruciformed people on board

--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -12,7 +12,7 @@ var/list/disciples = list()
 	access = list(access_nt_disciple)
 	power = 50
 	max_power = 50
-	power_regen = 2/(1 MINUTES)
+	power_regen = 20/(1 MINUTES)
 	price_tag = 500
 	var/obj/item/weapon/cruciform_upgrade/upgrade
 
@@ -28,7 +28,6 @@ var/list/disciples = list()
 	true_power_regen +=  power_regen * 1.5 * righteous_life / max_righteous_life
 	if(wearer && wearer.stats?.getPerk(/datum/perk/channeling))
 		true_power_regen += power_regen * disciples.len / 2.5  // Proportional to the number of cruciformed people on board
-
 	restore_power(true_power_regen)
 
 /obj/item/weapon/implant/core_implant/cruciform/proc/register_wearer()

--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -28,6 +28,7 @@ var/list/disciples = list()
 	true_power_regen +=  power_regen * 1.5 * righteous_life / max_righteous_life
 	if(wearer && wearer.stats?.getPerk(/datum/perk/channeling))
 		true_power_regen += power_regen * disciples.len / 2.5  // Proportional to the number of cruciformed people on board
+
 	restore_power(true_power_regen)
 
 /obj/item/weapon/implant/core_implant/cruciform/proc/register_wearer()

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -187,7 +187,7 @@ var/global/obj/machinery/power/eotp/eotp
 	else if(type_release == ENERGY_REWARD)
 		for(var/mob/living/carbon/human/H in disciples)
 			var/obj/item/weapon/implant/core_implant/cruciform/C = H.get_core_implant(/obj/item/weapon/implant/core_implant/cruciform)
-			C.power_regen += initial(C.power_regen) * 0.5
+			C.power_regen += initial(C.power_regen)
 			for(var/mob/living/carbon/human/disciple in disciples)
 				to_chat(disciple, SPAN_NOTICE("Your cruciform vibrates."))
 

--- a/code/modules/core_implant/cruciform/machinery/obelisk.dm
+++ b/code/modules/core_implant/cruciform/machinery/obelisk.dm
@@ -108,7 +108,7 @@ GLOBAL_LIST_EMPTY(all_obelisk)
 			if(!(mob in currently_affected)) // the mob just entered the range of the obelisk
 				mob.stats.addPerk(/datum/perk/sanityboost)
 				currently_affected += mob
-			I.restore_power(I.power_regen)
+			I.restore_power(I.power_regen*2)
 			for(var/r_tag in mob.personal_ritual_cooldowns)
 				mob.personal_ritual_cooldowns[r_tag] -= nt_buff_cd
 

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -256,7 +256,7 @@
 	category = "Offerings"
 	success_message = "Your prayers have been heard."
 	fail_message = "Your prayers have not been answered."
-	power = 30
+	power = 10
 	var/list/req_offerings = list()
 	var/list/miracles = list(ARMAMENTS, ALERT, INSPIRATION, ODDITY, STAT_BUFF, MATERIAL_REWARD)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes an obviously not broken code.

The power regeneration proc in byond runs every second but byond defines the seconds as 600 instead of 60 so it runs ten times slower than it should.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: cruciform energy
tweak: reduces the energy cost of the offerings to 10
tweak: doubles the energy regeneration coming from the obelisks.
tweak: the energy regeneration miracle further increases energy regeneration.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
