### PR TITLE
RCD's bug fix and some balancing

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -111,37 +111,43 @@
 				build_turf =  /turf/simulated/floor/airless
 			if(gotFloor)
 				build_delay = 40
-				build_cost =  5
+				build_cost =  3
 				build_type =  "wall"
 				build_turf =  /turf/simulated/wall
 		if(2)
-			if(!gotBlocked)
+			if(gotBlocked)
+				return 0
+			if(gotSpace)
+				build_type = "low wall"
+				build_delay = 30
+				build_cost = 3
+				build_turf = /turf/simulated/floor/airless //there is always floor under low wall
+				build_object = /obj/structure/low_wall
+			if(gotFloor)
 				build_type = "low wall"
 				build_object = /obj/structure/low_wall
-				if(gotSpace)
-					build_delay = 30
-					build_cost = 6
-					build_turf = /turf/simulated/floor/airless //there is always floor under low wall
-				if(gotFloor)
-					build_delay = 30
-					build_cost =  5
+				build_delay = 30
+				build_cost =  2
 
 		if(3)
-			if(!gotBlocked)
+			if(gotBlocked)
+				return 0
+			if(gotSpace)
 				build_type = "airlock"
+				build_cost =  8
+				build_delay = 50
+				build_turf =  /turf/simulated/floor/airless
 				build_object = /obj/machinery/door/airlock
-				if(gotSpace)
-					build_cost =  11
-					build_delay = 50
-					build_turf =  /turf/simulated/floor/airless
-				if(gotFloor)
-					build_cost =  10
-					build_delay = 40
+			if(gotFloor)
+				build_type = "airlock"
+				build_cost =  7
+				build_delay = 40
+				build_object = /obj/machinery/door/airlock
 
 		if(4)
 			build_type =  "deconstruct"
 			if(gotFloor)
-				build_cost =  10
+				build_cost =  5
 				build_delay = 50
 				build_turf = get_base_turf(local_turf.z)
 			else if(istype(T,/obj/structure/low_wall))

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -134,13 +134,13 @@
 				return 0
 			if(gotSpace)
 				build_type = "airlock"
-				build_cost =  8
+				build_cost =  7
 				build_delay = 50
 				build_turf =  /turf/simulated/floor/airless
 				build_object = /obj/machinery/door/airlock
 			if(gotFloor)
 				build_type = "airlock"
-				build_cost =  7
+				build_cost =  6
 				build_delay = 40
 				build_object = /obj/machinery/door/airlock
 


### PR DESCRIPTION
Not even that good at coding so whatever
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixed a little bug that allowed RCD to build low walls and airlocks inside other walls by clicking on them, and that doesnt spend any matter.

Also trying to make RCD's matter consumption a little more fair to the hand version since it's extremely unfun and feels unfair to use even in extreme situations. Tested how it affects borgs and rigs, the only problem might be the borgs since they can afford their cell charge to lose some energy and it might not even be that expensive for them but they are controlled by laws anyway, **so what could go wrong?**

## Why It's Good For The Game

In it's current state all RCDs that humans use are left to dust on the shelf and it feels very punishing to use it since building cost is very high and making new cartriges feels like getting scammed for resources by Asters Guild. I don't say I made the perfect rebalance but I hope the opinion for this thing goes from "extremely stupid thing" to "maybe less stupid thing"

## Changelog
:cl:
fix: Fixed RCD's ability to build airlocks and low walls inside other walls without spending any ammo
balance: Reduced some of the building costs for the RCD

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
