### PR TITLE
Enables a mob falling through an open space when gravity changes

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -341,6 +341,11 @@ var/list/mob/living/forced_ambiance_list = new
 	if(istype(get_turf(mob), /turf/space)) // Can't fall onto nothing.
 		return
 
+	if(istype(get_turf(mob), /turf/simulated/open))
+		var/turf/simulated/open/O = get_turf(mob)
+		O.fallThrough(mob)
+		return
+
 	if(istype(mob,/mob/living/carbon/human/))
 		var/mob/living/carbon/human/H = mob
 		if(istype(H.shoes, /obj/item/clothing/shoes/magboots) && (H.shoes.item_flags & NOSLIP))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes the issue where a mob would be standing on an open space if gravity is re-enabled. Instead, he would fall through as normal.

## Why It's Good For The Game

This issue doesn't make much sense in the game world and ruins immersion. My fix serves to remedy that.

## Changelog
:cl:
fix: enables falling through an open space after a change in gravity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
