### PR TITLE
organ module items now cannot be put in sliceable

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -895,6 +895,7 @@
 #include "code\game\objects\items\devices\organ_module\_module.dm"
 #include "code\game\objects\items\devices\organ_module\active.dm"
 #include "code\game\objects\items\devices\organ_module\debug.dm"
+#include "code\game\objects\items\devices\organ_module\is_item_attached.dm"
 #include "code\game\objects\items\devices\organ_module\simple.dm"
 #include "code\game\objects\items\devices\organ_module\active\armblades.dm"
 #include "code\game\objects\items\devices\organ_module\active\armguns.dm"

--- a/code/game/objects/items/devices/organ_module/is_item_attached.dm
+++ b/code/game/objects/items/devices/organ_module/is_item_attached.dm
@@ -1,0 +1,18 @@
+// couldn't figure out a better place to put this
+// move it to organ folder when organ modules are gone
+
+//I is the item you want to check if is attached to the human you called this on
+/mob/living/carbon/human/proc/is_item_attached(obj/item/I)
+	. = FALSE
+	var/held_in = get_holding_hand(I)
+	if (held_in)
+		var/obj/item/organ/external/relevant_arm = get_organ(held_in)
+		var/relevant_module = relevant_arm.module
+		if (relevant_module)
+			if (istype(relevant_module, /obj/item/organ_module/active/simple))
+				var/obj/item/organ_module/active/simple/active_simple = relevant_module
+				return I == active_simple.holding
+			else if (istype(relevant_module, /obj/item/organ_module/active/multitool))
+				var/obj/item/organ_module/active/multitool/active_multitool = relevant_module
+				return I in active_multitool.items
+

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -267,7 +267,12 @@
 		var/hide_item = !has_edge(W) || !can_slice_here
 
 		if (hide_item)
-			if (W.w_class >= src.w_class || is_robot_module(W))
+			var/illegal_item = FALSE // is used to allow for checks that need type definitions
+			if (ishuman(user))
+				var/mob/living/carbon/human/attached_to = user
+				if (attached_to.is_item_attached(W)) // checks if the item is an implant
+					illegal_item = TRUE
+			if (W.w_class >= src.w_class || is_robot_module(W) || illegal_item)
 				return
 
 			to_chat(user, SPAN_WARNING("You slip \the [W] inside \the [src]."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes it so that you cannot hide an implanted organ module item such as an armblade or implant multitool in a sliceable food item, and adds the is_item_attached proc to human for determining whether an item is the implanted organ module for the active hand.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Items should not be in multiple places at once in most cases.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Chickenish
fix: it is no longer possible to put implanted items in sliceable food items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
