### PR TITLE
Frag Grenade tweak

### DIFF
--- a/code/game/objects/items/weapons/grenades/frag.dm
+++ b/code/game/objects/items/weapons/grenades/frag.dm
@@ -6,8 +6,9 @@
 	loadable = TRUE
 
 	var/fragment_type = /obj/item/projectile/bullet/pellet/fragment/strong
-	var/num_fragments = 150  //total number of fragments produced by the grenade
-	var/fragment_damage = 5
+	var/num_fragments = 50  //total number of fragments produced by the grenade
+	var/fragment_damage = 15
+	var/fragment_penetration = 15
 	var/damage_step = 2      //projectiles lose a fragment each time they travel this distance. Can be a non-integer.
 
 	//The radius of the circle used to launch projectiles. Lower values mean less projectiles are used but if set too low gaps may appear in the spread pattern
@@ -42,5 +43,3 @@
 	icon_state = "frag_nt"
 	item_state = "frggrenade_nt"
 	matter = list(MATERIAL_BIOMATTER = 75)
-	fragment_damage = 7
-	damage_step = 3

--- a/code/modules/projectiles/projectile/fragment.dm
+++ b/code/modules/projectiles/projectile/fragment.dm
@@ -1,11 +1,12 @@
 /obj/item/projectile/bullet/pellet/fragment
 	damage_types = list(BRUTE = 10)
 	range_step = 2
+	embed = FALSE
 
 	base_spread = 0 //causes it to be treated as a shrapnel explosion instead of cone
 	spread_step = 20
 
-	silenced = TRUE //embedding messages are still produced so it's kind of weird when enabled.
+	silenced = FALSE //embedding messages are still produced so it's kind of weird when enabled.
 	no_attack_log = 1
 	muzzle_type = null
 

--- a/code/modules/projectiles/projectile/projectilegrenades.dm
+++ b/code/modules/projectiles/projectile/projectilegrenades.dm
@@ -42,8 +42,9 @@
 	name = "frag shell"
 	var/range = 7
 	var/f_type = /obj/item/projectile/bullet/pellet/fragment/strong
-	var/f_amount = 100
-	var/f_damage = 4
+	var/f_amount = 50
+	var/f_damage = 15
+	var/f_penetration = 15
 	var/f_step = 2
 	var/same_turf_hit_chance = 15
 
@@ -51,8 +52,9 @@
 	name = "frag shell"
 	range = 7
 	f_type = /obj/item/projectile/bullet/pellet/fragment/strong
-	f_amount = 100
-	f_damage = 2
+	f_amount = 50
+	f_damage = 15
+	f_penetration = 10
 	f_step = 1
 	same_turf_hit_chance = 10
 


### PR DESCRIPTION
## About The Pull Request

Tweaks frag grenades. They now only put out 50 shrapnel instead of 150, do 15 damage instead of 5 damage, and now have 15 AP. I also tweaked the weak shrapnel that the shellshock fires, it deals 15 damage and 10 AP instead. I've also removed their ability to embed.

## Why It's Good For The Game

Frag grenades are kind of in a weird place right now. To anyone wearing decent armor, they deal practically no damage, but fill people with so much shrapnel a doctor will take one look at you and commit suicide. I'm hoping this will make grenades a bit more useful in terms of direct damage, while making their after affects less annoying to deal with.

## Changelog
:cl:
tweak: Frag grenades put out less shrapnel, but deal more damage and now have AP. This applies to pommies, china lake grenades, and shellshock grenades.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
