### PR TITLE
fixes things calling death proc while dead

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/defense.dm
+++ b/code/modules/mob/living/carbon/superior_animal/defense.dm
@@ -188,7 +188,7 @@
 
 /mob/living/carbon/superior_animal/updatehealth()
 	. = ..() //health = maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss() - getCloneLoss() - halloss
-	if (health <= 0)
+	if (health <= 0 && stat != DEAD)
 		death()
 
 /mob/living/carbon/superior_animal/gib(var/anim = icon_gib, var/do_gibs = 1)

--- a/code/modules/mob/living/carbon/superior_animal/defense.dm
+++ b/code/modules/mob/living/carbon/superior_animal/defense.dm
@@ -141,11 +141,10 @@
 		blinded = TRUE
 		silent = 0
 	else
-		updatehealth()
+		updatehealth() // updatehealth calls death if health <= 0
 		handle_stunned()
 		handle_weakened()
 		if(health <= 0)
-			death()
 			blinded = TRUE
 			silent = 0
 			return 1

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -181,7 +181,7 @@
 		if(!.)
 			return FALSE
 
-		if(health <= 0)
+		if(health <= 0 && stat != DEAD)
 			death()
 			return FALSE
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -103,7 +103,7 @@
 	death_time = world.time
 	if(dead_icon)
 		icon_state = dead_icon
-	if(owner && vital)
+	if(owner && vital && owner.stat != DEAD)
 		owner.death()
 
 /obj/item/organ/get_item_cost()
@@ -317,7 +317,7 @@
 	if(!organ_blood || !organ_blood.data["blood_DNA"])
 		owner.vessel.trans_to(src, 5, 1, 1)
 
-	if(vital && !(owner.status_flags & REBUILDING_ORGANS))
+	if(vital && !(owner.status_flags & REBUILDING_ORGANS) && owner.stat != DEAD)
 		if(user)
 			admin_attack_log(user, owner, "Removed a vital organ ([src])", "Had a a vital organ ([src]) removed.", "removed a vital organ ([src]) from")
 		owner.death()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes it so that all uses of the death proc don't call it if they're already dead.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Infinite Tapes Bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Chickenish
fix: roaches no longer die over and over again while dead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
