### PR TITLE
Clown box added

### DIFF
--- a/code/game/objects/items/weapons/storage/misc.dm
+++ b/code/game/objects/items/weapons/storage/misc.dm
@@ -72,3 +72,17 @@
 	new /obj/item/weapon/storage/fancy/mre_cracker(src)
 	new /obj/item/weapon/reagent_containers/food/snacks/candy/mre(src)
 	new /obj/item/weapon/material/kitchen/utensil/spoon/mre(src)
+
+/obj/item/weapon/storage/box/clown
+	name = "clown costume box"
+	desc = "It's a cardboard box with a clown costume."
+	spawn_blacklisted = TRUE
+
+/obj/item/weapon/storage/box/clown/populate_contents()
+	new /obj/item/weapon/bikehorn(src)
+	new /obj/item/clothing/mask/gas/clown_hat(src)
+	new /obj/item/clothing/shoes/clown_shoes(src)
+	new /obj/item/clothing/under/rank/clown(src)
+	new /obj/item/weapon/stamp/clown(src)
+	new /obj/item/weapon/bananapeel(src)
+	

--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -19,6 +19,7 @@
 	display_name = "clown pack"
 	path = /obj/item/weapon/storage/box/clown
 	cost = 3
+	allowed_roles = list("Vagabond")
 
 /datum/gear/dice
 	display_name = "dice pack"

--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -18,6 +18,7 @@
 /datum/gear/clown
 	display_name = "clown pack"
 	path = /obj/item/weapon/storage/box/clown
+	cost = 3
 
 /datum/gear/dice
 	display_name = "dice pack"

--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -15,6 +15,10 @@
 	display_name = "cane"
 	path = /obj/item/weapon/cane
 
+/datum/gear/clown
+	display_name = "clown pack"
+	path = /obj/item/weapon/storage/box/clown
+
 /datum/gear/dice
 	display_name = "dice pack"
 	path = /obj/item/weapon/storage/pill_bottle/dice


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a clown box to the loadout

it contains a bikehorn, banana peel, clown stamp, clown shoes, uniform and mask

all for the sweet low price of 3 points

only for vagabonds

![image](https://user-images.githubusercontent.com/59490776/117495280-b6552580-af75-11eb-9dae-56143f02d787.png)
![image](https://user-images.githubusercontent.com/59490776/117495300-ba814300-af75-11eb-900f-339078e50550.png)
![image](https://user-images.githubusercontent.com/59490776/117495729-4eeba580-af76-11eb-835c-f6624a7c11bc.png)
![image](https://user-images.githubusercontent.com/59490776/117495819-6dea3780-af76-11eb-97d5-9738603859e1.png)



## Why It's Good For The Game

So vagabonds can roleplay as a clown, cost of 3 because it's free clothing, bike horn, stamp and the ultimate CQC weapon, a banana peel

## Changelog
:cl:
add: Added new loadout item, costs 3 points and contains clown clothing along with a bikehorn, clown stamp and a banana peel. PDA and actual sense of humor not included!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
