### PR TITLE
Malf AI should not be able to recall bluespace jumps

### DIFF
--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_interdiction.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_interdiction.dm
@@ -50,7 +50,6 @@
 	if(evacuation_controller?.emergency_evacuation)
 		if (alert(user, "Really recall the shuttle?", "Recall Shuttle: ", "Yes", "No") != "Yes")
 			return
-
 		if(!ability_pay(user, price))
 			return
 		message_admins("Malfunctioning AI [user.name] recalled the shuttle.")
@@ -251,7 +250,7 @@
 				to_chat(target, "SYSTEM LOG: User: Admin - Connection Lost. Changes Reverted.")
 				return
 			to_chat(user, "Hack succeeded. The AI is now under your exclusive control.")
-			to_chat(target, "SYSTEM LOG: System re�3RT5�^#COMU@(#$)TED)@$")
+			to_chat(target, "SYSTEM LOG: System re¡3RT5§^#COMU@(#$)TED)@$")
 			for(var/i = 0, i < 5, i++)
 				var/temptxt = pick("1101000100101001010001001001",\
 							   	   "0101000100100100000100010010",\

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_interdiction.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_interdiction.dm
@@ -47,13 +47,16 @@
 	if(!ability_prechecks(user, price))
 		return
 
-	if (alert(user, "Really recall the shuttle?", "Recall Shuttle: ", "Yes", "No") != "Yes")
-		return
+	if(evacuation_controller?.emergency_evacuation)
+		if (alert(user, "Really recall the shuttle?", "Recall Shuttle: ", "Yes", "No") != "Yes")
+			return
 
-	if(!ability_pay(user, price))
-		return
-	message_admins("Malfunctioning AI [user.name] recalled the shuttle.")
-	cancel_call_proc(user)
+		if(!ability_pay(user, price))
+			return
+		message_admins("Malfunctioning AI [user.name] recalled the shuttle.")
+		cancel_call_proc(user)
+	else
+		to_chat(user, "You cannot stop a bluespace jump.")
 
 
 /datum/game_mode/malfunction/verb/unlock_cyborg(var/mob/living/silicon/robot/target = null as mob in get_linked_cyborgs(usr))
@@ -248,7 +251,7 @@
 				to_chat(target, "SYSTEM LOG: User: Admin - Connection Lost. Changes Reverted.")
 				return
 			to_chat(user, "Hack succeeded. The AI is now under your exclusive control.")
-			to_chat(target, "SYSTEM LOG: System re¡3RT5§^#COMU@(#$)TED)@$")
+			to_chat(target, "SYSTEM LOG: System reï¿½3RT5ï¿½^#COMU@(#$)TED)@$")
 			for(var/i = 0, i < 5, i++)
 				var/temptxt = pick("1101000100101001010001001001",\
 							   	   "0101000100100100000100010010",\


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stop malf AI from being able to recall bluespace jumps.

## Why It's Good For The Game

Bluespace jumps are the equivalent of crew shift to end the round, it's different from ship evacuation with shuttles and AI should not be able to recall them.

## Changelog
:cl: Hyperio
tweak: Malf AI cannot recall bluespace jumps anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
