### PR TITLE
Blacklist ballistic NVGs from spawning

### DIFF
--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -22,7 +22,7 @@
 	darkness_view = 7
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
 	flags = ABSTRACT
-	spawn_blacklisted = FALSE
+	spawn_blacklisted = TRUE
 
 /obj/item/clothing/glasses/bullet_proof_ironhammer/Initialize()
 	. = ..()

--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -22,6 +22,7 @@
 	darkness_view = 7
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
 	flags = ABSTRACT
+	spawn_blacklisted = FALSE
 
 /obj/item/clothing/glasses/bullet_proof_ironhammer/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

They are treated as abstract item and shouldn't be spawned anywhere else other than when using the tactical ballistic helmet

## Why It's Good For The Game

less bugs

## Changelog
:cl:
fix: Fixed ballistic night vision goggles appearing outside of tactical ballistic helmet
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
