### PR TITLE
Blacklists debug parts from spawning in maint

### DIFF
--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -306,6 +306,7 @@
 	rating = 100 // rating doesn't really matter past a certain point - this makes autolathes print stuff at 1/5th the normal cost (item that costs 5 steel now costs 1 steel)
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 3, MATERIAL_PLASMA = 1)
 	bad_type = /obj/item/stock_parts/capacitor/debug
+	spawn_blacklisted = TRUE
 
 /obj/item/stock_parts/scanning_module/debug
 	name = "bluespace scanning module"
@@ -315,6 +316,7 @@
 	rating = 100
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1, MATERIAL_PLASMA = 1)
 	bad_type = /obj/item/stock_parts/scanning_module/debug
+	spawn_blacklisted = TRUE
 
 /obj/item/stock_parts/manipulator/debug
 	name = "bluespace yocto-manipulator"
@@ -324,6 +326,7 @@
 	rating = 100
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_PLASMA = 1)
 	bad_type = /obj/item/stock_parts/manipulator/debug
+	spawn_blacklisted = TRUE
 
 /obj/item/stock_parts/micro_laser/debug
 	name = "bluespace yocto-laser"
@@ -333,6 +336,7 @@
 	rating = 100
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1, MATERIAL_PLASMA = 1)
 	bad_type = /obj/item/stock_parts/micro_laser/debug
+	spawn_blacklisted = TRUE
 
 /obj/item/stock_parts/matter_bin/debug
 	name = "bluespace matter bin"
@@ -342,6 +346,7 @@
 	rating = 100
 	matter = list(MATERIAL_PLASTIC = 3, MATERIAL_GLASS = 1, MATERIAL_PLASMA = 1)
 	bad_type = /obj/item/stock_parts/matter_bin/debug
+	spawn_blacklisted = TRUE
 
 // Subspace stock parts
 /obj/item/stock_parts/subspace


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Blacklists debug stock-parts from spawning into maintenance

## Why It's Good For The Game
Debug parts aren't meant to appear in maintenance.. , it also allows players to easily break machinery due to the huge rating the components themselves have, or dupe materials.
## Changelog
:cl:
balance: Debug stockparts (bluespace ones) no longer spawn in maintenance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
