### PR TITLE
Meat grinding for synths fix

### DIFF
--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -267,7 +267,8 @@
 		/obj/item/reagent_containers/spray,
 		/obj/item/storage/pill_bottle,
 		/obj/item/hand_labeler,
-		/obj/item/stack/material/plasma
+		/obj/item/stack/material/plasma,
+		/obj/item/reagent_containers/food/snacks/meat
 		)
 
 /obj/item/gripper/service //Used to handle food, drinks, and seeds.

--- a/code/modules/reagents/machinery/grinder.dm
+++ b/code/modules/reagents/machinery/grinder.dm
@@ -76,9 +76,6 @@
 	SSnano.update_uis(src)
 	return 0
 
-/obj/machinery/reagentgrinder/attack_ai(mob/user as mob)
-	return 0
-
 /obj/machinery/reagentgrinder/attack_hand(mob/user)
 	. = ..()
 	if(.)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/65828539/130200564-19a02311-e2be-4bf8-a3bd-83ee9e3b84d4.png)

Added /meat to chemistry gripper list and allowed synthetics to interact with the grinder.

## Why It's Good For The Game

Fixes cool.

## Changelog
:cl:
fix: chemistry gripper not accepting meat
/:cl:
