### PR TITLE
Deepmaint hiveroom aka hive nest

### DIFF
--- a/maps/submaps/deepmaint_rooms/normal/hive_nest.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/hive_nest.dmm
@@ -32,7 +32,7 @@
 "R" = (/mob/living/simple_animal/hostile/hivemind/phaser,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
 "T" = (/mob/living/simple_animal/hostile/hivemind/lobber{malfunction_chance = 0},/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
 "V" = (/obj/structure/catwalk,/obj/spawner/pack/machine,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
-"W" = (/obj/structure/table/standard,/obj/structure/catwalk,/obj/item/weapon/reagent_containers/glass/beaker/hivemind,/obj/item/weapon/oddity/hivemind/old_pda,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"W" = (/obj/structure/table/standard,/obj/structure/catwalk,/obj/item/weapon/reagent_containers/glass/beaker/hivemind,/obj/spawner/oddities/low_chance,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
 "X" = (/obj/effect/window_lwall_spawn/smartspawn,/obj/structure/barricade,/turf/simulated/floor/plating/under,/area/deepmaint)
 "Y" = (/obj/item/trash/syndi_cakes,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
 "Z" = (/obj/structure/table/standard,/obj/structure/catwalk,/obj/spawner/soda,/obj/spawner/rations/low_chance,/obj/spawner/rations/low_chance,/obj/spawner/rations/low_chance,/obj/item/trash/tastybread,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)

--- a/maps/submaps/deepmaint_rooms/normal/hive_nest.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/hive_nest.dmm
@@ -1,0 +1,52 @@
+"d" = (/obj/structure/catwalk,/turf/simulated/floor/plating/under,/area/deepmaint)
+"e" = (/obj/item/weapon/material/shard/plasma{pixel_x = 5; pixel_y = 3},/obj/item/weapon/material/shard/plasma{pixel_x = -7; pixel_y = 8},/obj/item/stack/material/steel/random,/obj/effect/decal/cleanable/blood,/obj/machinery/door/blast/regular/open,/obj/item/trash/material/metal{pixel_x = -5; pixel_y = 2},/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"f" = (/obj/machinery/door/airlock/glass_science{name = "Nanite Research"},/obj/structure/barricade,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"h" = (/obj/item/weapon/material/shard/plasma{pixel_x = -5; pixel_y = 6},/obj/effect/decal/cleanable/blood/drip,/obj/item/trash/material/metal{pixel_x = 11; pixel_y = -3},/obj/machinery/door/blast/regular/open,/obj/item/trash/material/metal,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"j" = (/obj/structure/table/standard,/obj/structure/catwalk,/obj/item/device/lighting/toggleable/lamp,/obj/spawner/gun/normal,/obj/spawner/pack/rare/low_chance,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"l" = (/obj/structure/barricade,/obj/structure/low_wall,/turf/simulated/floor/plating/under,/area/deepmaint)
+"n" = (/obj/effect/window_lwall_spawn/smartspawnplasma,/obj/machinery/door/blast/regular,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"o" = (/mob/living/simple_animal/hostile/hivemind/mechiver{malfunction_chance = 0; name = "Test Subjet Beta-149"},/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"p" = (/obj/structure/table/standard,/obj/structure/catwalk,/obj/spawner/gun/shotgun/low_chance,/obj/item/device/lighting/toggleable/lamp,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"q" = (/obj/structure/catwalk,/obj/item/clothing/suit/storage/toggle/labcoat,/obj/item/clothing/shoes/reinforced/medical,/obj/structure/table/standard,/obj/spawner/gun/cheap/low_chance,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"s" = (/obj/structure/catwalk,/obj/structure/barricade,/turf/simulated/floor/plating/under,/area/deepmaint)
+"t" = (/obj/machinery/light/small{dir = 1},/obj/item/trash/sosjerky,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"u" = (/turf/simulated/wall,/area/deepmaint)
+"v" = (/obj/machinery/light/small{dir = 1},/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"w" = (/obj/structure/catwalk,/obj/item/clothing/suit/storage/toggle/labcoat,/obj/item/clothing/shoes/reinforced/medical,/obj/structure/table/standard,/obj/spawner/pizza,/obj/spawner/pack/rare/low_chance,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"x" = (/mob/living/simple_animal/hostile/hivemind{malfunction_chance = 0},/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"A" = (/obj/structure/table/standard,/obj/structure/catwalk,/obj/spawner/booze/low_chance,/obj/item/trash/cigbutt/cigarbutt,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"B" = (/obj/item/weapon/material/shard/plasma{pixel_y = -14},/obj/effect/decal/cleanable/blood/drip,/obj/machinery/door/blast/regular/open,/obj/item/trash/material/metal{pixel_x = 7; pixel_y = 12},/obj/item/trash/material/metal{pixel_x = -10; pixel_y = -6},/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"C" = (/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"D" = (/obj/machinery/light/small,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"E" = (/obj/structure/catwalk,/obj/item/weapon/material/shard/plasma{pixel_x = -5},/obj/item/stack/material/steel/random,/obj/effect/decal/cleanable/blood/drip,/obj/item/trash/material/metal{pixel_x = 13; pixel_y = -4},/obj/item/trash/material/metal{pixel_x = -6; pixel_y = 11},/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"F" = (/obj/structure/table/standard,/obj/structure/catwalk,/obj/item/weapon/reagent_containers/glass/beaker/hivemind,/obj/item/clothing/head/bio_hood/virology,/obj/item/clothing/suit/bio_suit/virology,/obj/item/clothing/shoes/reinforced/medical,/obj/spawner/firstaid/low_chance,/obj/spawner/medical,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"H" = (/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"J" = (/obj/structure/table/standard,/obj/structure/catwalk,/obj/spawner/gun_parts/low_chance,/obj/item/device/lighting/toggleable/lamp,/obj/spawner/pack/tech_loot/low_chance,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"K" = (/obj/machinery/light/small{dir = 8},/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"L" = (/mob/living/simple_animal/hostile/hivemind/hiborg{malfunction_chance = 0},/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"M" = (/obj/machinery/light/small{dir = 4},/obj/item/trash/mre_can,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"N" = (/obj/structure/table/standard,/obj/structure/catwalk,/obj/spawner/powercell,/obj/spawner/gun/energy_cheap/low_chance,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"O" = (/obj/spawner/pack/rare/low_chance,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"P" = (/obj/machinery/light/small{dir = 4},/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"Q" = (/mob/living/simple_animal/hostile/hivemind/himan{malfunction_chance = 0},/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"R" = (/mob/living/simple_animal/hostile/hivemind/phaser,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"T" = (/mob/living/simple_animal/hostile/hivemind/lobber{malfunction_chance = 0},/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"V" = (/obj/structure/catwalk,/obj/spawner/pack/machine,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"W" = (/obj/structure/table/standard,/obj/structure/catwalk,/obj/item/weapon/reagent_containers/glass/beaker/hivemind,/obj/item/weapon/oddity/hivemind/old_pda,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"X" = (/obj/effect/window_lwall_spawn/smartspawn,/obj/structure/barricade,/turf/simulated/floor/plating/under,/area/deepmaint)
+"Y" = (/obj/item/trash/syndi_cakes,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+"Z" = (/obj/structure/table/standard,/obj/structure/catwalk,/obj/spawner/soda,/obj/spawner/rations/low_chance,/obj/spawner/rations/low_chance,/obj/spawner/rations/low_chance,/obj/item/trash/tastybread,/turf/simulated/floor/tiled/steel/techfloor_grid,/area/deepmaint)
+
+(1,1,1) = {"
+ddsdddddddd
+duuXlfuXuud
+dXvHHHtRMus
+duHVVJwZYXd
+duKFnnnNHld
+dfTVhonVHfd
+dlCEeBnWPud
+suKjqAVpxud
+dXQHDLDOHus
+duulufuuXud
+dddddddddsd
+"}

--- a/maps/submaps/deepmaint_rooms/normal/normal_rooms.dm
+++ b/maps/submaps/deepmaint_rooms/normal/normal_rooms.dm
@@ -77,3 +77,8 @@
 	name = "sm_core"
 	desc = "sm_core"
 	mappath = 'maps/submaps/deepmaint_rooms/normal/sm_core.dmm'
+
+/datum/map_template/deepmaint_template/room/hive_nest
+	name = "hive_nest"
+	desc = "When a hive dies the machine die with it, but what about the little guys?"
+	mappath = 'maps/submaps/deepmaint_rooms/normal/hive_nest.dmm'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Another kneejerk PR
adds a normal sized deepmaint room with some loot and one of each hivemind mob (except bomber), along with a abnormal PDA and 2 hivemind beakers (so a total of 60 units of each nanite)
![image](https://user-images.githubusercontent.com/59490776/119240746-235de300-bb52-11eb-80fd-db37af962edd.png)
![image](https://user-images.githubusercontent.com/59490776/119240762-4092b180-bb52-11eb-8b3c-f8ffb1fc2ae8.png)



## Why It's Good For The Game

It's not

I believe this could spice up deepmaint a bit more, by having a new room with "new" enemies in it, while not having broken easy to gain loot within nor being bloat



## Changelog
:cl:
add: When the hive is destroyed all the machinery is destroyed aswell, what about the little guys? A group of hive mobs have been left behind deep within the ship.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
