### PR TITLE
Reworks the mindflayer, AEG, and Captain's laser.

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2344,7 +2344,6 @@
 #include "code\modules\projectiles\guns\energy\laser.dm"
 #include "code\modules\projectiles\guns\energy\lasersmg.dm"
 #include "code\modules\projectiles\guns\energy\lasertag.dm"
-#include "code\modules\projectiles\guns\energy\mindflayer.dm"
 #include "code\modules\projectiles\guns\energy\nt_svalinn.dm"
 #include "code\modules\projectiles\guns\energy\nuclear.dm"
 #include "code\modules\projectiles\guns\energy\plasma.dm"

--- a/code/datums/objective/steal.dm
+++ b/code/datums/objective/steal.dm
@@ -37,7 +37,7 @@
 	)
 
 	var/global/possible_items_special[] = list(
-		"mindflayer" = /obj/item/weapon/gun/energy/mindflayer,
+		"mindflayer" = /obj/item/weapon/gun/energy/psychic/mindflayer,
 		"diamond drill" = /obj/item/weapon/tool/pickaxe/diamonddrill,
 		"bag of holding" = /obj/item/weapon/storage/backpack/holding,
 		"hyper-capacity cell" = /obj/item/weapon/cell/large/hyper,

--- a/code/datums/objective/steal.dm
+++ b/code/datums/objective/steal.dm
@@ -38,6 +38,7 @@
 
 	var/global/possible_items_special[] = list(
 		"mindflayer" = /obj/item/weapon/gun/energy/psychic/mindflayer,
+		"advanced energy gun" = /obj/item/weapon/gun/energy/nuclear,
 		"diamond drill" = /obj/item/weapon/tool/pickaxe/diamonddrill,
 		"bag of holding" = /obj/item/weapon/storage/backpack/holding,
 		"hyper-capacity cell" = /obj/item/weapon/cell/large/hyper,

--- a/code/datums/objective/steal.dm
+++ b/code/datums/objective/steal.dm
@@ -37,7 +37,7 @@
 	)
 
 	var/global/possible_items_special[] = list(
-		"nuclear gun" = /obj/item/weapon/gun/energy/gun/nuclear,
+		"mindflayer" = /obj/item/weapon/gun/energy/mindflayer,
 		"diamond drill" = /obj/item/weapon/tool/pickaxe/diamonddrill,
 		"bag of holding" = /obj/item/weapon/storage/backpack/holding,
 		"hyper-capacity cell" = /obj/item/weapon/cell/large/hyper,

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -155,7 +155,7 @@
 			eshot_sound = 'sound/weapons/Laser.ogg'
 			egun = 1
 
-		if(/obj/item/weapon/gun/energy/gun/nuclear)
+		if(/obj/item/weapon/gun/energy/nuclear)
 			eprojectile = /obj/item/projectile/beam	//If it has, going to kill mode
 			eshot_sound = 'sound/weapons/Laser.ogg'
 			egun = 1

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -71,7 +71,7 @@
 			if (W.disposable)
 				to_chat(user, SPAN_NOTICE("Your gun is disposable, it cannot be charged."))
 				return
-		if(istype(I, /obj/item/weapon/gun/energy/gun/nuclear) || istype(I, /obj/item/weapon/gun/energy/crossbow))
+		if(istype(I, /obj/item/weapon/gun/energy/nuclear) || istype(I, /obj/item/weapon/gun/energy/crossbow))
 			to_chat(user, SPAN_NOTICE("Your gun's recharge port was removed to make room for a miniaturized reactor."))
 			return
 		var/obj/item/weapon/cell/cell = I.get_cell()

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -237,7 +237,7 @@
 		/obj/item/weapon/gun/projectile/mandella,
 		/obj/item/weapon/gun/energy/gun,
 		/obj/item/weapon/gun/energy/chameleon,
-		/obj/item/weapon/gun/energy/captain, //too unwieldy, use belt/suit slot or other storage
+		/obj/item/weapon/gun/energy/captain,
 		/obj/item/weapon/gun/energy/stunrevolver,
 		/obj/item/weapon/gun/projectile/revolver,
 		/obj/item/weapon/gun/projectile/automatic/molly,

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -237,7 +237,7 @@
 		/obj/item/weapon/gun/projectile/mandella,
 		/obj/item/weapon/gun/energy/gun,
 		/obj/item/weapon/gun/energy/chameleon,
-		//obj/item/weapon/gun/energy/captain, //too unwieldy, use belt/suit slot or other storage
+		/obj/item/weapon/gun/energy/captain, //too unwieldy, use belt/suit slot or other storage
 		/obj/item/weapon/gun/energy/stunrevolver,
 		/obj/item/weapon/gun/projectile/revolver,
 		/obj/item/weapon/gun/projectile/automatic/molly,

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -238,7 +238,7 @@
 	icon_state = "xray"
 	projectile_type = /obj/item/projectile/beam/psychic
 	fire_sound = 'sound/weapons/Laser.ogg'
-	slot_flags = SLOT_BELT|SLOT_BACK
+	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	fire_delay = 10
 	price_tag = 2200
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_SILVER = 5, MATERIAL_PLASMA = 3)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -231,6 +231,19 @@
 		)
 	twohanded = FALSE
 
+/obj/item/weapon/gun/energy/psychic/mindflayer
+	name = "Prototype: mind flayer"
+	desc = "A cruel weapon designed to break the minds of those it targets, causing sanity loss and mental breakdowns."
+	icon = 'icons/obj/guns/energy/xray.dmi'
+	icon_state = "xray"
+	projectile_type = /obj/item/projectile/beam/psychic
+	fire_sound = 'sound/weapons/Laser.ogg'
+	slot_flags = SLOT_BELT|SLOT_BACK
+	fire_delay = 10
+	price_tag = 3000
+	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_SILVER = 5, MATERIAL_PLASMA = 3)
+	twohanded = FALSE
+
 /obj/item/weapon/gun/energy/laser/makeshift
 	name = "makeshift laser carbine"
 	desc = "A makeshift laser carbine, rather wastefull on its chage, but nonetheless reliable"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -240,7 +240,7 @@
 	fire_sound = 'sound/weapons/Laser.ogg'
 	slot_flags = SLOT_BELT|SLOT_BACK
 	fire_delay = 10
-	price_tag = 3000
+	price_tag = 2200
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_SILVER = 5, MATERIAL_PLASMA = 3)
 	twohanded = FALSE
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -83,12 +83,12 @@
 	desc = "This weapon is old, yet still robust and reliable. It's marked with old Nanotrasen brand, a distant reminder of what this corporation was, before the Church took control of everything."
 	force = WEAPON_FORCE_PAINFUL
 	fire_sound = 'sound/weapons/Laser.ogg'
-	slot_flags = SLOT_BELT
+	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	w_class = ITEM_SIZE_NORMAL
 	can_dual = TRUE
-	projectile_type = /obj/item/projectile/beam
+	projectile_type = /obj/item/projectile/beam/midlaser
 	zoom_factor = 0
-	damage_multiplier = 1
+	damage_multiplier = 1.2
 	origin_tech = null
 	self_recharge = TRUE
 	charge_cost = 100

--- a/code/modules/projectiles/guns/energy/mindflayer.dm
+++ b/code/modules/projectiles/guns/energy/mindflayer.dm
@@ -1,8 +1,9 @@
 /obj/item/weapon/gun/energy/mindflayer
 	name = "Prototype: mind flayer"
-	desc = "A custom-built weapon of some kind."
+	desc = "A cruel weapon designed to break the minds of those it targets, causing sanity loss and mental breakdowns."
 	icon = 'icons/obj/guns/energy/xray.dmi'
 	icon_state = "xray"
-	projectile_type = /obj/item/projectile/beam/mindflayer
+	projectile_type = /obj/item/projectile/beam/psychic/mindflayer
 	fire_sound = 'sound/weapons/Laser.ogg'
 	price_tag = 3000
+	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_SILVER = 5, MATERIAL_PLASMA = 3)

--- a/code/modules/projectiles/guns/energy/mindflayer.dm
+++ b/code/modules/projectiles/guns/energy/mindflayer.dm
@@ -1,9 +1,0 @@
-/obj/item/weapon/gun/energy/mindflayer
-	name = "Prototype: mind flayer"
-	desc = "A cruel weapon designed to break the minds of those it targets, causing sanity loss and mental breakdowns."
-	icon = 'icons/obj/guns/energy/xray.dmi'
-	icon_state = "xray"
-	projectile_type = /obj/item/projectile/beam/psychic/mindflayer
-	fire_sound = 'sound/weapons/Laser.ogg'
-	price_tag = 3000
-	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_SILVER = 5, MATERIAL_PLASMA = 3)

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -1,27 +1,29 @@
-/obj/item/weapon/gun/energy/gun/nuclear
+/obj/item/weapon/gun/energy/nuclear
 	name = "Prototype: advanced energy gun"
-	desc = "An energy gun with an experimental miniaturized reactor."
+	desc = "An energy handgun with an experimental miniaturized reactor. Able to fire in two round bursts."
 	icon = 'icons/obj/guns/energy/nucgun.dmi'
 	icon_state = "nucgun"
 	item_charge_meter = TRUE
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 5, TECH_POWER = 3)
-	slot_flags = SLOT_BELT
-	force = WEAPON_FORCE_PAINFUL //looks heavier than a pistol
+	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	self_recharge = TRUE
+	twohanded = FALSE
+	projectile_type = /obj/item/projectile/beam
+	charge_cost = 50
 	modifystate = null
-	matter = list(MATERIAL_STEEL = 20, MATERIAL_URANIUM = 10)
+	matter = list(MATERIAL_STEEL = 15, MATERIAL_PLASTEEL = 5, MATERIAL_URANIUM = 6)
 	price_tag = 4000
 	spawn_blacklisted = TRUE
 
 	init_firemodes = list(
-		STUNBOLT,
-		LETHAL
+		WEAPON_NORMAL,
+		BURST_2_ROUND
 		)
 
 	var/lightfail = 0
 
 //override for failcheck behaviour
-/obj/item/weapon/gun/energy/gun/nuclear/Process()
+/obj/item/weapon/gun/energy/nuclear/Process()
 	charge_tick++
 	if(charge_tick < 4) return 0
 	charge_tick = 0
@@ -31,12 +33,12 @@
 		update_icon()
 	return 1
 
-/obj/item/weapon/gun/energy/gun/nuclear/proc/update_mode()
+/obj/item/weapon/gun/energy/nuclear/proc/update_mode()
 	var/datum/firemode/current_mode = firemodes[sel_mode]
 	switch(current_mode.name)
 		if("stun") overlays += "nucgun-stun"
 		if("lethal") overlays += "nucgun-kill"
 
-/obj/item/weapon/gun/energy/gun/nuclear/on_update_icon()
+/obj/item/weapon/gun/energy/nuclear/on_update_icon()
 	cut_overlays()
 	update_mode()

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/energy/nuclear
 	name = "Prototype: advanced energy gun"
-	desc = "An energy handgun with an experimental miniaturized reactor. Able to fire in two round bursts."
+	desc = "An energy handgun with an experimental miniaturized reactor. Able to fire in two shot bursts."
 	icon = 'icons/obj/guns/energy/nucgun.dmi'
 	icon_state = "nucgun"
 	item_charge_meter = TRUE

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -43,6 +43,7 @@
 	icon_state = "psychic_heavylaser"
 	var/obj/item/weapon/gun/energy/psychic/holder
 	var/traitor = FALSE //Check if it's a traitor psychic beam
+	damage_types = list(PSY = 30)
 	armor_penetration = 100
 
 	muzzle_type = /obj/effect/projectile/psychic_laser_heavy/muzzle
@@ -60,13 +61,6 @@
 	icon_state = "psychic_heavylaser"
 	damage_types = list(PSY = 40)
 	traitor = TRUE
-
-	muzzle_type = /obj/effect/projectile/psychic_laser_heavy/muzzle
-	tracer_type = /obj/effect/projectile/psychic_laser_heavy/tracer
-	impact_type = /obj/effect/projectile/psychic_laser_heavy/impact
-
-/obj/item/projectile/beam/psychic/mindflayer
-	damage_types = list(PSY = 30)
 
 	muzzle_type = /obj/effect/projectile/psychic_laser_heavy/muzzle
 	tracer_type = /obj/effect/projectile/psychic_laser_heavy/tracer

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -68,6 +68,10 @@
 /obj/item/projectile/beam/psychic/mindflayer
 	damage_types = list(PSY = 30)
 
+	muzzle_type = /obj/effect/projectile/psychic_laser_heavy/muzzle
+	tracer_type = /obj/effect/projectile/psychic_laser_heavy/tracer
+	impact_type = /obj/effect/projectile/psychic_laser_heavy/impact
+
 /obj/item/projectile/beam/xray
 	name = "xray beam"
 	icon_state = "xray"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -65,6 +65,9 @@
 	tracer_type = /obj/effect/projectile/psychic_laser_heavy/tracer
 	impact_type = /obj/effect/projectile/psychic_laser_heavy/impact
 
+/obj/item/projectile/beam/psychic/mindflayer
+	damage_types = list(PSY = 30)
+
 /obj/item/projectile/beam/xray
 	name = "xray beam"
 	icon_state = "xray"

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -132,14 +132,6 @@
 		return 1
 
 
-/obj/item/projectile/beam/mindflayer
-	name = "flayer ray"
-
-/obj/item/projectile/beam/mindflayer/on_hit(atom/target)
-	if(ishuman(target))
-		var/mob/living/carbon/human/M = target
-		M.confused += rand(5,8)
-
 /obj/item/projectile/chameleon
 	name = "bullet"
 	icon_state = "bullet"

--- a/code/modules/research/designs/weapon.dm
+++ b/code/modules/research/designs/weapon.dm
@@ -14,7 +14,7 @@
 	sort_string = "TAAAA"
 
 /datum/design/research/item/weapon/mindflayer
-	build_path = /obj/item/weapon/gun/energy/mindflayer
+	build_path = /obj/item/weapon/gun/energy/psychic/mindflayer
 	sort_string = "TAAAB"
 
 /datum/design/research/item/weapon/lasercannon

--- a/code/modules/research/designs/weapon.dm
+++ b/code/modules/research/designs/weapon.dm
@@ -13,8 +13,8 @@
 	build_path = /obj/item/weapon/gun/energy/stunrevolver/moebius
 	sort_string = "TAAAA"
 
-/datum/design/research/item/weapon/nuclear_gun
-	build_path = /obj/item/weapon/gun/energy/gun/nuclear
+/datum/design/research/item/weapon/mindflayer
+	build_path = /obj/item/weapon/gun/energy/mindflayer
 	sort_string = "TAAAB"
 
 /datum/design/research/item/weapon/lasercannon

--- a/code/modules/research/designs/weapon.dm
+++ b/code/modules/research/designs/weapon.dm
@@ -36,6 +36,10 @@
 	build_path = /obj/item/weapon/gun/energy/decloner
 	sort_string = "TAAAE"
 
+/datum/design/research/item/weapon/nuclear
+	build_path = /obj/item/weapon/gun/energy/nuclear
+	sort_string = "TAAAG"
+
 /datum/design/research/item/weapon/chemsprayer
 	desc = "An advanced chem spraying device."
 	build_path = /obj/item/weapon/reagent_containers/spray/chemsprayer

--- a/code/modules/research/nodes/combat.dm
+++ b/code/modules/research/nodes/combat.dm
@@ -201,7 +201,7 @@
 	required_tech_levels = list()
 	cost = 5000
 
-	unlocks_designs = list(/datum/design/research/item/weapon/nuclear_gun, /datum/design/research/item/weapon/lasercannon)
+	unlocks_designs = list(/datum/design/research/item/weapon/mindflayer, /datum/design/research/item/weapon/lasercannon)
 
 /datum/technology/advanced_armor
 	name = "Advanced Armor Solutions"

--- a/code/modules/research/nodes/combat.dm
+++ b/code/modules/research/nodes/combat.dm
@@ -201,7 +201,7 @@
 	required_tech_levels = list()
 	cost = 5000
 
-	unlocks_designs = list(/datum/design/research/item/weapon/mindflayer, /datum/design/research/item/weapon/lasercannon)
+	unlocks_designs = list(/datum/design/research/item/weapon/mindflayer,  /datum/design/research/item/weapon/nuclear, /datum/design/research/item/weapon/lasercannon)
 
 /datum/technology/advanced_armor
 	name = "Advanced Armor Solutions"


### PR DESCRIPTION
## About The Pull Request

Reworks the mindflayer, it now works similarly to the psionic laser cannon, though it is a bit weaker. It cannot however be used to complete the mindbreak contract. It can still be found in maintenance, and can now be printed by moebius after obtaining laser research.

AEG is now a one handed, 20 shot pistol with a 2 round burst. It's high ammo capacity is somewhat countered by the fact that it cannot be reloaded.

The captain's laser now has 10 AP and 36 damage per shot.

## Why It's Good For The Game

We don't have many psionic weapons, so I thought it'd be cool to add one. Given the mindflayer currently is just a regular laser that applies the confusion status affect, I thought it'd be a good idea to rework it.

Captain's laser quite frankly currently feels like a sidegrade to the spider rose, since it cannot be reloaded and deals the same amount of damage.

The AEG is in a rather poor place currently, being one of the worst laser guns available since it cannot be reloaded and has poor damage. By increasing it's ammo capacity and giving it a burst mode, it can now compete as a useful energy sidearm and justify its price.

## Changelog
:cl:
add: Adds the mindflayer to the moebius research printer, in place of the nuclear laser. It can still rarely be found in maintenance.
Tweak: The mindflayer is now a psionic weapon, similar to the psionic laser cannon. It can not be used to complete the mindbreak contracts however.
Tweak: The AEG is now a 2 round burst weapon with 20 shots.
Tweak: The captain's laser is stronger, with 10 AP and 36 damage per shot.
/:cl: