### PR TITLE
Fix zpipes display on standard tiles

### DIFF
--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -25,7 +25,8 @@ obj/machinery/atmospherics/pipe/zpipe
 		var/travel_direction_name = "UNDEFINED"
 		var/travel_direction = "UNDEFINED"
 
-		level = BELOW_PLATING_LEVEL
+		level = ABOVE_PLATING_LEVEL
+		layer = GAS_PIPE_VISIBLE_LAYER
 
 obj/machinery/atmospherics/pipe/zpipe/New()
 	..()
@@ -150,8 +151,6 @@ obj/machinery/atmospherics/pipe/zpipe/up/atmos_init()
 					break
 
 
-	var/turf/T = src.loc			// hide if turf is not intact
-	hide(!T.is_plating())
 
 ///////////////////////
 // and the down pipe //
@@ -193,8 +192,6 @@ obj/machinery/atmospherics/pipe/zpipe/down/atmos_init()
 					break
 
 
-	var/turf/T = src.loc			// hide if turf is not intact
-	hide(!T.is_plating())
 
 ///////////////////////
 // supply/scrubbers  //

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -13050,7 +13050,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
 "aFq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -13777,7 +13777,7 @@
 /obj/machinery/atmospherics/pipe/zpipe/up{
 	dir = 4
 	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
 "aHw" = (
 /obj/machinery/atmospherics/valve/digital{
@@ -14208,7 +14208,7 @@
 /area/eris/engineering/atmos)
 "aIF" = (
 /obj/machinery/atmospherics/pipe/zpipe/up,
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
 "aIG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix layer and level of zpipe so that they are properly displayed on standard tiles. No need to let plating tiles anymore.

![pipes](https://user-images.githubusercontent.com/64754494/121422172-3b659d00-c96f-11eb-8a70-035967c72428.png)

## Why It's Good For The Game

Plating bad.

## Changelog
:cl: Hyperio
fix: Fix zpipes display on standard tiles
add: Add normal tiles to atmos room to cover unecessary plating
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
