### PR TITLE
sugar doesnt KILL you on OD. 

### DIFF
--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -435,9 +435,9 @@
 	M.add_side_effect("Headache", 11)
 	M.make_jittery(5)
 	M.add_chemical_effect(CE_PULSE, 2)
-	if(prob(90))
+	if(prob(30))
 		to_chat(M, "<span class='danger'>You have too much sugar in your body.</span>")
-	else
+	if(prob(10))
 		to_chat(M, "<span class='danger'>A sweet yet disgusting taste o sugar comes to your mouth.</span>")
 		M.vomit()
 	

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -430,21 +430,19 @@
 	glass_name = "sugar"
 	glass_desc = "The organic compound commonly known as table sugar and sometimes called saccharose. This white, odorless, crystalline powder has a pleasing, sweet taste."
 
-/datum/reagent/organic/sugar/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
-	M.adjustNutrition(1 * effect_multiplier)
-
-/datum/reagent/organic/sugar/overdose(mob/living/carbon/M, alien)
+/datum/reagent/organic/sugar/overdose(mob/living/carbon/M, alien, effect_multiplier)
 	..()
 	M.add_side_effect("Headache", 11)
 	M.make_jittery(5)
 	M.add_chemical_effect(CE_PULSE, 2)
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/internal/heart/L = H.random_organ_by_process(OP_HEART)
-		if(istype(L))
-			L.take_damage(1, 0)
-	if(prob(5))
-		M.emote(pick("twitch", "blink_r", "shiver"))
+	if(prob(90))
+		to_chat(M, "<span class='danger'>You have too much sugar in your body.</span>")
+	else
+		to_chat(M, "<span class='danger'>A sweet yet disgusting taste o sugar comes to your mouth.</span>")
+		M.vomit()
+	
+	
+
 	
 /datum/reagent/sulfur
 	name = "Sulfur"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
sugar no long works as nutrition when injected IV, and also now the OD. makes you vomit "no longer deals heart damage"
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sugar shouldn't be deadly
and thi should hold powergamers out
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: sugar no longer kills on it OD. and no longer feed you IV
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
