### PR TITLE
makes True Faith activate like Exotic Inspiration

### DIFF
--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -154,12 +154,16 @@
 	desc = "When near an obelisk, you feel your mind at ease. Your sanity regeneration is boosted."
 	icon_state = "sanityboost" // https://game-icons.net/1x1/lorc/templar-eye.html
 
-/datum/perk/sanityboost/assign(mob/living/carbon/human/H)
+/datum/perk/active_sanityboost
+	name = "True Faith (Active)"
+	icon_state = "sanityboost" // https://game-icons.net/1x1/lorc/templar-eye.html
+
+/datum/perk/active_sanityboost/assign(mob/living/carbon/human/H)
 	..()
 	if(holder)
 		holder.sanity.sanity_passive_gain_multiplier *= 1.5
 
-/datum/perk/sanityboost/remove()
+/datum/perk/active_sanityboost/remove()
 	if(holder)
 		holder.sanity.sanity_passive_gain_multiplier /= 1.5
 	..()

--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -58,6 +58,7 @@ var/list/disciples = list()
 /obj/item/weapon/implant/core_implant/cruciform/uninstall()
 	unregister_wearer()
 	wearer.stats.removePerk(/datum/perk/sanityboost)
+	wearer.stats.removePerk(/datum/perk/active_sanityboost)
 	return ..()
 
 /obj/item/weapon/implant/core_implant/cruciform/get_mob_overlay(gender)

--- a/code/modules/core_implant/cruciform/machinery/obelisk.dm
+++ b/code/modules/core_implant/cruciform/machinery/obelisk.dm
@@ -33,7 +33,7 @@ GLOBAL_LIST_EMPTY(all_obelisk)
 /obj/machinery/power/nt_obelisk/Destroy()
 	for(var/i in currently_affected)
 		var/mob/living/carbon/human/H = i
-		H.stats.removePerk(/datum/perk/sanityboost)
+		H.stats.removePerk(/datum/perk/active_sanityboost)
 	currently_affected = null
 	return ..()
 
@@ -92,7 +92,7 @@ GLOBAL_LIST_EMPTY(all_obelisk)
 	var/list/no_longer_affected = currently_affected - affected
 	for(var/i in no_longer_affected)
 		var/mob/living/carbon/human/H = i
-		H.stats.removePerk(/datum/perk/sanityboost)
+		H.stats.removePerk(/datum/perk/active_sanityboost)
 	currently_affected -= no_longer_affected
 	for(var/mob/living/carbon/human/mob in affected)
 		var/obj/item/weapon/implant/core_implant/I = mob.get_core_implant(/obj/item/weapon/implant/core_implant/cruciform)
@@ -106,7 +106,7 @@ GLOBAL_LIST_EMPTY(all_obelisk)
 				eotp.addObservation(10)
 		if(I && I.active && I.wearer)
 			if(!(mob in currently_affected)) // the mob just entered the range of the obelisk
-				mob.stats.addPerk(/datum/perk/sanityboost)
+				mob.stats.addPerk(/datum/perk/active_sanityboost)
 				currently_affected += mob
 			I.restore_power(I.power_regen*2)
 			for(var/r_tag in mob.personal_ritual_cooldowns)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Instead of having True Faith added on cruciform installation and entering an obelisk's range and removed on cruciform uninstallation and exiting an obelisk's range, this PR makes True Faith added on cruciform installation and removed on cruciform uninstallation, and activated on entering an obelisk's range and deactivated on exiting an obelisk's range.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having a sanity bonus that you can permanently keep as long as you never enter an obelisk's range rewards you for playing NT badly; before this PR it would also appear as though you lost the perk permanently on leaving an obelisk's range. These are not good things.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Chickenish
fix: True Faith gave the benefit by itself and was added and removed by obelisks; now obelisks activate and deactivate it similarly to Exotic Inspiration.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
