### PR TITLE
Fixes people being able to put hardsuits inside themselves

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/storage.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/storage.dm
@@ -12,10 +12,10 @@
 	rarity_value = 2
 	spawn_tags = SPAWN_TAG_RIG_MODULE_COMMON
 	//These vars will be passed onto the storage
-	var/list/can_hold = new/list() //List of objects which this item can store (if set, it can't store anything else)
-	var/list/cant_hold = new/list(/obj/item/weapon/rig) //List of objects which this item can't store (in effect only if can_hold isn't set)
+	var/list/can_hold = list() //List of objects which this item can store (if set, it can't store anything else)
+	var/list/cant_hold = list(/obj/item/weapon/rig) //List of objects which this item can't store (in effect only if can_hold isn't set)
 	var/max_w_class = ITEM_SIZE_BULKY //Max size of objects that this object can store (in effect only if can_hold isn't set)
-	var/max_storage_space = 24 //This is a entire satchel of storage
+	var/max_storage_space = DEFAULT_HUGE_STORAGE * 0.7 //This is a entire satchel of storage 
 	var/storage_slots = null //The number of storage slots in this container.
 
 //Create the internal storage and pass on various parameters


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes people being able to alt-click and thus put rigs inside themselves

## Why It's Good For The Game

Its better than having this create a bluespace explosion whenever happens, also doesnțt let people delete items that shouldnțt be deleted.
## Changelog
:cl:
fix: Fixed being able to put RIGS inside Themselves , causing them to disspear.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
