### PR TITLE
replaces guns in roachless forgotten closets with gun parts

### DIFF
--- a/code/game/objects/random/packs.dm
+++ b/code/game/objects/random/packs.dm
@@ -89,6 +89,25 @@ They generally give more random result and can provide more divercity in spawn.
 	spawn_nothing_percentage = 70
 
 
+/obj/spawner/pack/gun_adjacent_loot // this is gun loot with the guns and all the ammo except for ammo kit's pool removed
+	name = "Random gun adjacent loot" // also everything remaining except for gun parts's weight is cut in half
+	icon_state = "gun-red"
+	desc = "This is a random technical loot."
+
+/obj/spawner/pack/gun_adjacent_loot/item_to_spawn()
+	return pickweight(list(
+					/obj/spawner/gun_parts = 20,
+					/obj/spawner/knife = 3,
+					/obj/spawner/ammo/lowcost = 9,
+					/obj/spawner/gun_upgrade = 5,
+					/obj/spawner/cloth/holster = 4
+				))
+
+/obj/spawner/pack/gun_adjacent_loot/low_chance
+	name = "low chance gun loot"
+	icon_state = "gun-red-low"
+	spawn_nothing_percentage = 70
+
 //Rare loot, where we need to be sure that reward is worth it
 /obj/spawner/pack/rare
 	name = "rare loot"

--- a/code/game/objects/structures/crates_lockers/closets/maint_loot.dm
+++ b/code/game/objects/structures/crates_lockers/closets/maint_loot.dm
@@ -27,9 +27,9 @@
 	new /obj/spawner/pack/tech_loot/low_chance(src)
 	new /obj/spawner/pack/cloth/low_chance(src)
 	new /obj/spawner/pack/cloth/low_chance(src)
-	new /obj/spawner/gun_parts/low_chance(src)
-	new /obj/spawner/gun_parts/low_chance(src)
-	new /obj/spawner/gun_parts/low_chance(src)
+	new /obj/spawner/pack/gun_adjacent_loot/low_chance(src)
+	new /obj/spawner/pack/gun_adjacent_loot/low_chance(src)
+	new /obj/spawner/pack/gun_adjacent_loot/low_chance(src)
 
 
 /obj/structure/closet/random/tech

--- a/code/game/objects/structures/crates_lockers/closets/maint_loot.dm
+++ b/code/game/objects/structures/crates_lockers/closets/maint_loot.dm
@@ -27,8 +27,9 @@
 	new /obj/spawner/pack/tech_loot/low_chance(src)
 	new /obj/spawner/pack/cloth/low_chance(src)
 	new /obj/spawner/pack/cloth/low_chance(src)
-	new /obj/spawner/pack/gun_loot/low_chance(src)
-	new /obj/spawner/pack/gun_loot/low_chance(src)
+	new /obj/spawner/gun_parts/low_chance(src)
+	new /obj/spawner/gun_parts/low_chance(src)
+	new /obj/spawner/gun_parts/low_chance(src)
 
 
 /obj/structure/closet/random/tech


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR replaces the two gun loot spawners in roachless forgotten closets with three copies of a new spawner, gun_adjacent_loot.
The gun_adjacent_loot spawner has mostly gun parts, with a chance for a knife, ammo, a gun upgrade, or a holster.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gun Parts are supposed to be used to make guns, but when the main source of them is destroying guns, it's hard to justify doing so. This PR makes gun parts more available.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Chickenish
balance: roachless forgotten closets now contain gun parts instead of guns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
