### PR TITLE
fixes helm null.check_link runtime on starting server with overmap disabled

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -20,7 +20,7 @@
 	new /obj/effect/overmap_event/movable/comet()
 
 	if (isnull(linked))
-		world.log << "There are no map_sectors on [src]'s z."
+		error("There are no map_sectors on [src]'s z.")
 		return
 	linked.check_link()
 

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -19,6 +19,9 @@
 	get_known_sectors()
 	new /obj/effect/overmap_event/movable/comet()
 
+	if (isnull(linked))
+		world.log << "There are no map_sectors on [src]'s z."
+		return
 	linked.check_link()
 
 /obj/machinery/computer/helm/proc/get_known_sectors()


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This code checks for whether linked is null, and if so calls the error proc with relevant info and returns from the helm's Initialize proc.
The Initialize proc before this change would call linked.check_link(), which as linked would be null, runtimed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
runtime bad, this one interrupts launching a local when runtime breakpoints are enabled.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Chickenish
fix: fixes helm runtime on starting server with overmap disabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
