### PR TITLE
Adds a back room et al. to the club

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -49,7 +49,7 @@
 	supervisors = "the Club Manager"
 	selection_color = "#dddddd"
 	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_JIVE = 60)
-	access = list(access_bar, access_kitchen)
+	access = list(access_bar, access_kitchen, access_maint_tunnels)
 	initial_balance = 750
 	perks = list(PERK_CLUB)
 	wage = WAGE_NONE //They should get paid by the club owner, otherwise you know what to do.

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -34889,13 +34889,12 @@
 /turf/simulated/open,
 /area/eris/security/prison)
 "bEb" = (
-/obj/machinery/door/airlock/maintenance_common{
-	name = "Service Maintenance";
-	req_access = list(12)
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	req_access = list(25)
+	},
 /turf/simulated/floor/tiled/techmaint_cargo,
-/area/eris/maintenance/section3deck4port)
+/area/eris/crew_quarters/kitchen)
 "bEc" = (
 /obj/structure/railing{
 	dir = 4
@@ -35044,7 +35043,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
-/area/eris/maintenance/section3deck4port)
+/area/eris/crew_quarters/kitchen)
 "bEr" = (
 /obj/machinery/door/window/southright{
 	dir = 1;
@@ -52420,8 +52419,10 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
 "csD" = (
-/turf/simulated/wall,
-/area/eris/maintenance/section3deck4port)
+/obj/structure/catwalk,
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/open,
+/area/eris/crew_quarters/kitchen)
 "csE" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -61908,11 +61909,9 @@
 	},
 /area/shuttle/mining/station)
 "cPH" = (
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/catwalk,
 /turf/simulated/open,
-/area/eris/maintenance/section3deck4port)
+/area/eris/crew_quarters/kitchen)
 "cPI" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "6,21"
@@ -66681,12 +66680,11 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/eris/medical/medbay)
 "dbp" = (
-/obj/machinery/door/airlock/maintenance_common{
-	name = "Service Maintenance";
-	req_access = list(12)
+/obj/machinery/door/airlock{
+	req_access = list(25)
 	},
 /turf/simulated/floor/tiled/techmaint_cargo,
-/area/eris/maintenance/section3deck4port)
+/area/eris/crew_quarters/kitchen)
 "dbq" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -94981,6 +94979,7 @@
 /obj/structure/closet/chefcloset,
 /obj/item/weapon/tool/knife,
 /obj/item/weapon/tool/knife,
+/obj/item/weapon/electronics/circuitboard/vending,
 /turf/simulated/floor/tiled/cafe,
 /area/eris/crew_quarters/kitchen)
 "epI" = (
@@ -103766,6 +103765,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
+"muf" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/open,
+/area/eris/crew_quarters/kitchen)
 "mxw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -104517,6 +104523,11 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/long_range_scanner)
+"scN" = (
+/obj/structure/catwalk,
+/obj/spawner/pack/junk_machine,
+/turf/simulated/open,
+/area/eris/crew_quarters/kitchen)
 "sds" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/railing/grey{
@@ -105036,6 +105047,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section3)
+"vSe" = (
+/obj/structure/catwalk,
+/obj/machinery/autolathe,
+/turf/simulated/open,
+/area/eris/crew_quarters/kitchen)
 "wja" = (
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/wall/r_wall,
@@ -162329,12 +162345,12 @@ bQU
 bVb
 cmm
 cpP
-cPv
-cPv
-cPv
-cPv
-cPv
-bUG
+csD
+csD
+csD
+csD
+scN
+cAS
 dHD
 dRr
 crv
@@ -162530,12 +162546,12 @@ cfb
 gXX
 ovh
 bQU
-bAZ
-cPv
-cPv
-cPv
-cPv
-cPv
+cpP
+muf
+cPH
+cPH
+cPH
+cPH
 bEq
 dmg
 dRu
@@ -162738,7 +162754,7 @@ cPH
 cPH
 cPH
 cPH
-bUG
+cAS
 dnb
 dRu
 bWh
@@ -162935,11 +162951,11 @@ chb
 cij
 com
 cpP
-cQe
-cQe
-cQe
-cQe
-cQe
+vSe
+scN
+cPH
+cPH
+cPH
 bEb
 bWh
 dHD
@@ -163137,12 +163153,12 @@ bzz
 cpP
 cpP
 cpP
-csD
-csD
+egG
+egG
 dbp
-csD
-csD
-anJ
+egG
+egG
+cAS
 anJ
 anJ
 anJ

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -34891,10 +34891,10 @@
 "bEb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	req_access = list(25)
+	req_access = list(28)
 	},
 /turf/simulated/floor/tiled/techmaint_cargo,
-/area/eris/crew_quarters/kitchen)
+/area/eris/crew_quarters/kitchen_storage)
 "bEc" = (
 /obj/structure/railing{
 	dir = 4
@@ -35043,7 +35043,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
-/area/eris/crew_quarters/kitchen)
+/area/eris/crew_quarters/kitchen_storage)
 "bEr" = (
 /obj/machinery/door/window/southright{
 	dir = 1;
@@ -52422,7 +52422,7 @@
 /obj/structure/catwalk,
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/open,
-/area/eris/crew_quarters/kitchen)
+/area/eris/crew_quarters/kitchen_storage)
 "csE" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -61911,7 +61911,7 @@
 "cPH" = (
 /obj/structure/catwalk,
 /turf/simulated/open,
-/area/eris/crew_quarters/kitchen)
+/area/eris/crew_quarters/kitchen_storage)
 "cPI" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "6,21"
@@ -66684,7 +66684,7 @@
 	req_access = list(25)
 	},
 /turf/simulated/floor/tiled/techmaint_cargo,
-/area/eris/crew_quarters/kitchen)
+/area/eris/crew_quarters/kitchen_storage)
 "dbq" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -103165,6 +103165,9 @@
 /obj/machinery/duct,
 /turf/simulated/floor/grass,
 /area/eris/crew_quarters/hydroponics)
+"hUG" = (
+/turf/simulated/wall,
+/area/eris/crew_quarters/kitchen_storage)
 "hUQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -103771,7 +103774,7 @@
 	dir = 1
 	},
 /turf/simulated/open,
-/area/eris/crew_quarters/kitchen)
+/area/eris/crew_quarters/kitchen_storage)
 "mxw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -104527,7 +104530,7 @@
 /obj/structure/catwalk,
 /obj/spawner/pack/junk_machine,
 /turf/simulated/open,
-/area/eris/crew_quarters/kitchen)
+/area/eris/crew_quarters/kitchen_storage)
 "sds" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/railing/grey{
@@ -104794,6 +104797,9 @@
 /obj/machinery/vending/assist,
 /turf/simulated/floor/tiled/dark,
 /area/eris/rnd/lab)
+"tVe" = (
+/turf/simulated/wall/r_wall,
+/area/eris/crew_quarters/kitchen_storage)
 "ubu" = (
 /obj/machinery/holomap{
 	pixel_y = 32
@@ -105051,7 +105057,7 @@
 /obj/structure/catwalk,
 /obj/machinery/autolathe,
 /turf/simulated/open,
-/area/eris/crew_quarters/kitchen)
+/area/eris/crew_quarters/kitchen_storage)
 "wja" = (
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/wall/r_wall,
@@ -162350,7 +162356,7 @@ csD
 csD
 csD
 scN
-cAS
+tVe
 dHD
 dRr
 crv
@@ -162754,7 +162760,7 @@ cPH
 cPH
 cPH
 cPH
-cAS
+tVe
 dnb
 dRu
 bWh
@@ -163153,12 +163159,12 @@ bzz
 cpP
 cpP
 cpP
-egG
-egG
+hUG
+hUG
 dbp
-egG
-egG
-cAS
+hUG
+hUG
+tVe
 anJ
 anJ
 anJ

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -41233,7 +41233,12 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/security/lobby)
 "bRH" = (
-/turf/simulated/floor/grass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall,
 /area/eris/crew_quarters/hydroponics/garden)
 "bRI" = (
 /obj/structure/disposalpipe/segment{
@@ -47081,6 +47086,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics/garden)
 "cfw" = (
@@ -52419,9 +52429,8 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
 "csD" = (
-/obj/structure/catwalk,
 /obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/open,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/crew_quarters/kitchen_storage)
 "csE" = (
 /obj/structure/extinguisher_cabinet{
@@ -103200,6 +103209,10 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/quartermaster/hangarsupply)
+"ihL" = (
+/obj/spawner/scrap/dense,
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/crew_quarters/kitchen_storage)
 "ijn" = (
 /obj/structure/table/bar_special,
 /obj/item/weapon/reagent_containers/food/condiment/peppermill{
@@ -103285,6 +103298,9 @@
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled/steel/panels,
 /area/eris/engineering/post)
+"iMs" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/crew_quarters/kitchen_storage)
 "iNx" = (
 /obj/spawner/oddities/low_chance,
 /turf/simulated/floor/tiled/techmaint_cargo,
@@ -103301,6 +103317,18 @@
 /obj/machinery/camera/motion/security,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section1deck4central)
+"iQX" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/crew_quarters/kitchen_storage)
 "iUs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 9
@@ -103550,6 +103578,11 @@
 "kLT" = (
 /turf/simulated/floor/carpet/gaycarpet,
 /area/eris/crew_quarters/clownoffice)
+"kTx" = (
+/obj/structure/catwalk,
+/obj/spawner/pack/machine,
+/turf/simulated/open,
+/area/eris/maintenance/section3deck4port)
 "kUI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -103858,6 +103891,13 @@
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/engineering/engine_room)
+"naM" = (
+/obj/structure/catwalk,
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/spawner/lathe_disk,
+/turf/simulated/open,
+/area/eris/crew_quarters/kitchen_storage)
 "ncx" = (
 /obj/effect/shuttle_landmark/merc/medbay,
 /turf/space,
@@ -104279,6 +104319,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/eris/crew_quarters/kitchen)
+"qcR" = (
+/obj/structure/catwalk,
+/obj/structure/table/rack/shelf,
+/obj/spawner/material/building,
+/obj/spawner/material/building,
+/turf/simulated/open,
+/area/eris/crew_quarters/kitchen_storage)
 "qkR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos{
@@ -104527,9 +104574,8 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/long_range_scanner)
 "scN" = (
-/obj/structure/catwalk,
-/obj/spawner/pack/junk_machine,
-/turf/simulated/open,
+/obj/spawner/pack/machine,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/crew_quarters/kitchen_storage)
 "sds" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -104736,6 +104782,15 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
+"tkP" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/open,
+/area/eris/crew_quarters/kitchen_storage)
 "tqZ" = (
 /obj/spawner/junk/low_chance,
 /obj/machinery/light/small,
@@ -104875,6 +104930,15 @@
 	},
 /turf/space,
 /area/space)
+"uyP" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/open,
+/area/eris/crew_quarters/kitchen_storage)
 "uCf" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -105054,9 +105118,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section3)
 "vSe" = (
-/obj/structure/catwalk,
 /obj/machinery/autolathe,
-/turf/simulated/open,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/crew_quarters/kitchen_storage)
 "wja" = (
 /obj/machinery/atmospherics/portables_connector,
@@ -162354,8 +162417,8 @@ cpP
 csD
 csD
 csD
-csD
-scN
+iMs
+ihL
 tVe
 dHD
 dRr
@@ -162557,7 +162620,7 @@ muf
 cPH
 cPH
 cPH
-cPH
+qcR
 bEq
 dmg
 dRu
@@ -162751,15 +162814,15 @@ bTJ
 bTJ
 bTJ
 cfv
+bTJ
+bTJ
+bTJ
 bRH
-bRH
-bRH
-cpP
-cPH
-cPH
-cPH
-cPH
-cPH
+tkP
+tkP
+tkP
+uyP
+naM
 tVe
 dnb
 dRu
@@ -162959,9 +163022,9 @@ com
 cpP
 vSe
 scN
-cPH
-cPH
-cPH
+iMs
+iQX
+iMs
 bEb
 bWh
 dHD
@@ -163361,7 +163424,7 @@ bBE
 cYb
 cjp
 aqa
-cQe
+kTx
 cQe
 cQe
 cQe

--- a/maps/CEVEris/_Eris_areas.dm
+++ b/maps/CEVEris/_Eris_areas.dm
@@ -457,6 +457,10 @@
 	name = "\improper Kitchen"
 	icon_state = "kitchen"
 
+/area/eris/crew_quarters/kitchen_storage
+	name = "\improper Kitchen Storage"
+	icon_state = "kitchen"
+
 /area/eris/crew_quarters/bar
 	name = "\improper Bar"
 	icon_state = "bar"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a kitchen storage over the NT reactor room, gives Club maint access by default, and adds a custom vendor board to the waiter cupboard.



![image](https://user-images.githubusercontent.com/71949337/118142389-9e185700-b40a-11eb-96e8-70c6bd50be1e.png)



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hopefully the club will be less cucked.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added kitchen backroom
add: Added custom vendor board to waiter closet
tweak: Club worker now has maint access
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
