### PR TITLE
Uplink implant is now hidden

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -379,11 +379,13 @@
 		if (e.implants.len)
 			var/unknown_body = FALSE
 			for(var/I in e.implants)
-				if(is_type_in_list(I,known_implants))
+				if(is_type_in_list(I,known_implants)) //ATTENTION ALL ANTAG GAMERS
 					var/obj/item/implant/device = I
 					other_wounds += "[device.get_scanner_name()] implanted"
 				else
-					unknown_body = TRUE
+					var/obj/item/implant/device = I
+					if(!device.scanner_hidden)
+						unknown_body = TRUE
 			if(unknown_body)
 				other_wounds += "Unknown body present"
 		if (e.is_stump() || e.burn_dam || e.brute_dam || other_wounds.len)

--- a/code/game/objects/items/weapons/implant/implant.dm
+++ b/code/game/objects/items/weapons/implant/implant.dm
@@ -19,6 +19,7 @@
 	var/position_flag = 0
 	var/external = FALSE
 	var/cruciform_resist = FALSE
+	var/scanner_hidden = FALSE	//Does this implant show up on the body scanner
 
 /obj/item/implant/attackby(obj/item/I, mob/user)
 	..()

--- a/code/game/objects/items/weapons/implant/implants/uplink.dm
+++ b/code/game/objects/items/weapons/implant/implants/uplink.dm
@@ -3,6 +3,7 @@
 	desc = "Summon things."
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_COVERT = 3)
 	spawn_blacklisted = TRUE
+	scanner_hidden = TRUE
 	var/activation_emote
 
 /obj/item/implant/uplink/New(var/loc, var/amount)


### PR DESCRIPTION
## About The Pull Request

Implants now have a variable for being scannable, uplink implants by default are hidden from medical scanners.

## Why It's Good For The Game

Design document

## Changelog
:cl:
balance: uplink implants are hidden from advanced medical scanners
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
