### PR TITLE
The Divine Blessing ritual now reduces the stats of the performer.

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -376,6 +376,8 @@
 		return FALSE
 
 	for(var/stat in inspiracion.stats)
-		inspiracion.stats[stat] += rand(1,8)
+		var/stat_gain = rand(1,8)
+		inspiracion.stats[stat] += stat_gain
+		user.stats.changeStat(stat, -max(round(stat_gain/2),1))
 	odditys.Add(I)
 	return TRUE

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -350,7 +350,7 @@
 /datum/ritual/cruciform/priest/divine_blessing
 	name = "Divine Blessing"
 	phrase = "Corpus Deus"
-	desc = "Increase an oddity's stats by a certain amount but reduce yours by half that amount."
+	desc = "Increase an oddity's stats by a certain amount but reduce yours by half of that amount."
 	success_message = "Your oddity has been blessed."
 	fail_message = "You feel cold in your active hand."
 	var/list/odditys = list()

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -350,7 +350,7 @@
 /datum/ritual/cruciform/priest/divine_blessing
 	name = "Divine Blessing"
 	phrase = "Corpus Deus"
-	desc = "Increases the stats of an oddity."
+	desc = "Increase an oddity's stats by a certain amount but reduce yours by half that amount."
 	success_message = "Your oddity has been blessed."
 	fail_message = "You feel cold in your active hand."
 	var/list/odditys = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

According to the documentation, this is the side effect of performing this ritual, when it appeared I forgot to add it at the time. The stats that are subtracted from the preacher will be half of what the oddity gains.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

makes the divine blessing ritual work as designed.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The Divine Blessing ritual now reduces the stats of the performer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
