### PR TITLE
Fixes exploit allowing people to spam-click to fire auto-guns faster

### DIFF
--- a/code/datums/datum_click_handlers.dm
+++ b/code/datums/datum_click_handlers.dm
@@ -76,7 +76,8 @@
 *****************************/
 /datum/click_handler/fullauto
 	var/atom/target = null
-	var/obj/item/gun/reciever //The thing we send firing signals to.
+	var/obj/item/gun/reciever // The thing we send firing signals to
+	var/time_since_last_init // Time since last start of full auto fire , used to prevent ANGRY smashing of M1 to fire faster.
 	//Todo: Make this work with callbacks
 
 /datum/click_handler/fullauto/Click()
@@ -94,11 +95,14 @@
 /datum/click_handler/fullauto/MouseDown(object, location, control, params)
 	if(!isturf(owner.mob.loc)) // This stops from firing full auto weapons inside closets or in /obj/effect/dummy/chameleon chameleon projector
 		return FALSE
+	if(time_since_last_init > world.time)
+		return FALSE
 
 	object = resolve_world_target(object)
 	if(object)
 		target = object
 		shooting_loop()
+		time_since_last_init = world.time + reciever.burst_delay
 	return TRUE
 
 /datum/click_handler/fullauto/proc/shooting_loop()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -616,6 +616,16 @@
 	update_hud_actions()
 	return new_mode
 
+/// Set firemode , but without a refresh_upgrades at the start
+/obj/item/gun/proc/very_unsafe_set_firemode(index)
+	if(index > firemodes.len)
+		index = 1
+	var/datum/firemode/new_mode = firemodes[sel_mode]
+	new_mode.apply_to(src)
+	new_mode.update()
+	update_hud_actions()
+	return new_mode
+
 /obj/item/gun/attack_self(mob/user)
 	if(zoom)
 		toggle_scope(user)
@@ -810,6 +820,8 @@
 	//Now lets have each upgrade reapply its modifications
 	SEND_SIGNAL(src, COMSIG_ADDVAL, src)
 	SEND_SIGNAL(src, COMSIG_APPVAL, src)
+
+	very_unsafe_set_firemode(sel_mode) // Reset the firemode so it gets the new changes
 
 	update_icon()
 	//then update any UIs with the new stats


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the exploit allowing people to fire faster by just smashing click.
Also fixes gun firing datum not updating its firerate when the gun gets upgraded

## Why It's Good For The Game
1 Exploit less, and powergamers can and will cope.
## Changelog
:cl:
fix : Fixed auto guns firing faster by just click smashing.
fix: Fixed guns receiving a super slow firerate on their enabled firemode  when upgraded
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
