### PR TITLE
fixes wire splicings spawning off of cable

### DIFF
--- a/code/game/objects/random/traps/traps.dm
+++ b/code/game/objects/random/traps/traps.dm
@@ -36,11 +36,13 @@
 //Checks if a trap can spawn in this location
 /proc/can_spawn_trap(turf/T, trap)
 	.=TRUE
-	if(ispath(trap, /obj/structure/wire_splicing))
-		if(locate(/obj/structure/cable) in dview(3, T))
-			return TRUE
 	if(locate(trap) in T)
 		return FALSE
+	if(ispath(trap, /obj/structure/wire_splicing))
+		if(locate(/obj/structure/cable) in dview(3, T))
+			return
+		else
+			return FALSE
 
 /obj/spawner/traps/find_smart_point(path)
 	var/list/spawn_points = ..()


### PR DESCRIPTION
now will check if trap is present before splicing behaviour
now will return false if there is no cable in range of splicing

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR fixes wire splicings spawning off of cables, and reduces the likelyhood of two wire splicings spawning on the same tile.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Wire splicings were supposed to never spawn off of cables, but did. The bug this PR patches enables it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Chickenish
fix: Wire Splicings no longer spawn off of cables.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
