### PR TITLE
Allows the carrion to re-evolve organs in the case they were removed

### DIFF
--- a/code/game/gamemodes/changeling/modularchangling.dm
+++ b/code/game/gamemodes/changeling/modularchangling.dm
@@ -10,6 +10,7 @@ var/list/datum/power/carrion/powerinstances = list()
 	var/genomecost = 500000 // Cost for the carrion to evolve this power.
 	var/organpath //Path to the organ that is getting evolved.
 	var/spiderpath //The path of the spider we spawn.
+	var/renewable = FALSE //Whether the power can be renewed (Primarily used for organs)
 
 /datum/power/carrion/flashbang_spider
 	name = "Flashbang spider"
@@ -106,20 +107,23 @@ var/list/datum/power/carrion/powerinstances = list()
 
 /datum/power/carrion/maw
 	name = "Carrion Maw"
-	desc = "Unlocks and expands your jaw, giving you the ability to spit acid, call upon spiders and tear off limbs."
+	desc = "Unlocks and expands your jaw, giving you the ability to spit acid, call upon spiders and tear off limbs. Renewable"
 	genomecost = 0
+	renewable = TRUE
 	organpath = /obj/item/organ/internal/carrion/maw
 
 /datum/power/carrion/spinneret
 	name = "Carrion Spinneret"
-	desc = "Grows a spinneret inside your lower body, making you able to create a spider nest, filter your blood from all chemicals and make webs."
+	desc = "Grows a spinneret inside your lower body, making you able to create a spider nest, filter your blood from all chemicals and make webs. Renewable"
 	genomecost = 7
+	renewable = TRUE
 	organpath = /obj/item/organ/internal/carrion/spinneret
 
 /datum/power/carrion/chemvessel
 	name = "Chemical Vessel"
-	desc = "Grows a chemical vessel that stores and produces chemicals needed for your abilities."
+	desc = "Grows a chemical vessel that stores and produces chemicals needed for your abilities. Renewable"
 	genomecost = 0
+	renewable = TRUE
 	organpath = /obj/item/organ/internal/carrion/chemvessel
 
 /obj/item/organ/internal/carrion/core/proc/EvolutionMenu()	//Topic proc is stored in code\modules\organs\internal\carrion.dm
@@ -343,7 +347,10 @@ var/list/datum/power/carrion/powerinstances = list()
 		var/ownsthis = 0
 
 		if(P in purchasedpowers)
-			ownsthis = 1
+			if(P.renewable && !(locate(P.organpath) in owner))
+				ownsthis = 0
+			else
+				ownsthis = 1
 
 
 		var/color = "#e6e6e6"
@@ -398,8 +405,12 @@ var/list/datum/power/carrion/powerinstances = list()
 		return
 
 	if(Thepower in purchasedpowers)
-		to_chat(owner, "You have already evolved this ability!")
-		return
+		if(Thepower.renewable && locate(Thepower.organpath) in owner)
+			to_chat(owner, "You already have this organ!")
+			return
+		else if(!Thepower.renewable)
+			to_chat(owner, "You have already evolved this ability!")
+			return
 
 	if(geneticpoints < Thepower.genomecost && !free)
 		to_chat(owner, "You cannot evolve this... yet.  You must acquire more DNA.")
@@ -408,7 +419,8 @@ var/list/datum/power/carrion/powerinstances = list()
 	if(!free)
 		geneticpoints -= Thepower.genomecost
 
-	purchasedpowers += Thepower
+	if(!(Thepower in purchasedpowers))
+		purchasedpowers += Thepower
 
 	if (Thepower.organpath)
 		var/obj/item/organ/internal/organ = new Thepower.organpath

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -38,6 +38,7 @@
 	parent_organ_base = BP_CHEST
 	organ_efficiency = list(OP_CHEMICALS = 100)
 	icon_state = "carrion_chemvessel"
+	unique_tag = OP_CHEMICALS
 
 /obj/item/organ/internal/carrion/core
 	name = "spider core"
@@ -127,7 +128,7 @@
 		var/obj/item/implant/carrion_spider/activated_spider = locate(href_list["activate_spider"]) in active_spiders
 		if(activated_spider)
 			activated_spider.activate()
-	
+
 	if(href_list["pop_out_spider"])
 		var/obj/item/implant/carrion_spider/activated_spider = locate(href_list["pop_out_spider"]) in active_spiders
 		if(activated_spider)
@@ -266,6 +267,7 @@
 	parent_organ_base = BP_HEAD
 	icon_state = "carrion_maw"
 	organ_efficiency = list(OP_MAW = 100)
+	unique_tag = OP_MAW
 	var/last_call = -5 MINUTES
 	var/tearing = FALSE
 
@@ -312,7 +314,7 @@
 						blacklist += to_blacklist
 						continue
 					if (istype(to_blacklist, /obj/item/organ/internal/brain/))
-						blacklist += to_blacklist// removing bones from a valid_organs list based on			
+						blacklist += to_blacklist// removing bones from a valid_organs list based on
 				var/list/valid_organs = E.internal_organs - blacklist// E.internal_organs gibs the victim.
 				if (!valid_organs.len)
 					visible_message(SPAN_DANGER("[owner] tears up [H]'s [E.name]!"))
@@ -325,7 +327,7 @@
 			else
 				tearing = FALSE
 		else
-			to_chat(owner, SPAN_WARNING("You can only tear flesh out of humanoids!"))	
+			to_chat(owner, SPAN_WARNING("You can only tear flesh out of humanoids!"))
 			return
 
 	if(istype(food, /obj/item/organ) || istype(food, /obj/item/reagent_containers/food/snacks/meat))
@@ -453,6 +455,7 @@
 	parent_organ_base = BP_GROIN
 	icon_state = "carrion_spinneret"
 	organ_efficiency = list(OP_SPINNERET = 100)
+	unique_tag = OP_SPINNERET
 	owner_verbs = list(
 		/obj/item/organ/internal/carrion/spinneret/proc/make_nest,
 		/obj/item/organ/internal/carrion/spinneret/proc/bloodpurge,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds renewability variable to the carrion powers, allowing carrion to re-evolve powers involving organs in the case those organs were removed. The price for the power, however, remains the same. Also adds a unique tag to maw, spinneret and the chemvessel, thus preventing the carrion from inserting a second organ of the type (due to the issues concerning the balance)

## Why It's Good For The Game

Having those organs removed could practically render the carrion useless. Moreover, it doesn't make sense that an antag capable of recovering from serious wounds would not be able to regrow its organs.

## Changelog
:cl:
balance: makes spinneret, maw and chemvessel unique organs - one per mob
fix: allows carrion to re-evolve removed organs
code: introduces a renewability variable to carrion powers, enables a check for removed carrion organs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
