### PR TITLE
Erismed 3 Knockout time nerf and self surgery buff

### DIFF
--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -129,7 +129,7 @@
 		enter_hard_crit()
 
 /mob/living/carbon/human/proc/enter_hard_crit()
-	var/knockout_time = rand(2 MINUTES, 3 MINUTES)
+	var/knockout_time = 90 SECONDS
 	to_chat(src, SPAN_DANGER("[pick("You are knocked out", "You can't feel anything anymore", "You just can't keep going anymore")]!"))
 	visible_message(SPAN_DANGER("[src] [species.knockout_message]"))
 	Weaken(knockout_time)

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -60,7 +60,7 @@ mob/living/carbon/human/proc/custom_pain(message, flash_strength)
 	if(species.flags & NO_PAIN)
 		return
 
-	if(analgesic >= 100)
+	if(analgesic >= 75)
 		return
 	else if(analgesic >= 40)
 		flash_strength -= 1
@@ -84,7 +84,7 @@ mob/living/carbon/human/proc/handle_pain()
 
 	if(stat >= DEAD)
 		return
-	if(analgesic > 50)
+	if(analgesic >= 50)
 		return
 	var/maxdam = 0
 	var/obj/item/organ/external/damaged_organ = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lowered the knockout time from 2-3 minutes to a flat 1.5 minutes. Makes self surgery possible with either tramadol + paracetamol or oxycodone + inaprov.

## Why It's Good For The Game

Should have just made knockout play admin "man up, deal with it, move on", but this is an alternative solution.

## Changelog
:cl:
balance: pain knockout duration lowered to 1.5 minutes
balance: self surgery now possible by stacking 2 painkillers
/:cl:

