### PR TITLE
Medical Specialist appreciation day

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -4810,12 +4810,7 @@
 /area/eris/security/exerooms)
 "alp" = (
 /obj/structure/table/glass,
-/obj/item/weapon/tool/cautery{
-	pixel_y = 4
-	},
-/obj/item/weapon/tool/hemostat{
-	pixel_y = 4
-	},
+/obj/item/weapon/storage/freezer/medical,
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/security/exerooms)
 "alq" = (
@@ -5095,7 +5090,9 @@
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/security/exerooms)
 "alX" = (
-/obj/machinery/optable,
+/obj/machinery/computer/operating{
+	name = "Brig Operating Computer"
+	},
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/security/exerooms)
 "alY" = (
@@ -5142,16 +5139,11 @@
 /area/eris/hallway/side/eschangarb)
 "ame" = (
 /obj/structure/table/glass,
-/obj/item/weapon/tool/retractor{
-	pixel_y = 6
-	},
-/obj/item/weapon/tool/scalpel,
-/obj/item/weapon/tool/surgicaldrill,
-/obj/item/weapon/tool/saw/circular,
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 22
 	},
+/obj/item/weapon/storage/firstaid/surgery,
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/security/exerooms)
 "amf" = (
@@ -5266,6 +5258,7 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
+/obj/item/weapon/storage/firstaid/o2,
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/security/exerooms)
 "amp" = (
@@ -5346,9 +5339,9 @@
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/security/exerooms)
 "amB" = (
-/obj/machinery/computer/operating{
+/obj/machinery/sleeper{
 	dir = 4;
-	name = "Brig Operating Computer"
+	req_access = list(67)
 	},
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/security/exerooms)
@@ -5366,7 +5359,6 @@
 	pixel_x = 1;
 	pixel_y = 1
 	},
-/obj/item/weapon/tool/bonesetter,
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/security/exerooms)
 "amE" = (
@@ -104295,8 +104287,9 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/security/prison)
 "pAH" = (
-/turf/simulated/wall,
-/area/space)
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/white/bluecorner,
+/area/eris/security/exerooms)
 "pHi" = (
 /obj/machinery/smartfridge/drying_rack,
 /turf/simulated/floor/plating,
@@ -125865,8 +125858,8 @@ aht
 ako
 akO
 aeH
-aln
 alX
+aln
 amB
 aht
 aaa
@@ -126067,7 +126060,7 @@ ajH
 akp
 akT
 aeH
-aln
+pAH
 aln
 amC
 aht
@@ -164294,7 +164287,7 @@ aqa
 bCz
 csD
 csD
-pAH
+csD
 qOT
 csD
 csD


### PR DESCRIPTION
## About The Pull Request

Medbrig now gets its own sleeper (I tried to restrict access to it so that only medspec can apply chems, it didn't really work though for whatever reason), proper surgery&oxyloss kit, organ freezer and a minor refurbishment. 

Removed area of space in bar's walls too, minor oversight would cause shield to pop in there.

![31Z](https://user-images.githubusercontent.com/59981504/122094343-5cfdd300-ce0c-11eb-98c5-1019683b34ef.png)

## Why It's Good For The Game

There is, in my opinion, no point in keeping medspec neutered as he is now (since he has to spend considerable time and resources to get nearly close to actual medbay's capabilities). While Medbrig shouldn't get everything medbay does, many people feel like sleeper is bare minimum to actually do any medicine there semi-reliablly. Either that, or give up on medspec entirely.

## Changelog
:cl:
tweak: tweaked birgmed's equipment
fix: fixed a shield tiel appearing in bar
/:cl:


