### PR TITLE
Motherfucker melee damage nerf

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic/motherfucker.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/motherfucker.dm
@@ -5,7 +5,7 @@
 	icon_state = "motherfucker"
 	item_state = "motherfucker"
 	w_class = ITEM_SIZE_HUGE
-	force = WEAPON_FORCE_ROBUST
+	force = WEAPON_FORCE_DANGEROUS
 	slot_flags = SLOT_BACK
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	caliber = CAL_PISTOL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

the ultimate "fuck you" shotgun should not deal the same damage as the boltgun in melee, especially since it can get a bayonet attached to deal even more damage, while the boltgun can not.

## Why It's Good For The Game
death in t+5-0.05 seconds

## Changelog
:cl:
balance: The melee damage of the motherfucker has been nerfed by 5 damage points.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
