### PR TITLE
Bugfixes 3 small edition

### DIFF
--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -163,6 +163,8 @@
 	src.add_fingerprint(user)
 	return
 
+/obj/item/weapon/storage/secure/briefcase/AltClick(mob/user)
+	return attack_hand(user)
 // -----------------------------
 //        Secure Safe
 // -----------------------------

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -382,6 +382,8 @@
 		return FALSE
 
 	for(var/stat in inspiracion.stats)
+		if(inspiracion.stats[stat] == 0)
+          continue
 		var/stat_gain = rand(1,8)
 		inspiracion.stats[stat] += stat_gain
 		user.stats.changeStat(stat, -max(round(stat_gain/2),1))

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -312,7 +312,7 @@
 
 /obj/item/stack/material/glass/plasmaglass
 	name = "borosilicate glass"
-	desc = "This sheet is special platinum-glass alloy designed to withstand large temperatures"
+	desc = "This sheet is special plasma-glass alloy designed to withstand large temperatures"
 	singular_name = "borosilicate glass sheet"
 	icon_state = "sheet-plasmaglass"
 	default_type = MATERIAL_PLASMAGLASS
@@ -326,7 +326,7 @@
 
 /obj/item/stack/material/glass/plasmarglass
 	name = "reinforced borosilicate glass"
-	desc = "This sheet is special platinum-glass alloy designed to withstand large temperatures. It is reinforced with few rods."
+	desc = "This sheet is special plasma-glass alloy designed to withstand large temperatures. It is reinforced with few rods."
 	singular_name = "reinforced borosilicate glass sheet"
 	icon_state = "sheet-plasmarglass"
 	default_type = MATERIAL_RPLASMAGLASS

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -70,6 +70,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	force = 7
 	matter = list(MATERIAL_PLASTIC = 8, MATERIAL_GLASS = 2)
+	gun_parts = list(obj/item/stack/material/plastic = 5)
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
 
 	fire_sound = 'sound/weapons/empty.ogg'

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -70,7 +70,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	force = 7
 	matter = list(MATERIAL_PLASTIC = 8, MATERIAL_GLASS = 2)
-	gun_parts = list(obj/item/stack/material/plastic = 5)
+	gun_parts = list(/obj/item/stack/material/plastic = 5)
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
 
 	fire_sound = 'sound/weapons/empty.ogg'

--- a/code/modules/projectiles/guns/mods/research_mods.dm
+++ b/code/modules/projectiles/guns/mods/research_mods.dm
@@ -104,7 +104,7 @@
 // Add radiation damage to your weapon
 /obj/item/weapon/gun_upgrade/barrel/isotope_diffuser
 	name = "Moebius \"Atomik\" isotope diffuser"
-	desc = "This experimental barrel constantly sprays a thin mist of radioactive isotopes to make projectiles leaving the weapons deadlier, whether bullets, lasers or energy bolts. Do not put it in your mouth."
+	desc = "This experimental barrel constantly sprays a thin mist of radioactive isotopes to make projectiles leaving the weapons deadlier. Do not put it in your mouth."
 	icon_state = "isotope_diffuser"
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_PLASTEEL = 1, MATERIAL_URANIUM = 2)
 	spawn_blacklisted = TRUE

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -50,6 +50,7 @@
 	fire_sound = 'sound/weapons/empty.ogg'
 	fire_sound_text = "a metallic click"
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_PLASTIC = 10)
+	gun_parts = list(/obj/item/stack/material/steel = 15 ,/obj/item/stack/material/plastic = 2)
 	recoil_buildup = 0
 	silenced = TRUE
 	load_method = MAGAZINE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

4 small bugfixes. Evan helped me with several doubts / errors regarding the first mentioned bug, by the way.
26. Artist and Kube Oddities turning all-stats oddities by Preacher Blessing Litany.
27. Secure Briefcase being able to be opened by altclick.
28. Borosilicate/Plasma glass being called Platinum glass and incorrect Moebius isotope diffuser description.
29. Dartgun and syringe guns gunpart exploit

## Why It's Good For The Game
less 🐛

## Changelog
:cl: Herbaon
fix: Artist and Kube Oddities turning all-stats oddities by Preacher Blessing Litany.
fix: Secure Briefcase being able to be opened by altclick.
fix: Borosilicate/Plasma glass being called Platinum glass and incorrect Moebius isotope diffuser description.
fix: dartgun and syringe guns gunpart exploit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
