### PR TITLE
Fixes holstered weapons having their click-handlers deleted when pulled out

### DIFF
--- a/code/modules/clothing/accessories/holster.dm
+++ b/code/modules/clothing/accessories/holster.dm
@@ -47,7 +47,7 @@
 				SPAN_NOTICE("[user] draws \the [holstered], pointing it at the ground."),
 				SPAN_NOTICE("You draw \the [holstered], pointing it at the ground.")
 				)
-		user.put_in_hands(holstered)
+		user.put_in_active_hand(holstered)
 		holstered.add_fingerprint(user)
 		w_class = initial(w_class)
 		clear_holster()

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -66,7 +66,10 @@ This saves us from having to call add_fingerprint() any time something is put in
 
 //Puts the item into our active hand if possible. returns 1 on success.
 /mob/living/carbon/human/put_in_active_hand(var/obj/item/W)
-	return (hand ? put_in_l_hand(W) : put_in_r_hand(W))
+	var/value = hand ? put_in_l_hand(W) : put_in_r_hand(W)
+	if(value)
+		W.swapped_to(src)
+	return value
 
 //Puts the item into our inactive hand if possible. returns 1 on success.
 /mob/living/carbon/human/put_in_inactive_hand(var/obj/item/W)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes Holstered weapons with the automatic firemode breaking when unholstered
Also likely fixes a lot of bugs caused by put in active hand lacking the swapped_to proccall
Credit to Bruh Momentium / Roma for giving me a very reliable test case to replicate the issue with

## Why It's Good For The Game
Full auto blasting

## Changelog
:cl:
fix: Fixed holstered weapons with the auto-firemode breaking upon being unholstered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
