### PR TITLE
No nutrition loss on organ healing.

### DIFF
--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -95,7 +95,6 @@
 	if(!damage || BP_IS_ROBOTIC(src) || !owner || owner.chem_effects[CE_TOXIN] || owner.is_asystole() || !current_blood)
 		return
 	if(damage < 0.1*max_damage)
-		owner.adjustNutrition(-(nutriment_req * 10))
 		heal_damage(0.1)
 
 /obj/item/organ/internal/examine(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the nutrition loss from organ healing.

## Why It's Good For The Game
Nutrition loss from organ healing was too quick, so I thought about lowering it, but I realized it doesn't make much sense organs need nutrition to heal so I removed it.

## Changelog
:cl:
balance: internal organs no longer take nutrition to heal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
