### PR TITLE
Itsy bitsy fix

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/iriska.dm
+++ b/code/modules/mob/living/simple_animal/friendly/iriska.dm
@@ -169,12 +169,13 @@ var/list/despised = list()
 	return ..(gibbed,deathmessage)
 
 /mob/living/simple_animal/iriska/proc/destroy_lifes()
-	for(var/mob/living/carbon/human/H in despised)
-		H.sanity.insight = 0
-		H.sanity.environment_cap_coeff = 0
-		H.sanity.negative_prob += 30
-		H.sanity.positive_prob = 0
-		H.sanity.level = 0
-		for(var/stat in ALL_STATS)
-			H.stats.changeStat(stat, -10)
-		to_chat(H, SPAN_DANGER("The shadows seem to lengthen, the walls are closing in. The ship itself wants you dead."))
+	for(var/mob/living/carbon/human/H in GLOB.human_mob_list)
+		if(H.real_name in despised)
+			H.sanity.insight = 0
+			H.sanity.environment_cap_coeff = 0
+			H.sanity.negative_prob += 30
+			H.sanity.positive_prob = 0
+			H.sanity.level = 0
+			for(var/stat in ALL_STATS)
+				H.stats.changeStat(stat, -10)
+			to_chat(H, SPAN_DANGER("The shadows seem to lengthen, the walls are closing in. The ship itself wants you dead."))


### PR DESCRIPTION
## About The Pull Request

So I woke up just now, checked discord and see that Iriska curse not working. Apparently, when removing mob reference lists from Iriska code right before merge - I forgot to adjust destroy_lifes() proc to new lists, but now it's fixed.

![image](https://user-images.githubusercontent.com/65828539/127729420-4bd58fdc-94f5-40bf-8266-bfe65491b221.png)

## Why It's Good For The Game

Fixes cool.
## Changelog
:cl:
fix: Iriska curse
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
