### PR TITLE
Light bulb nerf

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -199,8 +199,8 @@
 	icon_state = "bulb1"
 	base_state = "bulb"
 	fitting = "bulb"
-	brightness_range = 4
-	brightness_power = 2
+	brightness_range = 3
+	brightness_power = 1
 	desc = "A small lighting fixture."
 	light_type = /obj/item/weapon/light/bulb
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces the light coming from light bulbs
Pre Change
![image](https://user-images.githubusercontent.com/59490776/118200163-d2186a00-b454-11eb-9547-9aede1c12ec8.png)
Change
![image](https://user-images.githubusercontent.com/59490776/118200137-c5941180-b454-11eb-9b80-c2be4c2b35de.png)

Light tubes are inconsistent across maps and would need remapping to actually look good if i nerfed their range and/or power. As such im not touching them, atleast not now.

## Why It's Good For The Game

Makes maintenance tunnels (as those are usually the only places where light bulbs are used in majority) even darker, adding to a darker/dangerous feel/theme of said tunnels.

## Changelog
:cl:
tweak: reduced light bulb range and power
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
