### PR TITLE
Balances light rigs and makes them accessible to the commonfolk

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -14,17 +14,17 @@
 	)
 	emp_protection = 10
 	slowdown = 0
-	item_flags = STOPPRESSUREDAMAGE | THICKMATERIAL | DRAG_AND_DROP_UNEQUIP | EQUIP_SOUNDS
+	item_flags = THICKMATERIAL | DRAG_AND_DROP_UNEQUIP | EQUIP_SOUNDS
 	offline_slowdown = 0
 	offline_vision_restriction = 0
 	drain = 2
+
+	airtight = 0
 
 	chest_type = /obj/item/clothing/suit/space/rig/light
 	helm_type =  /obj/item/clothing/head/space/rig/light
 	boot_type =  /obj/item/clothing/shoes/magboots/rig/light
 	glove_type = /obj/item/clothing/gloves/rig/light
-
-	spawn_blacklisted = TRUE
 
 /obj/item/clothing/suit/space/rig/light
 	name = "suit"
@@ -41,13 +41,10 @@
 /obj/item/weapon/rig/light/hacker
 	name = "cybersuit control module"
 	suit_type = "cyber"
-	desc = "An advanced powered armour suit with many cyberwarfare enhancements. Comes with built-in insulated gloves for safely tampering with electronics."
+	desc = "An advanced powered armour suit with multiple cyberwarfare enhancements. Comes with built-in insulated gloves for safely tampering with electronics."
 	icon_state = "hacker_rig"
 
-	req_access = list(access_syndicate)
-
-	airtight = 0
-	seal_delay = 5 //not being vaccum-proof has an upside I guess
+	seal_delay = 5 //not being vacuum-proof has an upside I guess
 
 	helm_type = /obj/item/clothing/head/lightrig/hacker
 	chest_type = /obj/item/clothing/suit/lightrig/hacker
@@ -57,10 +54,9 @@
 	initial_modules = list(
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/power_sink,
-		/obj/item/rig_module/datajack,
 		/obj/item/rig_module/electrowarfare_suite,
-		/obj/item/rig_module/voice,
-		/obj/item/rig_module/vision,
+		/obj/item/rig_module/vision/meson,
+		/obj/item/rig_module/voice
 		)
 
 //The cybersuit is not space-proof. It does however, have good siemens_coefficient values
@@ -74,7 +70,6 @@
 
 /obj/item/clothing/shoes/lightrig/hacker
 	siemens_coefficient = 0.4
-	flags = NOSLIP //All the other rigs have magboots anyways, hopefully gives the hacker suit something more going for it.
 
 /obj/item/clothing/gloves/lightrig/hacker
 	siemens_coefficient = 0
@@ -99,6 +94,8 @@
 	glove_type = /obj/item/clothing/gloves/rig/light/ninja
 
 	req_access = list(access_syndicate)
+
+	spawn_blacklisted = TRUE
 
 	initial_modules = list(
 		/obj/item/rig_module/teleporter,
@@ -129,6 +126,8 @@
 	icon_state = "stealth_rig"
 
 	req_access = list(access_syndicate)
+
+	spawn_blacklisted = TRUE
 
 	initial_modules = list(
 		/obj/item/rig_module/stealth_field,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
balance things first:
 light rigsuits no longer have spaceproofing, to fit in with code comment at top of file
 hacker suit lost its ninja objective module as well as its night vision and thermals visors
 hacker suit no longer requires syndie ID or hacking (ironic) to wear

The light and hacker rig are no longer spawn blacklisted, but ninja and stealth (subtypes of light) are still blacklisted from random spawn. Might add a cargo crate for the light suit, but don't think I should unless someone asks specifically.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Well, for one, it increases the rarity of getting a fully-kitted crimson hardsuit from junk, so that's a plus!

More seriously, light rigs are kind of interesting in that they're fairly useless on their own but get potentially more useful than traditional rigs once you have good modules because of their speed. They have shittier armor and no spaceproofing, so they're probably just worse for combat use, but may feel nicer to use for general use and running around. They're not un-armored, so it's still better to wear a light suit than clothes, unless you count the fact you get no back storage slot.

Hacker rig is a little more debatable despite being toned down, VERY fast deploy timers and some decent utility modules. Doesn't seem godly for combat or anything, though. Maybe when cyberspace update comes out (never) someone can make it have cool cyberspace features or something.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can now find the light rigsuit and hacker rigsuit anywhere that a random rigsuit could spawn.
balance: Light rigsuits are no longer space-proof.
balance: Hacker rigsuit has lost its thermal vision, night vision, and data jack, but no longer requires hacking the control module to use.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
