### PR TITLE
Adds shave move to grabs

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -208,7 +208,7 @@ meteor_act
 	return FALSE
 
 /mob/living/carbon/human/resolve_item_attack(obj/item/I, mob/living/user, var/target_zone)
-	if(check_attack_throat(I, user))
+	if(check_attack(I, user))
 		return null
 
 	if(user == src) // Attacking yourself can't miss


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Are your operatives looking like glorified monkeys? Are you a clown looking for a new prank? LOOK NO FURTHER THAN THIS PR! You can now shave someone's head and beard by grabbing (any grab level) with help intent and aiming head for hair or mouth for beard shaving action! Clean as all things should be.

## Why It's Good For The Game

Memes.

## Changelog
:cl:
add: You can now shave someones head/beard with grab, help intent and a sharp item
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
