### PR TITLE
New technomancer origin by Benblu

### DIFF
--- a/code/datums/setup_option/backgrounds/origin.dm
+++ b/code/datums/setup_option/backgrounds/origin.dm
@@ -218,3 +218,22 @@
         STAT_VIG = 10,
         STAT_COG = -5
     )
+
+/datum/category_item/setup_option/background/origin/streltsy
+	name = "Wandering Streltsy"
+	desc = "The Streltsy are known for their actions during the corporate wars on certain worlds such as Eureka and Predstraza. Serbians know them as valuable debt settlers and an escape from the conditions of their worlds, while more civilized worlds view them as despoilers and raiders. \
+			While both of these preconceptions are correct in their own right, a less known fact is that most Streltsy who've survived the corporate war are still suffering the consequences of their participation due to the decimation of their numbers during the war, leading to a miserable quality of life and forcing them to start recruitment from wartorn worlds to desperately replenish their numbers from before the war. \
+			Despite this, the survivors and their newer members are unparalleled in the arts of war, but lacking in the art of general technomancy."
+	stat_modifiers = list(
+		STAT_ROB = 5,
+		STAT_TGH = 10,
+		STAT_BIO = -10,
+		STAT_MEC = -5,
+		STAT_VIG = 10,
+		STAT_COG = -10
+	)
+
+	restricted_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/chaplain, /datum/job/merchant, /datum/job/cmo, /datum/job/rd, /datum/job/ihc)
+	restricted_depts = IRONHAMMER | MEDICAL | SCIENCE | CHURCH | GUILD | CIVILIAN | SERVICE
+
+	perks = list(PERK_SURVIVOR)

--- a/code/datums/setup_option/backgrounds/origin.dm
+++ b/code/datums/setup_option/backgrounds/origin.dm
@@ -235,5 +235,3 @@
 
 	restricted_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/chaplain, /datum/job/merchant, /datum/job/cmo, /datum/job/rd, /datum/job/ihc)
 	restricted_depts = IRONHAMMER | MEDICAL | SCIENCE | CHURCH | GUILD | CIVILIAN | SERVICE
-
-	perks = list(PERK_SURVIVOR)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new origin restricted to technomancers, giving some nice combat stats, and the IH survivor perk. All code made by Beblu, PR-ed it at his request.

## Why It's Good For The Game
New origin inspired by lore. Another illusion of technomancer content.

## Changelog
:cl:
add: New combat focused origin for technomancers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
