### PR TITLE
offering rituals now increase the energy of the EOTP

### DIFF
--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -27,7 +27,7 @@ var/list/disciples = list()
 	true_power_regen += max(round(wearer.stats.getStat(STAT_COG) / 4), 0) * (1 / (1 MINUTES))
 	true_power_regen += power_regen * 1.5 * righteous_life / max_righteous_life
 	if(wearer && wearer.stats?.getPerk(/datum/perk/channeling))
-		true_power_regen += power_regen * disciples.len / 2.5  // Proportional to the number of cruciformed people on board
+		true_power_regen += power_regen * disciples.len / 5 // Proportional to the number of cruciformed people on board
 
 	restore_power(true_power_regen)
 

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -259,9 +259,10 @@
 	category = "Offerings"
 	success_message = "Your prayers have been heard."
 	fail_message = "Your prayers have not been answered."
-	power = 10
+	power = 15
 	var/list/req_offerings = list()
 	var/list/miracles = list(ARMAMENTS, ALERT, INSPIRATION, ODDITY, STAT_BUFF, MATERIAL_REWARD)
+	var/reward_power = 5
 
 /datum/ritual/cruciform/priest/offering/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C, targets)
 	var/list/OBJS = get_front(H)
@@ -282,6 +283,7 @@
 		return FALSE
 
 	EOTP.current_rewards = miracles
+	EOTP.power += reward_power
 	return TRUE
 
 /datum/ritual/cruciform/priest/offering/proc/make_offerings(list/offerings)
@@ -356,6 +358,7 @@
 	desc = "Increase an oddity's stats by a certain amount but reduce yours by half of that amount."
 	success_message = "Your oddity has been blessed."
 	fail_message = "You feel cold in your active hand."
+	power = 30
 	var/list/odditys = list()
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this makes several changes so that NT has more control over which miracles happen and how frequent they are, to avoid their abuse, the preachers regenerate a little less energy. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It gives NT a little more control over its mechanics.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: offering rituals now increase the energy of the EOTP
tweak: increases the energy cost of offering rituals
tweak: reduces the energy regeneration of the preachers.
tweak: the divine blessing ritual now costs energy.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
