### PR TITLE
Fix power issue with guild lobby APC

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -53449,9 +53449,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/weapon/paper_bin,
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/eris/quartermaster/office)
@@ -84586,7 +84586,12 @@
 "dQy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/table/rack/shelf,
-/turf/simulated/floor/tiled/steel/brown_platform,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/steel/brown_perforated,
 /area/eris/quartermaster/office)
 "dQz" = (
 /obj/structure/multiz/stairs/active/bottom{
@@ -84799,6 +84804,11 @@
 /area/eris/medical/chemstor)
 "dQV" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/office)
 "dQW" = (
@@ -84930,7 +84940,6 @@
 	},
 /obj/structure/cable/green{
 	d2 = 8;
-	dir = 4;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/steel,
@@ -98071,14 +98080,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
-"ewr" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/steel/brown_perforated,
-/area/eris/quartermaster/office)
 "ews" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -104139,16 +104140,6 @@
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
-"nXM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	dir = 1;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/eris/quartermaster/office)
 "nYI" = (
 /obj/structure/catwalk,
 /obj/structure/closet/wall_mounted/firecloset{
@@ -209050,7 +209041,7 @@ ctr
 evJ
 ctN
 dQV
-ewr
+cvx
 cvx
 cxQ
 cvx
@@ -209252,7 +209243,7 @@ cwq
 evI
 cyy
 dRn
-nXM
+ctV
 ctV
 cxX
 czc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Power cables next to Guild's lobby APC were glitched and did not transmit power. I just rearranged the cables in another way and it works now, don't ask me why.

New layout in green, with old layout in blue.

![rewired_lobby](https://user-images.githubusercontent.com/64754494/124188370-76b34180-dabf-11eb-818c-28ef521be058.png)


## Why It's Good For The Game

Fix power issue

## Changelog
:cl: Hyperio
fix: Fix glitched power cables in guild lobby
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
