### PR TITLE
Do not fail compile just because of version of byond

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -53,7 +53,9 @@
 #define MIN_COMPILER_BUILD 1513
 #if DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD
 //Don't forget to update this part
-#warn Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update. You need version 513.1513 or higher
+#warn Your version of BYOND is too out-of-date to compile this project.
+#warn Go to https://secure.byond.com/download and update.
+#warn You need version 513.1513 or higher
 #endif
 
 //Don't load extools on 514 and 513.1539+

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -50,11 +50,10 @@
 
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 513
-#define MIN_COMPILER_BUILD 1514
+#define MIN_COMPILER_BUILD 1513
 #if DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD
 //Don't forget to update this part
-#error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
-#error You need version 513.1514 or higher
+#warn Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update. You need version 513.1513 or higher
 #endif
 
 //Don't load extools on 514 and 513.1539+


### PR DESCRIPTION
## Why It's Good For The Game

Because you should able to compile things and just know that better to compile with another version.

## Changelog
:cl:
code: Compiling not failing if you have to old version of byond, now it will just warn you about this.
/:cl:
