### PR TITLE
Lexorin Spider Tweak

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/carrion/toxic_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/toxic_spider.dm
@@ -22,10 +22,10 @@
 
 /obj/item/weapon/implant/carrion_spider/toxicbomb/proc/prime()
 	var/location = get_turf(src)
-	gas_storage = new /datum/reagents(100, src)
-	gas_storage.add_reagent("lexorin", 100)
+	gas_storage = new /datum/reagents(50, src)
+	gas_storage.add_reagent("lexorin", 50)
 	var/datum/effect/effect/system/smoke_spread/chem/S = new
 	S.attach(location)
-	S.set_up(gas_storage, 10, 100, location)
+	S.set_up(gas_storage, 10, 50, location)
 	S.start()
 	die()


### PR DESCRIPTION
I'm putting this up again for the following reason:

- The first PR was clustered with misinformation and wrongful assumptions.
- If this doesn't do anything, then it doesn't cost anyone anything. It will purely be for my peace of mind and the peace of mind of everyone who agrees. You could still stack two spiders for the same effect if you really want to abuse this, it just becomes a tiny bit less ezkill.
- If the spider is eventually fixed from however you believe it to be broken, then you will want this change eventually.
- Yes, it is a bunch of one-line number changes. What do you expect, a complete rework of carrion accompanying this? My other PR was responded to with "Split this into 2 changes" so this clearly isn't a real concern you have.

Thank you.

## Changelog
:cl:
balance: Rebalances Lexorin spiders, 100u is too much.
/:cl:

