### PR TITLE
Resucitator nerf

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -201,7 +201,7 @@
 
 #define RANDOM_BLOOD_TYPE pick(4;"O-", 36;"O+", 3;"A-", 28;"A+", 1;"B-", 20;"B+", 1;"AB-", 5;"AB+")
 
-#define NECROZTIME 	(1 MINUTES)
+#define NECROZTIME 	(3 MINUTES)
 
 
 

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -201,7 +201,7 @@
 
 #define RANDOM_BLOOD_TYPE pick(4;"O-", 36;"O+", 3;"A-", 28;"A+", 1;"B-", 20;"B+", 1;"AB-", 5;"AB+")
 
-#define NECROZTIME 	(5 MINUTES)
+#define NECROZTIME 	(1 MINUTES)
 
 
 

--- a/code/modules/reagents/enricher.dm
+++ b/code/modules/reagents/enricher.dm
@@ -37,11 +37,11 @@
 	if(reagents.total_volume)
 		for(var/datum/reagent/reagent in reagents.reagent_list)
 			var/reagent_amount = 0
-			if(istype(reagent, /datum/reagent/organic/nutriment))
+			if(istype(reagent, /datum/reagent/organic/nutriment) && !istype(reagent, /datum/reagent/organic/nutriment/virus_food))
 				var/datum/reagent/organic/nutriment/N = reagent
 				reagent_amount = N.volume
 				N.remove_self(reagent_amount)
-				resuscitator_amount += (reagent_amount / 4)
+				resuscitator_amount += (reagent_amount / 8)
 			else
 				reagent_amount = reagent.volume
 				reagent.remove_self(reagent_amount) //Purge useless reagents out
@@ -52,7 +52,7 @@
 			bottle.name = "resuscitator bottle"
 			resuscitator_amount = 0
 			bottle.update_icon()
-			visible_message(SPAN_NOTICE("[src] drop [bottle]."))
+			visible_message(SPAN_NOTICE("[src] drops [bottle]."))
 		else
 			visible_message("\The [src] beeps, \"Not enough nutriment to produce resuscitator.\".")
 	else

--- a/code/modules/reagents/enricher.dm
+++ b/code/modules/reagents/enricher.dm
@@ -41,7 +41,7 @@
 				var/datum/reagent/organic/nutriment/N = reagent
 				reagent_amount = N.volume
 				N.remove_self(reagent_amount)
-				resuscitator_amount += (reagent_amount / 8)
+				resuscitator_amount += (reagent_amount / 4)
 			else
 				reagent_amount = reagent.volume
 				reagent.remove_self(reagent_amount) //Purge useless reagents out


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces the timer for resurrection from 5 minutes to 1 minute

Doubles the required amount of reagents (instead of 1 resucitator unit per 4 units of nutriment now its 1 res unit per 8 units of nutri)

Makes the enricher reject virus food

fixes a grammar(?) mistake (from drop to drops)

## Why It's Good For The Game

It's not

There is a virus food dispenser in medbay with roughly 1000 units, thats tons of round start resucitator, doesnt seem like a good idea

the required amount of reagents will in theory lower the amount of resucitator
in practice roughly each meat slice produces 8 or more units of animal protein
also you dont need to use just animal protein, you can use nutriment and any child of nutriment (egg yolk, rice, ketchup etc.)

now the big part, the timer reduction

5 minutes is extremely generous, i can understand dying right infront of medbay being an awful bother, so that's one of the reasons why 1 minute, so a chemist can quickly run up to chemistry and make atleast 1 unit and also have time to run back

with 5 minutes it meant you could have died at the other end of the ship, be found by a random vagabond stumbling around, dragged to medbay (while taking a detour) and STILL be revived, which i think is just ridiclous

if you want to be resurrected there's a reason the cruciform exists

## Changelog
:cl:
tweak: Tweaked Resucitator amount produced by the enricher (now you need twice more the amount of nutriment/protein) and reduced the timer for when you can still be revived (from 5 minutes to 3 minutes, pop that hyperzine pill)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
