### PR TITLE
Erismed 3 slowdown nerf and bugfix

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -32,8 +32,6 @@
 	if(hunger_deficiency >= 200) tally += (hunger_deficiency / 100) //If youre starving, movement slowdown can be anything up to 4.
 	if(health_deficiency >= 40) tally += (health_deficiency / 25)
 
-	if (!(species && (species.flags & NO_PAIN)))
-		if(halloss >= 10) tally += (halloss / 20) //halloss shouldn't slow you down if you can't even feel it
 	if(istype(buckled, /obj/structure/bed/chair/wheelchair))
 		//Not porting bay's silly organ checking code here
 		tally += 1 //Small slowdown so wheelchairs aren't turbospeed
@@ -43,7 +41,7 @@
 		if(shoes)
 			tally += shoes.slowdown
 
-	tally += min((shock_stage / 100) * 6, 3) //Scales from 0 to 3 over 0 to 50 shock stage
+	tally += min((shock_stage / 100) * 3, 3) //Scales from 0 to 3 over 0 to 100 shock stage
 
 	if (bodytemperature < 283.222)
 		tally += (283.222 - bodytemperature) / 10 * 1.75

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -91,7 +91,7 @@
 	if(shock_stage <= traumatic_shock)	//Shock stage slowly climbs to traumatic shock
 		shock_stage = min(shock_stage + shock_stage_speed, traumatic_shock)
 
-		if(shock_stage <= traumatic_shock * 0.4)	//If the difference is too big shock stage jumps to 40% of traumatic shock
+		if(shock_stage <= round(traumatic_shock * 0.4 / 2) * 2)	//If the difference is too big shock stage jumps to 40% of traumatic shock
 			shock_stage = (traumatic_shock * 0.4)
 			shock_stage = round(shock_stage / 2) * 2 //rounded to the nearest even sumber, so messages show up
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes extra hallos slowdown as hallos is already accounted in the shock stage, and nerfs the slowdown scaling from 0-3 at 0-50 shock stage, to 0-3 at 0-100 hallos. Also fixes a calculation bug that would make shock stage not go up.

## Why It's Good For The Game

Slowdown is too strong, and bugs are bad.

## Changelog
:cl:
balance: slowdown from pain is lowered.
fix: shock stage should now increase properly.
/:cl:

