### PR TITLE
Tweak copy tile with cyborg

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -193,7 +193,8 @@
  */
 
  // Cyborg tile stack can copy steel tiles by clicking on them (for easy reconstruction)
-/obj/item/stack/tile/floor/steel/attackby(obj/item/I, mob/living/user)
+/obj/item/stack/tile/floor/steel/AltClick(var/mob/living/user)
+	var/obj/item/I = user.get_active_hand()
 	if(istype(I, /obj/item/stack/tile/floor/cyborg))
 		var/obj/item/stack/tile/floor/cyborg/C = I
 		C.stacktype = src.type


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A few months ago I allowed cyborgs to copy stacks by clicking on them with their floor tile tool. #5983

Except by doing that it overwritted the ability to collect tiles on the floor by left clicking on them. Now you have to alt+click to copy a tile on the floor, so that it does not conflict anymore.

## Why It's Good For The Game

Able to collect tiles again.

## Changelog
:cl: Hyperio
tweak: Switch copy-tile stack ability to alt-click
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
