### PR TITLE
Pain effect threshold increase

### DIFF
--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -104,23 +104,23 @@
 
 	sanity.onShock(shock_stage)
 
-	if(shock_stage == 10)
+	if(shock_stage == 30)
 		to_chat(src, "<span class='danger'>[pick("It hurts so much", "You really need some painkillers", "Dear god, the pain")]!</span>")
 
-	if(shock_stage >= 30)
-		if(shock_stage == 30) emote("me",1,"is having trouble keeping their eyes open.")
+	if(shock_stage >= 60)
+		if(shock_stage == 60) emote("me",1,"is having trouble keeping their eyes open.")
 		stuttering = max(stuttering, 5)
 
-	if(shock_stage == 40)
+	if(shock_stage == 80)
 		to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!</span>")
 
-	if (shock_stage >= 60)
-		if(shock_stage == 60) emote("me",1,"'s body becomes limp.")
+	if (shock_stage >= 100)
+		if(shock_stage == 100) emote("me",1,"'s body becomes limp.")
 		if (prob(2))
 			to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!</span>")
 			Weaken(10)
 
-	if(shock_stage >= 80)
+	if(shock_stage >= 120)
 		if (prob(5))
 			to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!</span>")
 			Weaken(10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases the amount of pain needed to get negative effects from pain that are not paincrit.

## Why It's Good For The Game

Using old pain effect numbers doesn't make much senses now that pain can scale properly from 0 - 200 and effects went from 10 - 80.

## Changelog
:cl:
balance: negative effects of pain such as chat messages and stuttering take more pain to activate.
/:cl:
