### PR TITLE
Background tweak and removal.

### DIFF
--- a/code/datums/setup_option/backgrounds/origin.dm
+++ b/code/datums/setup_option/backgrounds/origin.dm
@@ -233,21 +233,3 @@
 		STAT_COG = -10
 	)
 
-	restricted_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/chaplain, /datum/job/merchant, /datum/job/cmo, /datum/job/rd, /datum/job/ihc)
-	restricted_depts = IRONHAMMER | MEDICAL | SCIENCE | CHURCH | GUILD | CIVILIAN | SERVICE
-
-/datum/category_item/setup_option/background/origin/ihmaids
-	name = "Ironhammer M.A.I.D.S Corps"
-	desc = "The Ironhammer Medical, Acquisition, Industrial Design and Security Corps are normally posted to construction work of particular importance to Ironhammer assets, such as fortifications or barracks for the garrisons on the way to the null sector, along with triage work for when an accident inevitably happens at those garrisons. \
-			At other times, they're assigned to Ironhammer security teams on exploratory missions into the null sector due to their prowess as construction specialists and medics."
-
-	stat_modifiers = list(
-		STAT_ROB = -10,
-		STAT_TGH = -5,
-		STAT_BIO = 10,
-		STAT_MEC = 10,
-		STAT_VIG = -10,
-		STAT_COG = 10
-	)
-	restricted_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/chaplain, /datum/job/merchant, /datum/job/cmo, /datum/job/rd, /datum/job/chief_engineer)
-	restricted_depts = ENGINEERING | MEDICAL | SCIENCE | CHURCH | GUILD | CIVILIAN | SERVICE


### PR DESCRIPTION
## About The Pull Request

Removes the ironhammer maid background and removes restrictions on the stretsley background.

## Why It's Good For The Game

Maid is a meme and I don't know why it got added. It's not even a real origin, it's a training camp.

Background restrictions are generally not something we should be moving towards. Freedom of character choice is important, locking off stretsley hurts that and sets a bad precedent.

## Changelog
:cl:
del: Deletes Ironhammer (M.A.I.D Corps)
tweak: Removes restrictions on Wandering Stretsley background.
/:cl: