### PR TITLE
fixes a division by zero runtime in sanity HUD

### DIFF
--- a/code/_onclick/hud/screen_objects/base_screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/base_screen_objects.dm
@@ -392,22 +392,26 @@
 	cut_overlays()
 	var/image/ovrl
 
-	switch(H.sanity.level / H.sanity.max_level)
-		if(-INFINITY to 0)
-			add_overlays(ovrls["sanity6"])
-			return
-		if(1 to INFINITY)
-			ovrl = ovrls["sanity0"]
-		if(0.8 to 1)
-			ovrl = ovrls["sanity1"]
-		if(0.6 to 0.8)
-			ovrl = ovrls["sanity2"]
-		if(0.4 to 0.6)
-			ovrl = ovrls["sanity3"]
-		if(0.2 to 0.4)
-			ovrl = ovrls["sanity4"]
-		if(0 to 0.2)
-			ovrl = ovrls["sanity5"]
+	if (H.sanity?.max_level > 0)
+		switch(H.sanity.level / H.sanity.max_level)
+			if(-INFINITY to 0)
+				add_overlays(ovrls["sanity6"])
+				return
+			if(1 to INFINITY)
+				ovrl = ovrls["sanity0"]
+			if(0.8 to 1)
+				ovrl = ovrls["sanity1"]
+			if(0.6 to 0.8)
+				ovrl = ovrls["sanity2"]
+			if(0.4 to 0.6)
+				ovrl = ovrls["sanity3"]
+			if(0.2 to 0.4)
+				ovrl = ovrls["sanity4"]
+			if(0 to 0.2)
+				ovrl = ovrls["sanity5"]
+	else
+		add_overlays(ovrls["sanity6"])
+		return
 
 	switch(H.sanity.insight)
 		if(-INFINITY to 20)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
this PR fixes a division by zero runtime that happened when max sanity was zero, sanity hud now always shows the breakdown overlay when max sanity is zero.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtime Bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Chickenish
fix: fixed division by zero runtime in sanity HUD
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
