### PR TITLE
Ethanol and mead no longer share same recipe

### DIFF
--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -1647,7 +1647,7 @@
 
 /datum/chemical_reaction/mead
 	result = "mead"
-	required_reagents = list("sugar" = 1, "water" = 1)
+	required_reagents = list("honey" = 1, "water" = 1)
 	catalysts = list("enzyme" = 5)
 	result_amount = 2
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixed the issue of mead and ethanol having the same recipe.

## Why It's Good For The Game

Oversights are bad.

## Changelog
:cl:
tweak: mead now uses honey instead of sugar
/:cl:


