### PR TITLE
Detective buff.

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -208,11 +208,11 @@
 	icon_state = "detective"
 	item_state = "det_suit"
 	blood_overlay_type = "coat"
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	armor = list(
 		melee = 30,
-		bullet = 20,
-		energy = 20,
+		bullet = 30,
+		energy = 30,
 		bomb = 0,
 		bio = 0,
 		rad = 0

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -219,7 +219,6 @@
 	)
 	siemens_coefficient = 0.8
 	price_tag = 250
-	style = STYLE_HIGH
 
 /obj/item/clothing/suit/storage/detective/ironhammer
 	name = "Inspector's armored trenchcoat"

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -219,6 +219,7 @@
 	)
 	siemens_coefficient = 0.8
 	price_tag = 250
+	style = STYLE_HIGH
 
 /obj/item/clothing/suit/storage/detective/ironhammer
 	name = "Inspector's armored trenchcoat"


### PR DESCRIPTION
## About The Pull Request

Gives the detective's coat leg protection and 30% against melee, bullet, and laser instead of 20%.

## Why It's Good For The Game

It isn't, this is the epitome of powercreep, sue me and ban me from contributing. 

Real reason is that the detective felt like he should have slightly better protection against body shots and the fact that coats are meant to be stylish. He can still be headshot with ease if he sticks with his basic drip though.

## Changelog
:cl:
balance: Made the detective's coat more protective, and made it offer leg protection.
/:cl: