### PR TITLE
changes bolt-action recoil to be more in-line with other .30 rifles

### DIFF
--- a/code/modules/projectiles/guns/projectile/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun.dm
@@ -14,7 +14,7 @@
 	fire_delay = 12 // double the standart
 	damage_multiplier = 1.4
 	penetration_multiplier = 1.5
-	recoil_buildup = 1.5
+	recoil_buildup = 1.6 // reduced from the AK's/Takeshi's buildup of 1.7/1.8 because >lol boltgun
 	handle_casings = HOLD_CASINGS
 	load_method = SINGLE_CASING|SPEEDLOADER
 	max_shells = 10
@@ -100,7 +100,7 @@
 	icon_state = "boltgun_wood"
 	item_suffix  = "_wood"
 	force = 23
-	recoil_buildup = 2
+	recoil_buildup = 1.7 // however, since it's not the excel mosin, it's not as good at recoil control, but it doesn't matter since >bolt
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_WOOD = 10)
 	wielded_item_state = "_doble_wood"
 	spawn_blacklisted = FALSE
@@ -118,7 +118,7 @@
 	fire_delay = 17 // abit more than the serbian one
 	damage_multiplier = 1
 	penetration_multiplier = 1
-	recoil_buildup = 2.5 // joonk gun probably doesn't handle recoil very well
+	recoil_buildup = 1.9 // joonk gun
 	max_shells = 5
 	fire_sound = 'sound/weapons/guns/fire/sniper_fire.ogg'
 	reload_sound = 'sound/weapons/guns/interact/rifle_load.ogg'

--- a/code/modules/projectiles/guns/projectile/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun.dm
@@ -14,7 +14,7 @@
 	fire_delay = 12 // double the standart
 	damage_multiplier = 1.4
 	penetration_multiplier = 1.5
-	recoil_buildup = 40 //same as AMR
+	recoil_buildup = 2
 	handle_casings = HOLD_CASINGS
 	load_method = SINGLE_CASING|SPEEDLOADER
 	max_shells = 10
@@ -100,7 +100,7 @@
 	icon_state = "boltgun_wood"
 	item_suffix  = "_wood"
 	force = 23
-	recoil_buildup = 0.4 // Double the excel variant
+	recoil_buildup = 4 // higher than excel variant though not too much?
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_WOOD = 10)
 	wielded_item_state = "_doble_wood"
 	spawn_blacklisted = FALSE
@@ -118,7 +118,7 @@
 	fire_delay = 17 // abit more than the serbian one
 	damage_multiplier = 1
 	penetration_multiplier = 1
-	recoil_buildup = 40 //same as AMR
+	recoil_buildup = 5 // joonk gun probably doesn't handle recoil very well
 	max_shells = 5
 	fire_sound = 'sound/weapons/guns/fire/sniper_fire.ogg'
 	reload_sound = 'sound/weapons/guns/interact/rifle_load.ogg'

--- a/code/modules/projectiles/guns/projectile/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun.dm
@@ -14,7 +14,7 @@
 	fire_delay = 12 // double the standart
 	damage_multiplier = 1.4
 	penetration_multiplier = 1.5
-	recoil_buildup = 2
+	recoil_buildup = 1.5
 	handle_casings = HOLD_CASINGS
 	load_method = SINGLE_CASING|SPEEDLOADER
 	max_shells = 10
@@ -100,7 +100,7 @@
 	icon_state = "boltgun_wood"
 	item_suffix  = "_wood"
 	force = 23
-	recoil_buildup = 4 // higher than excel variant though not too much?
+	recoil_buildup = 2
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_WOOD = 10)
 	wielded_item_state = "_doble_wood"
 	spawn_blacklisted = FALSE
@@ -108,7 +108,7 @@
 
 /obj/item/weapon/gun/projectile/boltgun/handmade
 	name = "handmade bolt action rifle"
-	desc = "A handmade bolt action rifle, made from junk. and some spare parts."
+	desc = "A handmade bolt action rifle, made from junk and some spare parts."
 	icon_state = "boltgun_hand"
 	item_suffix = "_hand"
 	matter = list(MATERIAL_STEEL = 10, MATERIAL_PLASTIC = 5)
@@ -118,7 +118,7 @@
 	fire_delay = 17 // abit more than the serbian one
 	damage_multiplier = 1
 	penetration_multiplier = 1
-	recoil_buildup = 5 // joonk gun probably doesn't handle recoil very well
+	recoil_buildup = 2.5 // joonk gun probably doesn't handle recoil very well
 	max_shells = 5
 	fire_sound = 'sound/weapons/guns/fire/sniper_fire.ogg'
 	reload_sound = 'sound/weapons/guns/interact/rifle_load.ogg'


### PR DESCRIPTION
## About The Pull Request
changes recoil around for the bolt-action guns:
excel mosin recoil_buildup from **40!!** -> 1.6
novakovic recoil buildup from 0.4 -> 1.7
handmade joonk boltaction from **40!!** -> 1.9

## Why It's Good For The Game
two bolt-actions with silly recoil buildups is a silly concept.

recoil is a scuffed system but these numbers really don't matter unless you reduce the fire delay on these bitches with the dangerzone/forged barrel

## Changelog
:cl:
balance: bolt-actions' recoil has been made a little more in-line with other .30 firing rifles
/:cl: