### PR TITLE
replaces tuxedo, payday 2 masks etc. with 4 "crates" (in the maint vendor of course)

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1528,13 +1528,10 @@
 					/obj/item/weapon/gun/projectile/automatic/z8 = 4,
 					/obj/item/weapon/gun/projectile/automatic/molly = 4,
 					/obj/item/weapon/gun/projectile/shotgun/pump/gladstone = 4,
-					/obj/item/clothing/mask/thief = 2,
-					/obj/item/clothing/mask/thief/wolf = 2,
-					/obj/item/clothing/mask/thief/hoxton = 2,
-					/obj/item/clothing/mask/thief/chains = 2,
-					/obj/item/clothing/under/tuxedo = 8,
-					/obj/item/weapon/storage/backpack/duffelbag/loot = 8,
-					/obj/item/clothing/gloves/latex/nitrile = 8
+					/obj/item/weapon/storage/deferred/crate/clown_crime = 2,
+					/obj/item/weapon/storage/deferred/crate/clown_crime/drillman = 2,
+					/obj/item/weapon/storage/deferred/crate/clown_crime/whatcocksuckingmotherfuckermeasuredthec4 = 2,
+					/obj/item/weapon/storage/deferred/crate/clown_crime/literallywho = 2
 					)
 	contraband = list(/obj/item/weapon/gun/projectile/mandella = 4,/obj/item/ammo_magazine/cspistol = 12)
 	prices = list(
@@ -1554,13 +1551,10 @@
 					/obj/item/weapon/gun/projectile/automatic/z8 = 3500,
 					/obj/item/weapon/gun/projectile/automatic/molly = 2000,
 					/obj/item/weapon/gun/projectile/shotgun/pump/gladstone = 2200,
-					/obj/item/clothing/mask/thief = 150,
-					/obj/item/clothing/mask/thief/wolf = 150,
-					/obj/item/clothing/mask/thief/hoxton = 150,
-					/obj/item/clothing/mask/thief/chains = 150,
-					/obj/item/clothing/under/tuxedo = 300,
-					/obj/item/weapon/storage/backpack/duffelbag/loot = 200,
-					/obj/item/clothing/gloves/latex/nitrile = 50
+					/obj/item/weapon/storage/deferred/crate/clown_crime = 1800,
+					/obj/item/weapon/storage/deferred/crate/clown_crime/drillman = 1800,
+					/obj/item/weapon/storage/deferred/crate/clown_crime/whatcocksuckingmotherfuckermeasuredthec4 = 1800,
+					/obj/item/weapon/storage/deferred/crate/clown_crime/literallywho = 1800
 					)
 	idle_power_usage = 211
 	vendor_department = DEPARTMENT_CIVILIAN

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1529,9 +1529,9 @@
 					/obj/item/weapon/gun/projectile/automatic/molly = 4,
 					/obj/item/weapon/gun/projectile/shotgun/pump/gladstone = 4,
 					/obj/item/weapon/storage/deferred/crate/clown_crime = 2,
-					/obj/item/weapon/storage/deferred/crate/clown_crime/drillman = 2,
-					/obj/item/weapon/storage/deferred/crate/clown_crime/whatcocksuckingmotherfuckermeasuredthec4 = 2,
-					/obj/item/weapon/storage/deferred/crate/clown_crime/literallywho = 2
+					/obj/item/weapon/storage/deferred/crate/clown_crime/wolf = 2,
+					/obj/item/weapon/storage/deferred/crate/clown_crime/hoxton = 2,
+					/obj/item/weapon/storage/deferred/crate/clown_crime/chains = 2
 					)
 	contraband = list(/obj/item/weapon/gun/projectile/mandella = 4,/obj/item/ammo_magazine/cspistol = 12)
 	prices = list(
@@ -1552,9 +1552,9 @@
 					/obj/item/weapon/gun/projectile/automatic/molly = 2000,
 					/obj/item/weapon/gun/projectile/shotgun/pump/gladstone = 2200,
 					/obj/item/weapon/storage/deferred/crate/clown_crime = 1800,
-					/obj/item/weapon/storage/deferred/crate/clown_crime/drillman = 1800,
-					/obj/item/weapon/storage/deferred/crate/clown_crime/whatcocksuckingmotherfuckermeasuredthec4 = 1800,
-					/obj/item/weapon/storage/deferred/crate/clown_crime/literallywho = 1800
+					/obj/item/weapon/storage/deferred/crate/clown_crime/wolf = 1800,
+					/obj/item/weapon/storage/deferred/crate/clown_crime/hoxton = 1800,
+					/obj/item/weapon/storage/deferred/crate/clown_crime/chains = 1800
 					)
 	idle_power_usage = 211
 	vendor_department = DEPARTMENT_CIVILIAN

--- a/code/game/objects/items/weapons/storage/deferred.dm
+++ b/code/game/objects/items/weapons/storage/deferred.dm
@@ -318,3 +318,50 @@
 	/obj/item/clothing/suit/armor/greatcoat/german_overcoat = 1,
 	/obj/item/clothing/under/germansuit = 1)
 
+/obj/item/weapon/storage/deferred/crate/clown_crime
+	name = "mastermind suit bag"
+	desc = "A duffelbag filled with clothing and... a second duffelbag?."
+	icon = 'icons/obj/storage/backpack.dmi'
+	icon_state = "lootbag"
+	spawn_blacklisted = TRUE
+	initial_contents = list(
+	/obj/item/clothing/mask/thief = 1,
+	/obj/item/weapon/storage/belt/tactical = 1,
+	/obj/item/weapon/storage/backpack/duffelbag/loot = 1,
+	/obj/item/clothing/under/tuxedo = 1,
+	/obj/item/clothing/shoes/reinforced = 1,
+	/obj/item/clothing/gloves/latex/nitrile = 1,
+	/obj/item/clothing/suit/armor/vest = 1)
+
+/obj/item/weapon/storage/deferred/crate/clown_crime/drillman
+	name = "technician suit bag"
+	initial_contents = list(
+	/obj/item/clothing/mask/thief/wolf = 1,
+	/obj/item/weapon/storage/belt/tactical = 1,
+	/obj/item/weapon/storage/backpack/duffelbag/loot = 1,
+	/obj/item/clothing/under/tuxedo = 1,
+	/obj/item/clothing/shoes/reinforced = 1,
+	/obj/item/clothing/gloves/latex/nitrile = 1,
+	/obj/item/clothing/suit/armor/vest = 1)
+
+/obj/item/weapon/storage/deferred/crate/clown_crime/whatcocksuckingmotherfuckermeasuredthec4	//https://www.youtube.com/watch?v=Hmp1da7pXTw&t=160s
+	name = "fugitive suit bag"
+	initial_contents = list(
+	/obj/item/clothing/mask/thief/hoxton = 1,
+	/obj/item/weapon/storage/belt/tactical = 1,
+	/obj/item/weapon/storage/backpack/duffelbag/loot = 1,
+	/obj/item/clothing/under/tuxedo = 1,
+	/obj/item/clothing/shoes/reinforced = 1,
+	/obj/item/clothing/gloves/latex/nitrile = 1,
+	/obj/item/clothing/suit/armor/vest = 1)
+
+/obj/item/weapon/storage/deferred/crate/clown_crime/literallywho
+	name = "enforcer suit bag"
+	initial_contents = list(
+	/obj/item/clothing/mask/thief/chains = 1,
+	/obj/item/weapon/storage/belt/tactical = 1,
+	/obj/item/weapon/storage/backpack/duffelbag/loot = 1,
+	/obj/item/clothing/under/tuxedo = 1,
+	/obj/item/clothing/shoes/reinforced = 1,
+	/obj/item/clothing/gloves/latex/nitrile = 1,
+	/obj/item/clothing/suit/armor/vest = 1)

--- a/code/game/objects/items/weapons/storage/deferred.dm
+++ b/code/game/objects/items/weapons/storage/deferred.dm
@@ -333,7 +333,7 @@
 	/obj/item/clothing/gloves/latex/nitrile = 1,
 	/obj/item/clothing/suit/armor/vest = 1)
 
-/obj/item/weapon/storage/deferred/crate/clown_crime/drillman
+/obj/item/weapon/storage/deferred/crate/clown_crime/wolf
 	name = "technician suit bag"
 	initial_contents = list(
 	/obj/item/clothing/mask/thief/wolf = 1,
@@ -344,7 +344,7 @@
 	/obj/item/clothing/gloves/latex/nitrile = 1,
 	/obj/item/clothing/suit/armor/vest = 1)
 
-/obj/item/weapon/storage/deferred/crate/clown_crime/whatcocksuckingmotherfuckermeasuredthec4	//https://www.youtube.com/watch?v=Hmp1da7pXTw&t=160s
+/obj/item/weapon/storage/deferred/crate/clown_crime/hoxton	//whatcocksuckingmotherfuckermeasuredthec4 https://www.youtube.com/watch?v=Hmp1da7pXTw&t=160s
 	name = "fugitive suit bag"
 	initial_contents = list(
 	/obj/item/clothing/mask/thief/hoxton = 1,
@@ -355,7 +355,7 @@
 	/obj/item/clothing/gloves/latex/nitrile = 1,
 	/obj/item/clothing/suit/armor/vest = 1)
 
-/obj/item/weapon/storage/deferred/crate/clown_crime/literallywho
+/obj/item/weapon/storage/deferred/crate/clown_crime/chains
 	name = "enforcer suit bag"
 	initial_contents = list(
 	/obj/item/clothing/mask/thief/chains = 1,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title, replaces the tuxedo, gloves, masks etc. with 4 crates (each having a different mask) that have the mask, tuxedo, gloves, the speshul dufflebag, basic armour, reinforced shoes and a tactical belt
![image](https://user-images.githubusercontent.com/59490776/119276545-122cd900-bc1b-11eb-8792-af3c5e0eef56.png)
![image](https://user-images.githubusercontent.com/59490776/119276548-1527c980-bc1b-11eb-8bb4-b980f42f24d2.png)
![image](https://user-images.githubusercontent.com/59490776/119276551-16f18d00-bc1b-11eb-9243-8446fcccbdfd.png)
![image](https://user-images.githubusercontent.com/59490776/119276556-1953e700-bc1b-11eb-8d5f-138b8e1a77cf.png)

## Why It's Good For The Game

It's not

Requested by Not rosalimo from eris and because of my own spite for players
![image](https://user-images.githubusercontent.com/59490776/119276619-6a63db00-bc1b-11eb-87fc-52666f53af04.png)

makes it so the players have to spend a fair amount of money to get the (un)funny reference masks


## Changelog
:cl:
add:  Replaced clothing in bill's vendor with 4 crates filled with clown accesories
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
