### PR TITLE
Fixes the storyteller (now without skin.dmf)

### DIFF
--- a/code/game/gamemodes/storyteller_meta.dm
+++ b/code/game/gamemodes/storyteller_meta.dm
@@ -2,7 +2,7 @@
 
 //Global list of all storyevents. This tracks things like how many times each has been called
 //It should persist so that storyteller changes don't reset how many calls have happened for each event
-var/global/list/storyevents = list()
+var/global/list/storyevents
 
 //A list of lists, which holds all events that have been scheduled but not fired yet
 //Each event is a list in the format..
@@ -16,7 +16,8 @@ var/global/list/scheduled_events = list()
 	var/list/base_types = list(/datum/storyevent,
 	/datum/storyevent/roleset,
 	/datum/storyevent/roleset/faction)
-
+	// Initialized here because we can't control when globals initialize
+	storyevents = list()
 	for(var/type in typesof(/datum/storyevent)-base_types)
 		storyevents.Add(new type)
 


### PR DESCRIPTION
## About The Pull Request
Fixes the storyteller , and finnaly gets rid of skin.dmf fuckery

## Why It's Good For The Game
Its not , self antag eris ancapistan is better.
Exactly the same code as https://github.com/discordia-space/CEV-Eris/pull/6487

## Changelog
:cl:
fix: The storyteller refusing to storytell
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
