### PR TITLE
Slight map edit of airlock above S3 hallway

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -80423,6 +80423,8 @@
 "dHh" = (
 /obj/structure/multiz/ladder/up,
 /obj/effect/floor_decal/rust,
+/obj/spawner/flora/low_chance,
+/obj/spawner/gun/cheap/low_chance,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section4deck2port)
 "dHi" = (
@@ -80469,11 +80471,17 @@
 "dHl" = (
 /obj/spawner/mob/roaches/cluster,
 /obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section4deck2port)
 "dHm" = (
 /obj/spawner/junk/low_chance,
 /obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section4deck2port)
 "dHn" = (
@@ -80574,16 +80582,18 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/foyer)
 "dHw" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section4deck2port)
 "dHx" = (
-/obj/spawner/gun/cheap/low_chance,
-/obj/spawner/flora/low_chance,
 /obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 1;
+	initialize_directions = 0
+	},
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section4deck2port)
 "dHy" = (


### PR DESCRIPTION
## About The Pull Request

This PR moves Pressurized Air tank assigned to eva access point a bit further to allow pasage to Engineering from there upon deconstruction of one wall (since I was told taht these tanks can't be really destroyed by player in any conventional way).

![3Z](https://user-images.githubusercontent.com/59981504/121909527-48e3a400-cd2e-11eb-8769-c00a0507ecf7.png)


This will be used ~~mostly by me and me alone~~ by many many people, I promise. 

## Why It's Good For The Game

~~It's not~~ It furthers our society in many ways.


## Changelog
:cl:
tweak: Edited bit of maint next to EVA access point above S3 hallway
/:cl:
