### PR TITLE
Splicings no longer get stuck in a state of being used

### DIFF
--- a/code/game/objects/structures/wire_splicing.dm
+++ b/code/game/objects/structures/wire_splicing.dm
@@ -119,11 +119,11 @@
 		if(used_now)
 			to_chat(user, "The [src.name] is already being manipulated!") //so people with low stats can't spam their way past the failure chance
 			return
-		used_now = TRUE
 		if(messiness >= 10)
 			messiness = 10
 			to_chat(user, SPAN_WARNING("Enough."))
 			return
+		used_now = TRUE
 		// keep goin!
 		var/obj/item/stack/cable_coil/coil = I
 		if(coil.get_amount() >= 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Presently, adding wires to a wire splicing past the 10th will set used_now to true, then give an error message and return, leaving used_now set to true for eternity, causing it to be forever uninteractable.
Now, we don't set used_now until after we've checked we're actually able to add cables.

## Why It's Good For The Game

Unremovable wire splicings seem like a pretty nasty bug that could potentially be abused.

## Changelog
:cl:
fix: Wire splicings no longer get stuck in a state of being used if you attempt to add wires past the max.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->