### PR TITLE
nt bioprinter buff

### DIFF
--- a/code/game/machinery/bioprinter_nt.dm
+++ b/code/game/machinery/bioprinter_nt.dm
@@ -3,7 +3,8 @@
 	desc = "NeoTheology machine for printing things using biomass."
 	icon_state = "bioprinter"
 	unsuitable_materials = list()
-
+	speed = 3 
+	storage_capacity = 360
 	build_type = AUTOLATHE | BIOPRINTER
 	high_quality_faction_list = list(FACTION_NEOTHEOLOGY)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Buffs printing speed of the NT lathe to being equivalent to a tier 2 lathe and the storage of a t3 lathe (360) because they were cucked since the ability to upgrade the lathe was removed with the new building system. 
## Why It's Good For The Game
This takes in account that the lathe can't be upgraded anymore so it's permanently stuck on a very bad level. It still has the efficiency of a normal lathe. 

An actual NT Buff that matters. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Herbaon
balance: NT Bioprinter was balanced to have better storage and printing speed. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
