### PR TITLE
Gives moebius maint access

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -75,7 +75,7 @@ Your second loyalty is to your career with Moebius corp, and to your coworkers i
 	outfit_type = /decl/hierarchy/outfit/job/medical/doctor
 
 	access = list(
-		access_moebius, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology,
+		access_moebius, access_medical_equip, access_maint_tunnels, access_morgue, access_surgery, access_chemistry, access_virology,
 		access_genetics
 	)
 
@@ -136,7 +136,7 @@ Your second loyalty is to your career with Moebius corp, and to your coworkers i
 	outfit_type = /decl/hierarchy/outfit/job/medical/chemist
 
 	access = list(
-		access_moebius, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology
+		access_moebius, access_medical_equip, access_maint_tunnels, access_morgue, access_surgery, access_chemistry, access_virology
 	)
 
 	stat_modifiers = list(

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -20,7 +20,7 @@
 		access_tox_storage, access_teleporter, access_sec_doors,
 		access_moebius, access_medical_equip, access_chemistry, access_virology, access_cmo, access_surgery, access_psychiatrist,
 		access_robotics, access_xenobiology, access_ai_upload, access_tech_storage, access_eva, access_external_airlocks,
-		access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network, access_research_equipment,
+		access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network, access_maint_tunnels, access_research_equipment,
 		access_change_research
 	)
 	ideal_character_age = 50
@@ -77,7 +77,7 @@ Your second loyalty is to moebius corp. In order to ensure it can continue its m
 	software_on_spawn = list(/datum/computer_file/program/signaller, /datum/computer_file/program/chem_catalog)
 
 	access = list(
-		access_robotics, access_tox, access_tox_storage, access_moebius, access_xenobiology, access_xenoarch, access_research_equipment,
+		access_robotics, access_tox, access_tox_storage, access_moebius, access_maint_tunnels, access_xenobiology, access_xenoarch, access_research_equipment,
 		access_genetics
 	)
 
@@ -134,7 +134,7 @@ Your second loyalty is to moebius corp. In order to ensure it can continue its m
 	outfit_type = /decl/hierarchy/outfit/job/science/roboticist
 
 	access = list(
-		access_robotics, access_tox, access_tox_storage, access_morgue, access_moebius, access_research_equipment
+		access_robotics, access_tox, access_maint_tunnels, access_tox_storage, access_morgue, access_moebius, access_research_equipment
 	) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 
 	software_on_spawn = list(/datum/computer_file/program/chem_catalog)


### PR DESCRIPTION
## About The Pull Request

Gives all moebius roles maintenance access.

## Why It's Good For The Game

Everyone else on the ship has maintenance access, and recent PRs have added it to most of the ones that didn't. I feel its about time moebius received this treatment as well. Given they can already get it quite easily, I don't feel this is a problem and see no reason to withhold it from them.

## Changelog
:cl:
add: Added maintenance access to all moebius roles.
/:cl: