### PR TITLE
Removes 1 second timer option from grenades.

### DIFF
--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -81,9 +81,6 @@
 		if(I.use_tool(user, src, WORKTIME_NEAR_INSTANT, QUALITY_SCREW_DRIVING, FAILCHANCE_EASY, required_stat = STAT_COG))
 			switch(det_time)
 				if (1)
-					det_time = 10
-					to_chat(user, SPAN_NOTICE("You set the [name] for 1 second detonation time."))
-				if (10)
 					det_time = 30
 					to_chat(user, SPAN_NOTICE("You set the [name] for 3 second detonation time."))
 				if (30)


### PR DESCRIPTION
## About The Pull Request

Removes 1 second timer setting for grenades.

## Why It's Good For The Game

Cook your nades or get a grenade launcher if you want them to explode this fast, or even better, grab two of them and run at the fool.

## Changelog
:cl:
del: Removed one second detonation option from grenades.
/:cl: