### PR TITLE
no more hiveborn oddities

### DIFF
--- a/code/datums/perks/oddity.dm
+++ b/code/datums/perks/oddity.dm
@@ -257,7 +257,7 @@
 			H.adjustBruteLoss(-healing_power)
 			H.adjustFireLoss(-healing_power)
 
-/datum/perk/oddity/hive_born
+/datum/perk/hive_oddity/hive_born
 	name = "Hiveborn"
 	desc = "You feel electricty flow within your body to your hands. Powercells recharge in your hands."
 	icon_state = "circuitry"  //https://game-icons.net/1x1/lorc/circuitry.html
@@ -266,11 +266,11 @@
 	var/initial_time
 	var/obj/item/weapon/cell/C
 
-/datum/perk/oddity/hive_born/assign(mob/living/carbon/human/H)
+/datum/perk/hive_oddity/hive_born/assign(mob/living/carbon/human/H)
 	..()
 	initial_time = world.time
 
-/datum/perk/oddity/hive_born/on_process()
+/datum/perk/hive_oddity/hive_born/on_process()
 	if(!..())
 		return
 	if(world.time < initial_time + cooldown)

--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -485,7 +485,7 @@
 		STAT_MEC = 8,
 		STAT_BIO = 8
 	)
-	perk = /datum/perk/oddity/hive_born
+	perk = /datum/perk/hive_oddity/hive_born
 
 //i copied the entire thing because beforehand it just did not work
 /obj/item/weapon/oddity/hivemind/hive_core/Initialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

makes it so hiveborn perk doesnt show up on normal odditties

## Why It's Good For The Game

speshul snowflake perk only for hive oddity

![image](https://user-images.githubusercontent.com/59490776/126075273-949f9f58-7ef1-4b1b-8d4b-37624a51ec4e.png)
proof that i somehow didnt fuck shit up and it still shows up on the normal one

## Changelog
:cl:
fix: fixed hiveborn perk showing up on non-hivecore oddities
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
