### PR TITLE
Organic buff: Makes limb HP separate from death.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -8,6 +8,7 @@
 	var/total_brute = 0
 	for(var/obj/item/organ/external/O in organs)	//hardcoded to streamline things a bit
 		if(BP_IS_ROBOTIC(O) && !O.vital)
+		if(BP_IS_ORGANIC(O) && !O.vital)
 			continue //*non-vital* robot limbs don't count towards shock and crit
 		total_brute += O.brute_dam
 		total_burn  += O.burn_dam

--- a/code/modules/organs/organ_description.dm
+++ b/code/modules/organs/organ_description.dm
@@ -62,7 +62,6 @@
 	max_damage = 100
 	min_broken_damage = 60
 	dislocated = -1
-	vital = TRUE
 
 	w_class = ITEM_SIZE_BULKY
 	max_volume = ITEM_SIZE_COLOSSAL

--- a/code/modules/organs/organ_description.dm
+++ b/code/modules/organs/organ_description.dm
@@ -62,6 +62,7 @@
 	max_damage = 100
 	min_broken_damage = 60
 	dislocated = -1
+	vital = TRUE
 
 	w_class = ITEM_SIZE_BULKY
 	max_volume = ITEM_SIZE_COLOSSAL


### PR DESCRIPTION
## About The Pull Request

Makes it so limbs and groin don't contribute to death. They only deal pain and the associated advantages of disabling limbs now.

## Why It's Good For The Game

Further augments erismed 3 by giving a safer location to shoot someone, even if you're using lethal ammunition. The end result may make humans a tad tankier in terms of surviving death, but paincrit should be about the same. Shooting people in the head and chest is still lethal of course.

## Changelog
:cl:
balance: Humans don't have shared HP between all limbs and groin, making them safer to shoot for non-lethal takedowns. Aim for the chest or head to kill.
/:cl:
