### PR TITLE
Advanced trauma kit fix

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -146,7 +146,7 @@
 				)
 				var/used = 0
 				for (var/datum/wound/W in affecting.wounds)
-					if (W.internal)
+					if(W.internal)
 						continue
 					if(W.bandaged)
 						continue
@@ -154,6 +154,12 @@
 						break
 					if(!do_mob(user, M, W.damage/5))
 						to_chat(user, SPAN_NOTICE("You must stand still to bandage wounds."))
+						break
+					if(W.internal)
+						continue
+					if(W.bandaged)
+						continue
+					if(used == amount)
 						break
 					if (W.current_stage <= W.max_bleeding_stage)
 						user.visible_message(
@@ -314,14 +320,20 @@
 			)
 			var/used = 0
 			for (var/datum/wound/W in affecting.wounds)
-				if (W.internal)
+				if(W.internal)
 					continue
-				if (W.bandaged && W.disinfected)
+				if(W.bandaged && W.disinfected)
 					continue
 				if(used == amount)
 					break
 				if(!do_mob(user, M, W.damage/5))
 					to_chat(user, SPAN_NOTICE("You must stand still to bandage wounds."))
+					break
+				if(W.internal)
+					continue
+				if(W.bandaged && W.disinfected)
+					continue
+				if(used == amount)
 					break
 				if (W.current_stage <= W.max_bleeding_stage)
 					user.visible_message(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a bug where advanced trauma kits and bandages could be spamed and used multiple times on a bandaged wound.

## Why It's Good For The Game

Bugs are bad.

## Changelog
:cl:
fix: advanced trauma kits and bandages can't be stacked anymore, don't try or you are gonna waste kits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
