### PR TITLE
Recuperation - Cling To Life

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/defense.dm
+++ b/code/modules/mob/living/carbon/superior_animal/defense.dm
@@ -157,12 +157,12 @@
 
 		if(sleeping)
 			adjustHalLoss(-5)
-			if(BruteLoss > 50)
-				AdjustBruteLoss(-0.25)
-			if(FireLoss > 50)
-				AdjustFireLoss(-0.25)
-			if(ToxLoss > 50)
-				AdjustFireLoss(-0.25)
+			if(bruteloss > 0)
+				adjustBruteLoss(-0.25)
+			if(toxloss > 0)
+				adjustToxLoss(-0.25)
+			if(burnloss > 0)
+				adjustBurnLoss(-0.25)	
 			sleeping = max(sleeping-1, 0)
 			blinded = TRUE
 			stat = UNCONSCIOUS

--- a/code/modules/mob/living/carbon/superior_animal/defense.dm
+++ b/code/modules/mob/living/carbon/superior_animal/defense.dm
@@ -161,8 +161,8 @@
 				adjustBruteLoss(-0.25)
 			if(toxloss > 0)
 				adjustToxLoss(-0.25)
-			if(burnloss > 0)
-				adjustBurnLoss(-0.25)	
+			if(fireloss > 0)
+				adjustFireLoss(-0.25)	
 			sleeping = max(sleeping-1, 0)
 			blinded = TRUE
 			stat = UNCONSCIOUS

--- a/code/modules/mob/living/carbon/superior_animal/defense.dm
+++ b/code/modules/mob/living/carbon/superior_animal/defense.dm
@@ -153,21 +153,27 @@
 			blinded = TRUE
 			stat = UNCONSCIOUS
 			if(halloss > 0)
-				adjustHalLoss(-3)
+				adjustHalLoss(-4)
 
 		if(sleeping)
-			adjustHalLoss(-3)
+			adjustHalLoss(-5)
+			if(BruteLoss > 50)
+				AdjustBruteLoss(-0.25)
+			if(FireLoss > 50)
+				AdjustFireLoss(-0.25)
+			if(ToxLoss > 50)
+				AdjustFireLoss(-0.25)
 			sleeping = max(sleeping-1, 0)
 			blinded = TRUE
 			stat = UNCONSCIOUS
 		else if(resting)
 			if(halloss > 0)
-				adjustHalLoss(-3)
+				adjustHalLoss(-4)
 
 		else
 			stat = CONSCIOUS
 			if(halloss > 0)
-				adjustHalLoss(-1)
+				adjustHalLoss(-2)
 
 		update_icons()
 


### PR DESCRIPTION
Slightly increases the halloss healing across the board when resting/incapacitated as a stop-gap until more measures to bring pain into line are taken, also adds a base level of brute, tox and burn healing. Oxygen healing is excluded as oxyloss is often used as a death timer, and sleeping should not be a get out of death free card in dire situations, but a way of recovering from injuries that might just be enough to tip someone into dying under the current system. 

Numbers could be tweaked downward but I feel like this is a good and decent base.

Sleeping is a vulnerable state that cannot be voluntarily ended, this wouldn't threaten unbalancing anything in my mind.

## Changelog
:cl:
add: Added a base healing level when sleeping, this should not heal you below to below 50 damage.
tweak: Tweaked the rate of halloss healing across the board while actively resting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
