### PR TITLE
Nerfs carrion maw's Consume Flesh and cleans it up a bit

### DIFF
--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -266,7 +266,7 @@
 	icon_state = "carrion_maw"
 	organ_efficiency = list(OP_MAW = 100)
 	var/last_call = -5 MINUTES
-	var/target_to_tear
+	var/tearing = FALSE
 
 	owner_verbs = list(
 		/obj/item/organ/internal/carrion/maw/proc/consume_flesh,
@@ -287,23 +287,23 @@
 	if(istype(food, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/grab = food
 		var/mob/living/carbon/human/H = grab.affecting
-		if (grab.state == GRAB_PASSIVE)
+		if (grab.state < GRAB_AGGRESSIVE)
 			to_chat(owner, SPAN_WARNING("Your grip upon [H] is too weak."))
 			return
 		if(istype(H))
 			var/obj/item/organ/external/E = H.get_organ(owner.targeted_organ)
-			if (!isnull(target_to_tear)) // one at a time, thank you.
+			if (tearing) // one at a time, thank you.
 				to_chat(owner, SPAN_WARNING("Your maw is already focused on something."))
 				return
 
 			if(E.is_stump())
 				to_chat(owner, SPAN_WARNING("You can't tear off a limb stump"))
 				return
-			target_to_tear = E // here is where it chooses what the maw is "focused on".
+			tearing = TRUE
 
 			visible_message(SPAN_DANGER("[owner] bites into [H]'s [E.name] and starts tearing it [E.functions ? "off": "apart"]!"))
 			if(do_after(owner, 5 SECONDS, H))
-				target_to_tear = null
+				tearing = FALSE
 				if (E.organ_tag == BP_HEAD)
 					if(!(H.incapacitated(INCAPACITATION_UNCONSCIOUS)))
 						var/datum/gender/G = gender_datums[H.gender]
@@ -328,7 +328,7 @@
 				visible_message(SPAN_DANGER("\The [owner] tears off \the [H]'s [E.name]!"))
 				return
 			else
-				target_to_tear = null
+				tearing = FALSE
 		else
 			to_chat(owner, SPAN_WARNING("You can only tear limbs off of humanoids!"))	
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR changes the Carrion's Maw's Consume Flesh ability in these ways:

- it now is unable to be used on victims that are in a grab weaker than an aggressive grab.
- it now is unable to be initiated while being used.
- it now is unable to tear groin off.
- it now will tear an organ out of chest or groin.
- it now will backlash with a Stun(5) and item drop when targeting head without all limbs being disabled and without the victim being unconscious.
- it now has better messages.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The Maw is supposed to be a tool for advancement and disabling downed opponents, not something that you can use to just instakill whoever you get into a grab for five seconds. This PR makes Consume Flesh an utility ability, instead of an OP weapon.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Chickenish
add: The carrion's Maw now damages and removes a random organ when the target is the chest.
balance: The carrion's Maw now also does the same when the groin is targeted instead of ripping it off, can't initiated while in progress, does not work with a weak grab, and will stun you if you try to tear off your victim's head without KOing them or disabling all their limbs first.
spellcheck: There was extra "the"s in the maw limb tear off ability, no more.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
