### PR TITLE
Removes slips from soap, peels and clown PDA.

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1329,17 +1329,6 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	else
 		to_chat(usr, SPAN_NOTICE("You cannot do this while restrained."))
 
-
-/obj/item/device/pda/clown/Crossed(AM as mob|obj) //Clown PDA is slippery.
-	if (isliving(AM))
-		var/mob/living/M = AM
-		if(locate(/obj/structure/multiz/stairs) in get_turf(loc) || locate(/obj/structure/multiz/ladder) in get_turf(loc))
-			visible_message(SPAN_DANGER("\The [M] carefully avoids stepping down on \the [src]."))
-			return
-		if(M.slip("the PDA",8) && M.real_name != src.owner && istype(src.cartridge, /obj/item/weapon/cartridge/clown))
-			if(src.cartridge.charges < 5)
-				src.cartridge.charges++
-
 /obj/item/device/pda/proc/available_pdas()
 	var/list/names = list()
 	var/list/plist = list()

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -4,17 +4,6 @@
  *		Soap
  *		Bike Horns
  */
-
-/*
- * Banana Peals
- */
-/obj/item/weapon/bananapeel/Crossed(AM as mob|obj)
-	if (isliving(AM))
-		var/mob/living/M = AM
-		if(locate(/obj/structure/multiz/stairs) in get_turf(loc) || locate(/obj/structure/multiz/ladder) in get_turf(loc))
-			visible_message(SPAN_DANGER("\The [M] carefully avoids stepping down on \the [src]."))
-			return
-		M.slip("the [src.name]",4)
 /*
  * Soap
  */
@@ -39,14 +28,6 @@
 /obj/item/weapon/soap/proc/wet()
 	playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 	reagents.add_reagent("cleaner", 20)
-
-/obj/item/weapon/soap/Crossed(AM as mob|obj)
-	if (isliving(AM))
-		var/mob/living/M = AM
-		if(locate(/obj/structure/multiz/stairs) in get_turf(loc) || locate(/obj/structure/multiz/ladder) in get_turf(loc))
-			visible_message(SPAN_DANGER("\The [M] carefully avoids stepping down on \the [src]."))
-			return
-		M.slip("the [src.name]",3)
 
 /obj/item/weapon/soap/afterattack(atom/target, mob/user as mob, proximity)
 	if(!proximity) return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Whats on the tin.

## Why It's Good For The Game

I make this with a heavy heart as this is one of the oldest SS13 pranks but people have used this fairly regularly to cheese ladders, stairs ect. to slip combatants and kill them during their stun when they are defenseless making it one of the strongest tools in combat.

## Changelog
:cl:
del: Removed slips from peels, soap and clown PDA.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
