### PR TITLE
Priming grenades in vest/belt

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -177,6 +177,40 @@
 		/obj/item/taperoll
 	)
 
+/obj/item/storage/belt/tactical/verb/prime_grenades(mob/user)
+	set name = "Prime grenades"
+	set category = "Object"
+	set src in usr
+
+	if(usr.incapacitated(INCAPACITATION_UNCONSCIOUS))
+		to_chat(usr, "You are unconcious and cannot do that!")
+		return
+
+	if(usr.incapacitated(INCAPACITATION_RESTRAINED))
+		to_chat(usr, "You are restrained and cannot do that!")
+		return
+
+	var/primed
+	for(var/obj/item/grenade/G in contents)
+		G.activate(user)
+		primed++
+
+	if(!primed)
+		to_chat(user, "There is no grenades inside.")
+		return
+
+	if(primed == 1)
+		user.visible_message(
+			SPAN_DANGER("[user] pulls the safety pin from grenade in [src]!"),
+			SPAN_DANGER("You prime the grenade in [src]!"))
+		return
+
+	else
+		user.visible_message(
+			SPAN_DANGER("[user] pulls the safety pins from grenades in [src]!"),
+			SPAN_DANGER("You prime the grenades in [src]!"))
+		return
+
 /obj/item/storage/belt/tactical/ironhammer
 	name = "ironhammer tactical belt"
 	icon_state = "tactical_ironhammer"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -178,7 +178,7 @@
 	)
 
 /obj/item/storage/belt/tactical/verb/prime_grenades(mob/user)
-	set name = "Prime grenades"
+	set name = "Prime grenades in belt"
 	set category = "Object"
 	set src in usr
 

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -187,7 +187,7 @@
 		return
 
 	if(usr.incapacitated(INCAPACITATION_RESTRAINED))
-		to_chat(usr, "You are restrained and cannot do that!")
+		to_chat(user, "You are restrained and cannot do that!")
 		return
 
 	var/primed

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -183,7 +183,7 @@
 	set src in usr
 
 	if(usr.incapacitated(INCAPACITATION_UNCONSCIOUS))
-		to_chat(usr, "You are unconscious and cannot do that!")
+		to_chat(user, "You are unconscious and cannot do that!")
 		return
 
 	if(usr.incapacitated(INCAPACITATION_RESTRAINED))

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -183,7 +183,7 @@
 	set src in usr
 
 	if(usr.incapacitated(INCAPACITATION_UNCONSCIOUS))
-		to_chat(usr, "You are unconcious and cannot do that!")
+		to_chat(usr, "You are unconscious and cannot do that!")
 		return
 
 	if(usr.incapacitated(INCAPACITATION_RESTRAINED))

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -177,7 +177,7 @@
 		/obj/item/taperoll
 	)
 
-/obj/item/storage/belt/tactical/verb/prime_grenades(mob/user)
+/obj/item/storage/belt/tactical/verb/prime_belt_grenades(mob/user)
 	set name = "Prime grenades in belt"
 	set category = "Object"
 	set src in usr

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -34,7 +34,7 @@
 	..()
 
 /obj/item/clothing/suit/storage/verb/prime_suit_grenades(mob/user)
-	set name = "Prime grenades"
+	set name = "Prime grenades on suit"
 	set category = "Object"
 	set src in usr
 

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -33,7 +33,7 @@
 	pockets.emp_act(severity)
 	..()
 
-/obj/item/clothing/suit/storage/verb/prime_grenades(mob/user)
+/obj/item/clothing/suit/storage/verb/prime_suit_grenades(mob/user)
 	set name = "Prime grenades"
 	set category = "Object"
 	set src in usr

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -39,7 +39,7 @@
 	set src in usr
 
 	if(usr.incapacitated(INCAPACITATION_UNCONSCIOUS))
-		to_chat(usr, "You are unconscious and cannot do that!")
+		to_chat(user, "You are unconscious and cannot do that!")
 		return
 
 	if(usr.incapacitated(INCAPACITATION_RESTRAINED))

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -43,7 +43,7 @@
 		return
 
 	if(usr.incapacitated(INCAPACITATION_RESTRAINED))
-		to_chat(usr, "You are restrained and cannot do that!")
+		to_chat(user, "You are restrained and cannot do that!")
 		return
 
 	var/primed

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -33,6 +33,40 @@
 	pockets.emp_act(severity)
 	..()
 
+/obj/item/clothing/suit/storage/verb/prime_grenades(mob/user)
+	set name = "Prime grenades"
+	set category = "Object"
+	set src in usr
+
+	if(usr.incapacitated(INCAPACITATION_UNCONSCIOUS))
+		to_chat(usr, "You are unconcious and cannot do that!")
+		return
+
+	if(usr.incapacitated(INCAPACITATION_RESTRAINED))
+		to_chat(usr, "You are restrained and cannot do that!")
+		return
+
+	var/primed
+	for(var/obj/item/grenade/G in pockets.contents)
+		G.activate(user)
+		primed++
+
+	if(!primed)
+		to_chat(user, "There is no grenades inside.")
+		return
+
+	if(primed == 1)
+		user.visible_message(
+			SPAN_DANGER("[user] pulls the safety pin from grenade on [src]!"),
+			SPAN_DANGER("You prime the grenade on [src]!"))
+		return
+
+	else
+		user.visible_message(
+			SPAN_DANGER("[user] pulls the safety pins from grenades on [src]!"),
+			SPAN_DANGER("You prime the grenades on [src]!"))
+		return
+
 //Jackets with buttons, used for labcoats, IA jackets, First Responder jackets, and brown jackets.
 /obj/item/clothing/suit/storage/toggle
 	bad_type = /obj/item/clothing/suit/storage/toggle

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -39,7 +39,7 @@
 	set src in usr
 
 	if(usr.incapacitated(INCAPACITATION_UNCONSCIOUS))
-		to_chat(usr, "You are unconcious and cannot do that!")
+		to_chat(usr, "You are unconscious and cannot do that!")
 		return
 
 	if(usr.incapacitated(INCAPACITATION_RESTRAINED))


### PR DESCRIPTION
## About The Pull Request

Allows to trigger all grenades in tactical belt or suit's pockets with a verb, available in "Object" tab or by right clicking on belt/suit.
User should be alive, conscious and not restrained.

Inspiration:
https://youtu.be/FxO4PEB46Ow?t=28

## Why It's Good For The Game

More options in combat.
For when you don't want to be taken alive but have no budget/uplink for explosive implant.

## Changelog
:cl:
add: "prime grenades" verb for tactical belt and armor with storage
/:cl:
