### PR TITLE
NT-branded AMR fix

### DIFF
--- a/code/datums/autolathe/guns.dm
+++ b/code/datums/autolathe/guns.dm
@@ -182,9 +182,8 @@
 // Heavy
 
 /datum/design/autolathe/gun/heavysniper
-	name = "NT AMR .60 \"Penetrator\""
-	build_path = /obj/item/gun/projectile/heavysniper/nt
-	factions = list(FACTION_NEOTHEOLOGY)
+	name = "SA AMR .60 \"Hristov\""
+	build_path = /obj/item/gun/projectile/heavysniper
 
 /datum/design/autolathe/gun/mg_pk
 	name = "SA MG .30 \"Pulemyot Kalashnikova\""

--- a/code/datums/autolathe/guns.dm
+++ b/code/datums/autolathe/guns.dm
@@ -183,7 +183,7 @@
 
 /datum/design/autolathe/gun/heavysniper
 	name = "NT AMR .60 \"Penetrator\""
-	build_path = /obj/item/gun/projectile/heavysniper
+	build_path = /obj/item/gun/projectile/heavysniper/nt
 	factions = list(FACTION_NEOTHEOLOGY)
 
 /datum/design/autolathe/gun/mg_pk

--- a/code/game/objects/items/weapons/design_disks/NeoTheology.dm
+++ b/code/game/objects/items/weapons/design_disks/NeoTheology.dm
@@ -305,18 +305,6 @@
 		/datum/design/autolathe/gun/grenade_launcher = 3, // "NT GL \"Protector\""
 	)
 
-/obj/item/computer_hardware/hard_drive/portable/design/guns/nt_heavysniper
-	disk_name = "NeoTheology Armory - .60 Penetrator AMR"
-	icon_state = "neotheology"
-	spawn_tags = SPAWN_TAG_DESIGN_ADVANCED
-	rarity_value = 90
-	license = 12
-	designs = list(
-		/datum/design/autolathe/gun/heavysniper = 3, // "NT AMR .60 \"Penetrator\""
-		/datum/design/autolathe/ammo/antim,
-		/datum/design/autolathe/ammo/box_antim,
-	)
-
 /obj/item/computer_hardware/hard_drive/portable/design/guns/nt_mk58
 	disk_name = "NeoTheology Armory - .35 MK58 Handgun Pack"
 	icon_state = "neotheology"

--- a/code/game/objects/items/weapons/design_disks/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/design_disks/autolathe_disks.dm
@@ -23,6 +23,18 @@
 		/datum/design/autolathe/ammo/lrifle_ammobox_small,
 	)
 
+/obj/item/computer_hardware/hard_drive/portable/design/guns/sa_heavysniper
+	disk_name = "Serbian Arms - .60 Hristov AMR"
+	icon_state = "serbian"
+	spawn_tags = SPAWN_TAG_DESIGN_ADVANCED
+	rarity_value = 90
+	license = 12
+	designs = list(
+		/datum/design/autolathe/gun/heavysniper = 3, // "SA AMR .60 \"Hristov\""
+		/datum/design/autolathe/ammo/antim,
+		/datum/design/autolathe/ammo/box_antim,
+	)
+
 /obj/item/computer_hardware/hard_drive/portable/design/guns/sa_pk
 	disk_name = "Serbian Arms - .30 Pulemyot Kalashnikova MG"
 	icon_state = "serbian"

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -31,9 +31,6 @@
 	var/bolt_open = 0
 	var/item_suffix = ""
 
-/obj/item/gun/projectile/heavysniper/nt
-	name = "NT AMR .60 \"Penetrator\""
-
 /obj/item/gun/projectile/heavysniper/on_update_icon()
 	..()
 

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/heavysniper
-	name = "SA AMR \"Hristov\""
+	name = "SA AMR .60 \"Hristov\""
 	desc = "A portable anti-armour rifle, fitted with a night-vision scope, it was originally designed for use against armoured exosuits. It is capable of punching through windows and non-reinforced walls with ease, but suffers from overpenetration at close range. Fires armor piercing .60 shells. Can be upgraded using thermal glasses."
 	icon = 'icons/obj/guns/projectile/heavysniper.dmi'
 	icon_state = "heavysniper"
@@ -30,6 +30,9 @@
 	no_internal_mag = TRUE
 	var/bolt_open = 0
 	var/item_suffix = ""
+
+/obj/item/gun/projectile/heavysniper/nt
+	name = "NT AMR .60 \"Penetrator\""
 
 /obj/item/gun/projectile/heavysniper/on_update_icon()
 	..()


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/65828539/130183453-5cf779d2-6a5c-4674-bb4f-5b245af22bb2.png)

Design disc states one name, but printed gun spawns with different one. Not anymore.

![image](https://user-images.githubusercontent.com/65828539/130185090-ec65b2e2-b011-4ff7-a6f0-86bfdbc04de1.png)
![image](https://user-images.githubusercontent.com/65828539/130185105-4222f7ab-70d1-498f-b1cc-9da1a4b83646.png)



## Why It's Good For The Game

Fixes cool.

## Changelog
:cl:
fix: NT-branded AMR having wrong name
/:cl:

