### PR TITLE
Fixes chem and tracking implants not showing up on the prisoner management console 

### DIFF
--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -22,7 +22,7 @@
 		var/turf/Tr = null
 		for(var/obj/item/weapon/implant/chem/C in world)
 			Tr = get_turf(C)
-			if((Tr) && (Tr.z != src.z))	continue//Out of range
+			if((Tr) && isNotStationLevel(Tr.z)) continue //Out of range
 			if(!C.implanted) continue
 			dat += "[C.wearer.name] | Remaining Units: [C.reagents.total_volume] | Inject: "
 			dat += "<A href='?src=\ref[src];inject=\ref[C];amount=1'>(<font color=red>(1)</font>)</A>"
@@ -32,7 +32,7 @@
 		dat += "<HR>Tracking Implants<BR>"
 		for(var/obj/item/weapon/implant/tracking/T in world)
 			Tr = get_turf(T)
-			if((Tr) && (Tr.z != src.z))	continue//Out of range
+			if((Tr) && isNotStationLevel(Tr.z)) continue //Out of range
 			if(!T.implanted) continue
 			var/loc_display = "Unknown"
 			var/mob/living/carbon/M = T.wearer


### PR DESCRIPTION

**Fixes chem and tracking implants not showing up on the prisoner management console** 
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
this PR fixes the tracking and chemical implants not showing up on the prisoner management console as it used to disappear as soon as you step 1 foot out the brig  
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix? 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: chem and tracking implants now show up if you leave the brig
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
