### PR TITLE
RnD Shutters aren't bugged roundstart

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -104948,11 +104948,11 @@
 	opacity = 0
 	},
 /obj/machinery/door/blast/shutters{
-	density = 0;
+	density = 1;
 	dir = 2;
 	id = "rnddesk";
 	name = "Research Desk Shutters";
-	opacity = 0
+	opacity = 1
 	},
 /obj/machinery/door/window/westleft{
 	name = "Research Desk";


### PR DESCRIPTION
## About The Pull Request
Fixes RnD Desk Shutters values to be actually closed since they had the closed sprite, but open values.
## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/70905548/118337899-d2f7dd00-b4e2-11eb-8444-3288013f0bcd.png)

Was annoying. Less bugs.

## Changelog
:cl: Herbaon
fix: RnD Shutters at roundstart are properly closed now.
/:cl: