### PR TITLE
Fixes propaganda chip and spy sesnsor origin tech

### DIFF
--- a/code/game/objects/items/devices/propaganda_chip.dm
+++ b/code/game/objects/items/devices/propaganda_chip.dm
@@ -2,7 +2,7 @@
 	name = "propaganda chip"
 	icon_state = "implant_evil" //placeholder
 	desc = "A delicate chip with an integrated speaker, you shouldn't disturb it"
-	origin_tech = list(TECH_MAGNETS = 3)
+	origin_tech = list(TECH_MAGNET = 3)
 	matter = list(MATERIAL_PLASTIC = 10, MATERIAL_STEEL = 5) //Needs to be a bit expensive so people cant spam messages
 	var/active = FALSE
 	var/last_talk_time = 0

--- a/code/game/objects/items/devices/spy_sensor.dm
+++ b/code/game/objects/items/devices/spy_sensor.dm
@@ -1,7 +1,7 @@
 /obj/item/device/spy_sensor
 	name = "spying sensor"
 	icon_state = "motion0" //placeholder
-	origin_tech = list(TECH_MAGNETS = 5, TECH_COVERT = 2)
+	origin_tech = list(TECH_MAGNET = 5, TECH_COVERT = 2)
 	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLATINUM = 2)
 	var/active = FALSE
 	var/datum/mind/owner


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title, before it was TECH_MAGNETS which doesn't exist and would break shit/not allow the propaganda chip to be deconstructed for research

## Why It's Good For The Game

Unintentional (probably) mistake has been fixed

## Changelog
:cl:
fix: The Electro-magnetic-feuro-nanite field of the propaganda chip and spy sensor has been realligned and repaired using neural-hyper-reflected-laser-connections, as such you can now properly deconstruct them for research using the destructive analyzer's solaris-mind-based-nano-manipulation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
