### PR TITLE
adds AP to tool tooltip

### DIFF
--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -220,6 +220,7 @@
 	data["force"] = force
 	data["force_max"] = initial(force) * 10
 
+	data["armor_penetration"] = armor_penetration
 
 	data["extra_volume"] = extra_bulk
 

--- a/nano/templates/tool_stats.tmpl
+++ b/nano/templates/tool_stats.tmpl
@@ -91,6 +91,13 @@
 		<div class="itemContent">
 			{{:helper.displayBar(data.force, 0, data.force_max, '', data.force)}}
 		</div>
+	
+		<div class="itemLabel">
+			Armor penetration:
+		</div>
+		<div class="itemContent">
+			{{:data.armor_penetration}}
+		</div>
 
 		{{if data.extra_volume}}
 			<div class="itemLabel">


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes the tooltip of tools include the Armor Penetration value, currently stated as a flat number.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Players should know the AP of the the melee weapons they're using.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Chickenish
add: tool tooltips now include the armor penetration value.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
