### PR TITLE
re-adds silicate reinforcement

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -62,7 +62,8 @@
 	var/initialhealth = health
 
 	if (!ignore_resistance)
-		damage -= resistance
+		damage = damage * (1 - silicate / 200) // up to 50% damage resistance 
+		damage -= resistance // then flat resistance from material
 	if (damage <= 0)
 		return 0
 

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -381,6 +381,7 @@
 		return trans_to_holder(target, amount, multiplier, copy)
 	else if(istype(target, /atom))
 		var/atom/A = target
+		touch(A)
 		if(ismob(target))
 			return splash_mob(target, amount, multiplier, copy)
 		if(isturf(target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR re-adds silicate reinforcing windows, which had the damage reduction removed apparently accidentally three years ago.
https://github.com/discordia-space/CEV-Eris/commit/55d92b204e7595e6b2d1758b2f1775dd5bac7982
This PR also adds touch to the trans_to, which has comments saying it has touch.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Both features appeared to exist prior, but didn't.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Chickenish
fix: reinforcing windows with silicate actually works now, and beaker splashes now apply touch effects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
