### PR TITLE
Lesser Forms can't be cruciformed anymore.

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -33,8 +33,6 @@
 #define isbrain(A) istype(A, /mob/living/carbon/brain)
 
 #define ishuman(A) istype(A, /mob/living/carbon/human)
-
-#define ismonkey(A) istype(A, /mob/living/carbon/human/monkey)
 //---------------------------------------------------
 
 #define isanimal(A) istype(A, /mob/living/simple_animal)

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -33,6 +33,8 @@
 #define isbrain(A) istype(A, /mob/living/carbon/brain)
 
 #define ishuman(A) istype(A, /mob/living/carbon/human)
+
+#define ismonkey(A) istype(A, /mob/living/carbon/human/monkey)
 //---------------------------------------------------
 
 #define isanimal(A) istype(A, /mob/living/simple_animal)

--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -82,11 +82,11 @@ var/list/disciples = list()
 /obj/item/weapon/implant/core_implant/cruciform/activate()
 	if(!wearer || active)
 		return
-
-	if(is_carrion(wearer))
+	
+	if(wearer.get_species() != SPECIES_HUMAN || is_carrion(wearer))
 		playsound(wearer.loc, 'sound/hallucinations/wail.ogg', 55, 1)
 		wearer.gib()
-		if(eotp)
+		if(eotp)  // le mutants reward
 			eotp.addObservation(200)
 		return
 	..()

--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -81,12 +81,11 @@ var/list/disciples = list()
 
 /obj/item/weapon/implant/core_implant/cruciform/activate()
 	var/observation_points = 200
-
-	if(wearer.get_species() == "Monkey")
-		observation_points /= 20
 	if(!wearer || active)
 		return
 	if(wearer.get_species() != SPECIES_HUMAN || is_carrion(wearer))
+		if(wearer.get_species() == "Monkey")
+			observation_points /= 20
 		playsound(wearer.loc, 'sound/hallucinations/wail.ogg', 55, 1)
 		wearer.gib()
 		if(eotp)  // le mutants reward

--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -80,14 +80,17 @@ var/list/disciples = list()
 	s.start()
 
 /obj/item/weapon/implant/core_implant/cruciform/activate()
+	var/observation_points = 200
+
+	if(wearer.get_species() == "Monkey")
+		observation_points /= 20
 	if(!wearer || active)
 		return
-	
 	if(wearer.get_species() != SPECIES_HUMAN || is_carrion(wearer))
 		playsound(wearer.loc, 'sound/hallucinations/wail.ogg', 55, 1)
 		wearer.gib()
 		if(eotp)  // le mutants reward
-			eotp.addObservation(200)
+			eotp.addObservation(observation_points)
 		return
 	..()
 	add_module(new CRUCIFORM_COMMON)
@@ -97,7 +100,7 @@ var/list/disciples = list()
 	if(M)
 		M.write_wearer(wearer) //writes all needed data to cloning module
 	if(eotp)
-		eotp.addObservation(50)
+		eotp.addObservation(observation_points*0.25)
 	return TRUE
 
 /obj/item/weapon/implant/core_implant/cruciform/examine(mob/user)

--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -281,6 +281,7 @@
 
 /datum/ritual/cruciform/base/install/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/mob/living/carbon/human/H = get_victim(user)
+
 	var/obj/item/weapon/implant/core_implant/cruciform/CI = get_implant_from_victim(user, /obj/item/weapon/implant/core_implant/cruciform, FALSE)
 	if(CI)
 		fail("[H] already have a cruciform installed.", user, C)
@@ -308,6 +309,10 @@
 
 	if(!H.lying || !locate(/obj/machinery/optable/altar) in L)
 		fail("[H] must lie on the altar.", user, C)
+		return FALSE
+
+	if(isslime(H) || isroach(H) || ismonkey(H))
+		fail("\The lesser creatures are unworthy.", user, C)
 		return FALSE
 
 	for(var/obj/item/clothing/CL in H)

--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -64,7 +64,7 @@
 /datum/ritual/cruciform/base/reveal
 	name = "Reveal Adversaries"
 	phrase = "Et fumus tormentorum eorum ascendet in saecula saeculorum: nec habent requiem die ac nocte, qui adoraverunt bestiam, et imaginem ejus, et si quis acceperit caracterem nominis ejus."
-	desc = "Gain knowledge of your surroundings, to reveal evil in people and places. Can tell you about hostile creatures around you, rarely can help you spot traps, and sometimes let you sense a carrion."
+	desc = "Gain knowledge of your surroundings, to reveal evil in people and places. Can tell you about hostile creatures around you, rarely can help you spot traps."
 	power = 35
 
 /datum/ritual/cruciform/base/reveal/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
@@ -311,7 +311,7 @@
 		fail("[H] must lie on the altar.", user, C)
 		return FALSE
 
-	if(isanimal(H) || isslime(H) || issuperioranimal(H) || ismonkey(H))
+	if(isanimal(H) || isslime(H) || issuperioranimal(H) || H.get_species() == "Monkey")
 		fail("The lesser creatures are unworthy.", user, C)
 		return FALSE
 

--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -312,7 +312,7 @@
 		return FALSE
 
 	if(isslime(H) || isroach(H) || ismonkey(H))
-		fail("\The lesser creatures are unworthy.", user, C)
+		fail("The lesser creatures are unworthy.", user, C)
 		return FALSE
 
 	for(var/obj/item/clothing/CL in H)

--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -311,7 +311,7 @@
 		fail("[H] must lie on the altar.", user, C)
 		return FALSE
 
-	if(isslime(H) || isroach(H) || ismonkey(H))
+	if(isanimal(H) || isslime(H) || issuperioranimal(H) || ismonkey(H))
 		fail("The lesser creatures are unworthy.", user, C)
 		return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

something something, makes lesser form not being able to be cruciformed and if they somehow manage to get it and activate it on, it should gibs then.

I have to say that I initially added mutated people to the gibbing one aswell, but noticed that if you get a breakdown it could fuck you aswell plus heterocromia is a thing. So no.
 
So the check is on nonhuman species & some funny carbons.

This count as my fix n19
## Why It's Good For The Game

It was funny for players, it wasn't funny for jannie.
<img src = "https://cdn.discordapp.com/attachments/716324050430984255/852068014458667058/Screenshot_3316.png">

And this count as a bugfix.
## Changelog
:cl: HerBaon
balance: Only glorious humans can be part of NT. Everyone else gets gibbed or isn't worthy anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
