### PR TITLE
Add AI controlled maintenance drone

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -18,6 +18,7 @@ var/list/ai_verbs_default = list(
 	/mob/living/silicon/ai/proc/ai_store_location,
 	/mob/living/silicon/ai/proc/ai_checklaws,
 	/mob/living/silicon/ai/proc/control_integrated_radio,
+	/mob/living/silicon/ai/proc/control_personal_drone,
 	/mob/living/silicon/ai/proc/core,
 	/mob/living/silicon/ai/proc/pick_icon,
 	/mob/living/silicon/ai/proc/sensor_mode,
@@ -106,6 +107,8 @@ var/list/ai_verbs_default = list(
 	var/carded
 
 	var/multitool_mode = 0
+
+	var/mob/living/silicon/robot/drone/aibound/bound_drone = null
 
 	defaultHUD = "Eris"
 
@@ -731,3 +734,17 @@ var/list/ai_verbs_default = list(
 /mob/living/silicon/ai/proc/view_photos()
 	var/obj/item/device/camera/siliconcam/ai_camera/cam = aiCamera
 	cam.view_images()
+
+// Control a tiny drone
+/mob/living/silicon/ai/proc/control_personal_drone()
+	set name = "Control Personal Drone"
+	set desc = "Take control of your own AI-bound maintenance drone."
+	set category = "Silicon Commands"
+	
+	// Switch to drone or spawn a new one
+	if(!bound_drone)
+		try_drone_spawn(src, aibound = TRUE)
+	else if(src?.mind)
+		bound_drone.ckey = src.ckey
+		bound_drone.laws = src.laws // Resync laws in case they have been changed
+		src.mind.transfer_to(bound_drone) // Transfer mind to drone

--- a/code/modules/mob/living/silicon/robot/drone/_drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/_drone.dm
@@ -392,3 +392,35 @@ var/list/mob_hat_cache = list()
 
 	verbs -= /mob/living/silicon/robot/drone/verb/choose_armguard
 	to_chat(src, "Your armguard has been set.")
+
+// AI-bound maintenance drone
+/mob/living/silicon/robot/drone/aibound
+
+	var/mob/living/silicon/ai/bound_ai = null
+
+/mob/living/silicon/robot/drone/aibound/verb/get_back_to_core()
+	set name = "Get Back To Core"
+	set desc = "Release drone control and get back to your main AI core."
+	set category = "Silicon Commands"
+
+	if(bound_ai && src.mind)
+		src.bound_ai.ckey = src.ckey
+		src.bound_ai.bound_drone = src
+		src.mind.transfer_to(bound_ai) // Transfer mind to AI core
+	else
+		to_chat(src, SPAN_WARNING("No AI core detected."))
+
+/mob/living/silicon/robot/drone/aibound/law_resync()
+	return
+
+/mob/living/silicon/robot/drone/aibound/shut_down()
+	return
+
+/mob/living/silicon/robot/drone/aibound/full_law_reset()
+	return
+
+/mob/living/silicon/robot/drone/aibound/SetName(pickedName as text)
+	to_chat(src, SPAN_WARNING("AI bound drones cannot be renamed."))
+
+/mob/living/silicon/robot/drone/aibound/emag_act(var/remaining_charges, var/mob/user)
+	to_chat(user, SPAN_DANGER("This drone is remotely controlled by the ship AI and cannot be directly subverted, the sequencer has no effect."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds the possibility for AI to print a maintenance drone that they can control remotely.

Use `Control Personal Drone` verb in silicon commands to print a drone and control it.

Use `Get Back To Core` verb to get back to your core when you are in the drone.

When you take control of the drone for the first time it prints the default drone laws but you actually have your AI laws (check in Show Laws). It's a default game behaviour that is a pain to remove.

## Why It's Good For The Game

Possibility for AI to fix some things during low pops and/or when technomancers cannot connect their brain cells to fix the ship.

## Changelog
:cl: Hyperio
add: Add AI controlled maintenance drone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
