### PR TITLE
Roach egg shit

### DIFF
--- a/code/game/objects/effects/roaches.dm
+++ b/code/game/objects/effects/roaches.dm
@@ -1,5 +1,5 @@
 //generic procs copied from obj/effect/alien
-/obj/item/weapon/roach
+/obj/item/roach
 	name = "roach effect"
 	desc = "A cockroach effect."
 	icon = 'icons/effects/effects.dmi'
@@ -7,7 +7,7 @@
 	density = FALSE
 	health = 5
 
-/obj/item/weapon/roach/attackby(var/obj/item/I, var/mob/user)
+/obj/item/roach/attackby(var/obj/item/I, var/mob/user)
 	if(I.attack_verb.len)
 		visible_message(SPAN_WARNING("\The [src] have been [pick(I.attack_verb)] with \the [I][(user ? " by [user]." : ".")]"))
 	else
@@ -16,37 +16,37 @@
 	health -= (I.force / 2)
 	healthcheck()
 
-/obj/item/weapon/roach/bullet_act(var/obj/item/projectile/Proj)
+/obj/item/roach/bullet_act(var/obj/item/projectile/Proj)
 	..()
 	health -= Proj.get_structure_damage()
 	healthcheck()
 
-/obj/item/weapon/roach/proc/healthcheck()
+/obj/item/roach/proc/healthcheck()
 	if(health <= 0)
 		visible_message(SPAN_WARNING("[src] is squished!"))
 		new /obj/effect/decal/cleanable/roach_egg_remains(loc)
 		qdel(src)
 
-/obj/item/weapon/roach/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+/obj/item/roach/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature > 300 + T0C)
 		health -= 5
 		healthcheck()
 
-/obj/item/weapon/roach/roach_egg
+/obj/item/roach/roach_egg
 	name = "roach egg"
 	desc = "A cockroach egg, can be eaten with proper preperation. It seems to pulse slightly with an inner life."
 	icon_state = "roach_egg"
 	w_class = ITEM_SIZE_TINY
 	var/amount_grown = 0
 
-/obj/item/weapon/roach/roach_egg/New(var/location, var/atom/parent)
+/obj/item/roach/roach_egg/New(var/location, var/atom/parent)
 	pixel_x = rand(3,-3)
 	pixel_y = rand(3,-3)
 	START_PROCESSING(SSobj, src)
 	get_light_and_color(parent)
 	..()
 
-/obj/item/weapon/roach/roach_egg/Destroy()
+/obj/item/roach/roach_egg/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	if(istype(loc, /obj/item/organ/external)) // In case the egg is still inside an organ
 		var/obj/item/organ/external/O = loc
@@ -54,7 +54,7 @@
 
 	. = ..()
 
-/obj/item/weapon/roach/roach_egg/Process()
+/obj/item/roach/roach_egg/Process()
 	amount_grown += rand(0,2)
 	if(amount_grown >= 100)
 		var/obj/item/organ/external/O

--- a/code/game/objects/effects/roaches.dm
+++ b/code/game/objects/effects/roaches.dm
@@ -34,7 +34,7 @@
 
 /obj/item/roach/roach_egg
 	name = "roach egg"
-	desc = "A cockroach egg, can be eaten with proper preperation. It seems to pulse slightly with an inner life."
+	desc = "A cockroach egg, can be eaten with proper preparation. It seems to pulse slightly with an inner life."
 	icon_state = "roach_egg"
 	w_class = ITEM_SIZE_TINY
 	var/amount_grown = 0

--- a/code/game/objects/effects/roaches.dm
+++ b/code/game/objects/effects/roaches.dm
@@ -1,13 +1,13 @@
 //generic procs copied from obj/effect/alien
-/obj/effect/roach
+/obj/item/weapon/roach
 	name = "roach effect"
 	desc = "A cockroach effect."
 	icon = 'icons/effects/effects.dmi'
 	anchored = TRUE
 	density = FALSE
-	var/health = 5
+	health = 5
 
-/obj/effect/roach/attackby(var/obj/item/I, var/mob/user)
+/obj/item/weapon/roach/attackby(var/obj/item/I, var/mob/user)
 	if(I.attack_verb.len)
 		visible_message(SPAN_WARNING("\The [src] have been [pick(I.attack_verb)] with \the [I][(user ? " by [user]." : ".")]"))
 	else
@@ -16,36 +16,37 @@
 	health -= (I.force / 2)
 	healthcheck()
 
-/obj/effect/roach/bullet_act(var/obj/item/projectile/Proj)
+/obj/item/weapon/roach/bullet_act(var/obj/item/projectile/Proj)
 	..()
 	health -= Proj.get_structure_damage()
 	healthcheck()
 
-/obj/effect/roach/proc/healthcheck()
+/obj/item/weapon/roach/proc/healthcheck()
 	if(health <= 0)
 		visible_message(SPAN_WARNING("[src] is squished!"))
 		new /obj/effect/decal/cleanable/roach_egg_remains(loc)
 		qdel(src)
 
-/obj/effect/roach/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+/obj/item/weapon/roach/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature > 300 + T0C)
 		health -= 5
 		healthcheck()
 
-/obj/effect/roach/roach_egg
+/obj/item/weapon/roach/roach_egg
 	name = "roach egg"
-	desc = "A cockroach egg. It seems to pulse slightly with an inner life."
+	desc = "A cockroach egg, can be eaten with proper preperation. It seems to pulse slightly with an inner life."
 	icon_state = "roach_egg"
+	w_class = ITEM_SIZE_TINY
 	var/amount_grown = 0
 
-/obj/effect/roach/roach_egg/New(var/location, var/atom/parent)
+/obj/item/weapon/roach/roach_egg/New(var/location, var/atom/parent)
 	pixel_x = rand(3,-3)
 	pixel_y = rand(3,-3)
 	START_PROCESSING(SSobj, src)
 	get_light_and_color(parent)
 	..()
 
-/obj/effect/roach/roach_egg/Destroy()
+/obj/item/weapon/roach/roach_egg/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	if(istype(loc, /obj/item/organ/external)) // In case the egg is still inside an organ
 		var/obj/item/organ/external/O = loc
@@ -53,7 +54,7 @@
 
 	. = ..()
 
-/obj/effect/roach/roach_egg/Process()
+/obj/item/weapon/roach/roach_egg/Process()
 	amount_grown += rand(0,2)
 	if(amount_grown >= 100)
 		var/obj/item/organ/external/O

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -36,7 +36,7 @@ I said no!
 /datum/recipe/roachegg
 	reagents = list("water" = 5, "sodiumchloride" = 1)
 	items = list(
-		/obj/item/weapon/roach/roach_egg
+		/obj/item/roach/roach_egg
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/roach_egg
 

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -34,7 +34,7 @@ I said no!
 	result = /obj/item/weapon/reagent_containers/food/snacks/boiledegg
 
 /datum/recipe/roachegg
-	reagents = list("water" = 5, "sodiumchloride" = 1)
+	reagents = list("water" = 5)
 	items = list(
 		/obj/item/roach/roach_egg
 	)

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -33,6 +33,13 @@ I said no!
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/boiledegg
 
+/datum/recipe/roachegg
+	reagents = list("water" = 5, "sodiumchloride" = 1)
+	items = list(
+		/obj/item/weapon/roach/roach_egg
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/roach_egg
+
 /datum/recipe/jellydonut
 	reagents = list("berryjuice" = 5, "sugar" = 5)
 	items = list(

--- a/code/modules/mob/living/carbon/superior_animal/roach/life.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/life.dm
@@ -95,8 +95,8 @@
 					stop_automated_movement = 1
 					spawn(50)
 						if(busy == LAYING_EGG)
-							if(!(locate(/obj/item/weapon/roach/roach_egg) in get_turf(src)))
-								new /obj/item/weapon/roach/roach_egg(loc, src)
+							if(!(locate(/obj/item/roach/roach_egg) in get_turf(src)))
+								new /obj/item/roach/roach_egg(loc, src)
 								fed--
 								update_openspace()
 							busy = 0

--- a/code/modules/mob/living/carbon/superior_animal/roach/life.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/life.dm
@@ -95,8 +95,8 @@
 					stop_automated_movement = 1
 					spawn(50)
 						if(busy == LAYING_EGG)
-							if(!(locate(/obj/effect/roach/roach_egg) in get_turf(src)))
-								new /obj/effect/roach/roach_egg(loc, src)
+							if(!(locate(/obj/item/weapon/roach/roach_egg) in get_turf(src)))
+								new /obj/item/weapon/roach/roach_egg(loc, src)
 								fed--
 								update_openspace()
 							busy = 0

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1096,6 +1096,18 @@
 	cooked = TRUE
 	taste_tag = list(INSECTS_FOOD,MEAT_FOOD)
 
+/obj/item/weapon/reagent_containers/food/snacks/roach_egg
+	name = "Boiled Roach Egg"
+	desc = "A cockroach egg that has been boiled in salted water. It no longer pulses with an inner life."
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "roach_egg"
+	w_class = ITEM_SIZE_TINY
+	bitesize = 4
+	nutriment_amt = 8
+	preloaded_reagents = list("protein" = 14)
+	cooked = TRUE
+	taste_tag = list(INSECTS_FOOD,MEAT_FOOD)
+
 
 /obj/item/weapon/reagent_containers/food/snacks/omelette
 	name = "Omelette Du Fromage"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1097,7 +1097,7 @@
 	taste_tag = list(INSECTS_FOOD,MEAT_FOOD)
 
 /obj/item/weapon/reagent_containers/food/snacks/roach_egg
-	name = "Boiled Roach Egg"
+	name = "boiled roach egg"
 	desc = "A cockroach egg that has been boiled in salted water. It no longer pulses with an inner life."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "roach_egg"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the roach egg a item/weapon now, allowing it to be implanted, picked up and shoved in a microwave

also makes a new snack, a boiled roach egg

also makes the egg and the snack both tiny items, the latter for consistency, the former so you can implant more eggs in people


## Why It's Good For The Game

There was already code for the roach egg to be implanted into people which i believe is really fucking cool, as such this PR makes it possible by making the roach egg a item/weapon

the roach egg can now also be prepared into a highly nutritious and high in protein snack, for that maintenance food experience

## Changelog
:cl:
add: Added new snack, a boiled roach egg, 5 parts water, 1 roach egg. Shove it all into a microwave/fire barrel at max heat
tweak: roach egg is now a tiny sized item that can be picked up
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
