### PR TITLE
Adds a lot of music tapes

### DIFF
--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -33,7 +33,7 @@
 	var/list/datum/track/tracks = list()		// Available tracks
 	var/list/datum/track/secret_tracks = list() // Only visible if hacked
 
-	var/obj/item/weapon/music_tape/my_tape //Jukebox tape
+	var/obj/item/music_tape/my_tape //Jukebox tape
 
 	var/sanity_value = 2
 
@@ -143,7 +143,7 @@
 				update_media_source()
 			return
 
-	if(istype(W, /obj/item/weapon/music_tape))
+	if(istype(W, /obj/item/music_tape))
 		if(my_tape)
 			to_chat(user, SPAN_NOTICE("There's already a tape inside [src]."))
 		else

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -50,11 +50,11 @@
 // On initialization, copy our tracks from the global list
 /obj/machinery/media/jukebox/Initialize()
 	. = ..()
-	if(all_jukebox_tracks.len < 1)
+	if(GLOB.all_jukebox_tracks.len < 1)
 		stat |= BROKEN // No tracks configured this round!
 	else
 		// Ootherwise load from the global list!
-		for(var/datum/track/T in all_jukebox_tracks)
+		for(var/datum/track/T in GLOB.all_jukebox_tracks)
 			if(T.secret)
 				secret_tracks |= T
 			else if(!T.playlist)

--- a/code/game/objects/items/boombox.dm
+++ b/code/game/objects/items/boombox.dm
@@ -18,7 +18,7 @@
 
 	var/ticks_to_update = 5
 
-	var/obj/item/weapon/music_tape/my_tape //boombox tape
+	var/obj/item/music_tape/my_tape //boombox tape
 
 	var/sanity_value = 2
 
@@ -100,7 +100,7 @@
 /obj/item/media/boombox/attackby(obj/item/W as obj, mob/user as mob)
 	src.add_fingerprint(user)
 
-	if(istype(W, /obj/item/weapon/music_tape))
+	if(istype(W, /obj/item/music_tape))
 		if(my_tape)
 			to_chat(user, SPAN_NOTICE("There's already a tape inside [src]."))
 		else

--- a/code/game/objects/items/musictapes.dm
+++ b/code/game/objects/items/musictapes.dm
@@ -10,7 +10,10 @@
 	var/list/datum/track/tracklist = list() //Actual list of media tracks
 
 /obj/item/weapon/music_tape/New()
-	for(var/datum/track/T in all_jukebox_tracks)
+	name = "[name] #[rand(1, 999)]"
+	icon_state = "[rand(1, 15)]"
+	songlist = pick(GLOB.all_playlists)
+	for(var/datum/track/T in GLOB.all_jukebox_tracks)
 		if(T.playlist == songlist)
 			tracklist |= T
 	..()
@@ -27,9 +30,10 @@
 	icon_state = "5"
 
 /obj/item/weapon/music_tape/cursed_songs_that_nobody_likes/New() //This one is special because it's all the songs everyone hated
-	for(var/datum/track/T in all_jukebox_tracks)
+	..()
+	tracklist = list() //Cleans up the song list
+	songlist = "cringe"
+	icon_state = "5"
+	for(var/datum/track/T in GLOB.all_jukebox_tracks)
 		if(T.secret)
 			tracklist |= T
-
-	..()
-

--- a/code/game/objects/items/musictapes.dm
+++ b/code/game/objects/items/musictapes.dm
@@ -1,4 +1,4 @@
-/obj/item/weapon/music_tape
+/obj/item/music_tape
 	name = "music tape"
 	desc = "Sweet sweet tunes."
 	icon = 'icons/obj/casettes.dmi'
@@ -9,7 +9,7 @@
 	var/songlist //string reference to the name of a songlist attached to this song
 	var/list/datum/track/tracklist = list() //Actual list of media tracks
 
-/obj/item/weapon/music_tape/New()
+/obj/item/music_tape/New()
 	name = "[name] #[rand(1, 999)]"
 	icon_state = "[rand(1, 15)]"
 	songlist = pick(GLOB.all_playlists)
@@ -18,18 +18,18 @@
 			tracklist |= T
 	..()
 
-/obj/item/weapon/music_tape/examine(mob/user)
+/obj/item/music_tape/examine(mob/user)
 	..()
 	var/msg = "This tape contains such tracks as:"
 	for(var/datum/track/T in tracklist)
 		msg += "\n[T.title]"
 	to_chat(user, msg)
 
-/obj/item/weapon/music_tape/cursed_songs_that_nobody_likes
+/obj/item/music_tape/cursed_songs_that_nobody_likes
 	songlist = "cringe"
 	icon_state = "5"
 
-/obj/item/weapon/music_tape/cursed_songs_that_nobody_likes/New() //This one is special because it's all the songs everyone hated
+/obj/item/music_tape/cursed_songs_that_nobody_likes/New() //This one is special because it's all the songs everyone hated
 	..()
 	tracklist = list() //Cleans up the song list
 	songlist = "cringe"

--- a/code/modules/media/media_tracks.dm
+++ b/code/modules/media/media_tracks.dm
@@ -32,8 +32,9 @@
 
 
 // Global list holding all configured jukebox tracks
-var/global/list/all_jukebox_tracks = list()
-var/global/list/all_lobby_tracks = list()
+GLOBAL_LIST_EMPTY(all_playlists)
+GLOBAL_LIST_EMPTY(all_jukebox_tracks)
+GLOBAL_LIST_EMPTY(all_lobby_tracks)
 
 // Read the jukebox configuration file on system startup.
 /hook/startup/proc/load_jukebox_tracks()
@@ -61,9 +62,11 @@ var/global/list/all_lobby_tracks = list()
 		T.lobby = entry["lobby"] ? 1 : 0
 		if(istext(entry["playlist"]))
 			T.playlist = entry["playlist"]
-		all_jukebox_tracks += T
+			if(!(T.playlist in GLOB.all_playlists))
+				GLOB.all_playlists += T.playlist
+		GLOB.all_jukebox_tracks += T
 		if(T.lobby)
-			all_lobby_tracks += T
+			GLOB.all_lobby_tracks += T
 	return 1
 
 

--- a/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
@@ -55,4 +55,4 @@
 
 	if(prob(3))
 		visible_message(SPAN_DANGER("\the [src] hacks up a tape!"))
-		new /obj/item/weapon/music_tape(get_turf(src))
+		new /obj/item/music_tape(get_turf(src))

--- a/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
@@ -52,3 +52,7 @@
 	if(.)
 		for (var/mob/living/carbon/superior_animal/roach/fuhrer/F in range(src,8))
 			F.distress_call()
+
+	if(prob(3))
+		visible_message(SPAN_DANGER("\the [src] hacks up a tape!"))
+		new /obj/item/weapon/music_tape(get_turf(src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds playlist autogeneration for music tapes, a lot of them added to our internal config file. GLOBalizes juke lists for easier tracking. Roaches have a chance to spit up a tape on death.

## Why It's Good For The Game

Uplifting musique. Lore justifications on as to why roaches have the tapes in the first place - you know how nintendo coated cartridges for Switch with a really bitter tasting liquid that was intended to make toddles reluctant to swallow them? And then everyone FUCKING EVERYONE started licking those stupid cartridges and posting it online? Yeah, they are coated in the same stuff, but roaches like it for some fucking reason.

## Changelog
:cl:
add: Many more tapes and a way to get them from roaches.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
