### PR TITLE
Shield handling with signals

### DIFF
--- a/code/_onclick/hud/screen_objects/base_screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/base_screen_objects.dm
@@ -982,9 +982,9 @@ obj/screen/fire/DEADelize()
 /obj/screen/mov_intent/Click()
 	var/move_intent_type = next_list_item(usr.move_intent.type, usr.move_intents)
 	var/decl/move_intent/newintent = decls_repository.get_decl(move_intent_type)
-	SEND_SIGNAL(parentmob, COMSIG_HUMAN_WALKINTENT_CHANGE, parentmob, newintent)
 	if (newintent.can_enter(parentmob, TRUE))
 		parentmob.move_intent = newintent
+		SEND_SIGNAL(parentmob, COMSIG_HUMAN_WALKINTENT_CHANGE, parentmob, newintent)
 		update_icon()
 
 	update_icon()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -178,10 +178,10 @@
 /obj/item/proc/pickup(mob/target)
 	throwing = 0
 	var/atom/old_loc = loc
-	SEND_SIGNAL(src, COMSIG_ITEM_PICKED, src, target)
 	if(target.put_in_active_hand(src) && old_loc )
 		if((target != old_loc) && (target != old_loc.get_holding_mob()))
 			do_pickup_animation(target,old_loc)
+		SEND_SIGNAL(src, COMSIG_ITEM_PICKED, src, target)
 	add_hud_actions(target)
 
 /obj/item/attack_ai(mob/user as mob)

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -58,8 +58,8 @@
 	return ..()
 
 /obj/item/weapon/shield/riot
-	name = "riot shield"
-	desc = "A shield adept at blocking blunt objects from connecting with the torso of the shield wielder."
+	name = "tactical shield"
+	desc = "A personal shield made of pre-preg aramid fibres designed to stop or deflect bullets and other projectiles fired at its wielder."
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "riot"
 	item_state = "riot"
@@ -75,7 +75,8 @@
 	price_tag = 500
 	attack_verb = list("shoved", "bashed")
 	var/cooldown = 0 //shield bash cooldown. based on world.time
-	var/is_covered = FALSE
+	var/picked_by_human = FALSE
+	var/mob/living/carbon/human/picking_human
 
 /obj/item/weapon/shield/riot/handle_shield(mob/user)
 	. = ..()
@@ -88,30 +89,36 @@
 		return base_block_chance
 
 /obj/item/weapon/shield/riot/New()
-	START_PROCESSING(SSobj, src)
-	return
+	RegisterSignal(src, COMSIG_ITEM_PICKED, .proc/is_picked)
+	RegisterSignal(src, COMSIG_ITEM_DROPPED, .proc/is_dropped)
+	return ..()
 
-/obj/item/weapon/shield/riot/Process()
-	update_icon()
-	update_wear_icon()
-
-/obj/item/weapon/shield/riot/on_update_icon()
+/obj/item/weapon/shield/riot/proc/is_picked()
 	var/mob/living/carbon/human/user = loc
-	if(!istype(user))
-		is_covered = FALSE
+	if(istype(user))
+		picked_by_human = TRUE
+		picking_human = user
+		RegisterSignal(picking_human, COMSIG_HUMAN_WALKINTENT_CHANGE, .proc/update_state)
+		update_state()
+
+/obj/item/weapon/shield/riot/proc/is_dropped()
+	if(picked_by_human && picking_human)
+		UnregisterSignal(picking_human, COMSIG_HUMAN_WALKINTENT_CHANGE)
+		picked_by_human = FALSE
+		picking_human = null
+
+/obj/item/weapon/shield/riot/proc/update_state()
+	if(!picking_human)
 		return
-	if(MOVING_QUICKLY(user))
+	if(MOVING_QUICKLY(picking_human))
 		item_state = "[initial(item_state)]_run"
 		armor = list(melee = 0, bullet = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
-		if(is_covered)
-			visible_message("[user] lets go of their cover.")
-			is_covered = FALSE
+		visible_message("[picking_human] lowers [gender_datums[picking_human.gender].his] [src.name].")
 	else
 		item_state = "[initial(item_state)]_walk"
 		armor = initial(armor)
-		if(!is_covered)
-			visible_message("[user] raises [src], covering themselves with it!")
-			is_covered = TRUE
+		visible_message("[picking_human] raises [gender_datums[picking_human.gender].his] [src.name] to cover [gender_datums[picking_human.gender].him]self!")
+	update_wear_icon()
 
 /obj/item/weapon/shield/riot/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/melee/baton))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cleaner handling of the shield raising/lowering with signals instead of a Process()

Name changed to `tactical shield` with description `A personal shield made of pre-preg aramid fibres designed to stop or deflect bullets and other projectiles fired at its wielder.`

## Why It's Good For The Game

Avoid adding `Process` to item.

## Changelog
:cl: Hyperio
refactor: Shield handling with signals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
