### PR TITLE
Adds the sanity damage reduction component for clothing , adds it to balaclavas

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -301,6 +301,7 @@
 #include "code\datums\autolathe\security.dm"
 #include "code\datums\autolathe\tools.dm"
 #include "code\datums\components\_component.dm"
+#include "code\datums\components\clothing_sanity_protection.dm"
 #include "code\datums\components\fabric.dm"
 #include "code\datums\craft\crafting_items.dm"
 #include "code\datums\craft\item.dm"

--- a/code/datums/components/clothing_sanity_protection.dm
+++ b/code/datums/components/clothing_sanity_protection.dm
@@ -1,5 +1,4 @@
 /datum/component/clothing_sanity_protection
-	dupe_mode = COMPONENT_DUPE_HIGHLANDER
 	var/environment_cap_buff
 	var/mob/living/carbon/human/current_user
 
@@ -20,6 +19,14 @@
 	current_user.sanity.environment_cap_coeff /= environment_cap_buff
 	UnregisterSignal(current_user, COMSIG_CLOTH_DROPPED)
 	current_user = null
+
+// Remove any references to avoid hard dels
+/datum/component/clothing_sanity_protection/Destroy()
+	if(current_user)
+		UnregisterSignal(current_user, COMSIG_CLOTH_DROPPED)
+		current_user = null
+	UnregisterSignal(parent, COMSIG_CLOTH_EQUIPPED)
+	..()
 
 
 

--- a/code/datums/components/clothing_sanity_protection.dm
+++ b/code/datums/components/clothing_sanity_protection.dm
@@ -30,7 +30,7 @@
 		current_user = null
 	UnregisterSignal(parent, COMSIG_CLOTH_EQUIPPED)
 	var/atom/current_parent = parent
-	current_parent.description_info -=  "This item reduces sanity damage taken from enviromental factors \n"
+	current_parent.description_info -=  "This item reduces sanity damage taken from environmental factors. \n"
 	..()
 
 

--- a/code/datums/components/clothing_sanity_protection.dm
+++ b/code/datums/components/clothing_sanity_protection.dm
@@ -1,0 +1,25 @@
+/datum/component/clothing_sanity_protection
+	dupe_mode = COMPONENT_DUPE_HIGHLANDER
+	var/environment_cap_buff
+	var/mob/living/carbon/human/current_user
+
+/datum/component/clothing_sanity_protection/Initialize(value)
+	if(!(istype(parent, /obj/item/clothing)))
+		return COMPONENT_INCOMPATIBLE
+	environment_cap_buff = value
+	RegisterSignal(parent, COMSIG_CLOTH_EQUIPPED, .proc/handle_sanity_buffs)
+
+/datum/component/clothing_sanity_protection/proc/handle_sanity_buffs(mob/living/carbon/human/user)
+	var/obj/item/current_parent = parent
+	if(current_parent.is_worn())
+		user.sanity.environment_cap_coeff *= environment_cap_buff
+		RegisterSignal(user, COMSIG_CLOTH_DROPPED, .proc/handle_sanity_debuff)
+		current_user = user
+
+/datum/component/clothing_sanity_protection/proc/handle_sanity_debuff()
+	current_user.sanity.environment_cap_coeff /= environment_cap_buff
+	UnregisterSignal(current_user, COMSIG_CLOTH_DROPPED)
+	current_user = null
+
+
+

--- a/code/datums/components/clothing_sanity_protection.dm
+++ b/code/datums/components/clothing_sanity_protection.dm
@@ -7,7 +7,7 @@
 		return COMPONENT_INCOMPATIBLE
 	environment_cap_buff = value
 	var/atom/current_parent = parent
-	current_parent.description_info += "This item reduces sanity damage taken from enviromental factors \n"
+	current_parent.description_info += "This item reduces sanity damage taken from environmental factors. \n"
 	RegisterSignal(current_parent, COMSIG_CLOTH_EQUIPPED, .proc/handle_sanity_buffs)
 
 /datum/component/clothing_sanity_protection/proc/handle_sanity_buffs(mob/living/carbon/human/user)

--- a/code/datums/components/clothing_sanity_protection.dm
+++ b/code/datums/components/clothing_sanity_protection.dm
@@ -6,7 +6,9 @@
 	if(!(istype(parent, /obj/item/clothing)))
 		return COMPONENT_INCOMPATIBLE
 	environment_cap_buff = value
-	RegisterSignal(parent, COMSIG_CLOTH_EQUIPPED, .proc/handle_sanity_buffs)
+	var/atom/current_parent = parent
+	current_parent.description_info += "This item reduces sanity damage taken from enviromental factors \n"
+	RegisterSignal(current_parent, COMSIG_CLOTH_EQUIPPED, .proc/handle_sanity_buffs)
 
 /datum/component/clothing_sanity_protection/proc/handle_sanity_buffs(mob/living/carbon/human/user)
 	var/obj/item/current_parent = parent
@@ -23,9 +25,12 @@
 // Remove any references to avoid hard dels
 /datum/component/clothing_sanity_protection/Destroy()
 	if(current_user)
+		current_user.sanity.environment_cap_coeff /= environment_cap_buff
 		UnregisterSignal(current_user, COMSIG_CLOTH_DROPPED)
 		current_user = null
 	UnregisterSignal(parent, COMSIG_CLOTH_EQUIPPED)
+	var/atom/current_parent = parent
+	current_parent.description_info -=  "This item reduces sanity damage taken from enviromental factors \n"
 	..()
 
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -208,6 +208,10 @@
 		unwield(user)
 	if(zoom)
 		zoom(user)
+	if(get_equip_slot() in unworn_slots)
+		SEND_SIGNAL(src, COMSIG_CLOTH_DROPPED, user)
+		if(user)
+			SEND_SIGNAL(user, COMSIG_CLOTH_DROPPED, src)
 
 
 //	Called before an item is picked up (loc is not yet changed)

--- a/code/game/objects/items/_inventory.dm
+++ b/code/game/objects/items/_inventory.dm
@@ -65,7 +65,7 @@
 	if(wielded)
 		unwield(user)
 	SEND_SIGNAL(user, COMSIG_CLOTH_EQUIPPED, src) // Theres instances in which its usefull to keep track of it both on the user and individually
-	SEND_SIGNAL(src, COMSIG_CLOTH_EQUIPPED)
+	SEND_SIGNAL(src, COMSIG_CLOTH_EQUIPPED, user)
 
 /obj/item/proc/dropped(mob/user)
 	if(zoom) //binoculars, scope, etc

--- a/code/modules/clothing/masks/balaclava.dm
+++ b/code/modules/clothing/masks/balaclava.dm
@@ -1,3 +1,5 @@
+#define BALACLAVA_SANITY_COEFF_BUFF 1.6
+
 /obj/item/clothing/mask/balaclava
 	name = "balaclava"
 	desc = "Designed to both hide your face and keep it comfy and warm."
@@ -8,6 +10,10 @@
 	body_parts_covered = FACE|HEAD
 	w_class = ITEM_SIZE_SMALL
 	var/open = 0 //0 = full, 1 = head only, 2 = face only
+
+/obj/item/clothing/mask/balaclava/New()
+	..()
+	AddComponent(/datum/component/clothing_sanity_protection, BALACLAVA_SANITY_COEFF_BUFF)
 
 /obj/item/clothing/mask/balaclava/proc/adjust_mask(mob/living/carbon/human/user)
 	if(!istype(user))

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -1,6 +1,8 @@
+#define GAS_MASK_SANITY_COEFF_BUFF 1.7
+
 /obj/item/clothing/mask/gas
 	name = "gas mask"
-	desc = "A face-covering mask that can be connected to an air supply. Filters harmful gases from the air."
+	desc = "A face-covering mask that can be connected to an air supply. Filters harmful gases from the air and the smell of roaches."
 	icon_state = "gas_alt"
 	item_flags = BLOCK_GAS_SMOKE_EFFECT | AIRTIGHT
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE
@@ -35,6 +37,10 @@
 	filtered.update_values()
 
 	return filtered
+
+/obj/item/clothing/mask/gas/New()
+	..()
+	AddComponent(/datum/component/clothing_sanity_protection, GAS_MASK_SANITY_COEFF_BUFF)
 
 //Plague Dr suit can be found in clothing/suits/bio.dm
 /obj/item/clothing/mask/gas/plaguedoctor

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -50,6 +50,10 @@
 	)
 	price_tag = 10
 
+/obj/item/clothing/mask/surgical/New()
+	..()
+	AddComponent(/datum/component/clothing_sanity_protection, NORMAL_MASK_SANITY_COEFF_BUFF)
+
 /obj/item/clothing/mask/thief
 	name = "mastermind's mask"
 	desc = "A white mask with some strange drawings. Designed to hide the wearer's face"

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -1,3 +1,6 @@
+#define THIEF_MASK_SANITY_COEFF_BUFF 1.6
+#define NORMAL_MASK_SANITY_COEFF_BUFF 1.3
+
 /obj/item/clothing/mask/muzzle
 	name = "muzzle"
 	desc = "To stop that awful noise."
@@ -63,6 +66,10 @@
 		rad = 0
 	)
 	price_tag = 150
+
+/obj/item/clothing/mask/thief/New()
+	..()
+	AddComponent(/datum/component/clothing_sanity_protection, THIEF_MASK_SANITY_COEFF_BUFF)
 
 /obj/item/clothing/mask/thief/wolf
 	name = "technician's mask"
@@ -206,6 +213,10 @@
 	siemens_coefficient = 0.9
 	body_parts_covered = HEAD|FACE|EYES
 
+/obj/item/clothing/mask/pig/New()
+	..()
+	AddComponent(/datum/component/clothing_sanity_protection, NORMAL_MASK_SANITY_COEFF_BUFF)
+
 /obj/item/clothing/mask/horsehead
 	name = "horse head mask"
 	desc = "A mask made of soft vinyl and latex, representing the head of a horse."
@@ -217,10 +228,12 @@
 	siemens_coefficient = 0.9
 
 /obj/item/clothing/mask/horsehead/New()
-    ..()
-    // The horse mask doesn't cause voice changes by default, the wizard spell changes the flag as necessary
-    say_messages = list("NEEIIGGGHHHH!", "NEEEIIIIGHH!", "NEIIIGGHH!", "HAAWWWWW!", "HAAAWWW!")
-    say_verbs = list("whinnies", "neighs", "says")
+	..()
+	// The horse mask doesn't cause voice changes by default, the wizard spell changes the flag as necessary
+	say_messages = list("NEEIIGGGHHHH!", "NEEEIIIIGHH!", "NEIIIGGHH!", "HAAWWWWW!", "HAAAWWW!")
+	say_verbs = list("whinnies", "neighs", "says")
+	AddComponent(/datum/component/clothing_sanity_protection, NORMAL_MASK_SANITY_COEFF_BUFF)
+
 
 /obj/item/clothing/mask/ai
 	name = "camera MIU"

--- a/code/modules/tips_and_tricks/gameplay.dm
+++ b/code/modules/tips_and_tricks/gameplay.dm
@@ -9,7 +9,7 @@
     tipText = "If you're trying to take on a blob, a flamethrower is your best weapon."
 
 /tipsAndTricks/gameplay/maskProtections
-    tipText = "Balaclavas, robber mask and other masks provide a buff to your sanity protection, better wear them than smoke ciggaretes."
+    tipText = "Balaclavas, robber mask and other masks provide a buff to your sanity protection, better wear them than smoke cigarettes."
 
 /tipsAndTricks/gameplay/dismantleGun
     tipText = "Did you know you can dismantle guns by using a wrench on them with harm intent ? Dismantling guns gives you gun parts."

--- a/code/modules/tips_and_tricks/gameplay.dm
+++ b/code/modules/tips_and_tricks/gameplay.dm
@@ -8,6 +8,9 @@
 /tipsAndTricks/gameplay/fightBlob
     tipText = "If you're trying to take on a blob, a flamethrower is your best weapon."
 
+/tipsAndTricks/gameplay/maskProtections
+    tipText = "Balaclavas, robber mask and other masks provide a buff to your sanity protection, better wear them than smoke ciggaretes."
+
 /tipsAndTricks/gameplay/dismantleGun
     tipText = "Did you know you can dismantle guns by using a wrench on them with harm intent ? Dismantling guns gives you gun parts."
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes balaclavas provide 60% more protection from environmental sanity damage.
Adds a component for this behaviour that can be added to any item
(Important note , this uses a multiplier , not added on directly , if you have a perk that sets your environment coeff to 0 , it won't help you at all)
Also im a dumbass and i fixed the clothing dropped signals,  because i forgot a case in which the item gets moved to another slot.

## Why It's Good For The Game
Players should be incentivized to wear something other than ciggaretes , vape masks , or drink chemicals every 10 minutes in order to preserve their sanity.
Also its badass to be more mentally tough if you wear a balaclava.
## Changelog
:cl:
add: Added the sanity_damage_reduction component for clothing
add: Made balaclavas and any subtype of gasmasks reduce sanity damage fron environment by 60% 
add:Made surgical masks and a few other masks reduce enviromental damage by 30%
fix: Clothing signals not working as expected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
