### PR TITLE
Reduces gibs per roach from 5 to 3

### DIFF
--- a/code/game/objects/effects/spawners/gibspawner.dm
+++ b/code/game/objects/effects/spawners/gibspawner.dm
@@ -1,7 +1,7 @@
 /obj/effect/gibspawner
 	generic
 		gibtypes = list(/obj/effect/decal/cleanable/blood/gibs,/obj/effect/decal/cleanable/blood/gibs,/obj/effect/decal/cleanable/blood/gibs/core)
-		gibamounts = list(2,2,1)
+		gibamounts = list(1,1,1)
 
 		New()
 			gibdirections = list(list(WEST, NORTHWEST, SOUTHWEST, NORTH),list(EAST, NORTHEAST, SOUTHEAST, SOUTH), list())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces the gibs per roach from 5 to 3

## Why It's Good For The Game
Less stacking decals and less processing for sanity datums , also , 5 is overkill for slaughtering 1 roach.

## Changelog
:cl:
tweak: Gibbing roaches now makes 3 splatters instead of 5.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
