### PR TITLE
Dusty cannot be carried anymore

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -367,6 +367,5 @@ var/cat_number = 0
 /mob/living/simple_animal/cat/runtime/singularity_act()
 	return
 
-/mob/living/simple_animal/cat/runtime/start_pulling(var/atom/movable/AM)
-	to_chat(src, SPAN_WARNING("Your hand passes through \the [src]."))
+/mob/living/simple_animal/cat/runtime/MouseDrop(atom/over_object)
 	return

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -277,6 +277,8 @@ var/cat_number = 0
 	icon_state = "runtimecat"
 	item_state = "runtimecat"
 	density = 0
+	anchored = TRUE  // So that people cannot pull Dusty
+	mob_size = MOB_HUGE // So that people cannot put Dusty in lockers to move it
 
 	status_flags = GODMODE // Bluespace cat
 	min_oxy = 0
@@ -295,6 +297,7 @@ var/cat_number = 0
 
 /mob/living/simple_animal/cat/runtime/New(loc)
 	..(loc)
+	stats.addPerk(PERK_TERRIBLE_FATE)
 	cat_number += 1
 	playsound(loc, 'sound/effects/teleport.ogg', 50, 1)
 	spawn(cat_life_duration)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I forgot to block people from carrying Dusty, which caused a "Fix me" glitched sprite.

## Why It's Good For The Game

Pet the cat, don't carry it.

## Changelog
:cl: Hyperio
tweak: Dusty cannot be carried anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
