### PR TITLE
Properly tweaks EMP

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -276,11 +276,11 @@
 		return
 	switch (severity)
 		if (1)
-			take_damage(20)
-		if (2)
 			take_damage(10)
-		if (3)
+		if (2)
 			take_damage(5)
+		if (3)
+			take_damage(2)
 
 /obj/item/organ/external/attack_self(var/mob/user)
 	if(!contents.len)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -277,11 +277,11 @@
 		return
 	switch (severity)
 		if (1)
-			take_damage(32)
+			take_damage(12)
 		if (2)
-			take_damage(18)
+			take_damage(6)
 		if (3)
-			take_damage(9)
+			take_damage(3)
 
 // Gets the limb this organ is located in, if any
 /obj/item/organ/proc/get_limb()


### PR DESCRIPTION
## About The Pull Request

Decreases EMP damage to cybernetics from the new values, and increases from the old values. These are

External 10/5/2

Internal 12/6/3

This translates to 70/35/24 damage to a full FBP externally per EMP. Please don't make me calculate internal damage, just know that for medium and heavy it's going to be in the hundreds if you count every organ that needs to be repaired.

## Why It's Good For The Game

The previous EMP PR was done very poorly, and tried to justify it with erismed 3. It was also a poor band-aid fix to nerf FBPs, when the solution is to fix the issues that were plaguing humans. These EMPs will do reasonable damage internal and external damage, reducing their efficiency and making them easier to kill or disable, while still taking into account that the majority of EMP sources are nigh impossible to dodge.

## Changelog
:cl:
balance: Adjusts the EMP damage dealt to FBPs. They are weaker now, but still capable of causing severe damage to internal and external machinery.
/:cl:
