### PR TITLE
Fixes a horrible runtime from signals

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -129,7 +129,8 @@
 	if(!canUnEquip(I))
 		return
 	SEND_SIGNAL(src, COMSIG_CLOTH_DROPPED, I)
-	SEND_SIGNAL(I, COMSIG_CLOTH_DROPPED, src)
+	if(I)
+		SEND_SIGNAL(I, COMSIG_CLOTH_DROPPED, src)
 	return drop_from_inventory(I,Target)
 
 //Attemps to remove an object on a mob.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
/mob/proc/unequip is apparently unsafe and its called to unequip WITHOUT an item.
## Why It's Good For The Game
Runtimes lag 
## Changelog
:cl:
fix: fixed the clothing drop signal being called on nulls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
