### PR TITLE
Faulty guns and you!

### DIFF
--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -19,6 +19,7 @@
 	var/destroy_on_removal = FALSE
 	//The upgrade can be applied to a tool that has any of these qualities
 	var/list/required_qualities = list()
+	var/removable = TRUE
 
 	//The upgrade can not be applied to a tool that has any of these qualities
 	var/list/negative_qualities = list()
@@ -583,30 +584,33 @@
 		if(toremove == "Cancel")
 			return 1
 		var/datum/component/item_upgrade/IU = toremove.GetComponent(/datum/component/item_upgrade)
-		if(C.use_tool(user = user, target =  upgrade_loc, base_time = IU.removal_time, required_quality = QUALITY_SCREW_DRIVING, fail_chance = IU.removal_difficulty, required_stat = STAT_MEC))
-			//If you pass the check, then you manage to remove the upgrade intact
-			if(!IU.destroy_on_removal && user)
-				to_chat(user, SPAN_NOTICE("You successfully remove \the [toremove] while leaving it intact."))
-			SEND_SIGNAL(toremove, COMSIG_REMOVE, upgrade_loc)
-			upgrade_loc.refresh_upgrades()
-			return 1
+		if(IU.removable == FALSE)
+			to_chat(user, SPAN_DANGER("\the [toremove] seems to be fused with the [upgrade_loc]"))
 		else
-			//You failed the check, lets see what happens
-			if(prob(50))
-				//50% chance to break the upgrade and remove it
-				to_chat(user, SPAN_DANGER("You successfully remove \the [toremove], but destroy it in the process."))
-				SEND_SIGNAL(toremove, COMSIG_REMOVE, parent)
-				QDEL_NULL(toremove)
+			if(C.use_tool(user = user, target =  upgrade_loc, base_time = IU.removal_time, required_quality = QUALITY_SCREW_DRIVING, fail_chance = IU.removal_difficulty, required_stat = STAT_MEC))
+				//If you pass the check, then you manage to remove the upgrade intact
+				if(!IU.destroy_on_removal && user)
+					to_chat(user, SPAN_NOTICE("You successfully remove \the [toremove] while leaving it intact."))
+				SEND_SIGNAL(toremove, COMSIG_REMOVE, upgrade_loc)
 				upgrade_loc.refresh_upgrades()
-				user.update_action_buttons()
 				return 1
-			else if(T && T.degradation) //Because robot tools are unbreakable
-				//otherwise, damage the host tool a bit, and give you another try
-				to_chat(user, SPAN_DANGER("You only managed to damage \the [upgrade_loc], but you can retry."))
-				T.adjustToolHealth(-(5 * T.degradation), user) // inflicting 4 times use damage
-				upgrade_loc.refresh_upgrades()
-				user.update_action_buttons()
-				return 1
+			else
+				//You failed the check, lets see what happens
+				if(prob(50))
+					//50% chance to break the upgrade and remove it
+					to_chat(user, SPAN_DANGER("You successfully remove \the [toremove], but destroy it in the process."))
+					SEND_SIGNAL(toremove, COMSIG_REMOVE, parent)
+					QDEL_NULL(toremove)
+					upgrade_loc.refresh_upgrades()
+					user.update_action_buttons()
+					return 1
+				else if(T && T.degradation) //Because robot tools are unbreakable
+					//otherwise, damage the host tool a bit, and give you another try
+					to_chat(user, SPAN_DANGER("You only managed to damage \the [upgrade_loc], but you can retry."))
+					T.adjustToolHealth(-(5 * T.degradation), user) // inflicting 4 times use damage
+					upgrade_loc.refresh_upgrades()
+					user.update_action_buttons()
+					return 1
 	return 0
 
 /obj/item/weapon/tool_upgrade

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -275,9 +275,8 @@
 		GUN_UPGRADE_FIRE_DELAY_MULT = rand(11,18)/10
 	)
 	I.destroy_on_removal = TRUE
-	I.removal_time *= rand(10.14)/10
-	I.removal_difficulty *= rand(5, 15)/10
 	I.gun_loc_tag = GUN_TRIGGER
+	I.removable = FALSE
 
 /obj/item/weapon/gun_upgrade/barrel/faulty
 	name = "Warped Barrel"
@@ -291,13 +290,12 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
 		GUN_UPGRADE_OFFSET = rand(5,15),
-		GUN_UPGRADE_PEN_MULT = rand(4,9)/10,
-		GUN_UPGRADE_DAMAGE_MULT = rand(4,9)/10
+		GUN_UPGRADE_PEN_MULT = rand(0.8,1.2),
+		GUN_UPGRADE_DAMAGE_MULT = rand(0.8,1.2)
 	)
 	I.destroy_on_removal = TRUE
-	I.removal_time *= rand(10.14)/10
-	I.removal_difficulty *= rand(5, 15)/10
 	I.gun_loc_tag = GUN_BARREL
+	I.removable = FALSE
 
 /obj/item/weapon/gun_upgrade/muzzle/faulty
 	name = "Failed Makeshift Silencer"
@@ -311,12 +309,12 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
 		GUN_UPGRADE_PEN_MULT = rand(4,9)/10,
-		GUN_UPGRADE_STEPDELAY_MULT = rand(12,18)/10
+		GUN_UPGRADE_STEPDELAY_MULT = rand(10,12)/10,
+		GUN_UPGRADE_SILENCER = TRUE
 	)
 	I.destroy_on_removal = TRUE
-	I.removal_time *= rand(10.14)/10
-	I.removal_difficulty *= rand(5, 15)/10
 	I.gun_loc_tag = GUN_MUZZLE
+	I.removable = FALSE
 
 /obj/item/weapon/gun_upgrade/mechanism/faulty
 	name = "Unknown Clockwork Mechanism"
@@ -329,12 +327,11 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_RECOIL = rand(5, 50)/10
+		GUN_UPGRADE_RECOIL = rand(5, 20)/10
 	)
 	I.destroy_on_removal = TRUE
-	I.removal_time *= rand(10.14)/10
-	I.removal_difficulty *= rand(5, 15)/10
 	I.gun_loc_tag = GUN_MECHANISM
+	I.removable = FALSE
 
 /obj/item/weapon/gun_upgrade/scope/faulty
 	name = "Misaligned sights"
@@ -347,12 +344,12 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_OFFSET = rand(3,6)
+		GUN_UPGRADE_OFFSET = rand(1,3),
+		GUN_UPGRADE_ZOOM = rand(0.4,0.8)
 	)
 	I.destroy_on_removal = TRUE
-	I.removal_time *= rand(10.14)/10
-	I.removal_difficulty *= rand(5, 15)/10
 	I.gun_loc_tag = GUN_SCOPE
+	I.removable = FALSE
 
 #define TRASH_GUNMODS list(/obj/item/weapon/gun_upgrade/trigger/faulty, /obj/item/weapon/gun_upgrade/barrel/faulty, \
 		/obj/item/weapon/gun_upgrade/muzzle/faulty, /obj/item/weapon/gun_upgrade/mechanism/faulty, \

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -368,7 +368,7 @@
 
 /obj/item/weapon/gun/make_old(low_quality_oldification)
 	.=..()
-	if(. && prob(60))
+	if(. && prob(90))
 		var/list/trash_mods = TRASH_GUNMODS
 		while(trash_mods.len)
 			var/trash_mod_path = pick_n_take(trash_mods)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Faulty gun mods are no longer removable and added a var that can force gun mods to be irremovable. Rebalanced faulty mods so they can be both a asset and a detriment to a gun but overall the gun will still be usable.

## Why It's Good For The Game

Printing a gun currently has no drawbacks aside from being a noob trap and faulty gun mods are far too punishing.

## Changelog
:cl:
add: Added var that enables irremovable gun mods
tweak: faulty gun mod values, higher chance of faulty gun mod
balance: rebalanced faulty gun mods, no longer removable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
