### PR TITLE
Fix camera alarm on camera destruction

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -70,6 +70,9 @@
 		assembly = null
 	qdel(wires)
 	wires = null
+	if(alarm_on)
+		alarm_on = 0
+		camera_alarm.clearAlarm(loc, src)
 	return ..()
 
 /obj/machinery/camera/Process()

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -265,7 +265,7 @@ mob/living/silicon/robot/tracking_initiated()
 
 mob/living/proc/tracking_cancelled()
 
-mob/living/silicon/robot/tracking_initiated()
+mob/living/silicon/robot/tracking_cancelled()
 	tracking_entities--
 	if(!tracking_entities && has_zeroth_law())
 		to_chat(src, SPAN_NOTICE("Internal camera is no longer being accessed."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #6345 
New behaviour upon total camera destruction, the camera alarm is removed from the network!

And on the side , because its camera related,
Small oversight with one of the proc names, so now Cyborgs will properly know when their camera is and isn't being looked at.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Cameras no longer stay infinitely alarming when they're repaired.
fix: Malf borgs properly know when their cameras are being accessed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
