### PR TITLE
Avoid search in world for del_event

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -5,6 +5,9 @@ var/list/directory = list()							//list of all ckeys with associated client
 //Since it didn't really belong in any other category, I'm putting this here
 //This is for procs to replace all the goddamn 'in world's that are chilling around the code
 
+GLOBAL_LIST_EMPTY(ships) // List of ships in the game.
+
+
 GLOBAL_LIST_EMPTY(mob_list)					//EVERY single mob, dead or alive
 GLOBAL_LIST_EMPTY(player_list)				//List of all mobs **with clients attached**. Excludes /mob/new_player
 GLOBAL_LIST_EMPTY(human_mob_list)				//List of all human mobs and sub-types, including clientless

--- a/code/datums/objective/individual_objective/command.dm
+++ b/code/datums/objective/individual_objective/command.dm
@@ -12,13 +12,13 @@
 /datum/individual_objective/beyond/can_assign(mob/living/L)
 	if(!..())
 		return FALSE
-	return locate(/obj/effect/overmap/ship/eris)
+	return (locate(/obj/effect/overmap/ship/eris) in GLOB.ships)
 
 /datum/individual_objective/beyond/assign()
 	..()
 	x = rand(2, GLOB.maps_data.overmap_size-1)
 	y = rand(2, GLOB.maps_data.overmap_size-1)
-	linked = locate(/obj/effect/overmap/ship/eris)
+	linked = (locate(/obj/effect/overmap/ship/eris) in GLOB.ships)
 	desc = "There is a mark made on your old star chart. You do not remember why you did it but your curiosity wont let you sleep.  \
 			Move [linked] to coordinates [x], [y] for [unit2time(units_requested)]."
 	timer = world.time

--- a/code/global.dm
+++ b/code/global.dm
@@ -4,9 +4,6 @@ var/global/datum/DB_search/db_search = new()
 var/global/list/all_areas                = list()
 var/global/list/ship_areas               = list()
 
-
-GLOBAL_LIST_EMPTY(ships) // List of ships in the game.
-
 //var/global/list/machines                 = list()		//Removed
 //var/global/list/processing_objects       = list()		//Removed
 //var/global/list/processing_power_items   = list()		//Removed

--- a/code/global.dm
+++ b/code/global.dm
@@ -5,7 +5,7 @@ var/global/list/all_areas                = list()
 var/global/list/ship_areas               = list()
 
 
-var/global/list/ships 	= list() // List of ships in the game.
+GLOBAL_LIST_EMPTY(ships) // List of ships in the game.
 
 //var/global/list/machines                 = list()		//Removed
 //var/global/list/processing_objects       = list()		//Removed

--- a/code/modules/long_range_scanner/long_range_scanner.dm
+++ b/code/modules/long_range_scanner/long_range_scanner.dm
@@ -95,8 +95,7 @@ var/list/ship_scanners = list()
 		S.scanners |= src
 
 	// Link to Eris object on the overmap
-	linked_ship = locate(/obj/effect/overmap/ship/eris)
-
+	linked_ship = (locate(/obj/effect/overmap/ship/eris) in GLOB.ships)
 
 /obj/machinery/power/long_range_scanner/Destroy()
 	toggle_tendrils(FALSE)

--- a/code/modules/overmap/events/movable.dm
+++ b/code/modules/overmap/events/movable.dm
@@ -5,9 +5,8 @@
 /obj/effect/overmap_event/proc/del_event()
 	STOP_PROCESSING(SSobj, src)
 	if(OE)
-		for(var/obj/effect/overmap/ship/victim in world)
-			if(istype(victim, /obj/effect/overmap/ship))
-				OE.leave(victim)
+		for(var/obj/effect/overmap/ship/victim in GLOB.ships)
+			OE.leave(victim)
 
 /obj/effect/overmap_event/proc/handle_wraparound()
 	var/low_edge = 1

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -20,7 +20,6 @@
 	var/in_space = 1	//can be accessed via lucky EVA
 
 	var/global/eris_start_set = FALSE //Tells us if we need to modify a random location for Eris to start at
-	var/global/eris
 
 	// Stage 0: close, well scanned by sensors
 	// Stage 1: medium, barely scanned by sensors
@@ -44,7 +43,7 @@
 	start_y = start_y || rand(OVERMAP_EDGE, GLOB.maps_data.overmap_size - OVERMAP_EDGE)
 
 	if ((!eris_start_set) && (name == config.start_location))
-		var/obj/effect/overmap/ship/eris/E = ships[eris]
+		var/obj/effect/overmap/ship/eris/E = (locate(/obj/effect/overmap/ship/eris) in GLOB.ships)
 		start_x = E.start_x
 		start_y = E.start_y
 		eris_start_set = TRUE

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -35,6 +35,14 @@
 					if(istype(src, /obj/effect/overmap/ship))
 						ME.OE:leave(src)
 
+/obj/effect/overmap/ship/New()
+	GLOB.ships += src
+	. = ..()
+
+/obj/effect/overmap/ship/Destroy()
+	GLOB.ships -= src
+	. = ..()
+
 /obj/effect/overmap/ship/Initialize()
 	. = ..()
 	for(var/datum/ship_engine/E in ship_engines)

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -123,7 +123,7 @@
 		toggle_flag(DM)
 
 	// Link to Eris object on the overmap
-	linked_ship = locate(/obj/effect/overmap/ship/eris)
+	linked_ship = (locate(/obj/effect/overmap/ship/eris) in GLOB.ships)
 
 /obj/machinery/power/shield_generator/Destroy()
 	toggle_tendrils(FALSE)

--- a/maps/CEVEris/overmap-eris.dm
+++ b/maps/CEVEris/overmap-eris.dm
@@ -46,11 +46,6 @@
 		"nav_bridge_aquila"
 	)*/
 
-/obj/effect/overmap/ship/eris/Initialize()
-	.=..()
-	if(name == "CEV Eris")
-		ships[eris] = src
-
 /obj/effect/overmap/ship/eris/Process()
 	overmap_event_handler.scan_loc(src, loc, can_scan()) // Eris uses its sensors to scan nearby events
 	.=..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

del_event function was searching `in world` instead of using the global list that contains all existing ships.

Minor tweak of how Eris is stored in that list because that `ships[eris]` with eris a global class variable made little sense to me.

## Why It's Good For The Game

Optimization

## Changelog
:cl: Hyperio
refactor: Refactor del_event function and global list for ships
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
