### PR TITLE
Makes Oborin colorblindness no longer bypassable through the usage of prosthetic eyes

### DIFF
--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -43,8 +43,8 @@
 	if(is_broken() && !oldbroken && owner && !owner.stat)
 		to_chat(owner, SPAN_DANGER("You go blind!"))
 
-/obj/item/organ/internal/eyes/proc/get_colourmatrix() //Returns a special colour matrix if the eyes are organic and the mob is colourblind, otherwise it uses the current one.
-	if(!(BP_IS_ROBOTIC(src)) && owner.stats.getPerk(PERK_OBORIN_SYNDROME) && !owner.is_dead())
+/obj/item/organ/internal/eyes/proc/get_colourmatrix() //Returns a special colour matrix if the mob is colourblind, otherwise it uses the current one.
+	if(owner.stats.getPerk(PERK_OBORIN_SYNDROME) && !owner.is_dead())
 		return colourblind_matrix
 	else
 		return colourmatrix


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the check for inorganic eyes for changing the colour matrix

## Why It's Good For The Game

The Oborin syndrome provides a ton of buffs in exchange for colorblindness, thus this exploit allows the player to bypass this drawback as easily as choosing a different option in character selection, which is bad. Moreover, lore-wise, Oborin is a "psionic" condition, so it doesn't make much sense that changing out the eyes would just remedy it.

## Changelog
:cl:
balance: prevents inorganic eyes from removing the colorblindness effect of Oborin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
