### PR TITLE
removes health_deficiency

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -27,10 +27,8 @@
 			var/obj/item/weapon/cruciform_upgrade/speed_of_the_chosen/sotc = upgrade
 			tally -= sotc.speed_increase
 
-	var/health_deficiency = (maxHealth - health)
 	var/hunger_deficiency = (MOB_BASE_MAX_HUNGER - nutrition)
 	if(hunger_deficiency >= 200) tally += (hunger_deficiency / 100) //If youre starving, movement slowdown can be anything up to 4.
-	if(health_deficiency >= 40) tally += (health_deficiency / 25)
 
 	if(istype(buckled, /obj/structure/bed/chair/wheelchair))
 		//Not porting bay's silly organ checking code here


### PR DESCRIPTION
## About The Pull Request

Removes slowdown from damage. It is now based only on limb efficiency and pain.

## Why It's Good For The Game

This is a relatively small change, but it could potentially have a big impact on the overall game. First shot advantaged will be leve important, enabling more interesting fire fighters and more options to retreat, rather than just trying to outdps each other with automatics and praying for the best. This also feels more consistent, since you would expect pain and limb efficiency to dictate speed, not some random, arbitrary damage number to stack with these things and slow you down massively.

## Changelog
:cl:
balance: Removes slowdown from damage. It is now based only on limb efficiency and pain.
/:cl: