### PR TITLE
Painkiller effect standardization

### DIFF
--- a/code/modules/reagents/reagents/drugs.dm
+++ b/code/modules/reagents/reagents/drugs.dm
@@ -209,7 +209,7 @@
 /datum/reagent/drug/nicotine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	..()
 	M.add_chemical_effect(CE_PULSE, 1)
-	M.add_chemical_effect(CE_PAINKILLER, 5 * effect_multiplier)
+	M.add_chemical_effect(CE_PAINKILLER, 5)
 	if(M.stats.getPerk(PERK_CHAINGUN_SMOKER))
 		M.add_chemical_effect(CE_ANTITOX, 5 * effect_multiplier)
 		M.heal_organ_damage(0.1 * effect_multiplier, 0.1 * effect_multiplier)

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -19,7 +19,7 @@
 
 /datum/reagent/medicine/inaprovaline/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.add_chemical_effect(CE_STABLE)
-	M.add_chemical_effect(CE_PAINKILLER, 15 * effect_multiplier)
+	M.add_chemical_effect(CE_PAINKILLER, 15)
 	M.add_chemical_effect(CE_PULSE, 1)
 
 /datum/reagent/medicine/inaprovaline/sleeper
@@ -291,7 +291,7 @@
 
 /datum/reagent/medicine/alkysine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.adjustBrainLoss(-(3 + (M.getBrainLoss() * 0.05)) * effect_multiplier)
-	M.add_chemical_effect(CE_PAINKILLER, 10 * effect_multiplier)
+	M.add_chemical_effect(CE_PAINKILLER, 10)
 
 /datum/reagent/medicine/imidazoline
 	name = "Imidazoline"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the `* effect_multiplier` from some painkillers that use it, making it consistent with all the other painkillers.

## Why It's Good For The Game

This would cause painkillers that are used in different ways to have different strength (inaprov pills would be stronger than inaprov injections), making it hard for players to do self surgery.

## Changelog
:cl:
balance: All painkillers have consistent strength anyway they consumed/injected.
/:cl:

