### PR TITLE
Gun recoil changes

### DIFF
--- a/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
@@ -15,7 +15,7 @@
 	price_tag = 600
 	damage_multiplier = 1.2
 	penetration_multiplier = 1.2
-	recoil_buildup = 6
+	recoil_buildup = 3.5
 	init_firemodes = list(
 		list(mode_name="semiauto", mode_desc="Fire almost as fast as you can pull the trigger", burst=1, fire_delay=1.2, move_delay=null, 				icon="semi"),
 		list(mode_name="2-round bursts", mode_desc="Not quite the Mozambique method", burst=2, fire_delay=0.2, move_delay=4,    	icon="burst"),

--- a/code/modules/projectiles/guns/projectile/revolver/havelock.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/havelock.dm
@@ -15,6 +15,6 @@
 	price_tag = 700
 	damage_multiplier = 1.4 //because pistol round
 	penetration_multiplier = 1.4
-	recoil_buildup = 8
+	recoil_buildup = 3
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title, from 6 to 3.5 for Olivaw, from 8 to 3 for havelock

## Why It's Good For The Game
As requested by frost
![image](https://user-images.githubusercontent.com/59490776/119152134-50c26800-ba50-11eb-997a-277e5ceba7ce.png)

I believe Havelock's and Olivaw's recoil was too damn high, and as such i reduced it

that's kinda it

## Changelog
:cl:
balance: Olivaw recoil reduced to 3.5 and havelock to 3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
