### PR TITLE
Technomancer armour changes

### DIFF
--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -77,7 +77,7 @@
 	flags_inv = BLOCKHEADHAIR|HIDEEARS
 
 /obj/item/clothing/head/armor/helmet/technomancer
-	name = "technomancer helmet"
+	name = "insulated technomancer helmet"
 	desc = "A piece of armor used in hostile work conditions to protect the head. Comes with a built-in flashlight."
 	body_parts_covered = HEAD|EARS|EYES|FACE
 	item_flags = THICKMATERIAL
@@ -86,11 +86,11 @@
 	light_overlay = "technohelmet_light"
 	brightness_on = 4
 	armor = list(
-		melee = 45,
-		bullet = 35,
-		energy = 35,
-		bomb = 30,
-		bio = 15,
+		melee = 35,
+		bullet = 25,
+		energy = 40,
+		bomb = 20,
+		bio = 0,
 		rad = 30
 	)//Mix between hardhat.dm armor values, helmet armor values in armor.dm, and armor values for TM void helmet in station.dm.
 	flash_protection = FLASH_PROTECTION_MAJOR

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -428,16 +428,16 @@
 
 //Technomancer armor
 /obj/item/clothing/suit/storage/vest/insulated
-	name = "insulated armor"
+	name = "insulated technomancer armor"
 	desc = "A set of armor insulated against heat and electrical shocks, shielded against radiation, and protected against energy weapon projectiles."
 	icon_state = "armor_engineering"
 	item_state = "armor_engineering"
 	blood_overlay_type = "armor"
 	armor = list(
-		melee = 30,
+		melee = 35,
 		bullet = 25,
 		energy = 40,
-		bomb = 10,
+		bomb = 20,
 		bio = 0,
 		rad = 30
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes stats of the technomancer helmet and armour (now called "Insulated technomancer helmet" and "Insulated technomancer armour" respectively) to
		melee = 35,
		bullet = 25,
		energy = 40,
		bomb = 20,
		bio = 0,
		rad = 30

which is basically both the items stats semi combined

## Why It's Good For The Game

Consistency

having the helmet have quite radically different stats to the armour is, personally, a dumb idea.

(if the stats are bad then i can edit the PR to only be a name change, since frankly i think thats more important)

also changed the names so its easier to find them and easiet to tell the two are from the same "set", also for consistency

## Changelog
:cl:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced the technomancer helmet and insulated armour (now called insulated technomancer helmet/armour) to have the same stats.  Not sure how this will look in the ingame change log. " melee = 35, bullet = 25, energy = 40, bomb = 20, bio = 0, rad = 30 "
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
