### PR TITLE
Tiny wintermute buff.

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
@@ -21,7 +21,7 @@
 	reload_sound = 'sound/weapons/guns/interact/ltrifle_magin.ogg'
 	cocked_sound = 'sound/weapons/guns/interact/ltrifle_cock.ogg'
 	zoom_factor = 0.4
-	recoil_buildup = 2
+	recoil_buildup = 1.5
 	one_hand_penalty = 15 //automatic rifle level
 	damage_multiplier = 1.15
 

--- a/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
@@ -23,6 +23,7 @@
 	zoom_factor = 0.4
 	recoil_buildup = 2
 	one_hand_penalty = 15 //automatic rifle level
+	damage_multiplier = 1.15
 
 	init_firemodes = list(
 		FULL_AUTO_400,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1.5 recoil and 1.15 damage mult. (25 * 1.15 brute with 25 pen)

## Why It's Good For The Game

This gun has fallen into disuse over the years and hopefully this will put it back into use, it is now a direct upgrade from the sol and provides good damage and AP along with full auto and not too bad recoil. Well suited for later game antags.

## Changelog
:cl:
tweak: tweaked wintermute recoil to 1.5 and damage multiplier to 1.15
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
