### PR TITLE
nt tweaks

### DIFF
--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -46,7 +46,7 @@ var/list/disciples = list()
 		righteous_life = max(righteous_life - 0.5, 0)
 
 /obj/item/weapon/implant/core_implant/cruciform/proc/on_ritual()
-	righteous_life = min(righteous_life + 20, max_righteous_life)
+	righteous_life = min(righteous_life + 25, max_righteous_life)
 
 
 /obj/item/weapon/implant/core_implant/cruciform/install(mob/living/target, organ, mob/user)

--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -25,7 +25,7 @@ var/list/disciples = list()
 
 	var/true_power_regen = power_regen
 	true_power_regen += max(round(wearer.stats.getStat(STAT_COG) / 4), 0) * (1 / (1 MINUTES))
-	true_power_regen +=  power_regen * 1.5 * righteous_life / max_righteous_life
+	true_power_regen += power_regen * 1.5 * righteous_life / max_righteous_life
 	if(wearer && wearer.stats?.getPerk(/datum/perk/channeling))
 		true_power_regen += power_regen * disciples.len / 2.5  // Proportional to the number of cruciformed people on board
 

--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -127,6 +127,7 @@
 	if(!T)
 		fail("No target.", H, C)
 		return FALSE
+	eotp.scanned -= T
 	T.hallucination(50,100)
 	var/sanity_gain = rand(0,10)
 	T.druggy = max(T.druggy, 10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

the ritual of revelation is supposed to allow you to be rescanned by the EOTP.

the second change is to make it easier for players to regenerate more energy.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: the ritual of revelation now allows the target to be scanned by EOTP again.
tweak: righteous life bar fills up faster.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
