### PR TITLE
fix atmos icons & rename phoron

### DIFF
--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -4,11 +4,11 @@
 /turf/var/needs_air_update = 0
 /turf/var/datum/gas_mixture/air
 
-/turf/simulated/proc/update_graphic(list/graphic_add = null, list/graphic_remove = null)
-	if(graphic_add && graphic_add.len)
-		add_overlays(graphic_add)
-	if(graphic_remove && graphic_remove.len)
-		remove_overlays(graphic_remove)
+/turf/simulated/proc/update_graphic(list/graphic_add = list(), list/graphic_remove = list())
+	for(var/I in graphic_add)
+		add_overlays(I)
+	for(var/I in graphic_remove)
+		remove_overlays(I)
 
 /turf/proc/update_air_properties()
 	var/block = c_airblock(src)

--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -322,11 +322,7 @@
 		atmosphere.adjust_gas("nitrogen", MOLES_N2STANDARD)
 	else //let the fuckery commence
 		var/list/newgases = gas_data.gases.Copy()
-		if(prob(90)) //all phoron planet should be rare
-			newgases -= "phoron"
-		if(prob(50)) //alium gas should be slightly less common than mundane shit
-			newgases -= "phoron"
-		newgases -= "phoron"
+		newgases -= "plasma"
 
 		var/total_moles = MOLES_CELLSTANDARD * rand(80,120)/100
 		var/badflag = 0

--- a/code/modules/overmap/exoplanets/planet_types/chlorine.dm
+++ b/code/modules/overmap/exoplanets/planet_types/chlorine.dm
@@ -21,7 +21,7 @@
 /obj/effect/overmap/sector/exoplanet/chlorine/generate_atmosphere()
 	..()
 	if(atmosphere)
-		atmosphere.adjust_gas("phoron", MOLES_O2STANDARD) //TODO GAS_CHLORINE
+		atmosphere.adjust_gas("plasma", MOLES_O2STANDARD) //TODO GAS_CHLORINE
 		atmosphere.temperature = T100C - rand(0, 100)
 		atmosphere.update_values()
 

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -328,29 +328,24 @@
 
 //Rechecks the gas_mixture and adjusts the graphic list if needed.
 //Two lists can be passed by reference if you need know specifically which graphics were added and removed.
-/datum/gas_mixture/proc/check_tile_graphic(list/graphic_add = null, list/graphic_remove = null)
+/datum/gas_mixture/proc/check_tile_graphic(list/graphic_add = list(), list/graphic_remove = list())
+	. = 0
 	for(var/g in gas_data.overlay_limit)
-		if(graphic.Find(gas_data.tile_overlay[g]))
+		var/OL = gas_data.overlay_limit[g]
+		var/TO = gas_data.tile_overlay[g]
+
+		if(TO in graphic)
 			//Overlay is already applied for this gas, check if it's still valid.
-			if(gas[g] <= gas_data.overlay_limit[g])
-				if(!graphic_remove)
-					graphic_remove = list()
-				graphic_remove += gas_data.tile_overlay[g]
+			if(gas[g] <= OL)
+				graphic_remove += TO
+				graphic -= TO
+				. = 1
 		else
 			//Overlay isn't applied for this gas, check if it's valid and needs to be added.
-			if(gas[g] > gas_data.overlay_limit[g])
-				if(!graphic_add)
-					graphic_add = list()
-				graphic_add += gas_data.tile_overlay[g]
-
-	. = 0
-	//Apply changes
-	if(graphic_add && graphic_add.len)
-		graphic += graphic_add
-		. = 1
-	if(graphic_remove && graphic_remove.len)
-		graphic -= graphic_remove
-		. = 1
+			if(gas[g] > OL)
+				graphic_add += TO
+				graphic += TO
+				. = 1
 
 
 //Simpler version of merge(), adjusts gas amounts directly and doesn't account for temperature or group_multiplier.

--- a/maps/submaps/planetary_ruins/datacapsule/datacapsule.dm
+++ b/maps/submaps/planetary_ruins/datacapsule/datacapsule.dm
@@ -58,8 +58,8 @@
 		to_chat(user, SPAN_NOTICE("You pry out the data drive from \the [src]."))
 		playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
 		var/obj/item/stock_parts/computer/hard_drive/cluster/drive = new(get_turf(src))
-		drive.origin_tech = list(TECH_DATA = rand(4,5), TECH_ENGINEERING = rand(4,5), TECH_PHORON = rand(4,5), TECH_COMBAT = rand(2,5), TECH_ESOTERIC = rand(0,6))
-		
+		drive.origin_tech = list(TECH_DATA = rand(4,5), TECH_ENGINEERING = rand(4,5), TECH_PLASMA = rand(4,5), TECH_COMBAT = rand(2,5), TECH_ESOTERIC = rand(0,6))
+
 /obj/effect/landmark/map_load_mark/ejected_datapod
 	name = "random datapod contents"
 	templates = list(/datum/map_template/ejected_datapod_contents, /datum/map_template/ejected_datapod_contents/type2, /datum/map_template/ejected_datapod_contents/type3)

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -411,10 +411,10 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                         {{:helper.string('<span class="{0}">{1}%</span>', data.aircontents.carbon_dioxide > 5 ? 'bad' : 'good' , data.aircontents.carbon_dioxide)}}
                     </div>
                     <div class="itemLabel">
-                        Phoron:
+                        Plasma:
                     </div>
                     <div class = "itemContent">
-                        {{:helper.string('<span class="{0}">{1}%</span>', data.aircontents.phoron  > 0 ? 'bad' : 'good' , data.aircontents.phoron)}}
+                        {{:helper.string('<span class="{0}">{1}%</span>', data.aircontents.plasma  > 0 ? 'bad' : 'good' , data.aircontents.plasma)}}
 
                     </div>
                     {{if data.aircontents.other > 0}}
@@ -932,10 +932,10 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                         <span class="average">({{:value.x}} / {{:value.y}}) - {{:value.dir}} - Status: {{:value.status}}</span><br>
                     {{/if}}
                 {{/for}}
-                
+
     {{else data.mode == 6}}
         <H2><span class="white">InstaNews ED 2.0.9</span></H2>
-        
+
         <div class="item">
             <div class="itemLabelNarrow">
                 <b>Functions</b>:
@@ -945,11 +945,11 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                 {{:helper.link('Set news tone', 'comment', {'choice' : "Newstone"}, null, 'fixedLeftWide')}}
             </div>
         </div>
-        
+
 		{{if data.reception != 1}}
 			<span class="bad">No reception with newscaster network.</span>
 		{{/if}}
-		
+
 		<div class="item">
             <div class="itemContent">
                 {{for data.feedChannels}}
@@ -964,14 +964,14 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
             </div>
 		</div>
 
-    {{else data.mode == 61}}      
+    {{else data.mode == 61}}
         <H2><span class="white">{{:data.feed.channel}}</span></H2>
         <span class="white">Created by: </span><span class="average">{{:data.feed.author}}<br></span>
-		
+
 		{{if data.reception != 1}}
 			<span class="bad">No reception with newscaster network.</span>
 		{{/if}}
-		
+
         <div class="statusDisplay" style="overflow: auto;">
             <div class="item">
                 <div class="itemContent" style="width: 100%;">
@@ -997,7 +997,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 				</div>
             </div>
         </div>
-        
+
     {{/if}}
 {{else}}
     <div class="wholeScreen">


### PR DESCRIPTION
## About The Pull Request

Remove phoron reference, fix unprocessing atmos icons

## Why It's Good For The Game

Allows you to see orange and sleeping gas
![plasma](https://user-images.githubusercontent.com/60922927/132196584-e0afa36e-8277-4459-a030-7bcafcb278ac.png)

## Changelog
:cl:
del: Rename phoron reference
fix: Allows you to see orange and sleeping gas
/:cl: