### PR TITLE
Fuel Type

### DIFF
--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -35,6 +35,7 @@
 	var/use_fuel_cost = 0	//Same, only for fuel. And for the sake of God, DONT USE CELLS AND FUEL SIMULTANEOUSLY.
 	var/passive_fuel_cost = 0.03 //Fuel consumed per process tick while active
 	var/max_fuel = 0
+	var/fuel_type = "fuel"
 
 	var/mode = NOMODE //For various tool icon updates.
 
@@ -82,7 +83,7 @@
 
 	if(use_fuel_cost)
 		create_reagents(max_fuel)
-		reagents.add_reagent("fuel", max_fuel)
+		reagents.add_reagent(fuel_type, max_fuel)
 
 	if(use_stock_cost)
 		stock = max_stock
@@ -719,7 +720,7 @@
 
 	if(use_fuel_cost)
 		if(!consume_fuel(use_fuel_cost*timespent))
-			to_chat(user, SPAN_NOTICE("You need more welding fuel to complete this task."))
+			to_chat(user, SPAN_NOTICE("You need more fuel to complete this task."))
 			return FALSE
 
 	if(use_stock_cost)
@@ -742,12 +743,12 @@
 
 	if(use_fuel_cost)
 		if(get_fuel() < (use_fuel_cost*time))
-			to_chat(user, SPAN_NOTICE("You need more welding fuel to complete this task."))
+			to_chat(user, SPAN_NOTICE("You need more fuel to complete this task."))
 			return FALSE
 
 	if (use_stock_cost)
 		if(stock < (use_stock_cost*time))
-			to_chat(user, SPAN_NOTICE("There is not enough left in [src] to complete this task."))
+			to_chat(user, SPAN_NOTICE("There is not enough fuel left in [src] to complete this task."))
 			return FALSE
 
 	if(eye_hazard)
@@ -763,11 +764,11 @@
 
 //Returns the amount of fuel in tool
 /obj/item/weapon/tool/proc/get_fuel()
-	return ( reagents ? reagents.get_reagent_amount("fuel") : 0 )
+	return ( reagents ? reagents.get_reagent_amount(fuel_type) : 0 )
 
 /obj/item/weapon/tool/proc/consume_fuel(var/volume)
 	if (get_fuel() >= volume)
-		reagents.remove_reagent("fuel", volume)
+		reagents.remove_reagent(fuel_type, volume)
 		return TRUE
 	return FALSE
 
@@ -833,7 +834,7 @@
 			to_chat(user, "The charge meter reads [round(cell.percent())]%.")
 
 	if(use_fuel_cost)
-		to_chat(user, text("\icon[] [] contains []/[] units of fuel!", src, src.name, get_fuel(),src.max_fuel ))
+		to_chat(user, text("\icon[] [] contains []/[] units of []!", src, src.name, get_fuel(), src.max_fuel, fuel_type))
 
 	if (use_stock_cost)
 		to_chat(user, SPAN_NOTICE("it has [stock] / [max_stock] units remaining."))

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -35,7 +35,11 @@
 	var/use_fuel_cost = 0	//Same, only for fuel. And for the sake of God, DONT USE CELLS AND FUEL SIMULTANEOUSLY.
 	var/passive_fuel_cost = 0.03 //Fuel consumed per process tick while active
 	var/max_fuel = 0
-	var/fuel_type = "fuel"
+	var/fuel_type = "fuel" //aight here's how this shitcode thing works
+	//each chem has an 'id' , for example welding fuel's 'id' is '"fuel"'
+	// blood's id is '"blood"' etc. You can check the id of each chem by, well just searching for it
+	//simply set the 'fuel_type' to the same id/string as the chem you want to be used as fuel
+	//for example a tool using blood as fuel would have 'fuel_type = "blood"'
 
 	var/mode = NOMODE //For various tool icon updates.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As the changelog describes, makes a new variable called `fuel_type` which would allow tools to use a different fuel type, also fixes some wording.

also im making this a draft cause you can't actually fucking refuel with anything other than welding fuel because of the fucking refueling code and im too tired to even bother refactoring that like who the hell wrote it it fucking checks if the target is a fuel tank or a welding pack THATS FUCKING IT. Im going fucking insane

## Why It's Good For The Game

Tools being restrained to the same chem isn't nice. Could make it possible in the future for tools to require a different chem to operate.

## Changelog
:cl:
code: tools now have a new variable called `fuel_type` , which would allow a tool to use a different fuel type than welding fuel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
