### PR TITLE
Some love for the Kitchen

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -19,6 +19,7 @@
 		"Food",
 			list(name="Milk, 30u", cost=60, reagent="milk"),
 			list(name="Slab of meat", cost=50, path=/obj/item/reagent_containers/food/snacks/meat),
+			list(name="Box of eggs", cost=200, path=/obj/item/storage/fancy/egg_box),
 		"Nutrient",
 			list(name="EZ-Nutrient, 30u", cost=30, reagent="eznutrient"),
 			list(name="Left4Zed, 30u", cost=60, reagent="left4zed"),

--- a/code/game/objects/effects/roaches.dm
+++ b/code/game/objects/effects/roaches.dm
@@ -4,9 +4,20 @@
 	desc = "A cockroach egg, can be eaten with proper preparation. It seems to pulse slightly with an inner life."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "roach_egg"
+	preloaded_reagents = list("egg" = 9, "blattedin" = 3)
 	w_class = ITEM_SIZE_TINY
 	health = 5
 	var/amount_grown = 0
+
+/obj/item/roach_egg/afterattack(obj/O as obj, mob/user as mob, proximity)
+	if(istype(O,/obj/machinery/microwave))
+		return ..()
+	if(!proximity || !O.is_refillable())
+		return
+	to_chat(user, "You crack \the [src] into \the [O].")
+	reagents.trans_to(O, reagents.total_volume)
+	user.drop_from_inventory(src)
+	qdel(src)
 
 /obj/item/roach_egg/attackby(var/obj/item/I, var/mob/user)
 	if(I.attack_verb.len)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3390,7 +3390,7 @@
 	icon_state = "rawmeatball"
 	bitesize = 3
 	center_of_mass = list("x"=16, "y"=15)
-	preloaded_reagents = list("protein" = 3, "flour" = 5)
+	preloaded_reagents = list("protein" = 2)
 	taste_tag = list(MEAT_FOOD)
 
 /obj/item/reagent_containers/food/snacks/hotdog

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3368,10 +3368,10 @@
 	desc = "A thin piece of raw meat."
 	icon = 'icons/obj/food_ingredients.dmi'
 	icon_state = "rawcutlet"
-	bitesize = 1
+	bitesize = 2
 	center_of_mass = list("x"=17, "y"=20)
-	preloaded_reagents = list("protein" = 1)
-	taste_tag = list(MEAT_FOOD,FLOURY_FOOD)
+	preloaded_reagents = list("protein" = 3)
+	taste_tag = list(MEAT_FOOD)
 
 /obj/item/reagent_containers/food/snacks/cutlet
 	name = "cutlet"
@@ -3380,7 +3380,7 @@
 	icon_state = "cutlet"
 	bitesize = 2
 	center_of_mass = list("x"=17, "y"=20)
-	preloaded_reagents = list("protein" = 2)
+	preloaded_reagents = list("protein" = 3)
 	taste_tag = list(MEAT_FOOD,SPICY_FOOD)
 
 /obj/item/reagent_containers/food/snacks/rawmeatball
@@ -3388,22 +3388,22 @@
 	desc = "A raw meatball."
 	icon = 'icons/obj/food_ingredients.dmi'
 	icon_state = "rawmeatball"
-	bitesize = 2
+	bitesize = 3
 	center_of_mass = list("x"=16, "y"=15)
-	preloaded_reagents = list("protein" = 2)
+	preloaded_reagents = list("protein" = 3, "flour" = 5)
 	taste_tag = list(MEAT_FOOD)
 
 /obj/item/reagent_containers/food/snacks/hotdog
 	name = "hotdog"
 	desc = "Unrelated to dogs, maybe."
 	icon_state = "hotdog"
-	bitesize = 2
+	bitesize = 3
 	center_of_mass = list("x"=16, "y"=17)
 	preloaded_reagents = list("protein" = 6)
 	junk_food = TRUE
 	spawn_tags = SPAWN_TAG_JUNKFOOD
 	rarity_value = 20
-	taste_tag = list(MEAT_FOOD)
+	taste_tag = list(MEAT_FOOD,FLOURY_FOOD)
 
 /obj/item/reagent_containers/food/snacks/flatbread
 	name = "flatbread"

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -9,17 +9,8 @@
 	matter = list(MATERIAL_BIOMATTER = 20)
 	preloaded_reagents = list("protein" = 9)
 	taste_tag = list(MEAT_FOOD)
-
-/obj/item/reagent_containers/food/snacks/meat/attackby(obj/item/I, mob/user)
-	if(QUALITY_CUTTING in I.tool_qualities)
-		if(I.use_tool(user, src, WORKTIME_NORMAL, QUALITY_CUTTING, FAILCHANCE_ZERO, required_stat = STAT_BIO))
-			to_chat(user, SPAN_NOTICE("You cut the meat into thin strips."))
-			new /obj/item/reagent_containers/food/snacks/rawcutlet(src)
-			new /obj/item/reagent_containers/food/snacks/rawcutlet(src)
-			new /obj/item/reagent_containers/food/snacks/rawcutlet(src)
-			qdel(src)
-	else
-		..()
+	slice_path = /obj/item/reagent_containers/food/snacks/rawcutlet
+	slices_num = 3
 
 /obj/item/reagent_containers/food/snacks/meat/syntiflesh
 	name = "synthetic meat"


### PR DESCRIPTION
## About The Pull Request

Roach eggs contain eggyolk and blattedin.
Removed the code for making cutlets, replaced with the pizza code instead, allowing chems from cutlets to be transferred into foods you cook from them. Now the only way to make blattedin-free food from roaches is to make meatballs.
Biogenerator can now print boxes of eggs.

## Why It's Good For The Game

Removes some exploits, gives more power to vagabonds doing ghetto cooking.

## Changelog
:cl:
fix: Replaced broken cutlet cutting code with sliceable code
tweak: Biogenerator can print egg boxes
tweak: Roach eggs contain 9 units of eggyolk and 3 units of blattedin
/:cl: