### PR TITLE
Music tapes runtime fixes

### DIFF
--- a/code/game/objects/items/musictapes.dm
+++ b/code/game/objects/items/musictapes.dm
@@ -36,6 +36,7 @@
 	tracklist = list() //Cleans up the song list
 	songlist = "cringe"
 	icon_state = "5"
-	for(var/datum/track/T in GLOB.all_jukebox_tracks)
-		if(T.secret)
-			tracklist |= T
+	if(length(GLOB.all_jukebox_tracks))
+		for(var/datum/track/T in GLOB.all_jukebox_tracks)
+			if(T.secret)
+				tracklist |= T


### PR DESCRIPTION
## About The Pull Request
Fixes autofailing of CI tests, caused by not setuped music for tapes

## Changelog
:cl:
fix: Fixes autofailing of CI tests, because of not setuped music for tapes
/:cl: