### PR TITLE
[JTB] Rebalance loot

### DIFF
--- a/maps/submaps/junk_field/j25_25/ironhammer/ironhammer1.dmm
+++ b/maps/submaps/junk_field/j25_25/ironhammer/ironhammer1.dmm
@@ -43,8 +43,6 @@
 /obj/structure/table/rack,
 /obj/item/device/flash,
 /obj/item/device/flash,
-/obj/item/device/flash,
-/obj/item/device/flash,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/template_noop)
 "bi" = (
@@ -198,8 +196,6 @@
 /obj/item/cell/medium/high,
 /obj/item/cell/medium/high,
 /obj/item/cell/medium/high,
-/obj/item/cell/medium/high,
-/obj/item/cell/medium/high,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/template_noop)
 "qA" = (
@@ -217,9 +213,6 @@
 /area/template_noop)
 "rd" = (
 /obj/structure/table/rack,
-/obj/item/cell/small/high,
-/obj/item/cell/small/high,
-/obj/item/cell/small/high,
 /obj/item/cell/small/high,
 /obj/item/cell/small/high,
 /obj/item/cell/small/high,
@@ -260,7 +253,7 @@
 /area/template_noop)
 "to" = (
 /obj/structure/table/rack,
-/obj/spawner/gun/shotgun,
+/obj/spawner/gun/shotgun/low_chance,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/template_noop)
 "tv" = (
@@ -309,6 +302,11 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
+/area/template_noop)
+"xA" = (
+/obj/structure/table/rack,
+/obj/spawner/gun/cheap,
+/turf/simulated/floor/tiled/dark/cargo,
 /area/template_noop)
 "yJ" = (
 /obj/structure/table/standard,
@@ -447,8 +445,6 @@
 /obj/structure/table/rack,
 /obj/item/clothing/suit/armor/heavy/riot/ironhammer,
 /obj/item/clothing/suit/armor/heavy/riot/ironhammer,
-/obj/item/clothing/suit/armor/heavy/riot/ironhammer,
-/obj/item/clothing/head/armor/riot_hud,
 /obj/item/clothing/head/armor/riot_hud,
 /obj/item/clothing/head/armor/riot_hud,
 /turf/simulated/floor/tiled/dark/cargo,
@@ -478,7 +474,6 @@
 /obj/structure/table/rack,
 /obj/item/storage/belt/tactical/ironhammer,
 /obj/item/storage/belt/tactical/ironhammer,
-/obj/item/storage/belt/tactical/ironhammer,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/template_noop)
 "RC" = (
@@ -502,7 +497,7 @@
 /area/template_noop)
 "Ul" = (
 /obj/structure/table/rack,
-/obj/spawner/gun/normal,
+/obj/spawner/gun/normal/low_chance,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/template_noop)
 "Vq" = (
@@ -544,7 +539,6 @@
 /area/template_noop)
 "Yp" = (
 /obj/structure/table/rack,
-/obj/item/gun/energy/gun/martin,
 /obj/item/gun/energy/gun/martin,
 /obj/item/gun/energy/gun/martin,
 /obj/machinery/light{
@@ -800,7 +794,7 @@ YZ
 by
 Ul
 to
-Ul
+xA
 js
 Mb
 wR

--- a/maps/submaps/junk_field/j25_25/ironhammer/ironhammer2.dmm
+++ b/maps/submaps/junk_field/j25_25/ironhammer/ironhammer2.dmm
@@ -19,7 +19,7 @@
 /area/template_noop)
 "aP" = (
 /obj/structure/table/rack,
-/obj/spawner/gun/normal,
+/obj/spawner/gun/cheap,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/template_noop)
 "aU" = (

--- a/maps/submaps/junk_field/j25_25/ironhammer/ironhammer3.dmm
+++ b/maps/submaps/junk_field/j25_25/ironhammer/ironhammer3.dmm
@@ -161,14 +161,12 @@
 /obj/structure/table/rack,
 /obj/spawner/gun_parts,
 /obj/spawner/gun/normal/low_chance,
-/obj/spawner/gun/normal/low_chance,
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/template_noop)
 "aN" = (
 /obj/structure/table/rack,
 /obj/spawner/gun_parts/low_chance,
 /obj/spawner/gun_parts/low_chance,
-/obj/spawner/gun_parts,
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/template_noop)
 "aO" = (
@@ -338,6 +336,12 @@
 /obj/spawner/ammo/shotgun,
 /obj/spawner/rig_module/low_chance,
 /obj/spawner/rig_module/rare/low_chance,
+/turf/simulated/floor/tiled/steel/bluecorner,
+/area/template_noop)
+"qx" = (
+/obj/structure/table/rack,
+/obj/spawner/gun_parts/low_chance,
+/obj/spawner/gun_parts,
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/template_noop)
 "Qv" = (
@@ -519,7 +523,7 @@ aB
 ad
 aj
 ae
-aN
+qx
 an
 aY
 ae

--- a/maps/submaps/junk_field/j25_25/serbian/serbian1.dmm
+++ b/maps/submaps/junk_field/j25_25/serbian/serbian1.dmm
@@ -79,7 +79,7 @@
 /area/template_noop)
 "dI" = (
 /obj/structure/table/standard,
-/obj/item/storage/deferred/rations,
+/obj/item/deck/cards,
 /turf/unsimulated/floor{
 	icon_state = "cult";
 	name = "plating"
@@ -267,10 +267,10 @@
 /area/template_noop)
 "nu" = (
 /obj/structure/table/rack,
-/obj/spawner/gun/normal,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/spawner/gun/cheap,
 /turf/unsimulated/floor{
 	icon_state = "cult";
 	name = "plating"
@@ -280,7 +280,6 @@
 /obj/structure/closet,
 /obj/item/tool/pickaxe/diamonddrill,
 /obj/item/tool/pickaxe/diamonddrill,
-/obj/item/storage/backpack/military,
 /obj/item/storage/backpack/military,
 /turf/unsimulated/floor{
 	icon_state = "cult";
@@ -365,7 +364,6 @@
 /obj/spawner/ammo,
 /obj/spawner/ammo,
 /obj/spawner/ammo,
-/obj/spawner/ammo,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -393,7 +391,7 @@
 /area/template_noop)
 "tv" = (
 /obj/structure/table/rack,
-/obj/spawner/gun/shotgun,
+/obj/spawner/gun/shotgun/low_chance,
 /turf/unsimulated/floor{
 	icon_state = "cult";
 	name = "plating"
@@ -439,9 +437,7 @@
 "wR" = (
 /obj/structure/table/rack,
 /obj/item/storage/belt/tactical,
-/obj/item/storage/belt/tactical,
-/obj/item/storage/belt/tactical,
-/obj/item/storage/pouch/large_generic,
+/obj/item/storage/pouch/medium_generic,
 /turf/unsimulated/floor{
 	icon_state = "cult";
 	name = "plating"
@@ -830,7 +826,7 @@
 /area/template_noop)
 "Zt" = (
 /obj/structure/table/rack,
-/obj/spawner/gun/normal,
+/obj/spawner/gun/cheap,
 /turf/unsimulated/floor{
 	icon_state = "cult";
 	name = "plating"

--- a/maps/submaps/junk_field/j25_25/serbian/serbian2.dmm
+++ b/maps/submaps/junk_field/j25_25/serbian/serbian2.dmm
@@ -254,7 +254,7 @@
 /area/template_noop)
 "xN" = (
 /obj/structure/table/rack,
-/obj/spawner/gun/normal,
+/obj/spawner/gun/cheap,
 /turf/unsimulated/floor{
 	icon_state = "lino"
 	},
@@ -331,7 +331,7 @@
 /area/template_noop)
 "Dy" = (
 /obj/structure/table/rack,
-/obj/spawner/gun/shotgun,
+/obj/spawner/gun/normal/low_chance,
 /turf/unsimulated/floor{
 	icon_state = "lino"
 	},
@@ -390,7 +390,6 @@
 /area/template_noop)
 "Js" = (
 /obj/structure/closet,
-/obj/item/clothing/mask/balaclava/tactical,
 /obj/item/clothing/mask/balaclava/tactical,
 /obj/item/clothing/mask/balaclava/tactical,
 /turf/unsimulated/floor{
@@ -498,7 +497,6 @@
 /obj/item/tool/pickaxe/diamonddrill,
 /obj/item/tool/pickaxe/diamonddrill,
 /obj/item/storage/backpack/military,
-/obj/item/storage/backpack/military,
 /turf/unsimulated/floor{
 	icon_state = "lino"
 	},
@@ -558,12 +556,10 @@
 "Ur" = (
 /obj/structure/table/rack,
 /obj/item/storage/belt/tactical,
-/obj/item/storage/belt/tactical,
-/obj/item/storage/belt/tactical,
-/obj/item/storage/pouch/large_generic,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/storage/pouch/medium_generic,
 /turf/unsimulated/floor{
 	icon_state = "lino"
 	},

--- a/maps/submaps/junk_field/j25_25/serbian/serbian3.dmm
+++ b/maps/submaps/junk_field/j25_25/serbian/serbian3.dmm
@@ -143,7 +143,10 @@
 /area/template_noop)
 "aw" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/deferred/rations,
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -5;
+	pixel_y = 1
+	},
 /turf/unsimulated/floor{
 	icon_state = "white"
 	},
@@ -519,24 +522,29 @@
 	},
 /area/template_noop)
 "bz" = (
-/obj/spawner/gun_parts/low_chance,
+/obj/structure/closet,
+/obj/item/reagent_containers/food/drinks/bottle/vodka{
+	pixel_x = 6;
+	pixel_y = 7
+	},
 /turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
+	icon_state = "lino"
 	},
 /area/template_noop)
 "bA" = (
 /obj/structure/closet,
-/obj/item/storage/deferred/rations,
+/obj/item/reagent_containers/food/drinks/bottle/vodka{
+	pixel_x = 5;
+	pixel_y = 17
+	},
+/obj/item/reagent_containers/food/drinks/flask/barflask,
 /turf/unsimulated/floor{
-	icon_state = "cult";
-	name = "plating"
+	icon_state = "lino"
 	},
 /area/template_noop)
 "bB" = (
-/obj/structure/table/rack,
-/obj/spawner/gun_parts/low_chance,
-/obj/spawner/gun_parts/low_chance,
+/obj/structure/closet,
+/obj/item/storage/belt/tactical,
 /turf/unsimulated/floor{
 	icon_state = "cult";
 	name = "plating"
@@ -552,7 +560,7 @@
 /area/template_noop)
 "bD" = (
 /obj/structure/table/rack,
-/obj/spawner/gun/normal,
+/obj/spawner/gun/normal/low_chance,
 /turf/unsimulated/floor{
 	icon_state = "cult";
 	name = "plating"
@@ -560,8 +568,7 @@
 /area/template_noop)
 "bE" = (
 /obj/structure/table/rack,
-/obj/spawner/gun/normal,
-/obj/spawner/gun_parts,
+/obj/spawner/gun/cheap/low_chance,
 /turf/unsimulated/floor{
 	icon_state = "cult";
 	name = "plating"
@@ -589,7 +596,7 @@
 /area/template_noop)
 "bJ" = (
 /obj/structure/lattice,
-/obj/item/storage/pouch/medium_generic,
+/obj/item/storage/pouch/small_generic,
 /turf/template_noop,
 /area/template_noop)
 "bK" = (
@@ -622,6 +629,14 @@
 "bQ" = (
 /obj/item/material/shard,
 /turf/simulated/floor/plating/under,
+/area/template_noop)
+"My" = (
+/obj/structure/table/rack,
+/obj/spawner/gun/cheap,
+/turf/unsimulated/floor{
+	icon_state = "cult";
+	name = "plating"
+	},
 /area/template_noop)
 
 (1,1,1) = {"
@@ -751,8 +766,8 @@ ab
 ab
 ab
 by
-bB
-aQ
+by
+by
 aQ
 bF
 ab
@@ -804,9 +819,9 @@ aL
 ab
 bb
 ab
-bz
-bz
 ac
+ac
+ao
 ac
 bG
 ab
@@ -861,8 +876,8 @@ ab
 ac
 bC
 aQ
+by
 bE
-bD
 bi
 ax
 ax
@@ -946,7 +961,7 @@ aP
 ax
 bb
 bH
-bL
+aP
 "}
 (13,1,1) = {"
 aa
@@ -970,7 +985,7 @@ ac
 ac
 ac
 aP
-bD
+My
 ab
 bk
 ax
@@ -997,7 +1012,7 @@ aX
 aP
 aP
 ao
-bC
+aQ
 ab
 aa
 aa
@@ -1008,8 +1023,8 @@ aP
 aP
 ad
 aS
-aS
-aJ
+bz
+bA
 ad
 ad
 ab
@@ -1128,7 +1143,7 @@ ad
 ad
 bo
 ab
-aX
+bB
 ac
 by
 ac
@@ -1155,11 +1170,11 @@ aV
 aW
 aT
 ab
-bA
+aX
 ac
 bD
 ac
-bD
+bE
 ab
 aa
 aa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduce the quality of loot in some JTB 25 x 25 chunks to avoid people rushing there for gamer loot (good guns, pouches, gear)

## Why It's Good For The Game

Less gamer loot.

## Changelog
:cl: Hyperio
balance: Reduce quality of loot in JTB chunks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
