### PR TITLE
Modifies .60 rarity to something more sane, unblacklists .35 ammo types

### DIFF
--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -255,7 +255,6 @@
 	caliber = CAL_ANTIM
 	ammo_type = /obj/item/ammo_casing/antim
 	max_ammo = 30
-	rarity_value = 50
 
 /obj/item/ammo_magazine/ammobox/antim/scrap
 	name = "ammunition box (old .60 Anti Material)"

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -52,13 +52,11 @@
 	name = "ammunition packet (.35 Auto practice)"
 	icon_state = "pistol_p"
 	ammo_type = /obj/item/ammo_casing/pistol/practice
-	spawn_blacklisted = TRUE
 
 /obj/item/ammo_magazine/ammobox/pistol/hv
 	name = "ammunition packet (.35 Auto high-velocity)"
 	icon_state = "pistol_hv"
 	ammo_type = /obj/item/ammo_casing/pistol/hv
-	spawn_blacklisted = TRUE
 
 /obj/item/ammo_magazine/ammobox/pistol/rubber
 	name = "ammunition packet (.35 Auto rubber)"
@@ -257,10 +255,11 @@
 	caliber = CAL_ANTIM
 	ammo_type = /obj/item/ammo_casing/antim
 	max_ammo = 30
+	rarity_value = 50
 
 /obj/item/ammo_magazine/ammobox/antim/scrap
 	name = "ammunition box (old .60 Anti Material)"
 	icon_state = "antim_s"
 	ammo_type = /obj/item/ammo_casing/antim/scrap
 	max_ammo = 30
-	rarity_value = 1
+	rarity_value = 15

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -67,7 +67,7 @@
 /obj/item/ammo_magazine/ammobox/pistol/scrap
 	name = "ammunition packet (old .35 Auto)"
 	icon_state = "pistol_s"
-	rarity_value = 30
+	rarity_value = 5
 	ammo_type = /obj/item/ammo_casing/pistol/scrap
 
 //// . 40 ////
@@ -261,4 +261,4 @@
 	icon_state = "antim_s"
 	ammo_type = /obj/item/ammo_casing/antim/scrap
 	max_ammo = 30
-	rarity_value = 15
+	rarity_value = 20


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Modifies .60 ammo to something a bit more sane. Scrap .60 ammo is slightly more rare than .35 ammo, leaving it findable but not something you'll trip over constantly. 
I'm not sure why .35 ammo has its HV and Practice variants blacklisted from trash spawning whilst every other ammo type's is allowed - if it was intentional then I'd like to know why for future documentation. I've not touched any of the other ammo rarity due to a lack of feedback, if there's any you feel are too common, or not common enough, please let me know and I'll check with others how they feel before making adjustments.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
AMR ammo really should not be the most common ammo type to spawn.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: .60 ammo is now more scarce. .35 HV and Practice removed from trash spawn blacklisting, the scrap variant is now much more common.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
