### PR TITLE
Blank no more

### DIFF
--- a/code/game/objects/items/weapons/design_disks/NeoTheology.dm
+++ b/code/game/objects/items/weapons/design_disks/NeoTheology.dm
@@ -153,12 +153,17 @@
 	)
 
 /obj/item/computer_hardware/hard_drive/portable/design/nt
+	disk_name = "NeoTheology Armory - NeoTheologian Medkit"
+	icon_state = "neotheology"
+	designs = list(
+		/datum/design/autolathe/firstaid/nt
+	)
+
+/obj/item/computer_hardware/hard_drive/portable/design/nt_blank
 	disk_name = "NeoTheology Armory - Blank"
 	rarity_value = 50
 	license = -1
-	spawn_blacklisted = TRUE
 	price_tag = 1000
-	bad_type = /obj/item/computer_hardware/hard_drive/portable/design/nt
 
 /obj/item/computer_hardware/hard_drive/portable/design/nt/melee
 	disk_name = "NeoTheology Armory - Basic Melee Weapons"
@@ -181,13 +186,6 @@
 		/datum/design/autolathe/nt/sword/nt_halberd,
 		/datum/design/autolathe/nt/shield/nt_shield,
 		/datum/design/autolathe/nt/sword/nt_spear
-	)
-
-/obj/item/computer_hardware/hard_drive/portable/design/nt/firstaid
-	disk_name = "NeoTheology Armory - NeoTheologian Medkit"
-	icon_state = "neotheology"
-	designs = list(
-		/datum/design/autolathe/firstaid/nt
 	)
 
 /obj/item/computer_hardware/hard_drive/portable/design/nt/guns/nt_dominion

--- a/code/game/objects/items/weapons/design_disks/NeoTheology.dm
+++ b/code/game/objects/items/weapons/design_disks/NeoTheology.dm
@@ -153,18 +153,11 @@
 	)
 
 /obj/item/computer_hardware/hard_drive/portable/design/nt
-	disk_name = "NeoTheology Armory - NeoTheologian Medkit"
+	disk_name = "NeoTheology Armory - NeoTheology Medkit"
 	icon_state = "neotheology"
 	designs = list(
 		/datum/design/autolathe/firstaid/nt
 	)
-
-/obj/item/computer_hardware/hard_drive/portable/design/nt_blank
-	disk_name = "NeoTheology Armory - Blank"
-	rarity_value = 50
-	license = -1
-	spawn_blacklisted = TRUE
-	price_tag = 1000
 
 /obj/item/computer_hardware/hard_drive/portable/design/nt/melee
 	disk_name = "NeoTheology Armory - Basic Melee Weapons"

--- a/code/game/objects/items/weapons/design_disks/NeoTheology.dm
+++ b/code/game/objects/items/weapons/design_disks/NeoTheology.dm
@@ -163,6 +163,7 @@
 	disk_name = "NeoTheology Armory - Blank"
 	rarity_value = 50
 	license = -1
+	spawn_blacklisted = TRUE
 	price_tag = 1000
 
 /obj/item/computer_hardware/hard_drive/portable/design/nt/melee


### PR DESCRIPTION
## About The Pull Request

Removes "NeoTheology - Blank" from EOTP rotation. Parent of NT discs was made into medkit disk, and blank ~~now /nt_blank~~ is gone forever.
This PR is tested out, NT disks work as intended, with no design lists or resource cost altered.

https://github.com/discordia-space/CEV-Eris/issues/6281

## Why It's Good For The Game

Fixes cool.

## Changelog
:cl:
fix: empty disk no longer appearing in EOTP
/:cl:
