### PR TITLE
Removes Prison Hulk

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2771,7 +2771,6 @@
 #include "maps\dungeons\deepmaint\deepmaint.dm"
 #include "maps\encounters\asteroid\asteroid.dm"
 #include "maps\encounters\junk_tractor_beam\junk_tractor_beam.dm"
-#include "maps\encounters\prisonhulk\prisonhulk.dm"
 #include "maps\encounters\spacefortress\spacefortress.dm"
 #include "maps\encounters\spaceruins\spaceruins.dm"
 #include "maps\submaps\deepmaint_rooms\template.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Map is temporarily removed for improvements

## Why It's Good For The Game

There's a dozen sleepers and only four spacesuits to get to the teleporter. So we either get four more raiders to handle every round or a bunch of people locked in a room with nothing to do

## Changelog
:cl:
del: Removed prison hulk
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
