### PR TITLE
Clown Ressurection

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -8,7 +8,7 @@
 #define JOBS_SCIENCE "Moebius Expedition Overseer","Moebius Scientist","Moebius Roboticist"
 #define JOBS_MOEBIUS "Moebius Biolab Officer","Moebius Doctor","Moebius Psychiatrist","Moebius Chemist","Moebius Paramedic","Moebius Expedition Overseer","Moebius Scientist","Moebius Roboticist"
 #define JOBS_CARGO "Guild Merchant","Guild Technician","Guild Miner","Artist"
-#define JOBS_CIVILIAN "Club Manager","Club Worker",ASSISTANT_TITLE
+#define JOBS_CIVILIAN "Club Manager","Club Worker",ASSISTANT_TITLE, "Clown"
 #define JOBS_CHURCH	"NeoTheology Preacher","NeoTheology Acolyte","NeoTheology Agrolyte","NeoTheology Custodian"
 #define JOBS_NONHUMAN "AI","Robot","pAI"
 #define CREDITS "&cent;"

--- a/code/datums/outfits/jobs/civilian.dm
+++ b/code/datums/outfits/jobs/civilian.dm
@@ -4,6 +4,25 @@
 	uniform = /obj/item/clothing/under/rank/assistant
 	r_pocket = /obj/item/weapon/spacecash/bundle/vagabond
 
+/decl/hierarchy/outfit/job/free_clown //literally just the guild artist but renamed, making it a child of the guild clown would be more bothersome
+	name = OUTFIT_JOB_NAME("Clown")
+	uniform = /obj/item/clothing/under/rank/clown
+	shoes = /obj/item/clothing/shoes/clown_shoes
+	mask = /obj/item/clothing/mask/gas/clown_hat
+	l_pocket = /obj/item/weapon/bikehorn
+	backpack_contents = list(/obj/item/weapon/bananapeel = 1, /obj/item/weapon/storage/fancy/crayons = 1, /obj/item/toy/waterflower = 1, /obj/item/weapon/stamp/clown = 1, /obj/item/weapon/handcuffs/fake = 1)
+
+/decl/hierarchy/outfit/job/free_clown/New()
+	..()
+	backpack_overrides[/decl/backpack_outfit/backpack] = /obj/item/weapon/storage/backpack/clown
+	backpack_overrides[/decl/backpack_outfit/satchel] = /obj/item/weapon/storage/backpack/satchel/leather
+
+
+/decl/hierarchy/outfit/job/free_clown/post_equip(var/mob/living/carbon/human/H)
+	..()
+	H.mutations.Add(CLUMSY)
+
+
 /decl/hierarchy/outfit/job/service
 	l_ear = /obj/item/device/radio/headset/headset_service
 	hierarchy_type = /decl/hierarchy/outfit/job/service

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -77,3 +77,56 @@
 	icon_state = "player-grey"
 	join_tag = /datum/job/clubworker
 
+/datum/job/clown
+	title = "Clown"
+	flag = CLOWN
+	department = DEPARTMENT_CIVILIAN
+	department_flag = CIVILIAN
+	faction = "CEV Eris"
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "anyone who pays you, yourself, and whatever you believe in"
+	selection_color = "#dddddd"
+	initial_balance	= 0 //A starving artist on a dying ship
+	wage = WAGE_NONE //look up
+	//Having to entertain a lot of people, all over the galaxy, helps at times, low chance to know most languages.
+	also_known_languages = list(
+		LANGUAGE_CYRILLIC = 5, 
+		LANGUAGE_SERBIAN = 5, 
+		LANGUAGE_NEOHONGO = 5, 
+		LANGUAGE_GERMAN = 5, 
+		LANGUAGE_JIVE = 5, 
+		LANGUAGE_LATIN = 5
+		)
+
+	access = list(access_maint_tunnels, access_theatre)
+	outfit_type = /decl/hierarchy/outfit/job/free_clown
+
+	stat_modifiers = list(
+		STAT_ROB = 4,
+		STAT_TGH = 4,
+		STAT_BIO = 4,
+		STAT_MEC = 4,
+		STAT_VIG = 4,
+		STAT_COG = 4
+	)
+
+
+	description = "You go by many names an artist, a performer, a jester, a bard. But always and forever, a Clown that is free. You have no wage, no starting money, only your wits and sense of humor on this dying ship.<br>\
+
+How you act is most important. Maybe you're a sad old jester, with nothing more than his alcoholism, old dusty clothes and sad jokes, followed by a honk.<br>\
+Or a cheerful clown, wearing bright colours and slipping everyone around with your banana peel and soap you grabbed off of someone.<br>\
+Or one of the silent mimes, wearing nothing but black and white, observing in silence.<br>\
+All of them however have one thing in common, entertainment.<br>\
+
+Perhaps you boarded the CEV Eris with this new crew, or are like one of the vagabonds, a reminder of the prievous crewmates.<br>\
+While your wage is non-existent, this does not mean you don't. You still exist, with all your skills and knowledge.<br>\
+The ID you wear has acces to your theatre and maintenance, incase you need to look for inspiration amongst the roaches and mushrooms.<br>\
+As a Clown, you should strive to entertain the crew, or anyone who pays you. Perhaps you could become the court jester to the Captain, or an informant to one of the Heads of Staff."
+
+	loyalties = "Your loyalty is yours to decide. In whatever you believe."
+
+/obj/landmark/join/start/clown
+	name = "Clown"
+	icon_state = "player-grey"
+	join_tag = /datum/job/clown

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -51,6 +51,7 @@ var/const/GUILDTECH			=(1<<4)
 var/const/MINER				=(1<<5)
 var/const/ARTIST			=(1<<6)
 var/const/ASSISTANT			=(1<<7)
+var/const/CLOWN				=(1<<8)
 
 
 var/const/CHAPLAIN			=(1<<0)

--- a/code/modules/multiz/map_data.dm
+++ b/code/modules/multiz/map_data.dm
@@ -99,7 +99,7 @@ ADMIN_VERB_ADD(/client/proc/test_MD, R_DEBUG, null)
 						/datum/job/doctor, /datum/job/chemist, /datum/job/paramedic, /datum/job/psychiatrist,
 						/datum/job/technomancer,
 						/datum/job/cargo_tech, /datum/job/mining, /datum/job/merchant,
-						/datum/job/clubworker, /datum/job/clubmanager, /datum/job/artist,
+						/datum/job/clubworker, /datum/job/clubmanager, /datum/job/artist, /datum/job/clown,
 						/datum/job/chaplain, /datum/job/acolyte, /datum/job/janitor, /datum/job/hydro,
 						/datum/job/scientist, /datum/job/roboticist,
 						/datum/job/ai, /datum/job/cyborg,

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -95748,6 +95748,9 @@
 /obj/item/clothing/under/soviet,
 /obj/item/clothing/head/ushanka,
 /obj/item/clothing/head/ushanka,
+/obj/machinery/light/built{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/clownoffice)
 "erx" = (
@@ -95859,6 +95862,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/light/built,
 /turf/simulated/floor/carpet/gaycarpet,
 /area/eris/crew_quarters/clownoffice)
 "erJ" = (

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -95843,6 +95843,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/landmark/join/start/clown,
 /turf/simulated/floor/carpet/gaycarpet,
 /area/eris/crew_quarters/clownoffice)
 "erH" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reintroduces/adds a new job, the Clown (or rather, Free Clown)

spawns in the theater, has theater and maint acces

_**No starting money at all**_
worse stats than a vag
is clumsy

![image](https://user-images.githubusercontent.com/59490776/117439231-e202ec00-af32-11eb-8a39-56b0652a8ff9.png)
![image](https://user-images.githubusercontent.com/59490776/117439252-eb8c5400-af32-11eb-99c3-c2fbb1d6943a.png)
![image](https://user-images.githubusercontent.com/59490776/117439521-3a39ee00-af33-11eb-822c-453377bbfceb.png)


also adds light fixtures to the theater
![image](https://user-images.githubusercontent.com/59490776/117440838-e0d2be80-af34-11eb-815e-576e0f9a940d.png)
yell at me if for some reason they don't work and or they break shit

## Why It's Good For The Game

Having a clown to entertain the crew is important to everyone
I'm joking

True answer is that i believe a gimmick job as the clown is important for people to interact with, even if said job literally is clumsy, has worse stats than a vag and no money.
Having removed the clown from eris has been, I believe, a bad idea
Guild Artist is good, but one shouldn't have been sacraficed for the other.

## Changelog
:cl:
add: Added new job, the Clown, a vagabond but worse. Also added light fixtures to the theater.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
