### PR TITLE
Removes fluid subsystem

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -244,7 +244,6 @@
 #include "code\controllers\subsystems\wireless.dm"
 #include "code\controllers\subsystems\xenoarch.dm"
 #include "code\controllers\subsystems\initialization\character_setup.dm"
-#include "code\controllers\subsystems\processing\fluids.dm"
 #include "code\controllers\subsystems\processing\mobs.dm"
 #include "code\controllers\subsystems\processing\nano.dm"
 #include "code\controllers\subsystems\processing\objs.dm"

--- a/code/controllers/subsystems/processing/fluids.dm
+++ b/code/controllers/subsystems/processing/fluids.dm
@@ -1,4 +1,0 @@
-PROCESSING_SUBSYSTEM_DEF(fluids)
-	name = "Fluids"
-	wait = 20
-	flags = SS_NO_INIT | SS_TICKER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes a redundant subsystem I missed when removing plumbing

## Why It's Good For The Game

It doesn't even do anything, why is it here?

## Changelog
:cl:
del: Redundant fluid subsystem
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
