### PR TITLE
Pizza implants dupe and knife eating fix

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -267,7 +267,7 @@
 		var/hide_item = !has_edge(W) || !can_slice_here
 
 		if (hide_item)
-			if (W.w_class >= src.w_class || is_robot_module(W))
+			if (W.w_class >= src.w_class || is_robot_module(W) || (QUALITY_CUTTING in W.tool_qualities))
 				return
 
 			to_chat(user, SPAN_WARNING("You slip \the [W] inside \the [src]."))


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/65828539/130195894-11a58185-c7af-4349-a95d-705e7091a0b3.png)

Sliceable snacks no longer take any of the arm-embedded augments and any tool with cutting quality.
Once lost two cleavers in a pizza, that was pretty stupid.

## Why It's Good For The Game

Fixes cool.

## Changelog
:cl:

fix: pizza won't accept tools with cutting quality

/:cl: