### PR TITLE
NT Tweaks

### DIFF
--- a/code/game/objects/items/weapons/design_disks/NeoTheology.dm
+++ b/code/game/objects/items/weapons/design_disks/NeoTheology.dm
@@ -273,7 +273,7 @@
 	spawn_blacklisted = FALSE
 	designs = list(
 		/datum/design/autolathe/gun/taser = 3, // "NT SP \"Counselor\""
-		/datum/design/autolathe/cell/medium/high,
+		/datum/design/autolathe/cell/medium/high
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_svalinn

--- a/code/game/objects/items/weapons/design_disks/NeoTheology.dm
+++ b/code/game/objects/items/weapons/design_disks/NeoTheology.dm
@@ -205,7 +205,7 @@
 		/datum/design/autolathe/nt/grenade/nt_smokebomb
 	)
 
-/obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/grenades
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/explosivegrenades
 	disk_name = "NeoTheology Armory - High Explosive Pack"
 	icon_state = "neotheology"
 	license = 2

--- a/code/game/objects/items/weapons/design_disks/NeoTheology.dm
+++ b/code/game/objects/items/weapons/design_disks/NeoTheology.dm
@@ -206,7 +206,7 @@
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/explosivegrenades
-	disk_name = "NeoTheology Armory - High Explosive Pack"
+	disk_name = "NeoTheology Armory - High Explosives Pack"
 	icon_state = "neotheology"
 	license = 2
 	designs = list(

--- a/code/game/objects/items/weapons/design_disks/NeoTheology.dm
+++ b/code/game/objects/items/weapons/design_disks/NeoTheology.dm
@@ -270,7 +270,7 @@
 	spawn_tags = SPAWN_TAG_DESIGN_ADVANCED
 	rarity_value = 17
 	license = 12
-	spawn_blacklisted = TRUE
+	spawn_blacklisted = FALSE
 	designs = list(
 		/datum/design/autolathe/gun/taser = 3, // "NT SP \"Counselor\""
 		/datum/design/autolathe/cell/medium/high,

--- a/code/game/objects/items/weapons/design_disks/NeoTheology.dm
+++ b/code/game/objects/items/weapons/design_disks/NeoTheology.dm
@@ -122,16 +122,11 @@
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/crusader
-	disk_name = "NeoTheology Armory - Crusader Armor"
+	disk_name = "NeoTheology Armory - Neotheology Armor and Voidsuits"
 	icon_state = "neotheology"
 	designs = list(
 		/datum/design/autolathe/nt/helmet/crusader,
-		/datum/design/autolathe/nt/armor/crusader
-	)
-/obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/void
-	disk_name = "NeoTheology Armory - Neotheology Voidsuit"
-	icon_state = "neotheology"
-	designs = list(
+		/datum/design/autolathe/nt/armor/crusader,
 		/datum/design/autolathe/clothing/NTvoid
 	)
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/excruciator
@@ -159,43 +154,16 @@
 		/datum/design/autolathe/nt/tool_upgrade/sanctifier
 	)
 
-/obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/longsword
-	disk_name = "NeoTheology Armory - NT Longsword"
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/advancedmelee
+	disk_name = "NeoTheology Armory - Advanced Melee Weapons"
 	icon_state = "neotheology"
 	designs = list(
+		/datum/design/bioprinter/storage/sheath,
+		/datum/design/autolathe/nt/tool_upgrade/sanctifier,
 		/datum/design/autolathe/nt/sword/nt_longsword,
-		/datum/design/bioprinter/storage/sheath,
-		/datum/design/autolathe/nt/tool_upgrade/sanctifier
-	)
-
-/obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/scourge
-	disk_name = "NeoTheology Armory - NT Scourge"
-	icon_state = "neotheology"
-	designs = list(
 		/datum/design/autolathe/nt/sword/nt_scourge,
-		/datum/design/bioprinter/storage/sheath,
-		/datum/design/autolathe/nt/tool_upgrade/sanctifier
-	)
-
-/obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/halberd
-	disk_name = "NeoTheology Armory - NT Halberd"
-	icon_state = "neotheology"
-	designs = list(
 		/datum/design/autolathe/nt/sword/nt_halberd,
-		/datum/design/bioprinter/storage/sheath,
-		/datum/design/autolathe/nt/tool_upgrade/sanctifier
-	)
-
-/obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/shield
-	disk_name = "NeoTheology Armory - NT Shield"
-	icon_state = "neotheology"
-	spawn_blacklisted = TRUE
-	designs = list(
-		/datum/design/autolathe/nt/sword/nt_sword,
-		/datum/design/autolathe/nt/sword/nt_dagger,
-		/datum/design/autolathe/nt/shield/nt_shield,
-		/datum/design/bioprinter/storage/sheath,
-		/datum/design/autolathe/nt/tool_upgrade/sanctifier
+		/datum/design/autolathe/nt/shield/nt_shield
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/firstaid
@@ -205,12 +173,13 @@
 		/datum/design/autolathe/firstaid/nt
 	)
 
-/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_dominion
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/guns/nt_dominion
 	disk_name = "NeoTheology Armory - Dominion Plasma Rifle"
 	icon_state = "neotheology"
 	spawn_tags = SPAWN_TAG_DESIGN_ADVANCED
 	rarity_value = 50
 	license = 12
+	spawn_blacklisted = FALSE
 	designs = list(
 		/datum/design/autolathe/gun/plasma/dominion = 3, //"NT PR \"Dominion\""
 		/datum/design/autolathe/cell/medium/high,
@@ -231,10 +200,17 @@
 	disk_name = "NeoTheology Armory - Grenades Pack"
 	icon_state = "neotheology"
 	designs = list(
-		/datum/design/autolathe/nt/grenade/nt_explosive,
 		/datum/design/autolathe/nt/grenade/nt_flashbang,
 		/datum/design/autolathe/nt/grenade/nt_frag,
 		/datum/design/autolathe/nt/grenade/nt_smokebomb
+	)
+
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/nt/grenades
+	disk_name = "NeoTheology Armory - High Explosive Pack"
+	icon_state = "neotheology"
+	license = 2
+	designs = list(
+		/datum/design/autolathe/nt/grenade/nt_explosive
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_nemesis
@@ -288,12 +264,13 @@
 		/datum/design/autolathe/cell/medium/high,
 	)
 
-/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt_counselor
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/nt/nt_counselor
 	disk_name = "NeoTheology Armory - Councelor PDW E"
 	icon_state = "neotheology"
 	spawn_tags = SPAWN_TAG_DESIGN_ADVANCED
 	rarity_value = 17
 	license = 12
+	spawn_blacklisted = TRUE
 	designs = list(
 		/datum/design/autolathe/gun/taser = 3, // "NT SP \"Counselor\""
 		/datum/design/autolathe/cell/medium/high,

--- a/code/game/objects/items/weapons/grenades/explosive.dm
+++ b/code/game/objects/items/weapons/grenades/explosive.dm
@@ -28,6 +28,6 @@
 	desc = "There's an inscription along the bands. \'And the Lord spake, saying: First shalt thou take out the Holy Pin. Then, shalt thou count to three, no more, no less. Three shall be the number thou shalt count, and the number of the counting shall be three. Four shalt thou not count, nor either count thou two, excepting that thou then proceed to three. Five is right out! Once the number three, being the third number, be reached, then lobbest thou thy Holy Hand Grenade of Antioch towards thou foe, who being naughty in my sight, shall snuff it.\'"
 	icon_state = "explosive_nt"
 	item_state = "explosive_nt"
-	heavy_range = 1.5
+	heavy_range = 1
 	weak_range = 5
 	matter = list(MATERIAL_BIOMATTER = 100)

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -103,7 +103,7 @@
 	icon_state = "nt_shield"
 	item_state = "nt_shield"
 	force = WEAPON_FORCE_DANGEROUS
-	armor = list(melee = 20, bullet = 30, energy = 30, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 20, bullet = 20, energy = 20, bomb = 0, bio = 0, rad = 0)
 	matter = list(MATERIAL_BIOMATTER = 25, MATERIAL_STEEL = 5, MATERIAL_PLASTEEL = 2)
 	aspects = list(SANCTIFIED)
 	spawn_blacklisted = TRUE

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -507,13 +507,13 @@
 	desc = "God will protect those who defend his faith."
 	icon_state = "crusader_suit"
 	item_state = "crusader_suit"
-	slowdown = 0.3
+	slowdown = 0.15
 	matter = list(MATERIAL_BIOMATTER = 25, MATERIAL_PLASTEEL = 10, MATERIAL_STEEL = 15, MATERIAL_GOLD = 2)
 	armor = list(
-		melee = 70,
+		melee = 50,
 		bullet = 50,
 		energy = 50,
-		bomb = 30,
+		bomb = 25,
 		bio = 0,
 		rad = 0
 	)


### PR DESCRIPTION
## About The Pull Request

Adds Dominion and Counselor disks to EOTP
Merges all EOTP melee drops into the "advanced melee disk"
Merges crusader and void disks into "neotheology armor and voidsuits"
Nerfs crusader armor and NT shield slightly
Removed explosive grenade disk from grenade pack, made it its own pack with a limit of two grenades.

## Why It's Good For The Game

Aight so let me just take this in segments.

disk merges: The EOTP disk options aren't all terrible, but somewhat oversaturated with melee disks. Having melee is nice, but NT doesn't need to be this diluted with weapon disks. As for the crusader and voidsuit merge, I was originally against this, but after thinking it over I felt it was a good change, as getting a rather unimpressive voidsuit from your EOTP is rather lame.

disk additions: The EOTP felt like it was missing some firepower, so I added the dominion, a decent laser weapon, and the counselor, an effective non-lethal sidearm. They are decent NT weapons and I feel they will be a good addition to the game.

Nerfs to crusader armor and NT shield: I felt I could justifiably nerf the shield since it was made a part of the melee kit, and I felt the protection values were too high on it. It is now the same as a regular riot shield. As for the crusader armor, it was just powercreeped heavy traitor armor which was unnecessary, so I reduced it. It now has the same stats as the heavy armor.

NT explosive nade disk change: I'm going to be honest, I almost went with deleting this. These are very expensive traitor weapons that not even IH can access, giving it to NT in an unlimited disk, even with slow printing, felt wrong, especially since these were powercreeped ones with larger radius. However, I decided it would be more interesting to make them their own disk, with a limit of two. They still have a larger radius than a regular HE, making them more likely to hit, but they are also more limited.

All in all, these changes should make the EOTP drops more meaningful, while still preserving balance.

## Changelog
:cl:
add: added the dominion and counselor to the EOTP spawn pool.
tweak: The explosive disk was removed from the NT grenade pack. It was moved into its own grenade pack, with a limit of two grenades.
tweak: tweaked the EOTP disks. The crusader and voidsuit disk were merged together into the armor and voidsuit disk, and all melee disks and the shield disk from the EOTP were merged into the advanced melee disk.
balance: nerfed the crusader armor's melee and bomb armor slightly, decreased its slowdown, and nerfed NT shield slightly.
/:cl: