### PR TITLE
Increases NT job cognition

### DIFF
--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -27,7 +27,7 @@
 		STAT_TGH = 10,
 		STAT_ROB = 20,
 		STAT_VIG = 15,
-		STAT_COG = 10,
+		STAT_COG = 20,
 	)
 
 	perks = list(/datum/perk/channeling)
@@ -84,9 +84,10 @@
 	outfit_type = /decl/hierarchy/outfit/job/church/acolyte
 
 	stat_modifiers = list(
-	STAT_VIG = 15,
-	STAT_TGH = 15,
-	STAT_ROB = 15
+		STAT_VIG = 15,
+		STAT_TGH = 15,
+		STAT_ROB = 15,
+		STAT_COG = 10,
 	)
 
 	core_upgrades = list(
@@ -130,6 +131,7 @@
 		STAT_BIO = 20,
 		STAT_TGH = 10,
 		STAT_ROB = 10,
+		STAT_COG = 10,
 	)
 
 	core_upgrades = list(
@@ -174,7 +176,8 @@
 	stat_modifiers = list(
 		STAT_ROB = 15,
 		STAT_TGH = 10,
-		STAT_VIG = 15
+		STAT_VIG = 15,
+		STAT_COG = 10,
 	)
 
 	core_upgrades = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title, increased each NT job cognition by 10

## Why It's Good For The Game

Primarly because of this
![image](https://user-images.githubusercontent.com/59490776/119049429-ce3e9780-b9c0-11eb-900c-738903d19116.png)
along with the fact that new rome gives a -10 to cog
![image](https://user-images.githubusercontent.com/59490776/119049495-e9110c00-b9c0-11eb-9f05-4ac7f11a12b6.png)
however according to Evan:
![image](https://user-images.githubusercontent.com/59490776/119049531-f5956480-b9c0-11eb-8b76-7a7c351e689a.png)

Tl;DR - this should increase Cruciform regeneration by more than 10% for NT jobs (preacher being 25% instead)
Taking the New Rome origin will put them back at their original cog stat so i believe this also synergises nicely.

I believe this change is more of a quality of life improvment than some kind of NT buff, since the cog increase is for jobs rather than anyone with a cruciform, meaning new converts or non NT-job cruci-bearers won't get the regen boost

## Changelog
:cl:
tweak: The Neotheology Church on the CEV Eris has gotten a proper education now! Atleast for New Rome standards. Their cognitive capabilities have been increased by 10, whatever that means.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
