### PR TITLE
Massively increases malf CPU gain

### DIFF
--- a/code/modules/mob/living/silicon/ai/malf.dm
+++ b/code/modules/mob/living/silicon/ai/malf.dm
@@ -64,13 +64,13 @@
 // Recalculates CPU time gain and storage capacities.
 /mob/living/silicon/ai/proc/recalc_cpu()
 	// AI Starts with these values.
-	var/cpu_gain = 0.01
+	var/cpu_gain = 0.2
 	var/cpu_storage = 10
 
 	// Off-Station APCs should not count towards CPU generation.
 	for(var/obj/machinery/power/apc/A in hacked_apcs)
 		if(isOnStationLevel(A))
-			cpu_gain += 0.004
+			cpu_gain += 0.08
 			cpu_storage += 10
 
 	research.max_cpu = cpu_storage + override_CPUStorage


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Massively increases the malf AI's idle CPU gain from 0.01 to 0.2 and a hacked APC to contribute 0.08 CPU gain per tick, increasing each by a factor of 20.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Predominantly a stop-gap measure to increase the threat the antag represents until a full refactor/replacement is implemented. Taking into account the the sheer number of points it takes to develop T3 abilities, most rounds will end by the time you get them and often require the rest of the playerbase playing dumb to give you the chance. In addition, the CPU upgrade is a complete no-brainer as it is the only hardware chocie that will actually give you the chance to play around with malf abilities - it's still the strongest choice but now it's not the *obvious* choice.
Values open to adjustment.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Malfunctioning AIs have deleted system32 and generate CPU 20x as fast now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
