### PR TITLE
Bolt rifle tweak

### DIFF
--- a/code/modules/projectiles/guns/projectile/battle_rifle/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/battle_rifle/boltgun.dm
@@ -17,7 +17,7 @@
 	recoil_buildup = 1.6 // reduced from the AK's/Takeshi's buildup of 1.7/1.8 because >lol boltgun
 	handle_casings = HOLD_CASINGS
 	load_method = SINGLE_CASING|SPEEDLOADER
-	max_shells = 10
+	max_shells = 5
 	magazine_type = /obj/item/ammo_magazine/lrifle
 	fire_sound = 'sound/weapons/guns/fire/sniper_fire.ogg'
 	reload_sound = 'sound/weapons/guns/interact/rifle_load.ogg'
@@ -64,11 +64,17 @@
 	playsound(src.loc, 'sound/weapons/guns/interact/rifle_boltback.ogg', 75, 1)
 	bolt_open = !bolt_open
 	if(bolt_open)
-		if(chambered)
-			to_chat(user, SPAN_NOTICE("You work the bolt open, ejecting [chambered]!"))
-			chambered.forceMove(get_turf(src))
-			loaded -= chambered
-			chambered = null
+		if(contents.len)
+			if(chambered)
+				to_chat(user, SPAN_NOTICE("You work the bolt open, ejecting [chambered]!"))
+				chambered.forceMove(get_turf(src))
+				loaded -= chambered
+				chambered = null
+			else
+				var/obj/item/ammo_casing/B = loaded[loaded.len]
+				to_chat(user, SPAN_NOTICE("You work the bolt open, ejecting [B]!"))
+				B.forceMove(get_turf(src))
+				loaded -= B
 		else
 			to_chat(user, SPAN_NOTICE("You work the bolt open."))
 	else

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -62,11 +62,17 @@
 	playsound(src.loc, 'sound/weapons/guns/interact/rifle_boltback.ogg', 75, 1)
 	bolt_open = !bolt_open
 	if(bolt_open)
-		if(chambered)
-			to_chat(user, SPAN_NOTICE("You work the bolt open, ejecting [chambered]!"))
-			chambered.loc = get_turf(src)
-			loaded -= chambered
-			chambered = null
+		if(contents.len)
+			if(chambered)
+				to_chat(user, SPAN_NOTICE("You work the bolt open, ejecting [chambered]!"))
+				chambered.forceMove(get_turf(src))
+				loaded -= chambered
+				chambered = null
+			else
+				var/obj/item/ammo_casing/B = loaded[loaded.len]
+				to_chat(user, SPAN_NOTICE("You work the bolt open, ejecting [B]!"))
+				B.forceMove(get_turf(src))
+				loaded -= B
 		else
 			to_chat(user, SPAN_NOTICE("You work the bolt open."))
 	else


### PR DESCRIPTION
## About The Pull Request

Makes bolt rifles eject ammo each time bolt is worked, no matter spent or not. AMR too.
Because that's how bolt rifles work. (Or so I've been told)
Changed bolt rifle ammo capacity to 5, (also increases time it takes to reload from a box) so ammo clips isn't useless anymore.

## Why It's Good For The Game

Ammo clips is good and should be used.

## Changelog
:cl:
tweak: bolt rifles eject ammo when bolt is worked, spent or not
balance: bolt rifle ammo capacity halved
/:cl:
