### PR TITLE
Erismed 3 faster knockout

### DIFF
--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -91,8 +91,8 @@
 	if(shock_stage <= traumatic_shock)	//Shock stage slowly climbs to traumatic shock
 		shock_stage = min(shock_stage + shock_stage_speed, traumatic_shock)
 
-		if(shock_stage <= round(traumatic_shock * 0.4 / 2) * 2)	//If the difference is too big shock stage jumps to 40% of traumatic shock
-			shock_stage = (traumatic_shock * 0.4)
+		if(shock_stage <= round(traumatic_shock * 0.6 / 2) * 2)	//If the difference is too big shock stage jumps to 60% of traumatic shock
+			shock_stage = (traumatic_shock * 0.6)
 			shock_stage = round(shock_stage / 2) * 2 //rounded to the nearest even sumber, so messages show up
 
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Applying shock stage from initial damage jumps to 60% of the damage, instead of 40%.

## Why It's Good For The Game

I noticed in some situations people would die before getting knocked out, and hallos weapons had problems catching up with the shock stage. 

## Changelog
:cl:
balance: speed of which shock stage goes to regular damage increased
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
