### PR TITLE
Increases the EMP damage deals to robotic internal and external organs

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -276,11 +276,11 @@
 		return
 	switch (severity)
 		if (1)
-			take_damage(10)
+			take_damage(20)
 		if (2)
-			take_damage(5)
+			take_damage(10)
 		if (3)
-			take_damage(1)
+			take_damage(5)
 
 /obj/item/organ/external/attack_self(var/mob/user)
 	if(!contents.len)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -277,11 +277,11 @@
 		return
 	switch (severity)
 		if (1)
-			take_damage(9)
+			take_damage(32)
 		if (2)
-			take_damage(3)
+			take_damage(18)
 		if (3)
-			take_damage(1)
+			take_damage(9)
 
 // Gets the limb this organ is located in, if any
 /obj/item/organ/proc/get_limb()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
External damage changed from  10 to 20 , 5 to 10 , 1 to 5
Internal damage changed from  9 to 32,  3 to  18 , 1 to 9
## Why It's Good For The Game
FBPs barely feel any pain , get armour by default , don't have to deal with blood. EMP's are often used against them but they yield no result , this should change it .
Organ health also got increased , so should the damage to keep up.

## Changelog
:cl:
balance: Rebalanced the emp damage taken by robotic organs and limbs, they now take on the average twice as much damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
