### PR TITLE
Adds CO2 canister to guild trading beacon

### DIFF
--- a/code/modules/trade/datums/trade_stations_presets/zarya.dm
+++ b/code/modules/trade/datums/trade_stations_presets/zarya.dm
@@ -10,7 +10,8 @@
 			/obj/machinery/portable_atmospherics/canister/sleeping_agent,
 			/obj/machinery/portable_atmospherics/canister/nitrogen,
 			/obj/machinery/portable_atmospherics/canister/oxygen,
-			/obj/machinery/portable_atmospherics/canister/air
+			/obj/machinery/portable_atmospherics/canister/air,
+			/obj/machinery/portable_atmospherics/canister/carbon_dioxide
 		),
 		"CHAPR*EHNE" = list(
 			/obj/item/clothing/mask/gas,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds CO2 canister to guild trading beacon.

## Why It's Good For The Game

All 3 basic gasses should be replenishable in case they run out.

## Changelog
:cl:
add: Adds CO2 canister to guild's trading beacon.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
