### PR TITLE
Barrel stays lit

### DIFF
--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -406,35 +406,60 @@
 	idle_power_usage = 0
 	active_power_usage = 0
 	dinger = FALSE
+	var/lit = FALSE
 
+/obj/machinery/microwave/campfire/verb/ToggleLight()
+	set name = "Toggle Fire"
+	set category = "Object"
+	set src in view(1)
+
+	if (!Adjacent(usr))
+		to_chat(usr, SPAN_WARNING("You need to be in arm's reach for that!"))
+		return
+
+	if (usr.incapacitated())
+		return
+
+	if(!lit)
+		playsound(loc, 'sound/effects/flare.ogg', 50, 1)
+		visible_message(SPAN_NOTICE("The fire is stoked up."), SPAN_NOTICE("You hear a crackling fire."))
+		icon_state = "barrelfire1"
+		set_light(3,2)
+		lit = TRUE
+	else
+		playsound(loc, 'sound/effects/flare.ogg', 50, 1)
+		icon_state = "barrelfire"
+		set_light(0)
+		lit = FALSE
 
 /obj/machinery/microwave/campfire/start()
 	..()
-	playsound(loc, 'sound/effects/flare.ogg', 50, 1)
-	//playsound(loc, 'sound/effects/campfirecrackle.ogg', 50, 1) // I don't  know how to loop stuff
-	visible_message(SPAN_NOTICE("The fire is stoked up."), SPAN_NOTICE("You hear a crackling fire."))
-	icon_state = "barrelfire1"
-	set_light(3,2)
+	if(!lit)
+		playsound(loc, 'sound/effects/flare.ogg', 50, 1)
+		//playsound(loc, 'sound/effects/campfirecrackle.ogg', 50, 1) // I don't  know how to loop stuff
+		visible_message(SPAN_NOTICE("The fire is stoked up."), SPAN_NOTICE("You hear a crackling fire."))
+		icon_state = "barrelfire1"
+		set_light(3,2)
+		lit = TRUE
+	else
+		playsound(loc, 'sound/effects/flare.ogg', 50, 1)
+		icon_state = "barrelfire1"
+		visible_message(SPAN_NOTICE("You hear a crackling fire."))
 
 /obj/machinery/microwave/campfire/abort()
 	..()
 	playsound(loc, 'sound/effects/flare.ogg', 50, 1)
-	icon_state = "barrelfire"
-	set_light(0)
-	
+	icon_state = "barrelfire1"	
 
 /obj/machinery/microwave/campfire/stop()
 	..()
 	playsound(loc, 'sound/effects/flare.ogg', 50, 1)
-	icon_state = "barrelfire"
-	set_light(0)
+	icon_state = "barrelfire1"
 	
-
 /obj/machinery/microwave/campfire/dispose()
 	..()
 	playsound(loc, 'sound/effects/flare.ogg', 50, 1)
-	icon_state = "barrelfire"
-	set_light(0)
+	icon_state = "barrelfire1"
 
 /obj/machinery/microwave/campfire/muck_start()
 	..()
@@ -444,4 +469,3 @@
 	..()
 	playsound(loc, 'sound/effects/flare.ogg', 50, 1)
 	icon_state = "barrelfire"
-	set_light(0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The burn barrel now stays lit unless you toggle it off.

## Why It's Good For The Game

Take a rest.

## Changelog
:cl:
add: Toggle to light barrel
tweak: barrel stays lit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
