### PR TITLE
Add tickets shortcut to game interface

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -35,6 +35,16 @@
 		to_chat(src, SPAN_WARNING("The Discordia Github is not set in the server configuration."))
 	return
 
+/client/verb/ticketsshortcut()
+	set name = "ticketsshortcut"
+	set desc = "Access your tickets."
+	set hidden = 1
+
+	if(check_rights(R_ADMIN))
+		SStickets.showUI(usr)  // Admins access the ticket management interface
+	else
+		SStickets.userDetailUI(usr)  // Users access their tickets
+	return
 
 #define RULES_FILE "config/rules.html"
 /client/verb/rules()

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1325,6 +1325,16 @@ window "rpane"
 		text = "Changelog"
 		command = "Changelog"
 		group = "rpanemode"
+	elem "tickets"
+		type = BUTTON
+		pos = 487,0
+		size = 67x16
+		anchor1 = none
+		anchor2 = none
+		saved-params = "is-checked"
+		text = "Tickets"
+		command = "ticketsshortcut"
+		group = "rpanemode"
 	elem "rulesb"
 		type = BUTTON
 		pos = 288,0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Add a shortcut in the interface to access your tickets (if you're a normal player) or the ticket management interface (if you're an admin).

![image](https://user-images.githubusercontent.com/64754494/130318399-f1a9f60f-1fda-4559-89e4-49b561ca6f53.png)

## Why It's Good For The Game

Easier ~~banhammer~~ ticket management.

## Changelog
:cl: Hyperio
add: Add tickets shortcut to the interface
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
