### PR TITLE
adds new tactical reload

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -244,6 +244,7 @@
 				return
 			gun_to_load.load_ammo(src, user)
 			to_chat(user, SPAN_NOTICE("It takes a bit of time for you to reload your [W] with [src] using only one hand!"))
+			visible_message("[user] tactically reloads [W] using only one hand!")	
 
 /obj/item/ammo_magazine/attack_hand(mob/user)
 	if(user.get_inactive_hand() == src && stored_ammo.len)

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -237,6 +237,13 @@
 			to_chat(user, SPAN_NOTICE("You finish loading \the [other]. It now contains [other.stored_ammo.len] rounds, and \the [src] now contains [stored_ammo.len] rounds."))
 		else
 			to_chat(user, SPAN_WARNING("You fail to load anything into \the [other]"))
+	if(istype(W, /obj/item/weapon/gun/projectile))
+		var/obj/item/weapon/gun/projectile/gun_to_load = W
+		if(gun_to_load.can_dual && !gun_to_load.ammo_magazine)
+			if(!do_after(user, 0.5 SECONDS, src))
+				return
+			gun_to_load.load_ammo(src, user)
+			to_chat(user, SPAN_NOTICE("It takes a bit of time for you to reload your [W] with [src] using only one hand!"))
 
 /obj/item/ammo_magazine/attack_hand(mob/user)
 	if(user.get_inactive_hand() == src && stored_ammo.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Now, if you have a spare mag on the floor, in your belt, in your bag or anywhere alse near you and your gun has no mag inside, you can click on the spare mag with your gun and after 0.5 second it will be reloaded and you will be ready for a shootout
It works with all the mag fed ballistic pistols, some SMGs (Molly, Atreides, but not Straylight)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People who likes dual wielding, "tactical reloads" and doesn't likes reloading like a normal person will be happy now
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: CeUvi, SPCR/MLGSTATICa
add: Added new tactical reload (empty gun -> click on mag -> loaded gun)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
