### PR TITLE
Virus Food Nerf: Remastered

### DIFF
--- a/code/modules/reagents/enricher.dm
+++ b/code/modules/reagents/enricher.dm
@@ -37,7 +37,7 @@
 	if(reagents.total_volume)
 		for(var/datum/reagent/reagent in reagents.reagent_list)
 			var/reagent_amount = 0
-			if(istype(reagent, /datum/reagent/organic/nutriment))
+			if(istype(reagent, /datum/reagent/organic/nutriment) && !istype(reagent, /datum/reagent/organic/nutriment/virus_food))
 				var/datum/reagent/organic/nutriment/N = reagent
 				reagent_amount = N.volume
 				N.remove_self(reagent_amount)
@@ -52,7 +52,7 @@
 			bottle.name = "resuscitator bottle"
 			resuscitator_amount = 0
 			bottle.update_icon()
-			visible_message(SPAN_NOTICE("[src] drop [bottle]."))
+			visible_message(SPAN_NOTICE("[src] drops [bottle]."))
 		else
 			visible_message("\The [src] beeps, \"Not enough nutriment to produce resuscitator.\".")
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

makes the enricher reject virus food

also fixes a word(?) mistake

## Why It's Good For The Game

roundstart (there is a dispenser in virology) easy rescuitator might not be the best of ideas frankly

also english is better than engrish

## Changelog
:cl:
tweak: enricher rejects virus food
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
