### PR TITLE
Pouches rebalance

### DIFF
--- a/code/datums/autolathe/biomatter.dm
+++ b/code/datums/autolathe/biomatter.dm
@@ -188,7 +188,7 @@
 
 /datum/design/bioprinter/tubular/vial
 	name= "Vial pouch"
-	build_path = /obj/item/storage/pouch/tubular/vial
+	build_path = /obj/item/storage/pouch/vial
 
 /datum/design/bioprinter/part
 	name = "Part pouch"

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -164,7 +164,7 @@
 
 /obj/item/storage/pouch/ammo
 	name = "ammo pouch"
-	desc = "Can hold ammo magazines and bullets, not the boxes though."
+	desc = "Can hold ammo magazines and bullets."
 	icon_state = "ammo"
 	item_state = "ammo"
 	matter = list(MATERIAL_BIOMATTER = 19, MATERIAL_STEEL = 1 )
@@ -215,7 +215,7 @@
 
 /obj/item/storage/pouch/vial
 	name = "vial pouch"
-	desc = "Can hold about five vials. Rebranding!"
+	desc = "Can hold about ten vials. Rebranding!"
 	icon_state = "flare"
 	item_state = "flare"
 	matter = list(MATERIAL_BIOMATTER = 14, MATERIAL_STEEL = 1 )

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -47,7 +47,7 @@
 	matter = list(MATERIAL_BIOMATTER = 9, MATERIAL_STEEL = 3)
 	storage_slots = null //Uses generic capacity
 	max_storage_space = DEFAULT_SMALL_STORAGE * 0.5
-	max_w_class = ITEM_SIZE_SMALL
+	max_w_class = ITEM_SIZE_NORMAL
 	rarity_value = 10
 
 /obj/item/storage/pouch/medium_generic
@@ -56,6 +56,7 @@
 	icon_state = "medium_generic"
 	item_state = "medium_generic"
 	matter = list(MATERIAL_BIOMATTER = 24, MATERIAL_STEEL = 6 )
+	w_class = ITEM_SIZE_BULKY
 	storage_slots = null //Uses generic capacity
 	max_storage_space = DEFAULT_SMALL_STORAGE
 	max_w_class = ITEM_SIZE_NORMAL
@@ -67,7 +68,7 @@
 	icon_state = "large_generic"
 	item_state = "large_generic"
 	matter = list(MATERIAL_BIOMATTER = 39, MATERIAL_STEEL = 9 )
-	w_class = ITEM_SIZE_NORMAL
+	w_class = ITEM_SIZE_HUGE // It's size of a satchel after all
 	slot_flags = SLOT_BELT | SLOT_DENYPOCKET
 	storage_slots = null //Uses generic capacity
 	max_storage_space = DEFAULT_NORMAL_STORAGE
@@ -82,7 +83,7 @@
 	matter = list(MATERIAL_BIOMATTER = 9, MATERIAL_STEEL = 1 )
 	rarity_value = 33
 
-	storage_slots = 3
+	storage_slots = 6
 	max_w_class = ITEM_SIZE_NORMAL
 
 	can_hold = list(
@@ -104,14 +105,14 @@
 
 /obj/item/storage/pouch/engineering_tools
 	name = "engineering tools pouch"
-	desc = "Can hold small engineering tools. But only about three pieces of them."
+	desc = "Can hold engineering tools. About six pieces of them."
 	icon_state = "engineering_tool"
 	item_state = "engineering_tool"
 	matter = list(MATERIAL_BIOMATTER = 9, MATERIAL_STEEL = 1 )
 	rarity_value = 20
 
-	storage_slots = 3
-	max_w_class = ITEM_SIZE_SMALL
+	storage_slots = 6
+	max_w_class = ITEM_SIZE_NORMAL
 
 	can_hold = list(
 		/obj/item/tool,
@@ -122,8 +123,6 @@
 		/obj/item/device/scanner/gas,
 		/obj/item/taperoll/engineering,
 		/obj/item/device/robotanalyzer,
-		/obj/item/tool/minihoe,
-		/obj/item/tool/hatchet,
 		/obj/item/device/scanner/plant,
 		/obj/item/extinguisher/mini,
 		/obj/item/hand_labeler,
@@ -136,13 +135,13 @@
 
 /obj/item/storage/pouch/engineering_supply
 	name = "engineering supply pouch"
-	desc = "Can hold engineering equipment. But only about two pieces of it."
+	desc = "Can hold engineering equipment. But only about three pieces of it."
 	icon_state = "engineering_supply"
 	item_state = "engineering_supply"
 	matter = list(MATERIAL_BIOMATTER = 9, MATERIAL_STEEL = 1 )
 	rarity_value = 33
 
-	storage_slots = 2
+	storage_slots = 3
 	w_class = ITEM_SIZE_NORMAL
 	max_w_class = ITEM_SIZE_NORMAL
 
@@ -154,6 +153,7 @@
 		/obj/item/material,
 		/obj/item/device/lighting/toggleable/flashlight,
 		/obj/item/stack/cable_coil,
+		/obj/item/stack/rods,
 		/obj/item/device/t_scanner,
 		/obj/item/device/scanner/gas,
 		/obj/item/taperoll/engineering,
@@ -170,11 +170,13 @@
 	matter = list(MATERIAL_BIOMATTER = 19, MATERIAL_STEEL = 1 )
 	rarity_value = 33
 
-	storage_slots = 3
+	storage_slots = null // Uses generic capacity
 	w_class = ITEM_SIZE_NORMAL
-	max_w_class = ITEM_SIZE_NORMAL
+	max_storage_space = DEFAULT_SMALL_STORAGE + 2 // 6 medium cells/magazines/grenades or 12 small cells
 
 	can_hold = list(
+		/obj/item/cell/small,
+		/obj/item/cell/medium,
 		/obj/item/ammo_magazine,
 		/obj/item/ammo_casing
 		)
@@ -192,6 +194,8 @@
 	max_w_class = ITEM_SIZE_NORMAL
 
 	can_hold = list(
+		/obj/item/cell/small,
+		/obj/item/cell/medium,
 		/obj/item/device/lighting/glowstick,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/reagent_containers/glass/beaker/vial,
@@ -203,11 +207,36 @@
 		/obj/item/ammo_casing/grenade
 		)
 
-/obj/item/storage/pouch/tubular/vial
+/obj/item/storage/pouch/tubular/on_update_icon()
+	..()
+	cut_overlays()
+	if(contents.len)
+		add_overlays(image('icons/inventory/pockets/icon.dmi', "flare_[contents.len]"))
+
+/obj/item/storage/pouch/vial
 	name = "vial pouch"
 	desc = "Can hold about five vials. Rebranding!"
+	icon_state = "flare"
+	item_state = "flare"
+	matter = list(MATERIAL_BIOMATTER = 14, MATERIAL_STEEL = 1 )
+	rarity_value = 14
 
-/obj/item/storage/pouch/tubular/on_update_icon()
+	storage_slots = 10
+	w_class = ITEM_SIZE_NORMAL
+	max_w_class = ITEM_SIZE_SMALL
+
+	can_hold = list(
+		/obj/item/cell/small,
+		/obj/item/device/lighting/glowstick,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/reagent_containers/glass/beaker/vial,
+		/obj/item/reagent_containers/hypospray,
+		/obj/item/pen,
+		/obj/item/storage/pill_bottle,
+		/obj/item/hatton_magazine,
+		)
+
+/obj/item/storage/pouch/vial/on_update_icon()
 	..()
 	cut_overlays()
 	if(contents.len)

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -172,6 +172,7 @@
 
 	storage_slots = null // Uses generic capacity
 	w_class = ITEM_SIZE_NORMAL
+	max_w_class = ITEM_SIZE_SMALL
 	max_storage_space = DEFAULT_SMALL_STORAGE + 2 // 6 medium cells/magazines/grenades or 12 small cells
 
 	can_hold = list(

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -135,4 +135,4 @@
 /obj/structure/closet/secure_closet/chemical/populate_contents()
 	new /obj/item/storage/box/pillbottles(src)
 	new /obj/item/storage/box/pillbottles(src)
-	new /obj/item/storage/pouch/tubular/vial(src)
+	new /obj/item/storage/pouch/vial(src)

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -528,7 +528,6 @@
 	ammo_type = /obj/item/ammo_casing/lrifle
 	max_ammo = 5
 	multiple_sprites = 1
-	w_class = ITEM_SIZE_SMALL
 
 /obj/item/ammo_magazine/sllrifle/hv
 	name = "ammo strip (.30 Rifle HV)"

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -427,6 +427,7 @@
 	max_ammo = 96
 	multiple_sprites = 1
 	ammo_color = "-l"
+	w_class = ITEM_SIZE_NORMAL
 
 /obj/item/ammo_magazine/maxim/rubber
 	name = "pan magazine (.30 Rifle rubber)"
@@ -527,6 +528,7 @@
 	ammo_type = /obj/item/ammo_casing/lrifle
 	max_ammo = 5
 	multiple_sprites = 1
+	w_class = ITEM_SIZE_SMALL
 
 /obj/item/ammo_magazine/sllrifle/hv
 	name = "ammo strip (.30 Rifle HV)"

--- a/code/modules/trade/datums/trade_stations_presets/nt_cruisers.dm
+++ b/code/modules/trade/datums/trade_stations_presets/nt_cruisers.dm
@@ -17,7 +17,7 @@
 			/obj/item/storage/pouch/engineering_tools,
 			/obj/item/storage/pouch/engineering_supply,
 			/obj/item/storage/pouch/tubular,
-			/obj/item/storage/pouch/tubular/vial,
+			/obj/item/storage/pouch/vial,
 			/obj/item/storage/pouch/ammo,
 			/obj/item/storage/pouch/medical_supply,
 			/obj/item/clothing/accessory/holster,


### PR DESCRIPTION
## About The Pull Request

Alternative version of [this PR](https://github.com/discordia-space/CEV-Eris/pull/6556).

Small generic pouch:
Item size set to "normal"

Medium generic pouch:
Item size set to "bulky"

Large generic pouch:
Item size set to "huge" - same size a satchel have, also preventing it from being placed in a backpack. Bluespace magic no more.

Medical supply pouch:
Storage capacity increased to 6

Engineering tools pouch:
Storage capacity increased to 6
Max stored item size set to "normal"

Engineering supply pouch:
Storage capacity increased to 3
Can hold metal rods

Ammo pouch:
Uses generic capacity instead of slots
Can cold medium and small power cells
Fits 6 ammo magazines / medium cells / underslung grenades or 12 small cells

Tubular pouch:
Can cold medium and small power cells

Vial pouch:
Storage capacity increased to 10
Can't hold RPG charges and grenades
Can cold small power cells

Pan magazine:
Item size set to "normal" - fat ass pan magazine shouldn't fit in ammo pouch

## Why It's Good For The Game

More use for specialized pouches.
Fixed large pouch + duffle bag combo, no longer possible to carry half the ship in a bag.

## Changelog
:cl:
balance: buffed specialized pouches
balance: nerfed generic pouches
balance: increased pan magazine size
/:cl:
