### PR TITLE
Da crab increase

### DIFF
--- a/code/game/objects/items/devices/von-krabin.dm
+++ b/code/game/objects/items/devices/von-krabin.dm
@@ -18,7 +18,7 @@
 	var/active = FALSE
 	var/area_radius = 7
 
-	var/buff_power = 5
+	var/buff_power = 15
 
 	var/stats_buff = list(STAT_BIO, STAT_COG, STAT_MEC)
 	var/list/mob/living/carbon/human/currently_affected = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/59490776/127656527-11a8c768-ce86-4ed5-9167-466340dbb130.png)

makes the stat increase of the von krabin thing be 15 instead of 5

## Why It's Good For The Game

~~its not~~

von krabin felt underwhelming ever since it was introduced, hopefully this makes it see a bit more use in science instead of collecting dust

## Changelog
:cl:
tweak: tweaked Von-Krabin Stimulator stat increase to 15 (from 5)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
