### PR TITLE
Cognition now influences chance to trip,Cognition/Biological is required to see reagents inside a container, Chemist buff

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -342,3 +342,7 @@
 
 //Prevent the master controller from starting automatically
 #define NO_INIT_PARAMETER "no-init"
+
+/// Required minimum values to see reagents in a beaker
+#define HUMAN_REQ_COG_FOR_REG 20
+#define HUMAN_REQ_BIO_FOR_REG 50

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -344,5 +344,5 @@
 #define NO_INIT_PARAMETER "no-init"
 
 /// Required minimum values to see reagents in a beaker
-#define HUMAN_REQ_COG_FOR_REG 20
+#define HUMAN_REQ_COG_FOR_REG 35
 #define HUMAN_REQ_BIO_FOR_REG 50

--- a/code/__DEFINES/mob_stats.dm
+++ b/code/__DEFINES/mob_stats.dm
@@ -21,3 +21,8 @@
 
 /// Bitflag for shared perk abilities
  #define PERK_SHARED_SEE_REAGENTS 0x1
+ /*
+ #define PERK_SHARED_SEE_CONSUMER_REAGENTS 0x2
+ */
+
+

--- a/code/__DEFINES/mob_stats.dm
+++ b/code/__DEFINES/mob_stats.dm
@@ -18,3 +18,6 @@
 
 #define STAT_LEVEL_MIN      0 // Min stat value selectable
 #define STAT_LEVEL_MAX      60 // Max stat value selectable
+
+/// Bitflag for shared perk abilities
+ #define PERK_SHARED_SEE_REAGENTS 0x1

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -338,6 +338,9 @@ Proc for attack log creation, because really why not
 	. = ..()
 	. |= CLASSIFICATION_ORGANIC | CLASSIFICATION_HUMANOID
 
+/mob/proc/can_see_reagents()
+	return TRUE
+
 
 // Returns true if M was not already in the dead mob list
 /mob/proc/switch_from_living_to_dead_mob_list()

--- a/code/datums/mob_stats.dm
+++ b/code/datums/mob_stats.dm
@@ -14,10 +14,24 @@
 	holder = null
 	return ..()
 
+/datum/stat_holder/proc/check_for_shared_perk(ability_bitflag)
+	for(var/datum/perk/target_perk in perks)
+		if(target_perk.check_shared_ability(ability_bitflag))
+			return TRUE
+	return FALSE
+
+/* Uncomment when we have more than 1 bitflag for shared abilities
+/datum/stat_holder/proc/check_for_shared_perks(list/ability_bitflags)
+	for(var/datum/perk/target_perk in perks)
+		if(target_perk.check_shared_abilities(ability_bitflags))
+			return TRUE
+	return FALSE
+*/
 /datum/stat_holder/proc/addTempStat(statName, Value, timeDelay, id = null)
 	var/datum/stat/S = stat_list[statName]
 	S.addModif(timeDelay, Value, id)
 	SEND_SIGNAL(holder, COMSIG_STAT, S.name, S.getValue(), S.getValue(TRUE))
+
 
 /datum/stat_holder/proc/removeTempStat(statName, id)
 	if(!id)

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -62,7 +62,7 @@
 /datum/perk/selfmedicated/chemist
 	name = "Chemical-junkie"
 	desc = "You know what the atoms around you react to and in what way they do. You are used to making organic substites and pumping them into yourself in the name of science! \
-			You get 10 more NSA points and a quarter more NSA ontop than a normal person. Your chance of getting addicted is also reduced to half."
+			You get 10 more NSA points and a quarter more NSA ontop than a normal person. Your chance of getting addicted is also reduced to half and you can also see all reagents in beakers."
 	perk_shared_ability = PERK_SHARED_SEE_REAGENTS
 
 /datum/perk/selfmedicated/chemist/assign(mob/living/carbon/human/H)
@@ -245,7 +245,7 @@
 
 /datum/perk/job/club
 	name = "Raising the bar"
-	desc = "You know how to mix drinks and change lives. People near you recover sanity."
+	desc = "You know how to mix drinks and change lives. People near you recover sanity and you always know what is in the glasses."
 	icon_state = "inspiration"
 	perk_shared_ability = PERK_SHARED_SEE_REAGENTS
 

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -245,9 +245,8 @@
 
 /datum/perk/job/club
 	name = "Raising the bar"
-	desc = "You know how to mix drinks and change lives. People near you recover sanity and you always know what is in the glasses."
+	desc = "You know how to mix drinks and change lives. People near you recover sanity."
 	icon_state = "inspiration"
-	perk_shared_ability = PERK_SHARED_SEE_REAGENTS
 
 /datum/perk/job/club/assign(mob/living/carbon/human/H)
 	..()

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -61,7 +61,7 @@
 
 /datum/perk/selfmedicated/chemist
 	name = "Chemical-junkie"
-	desc = "You know what the atoms around you react to and in what way they do. You are used to making organic substites and pumping them into yourself in the name of science! \
+	desc = "You know what the atoms around you react to and in what way they do. You are used to making organic substitutes and pumping them into yourself in the name of science! \
 			You get 10 more NSA points and a quarter more NSA ontop than a normal person. Your chance of getting addicted is also reduced to half and you can also see all reagents in beakers."
 	perk_shared_ability = PERK_SHARED_SEE_REAGENTS
 

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -44,7 +44,7 @@
 /datum/perk/selfmedicated
 	name = "Self-medicated"
 	desc = "You have very shoddy handwriting. This lets you write prescriptions to yourself! \
-			You total NSA is increased and chance to gain an addiction decreased."
+			Your total NSA is increased and chance to gain an addiction decreased."
 	icon_state = "selfmedicated" // https://game-icons.net/1x1/lorc/overdose.html
 
 /datum/perk/selfmedicated/assign(mob/living/carbon/human/H)
@@ -58,6 +58,24 @@
 		holder.metabolism_effects.addiction_chance_multiplier = 1
 		holder.metabolism_effects.nsa_threshold_base -= 10
 	..()
+
+/datum/perk/selfmedicated/chemist
+	name = "Chemical-junkie"
+	desc = "You know what the atoms around you react to and in what way they do. You are used to making organic substites and pumping them into yourself in the name of science! \
+			You get 10 more NSA points and a quarter more NSA ontop than a normal person. Your chance of getting addicted is also reduced to half."
+	perk_shared_ability = PERK_SHARED_SEE_REAGENTS
+
+/datum/perk/selfmedicated/chemist/assign(mob/living/carbon/human/H)
+	..()
+	if(holder)
+		holder.metabolism_effects.nsa_threshold_base *= 1.25
+
+// Added on top , removed first
+/datum/perk/selfmedicated/chemist/remove()
+	if(holder)
+		holder.metabolism_effects.nsa_threshold_base /= 1.25
+	..()
+
 
 /datum/perk/vagabond
 	name = "Vagabond"
@@ -229,6 +247,7 @@
 	name = "Raising the bar"
 	desc = "You know how to mix drinks and change lives. People near you recover sanity."
 	icon_state = "inspiration"
+	perk_shared_ability = PERK_SHARED_SEE_REAGENTS
 
 /datum/perk/job/club/assign(mob/living/carbon/human/H)
 	..()

--- a/code/datums/perks/perk.dm
+++ b/code/datums/perks/perk.dm
@@ -15,6 +15,7 @@
 	var/mob/living/carbon/human/holder
 	var/gain_text
 	var/lose_text
+	var/perk_shared_ability
 
 /datum/perk/Destroy()
 	if(holder)
@@ -43,3 +44,19 @@
 /datum/perk/proc/remove()
 	SHOULD_CALL_PARENT(TRUE)
 	qdel(src)
+
+/// Proc called , a bitflag is always expected.
+/datum/perk/proc/check_shared_ability(ability_bitflag)
+	if(!(perk_shared_ability & ability_bitflag))
+		return FALSE
+	return TRUE
+
+/* Uncomment this when  more shared abilities are
+/datum/perk/proc/check_shared_abilities(list/ability_bitflags)
+	var/accumulated_bitflags = 0
+	for(var/bitflag in ability_bitflags)
+		if(!check_shared_ability(bitflag))
+			continue
+		accumulated_bitflags++
+	return ability_bitflags.len == accumulated_bitflags ? TRUE : FALSE
+*/

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -298,28 +298,20 @@ its easier to just keep the beam vertical.
 	if(reagents)
 		if(reagent_flags & TRANSPARENT)
 			to_chat(user, "<span class='notice'>It contains:</span>")
-			if(reagents.reagent_list.len)
+			if(user.can_see_reagents()) //Show each individual reagent
 				for(var/I in reagents.reagent_list)
 					var/datum/reagent/R = I
 					to_chat(user, "<span class='notice'>[R.volume] units of [R.name]</span>")
-
-				// TODO: reagent vision googles? code below:
-				/*
-				if(user.can_see_reagents()) //Show each individual reagent
-					for(var/I in reagents.reagent_list)
-						var/datum/reagent/R = I
-						to_chat(user, "<span class='notice'>[R.volume] units of [R.name]</span>")
-				else //Otherwise, just show the total volume
-					if(reagents && reagents.reagent_list.len)
-						to_chat(user, "<span class='notice'>[reagents.total_volume] units of various reagents.</span>")
-				*/
-			else
-				to_chat(user, "<span class='notice'>Nothing.</span>	")
-		else if(reagent_flags & AMOUNT_VISIBLE)
-			if(reagents.total_volume)
-				to_chat(user, "<span class='notice'>It has [reagents.total_volume] unit\s left.</span>")
-			else
-				to_chat(user, "<span class='danger'>It's empty.</span>")
+			else //Otherwise, just show the total volume
+				if(reagents && reagents.reagent_list.len)
+					to_chat(user, "<span class='notice'>[reagents.total_volume] units of various reagents.</span>")
+		else
+			to_chat(user, "<span class='notice'>Nothing</span>	")
+	else if(reagent_flags & AMOUNT_VISIBLE)
+		if(reagents.total_volume)
+			to_chat(user, "<span class='notice'>It has [reagents.total_volume] unit\s left.</span>")
+		else
+			to_chat(user, "<span class='danger'>It's empty.</span>")
 
 	if(ishuman(user) && user.stats && user.stats.getPerk(/datum/perk/greenthumb))
 		var/datum/perk/greenthumb/P = user.stats.getPerk(/datum/perk/greenthumb)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -297,21 +297,27 @@ its easier to just keep the beam vertical.
 
 	if(reagents)
 		if(reagent_flags & TRANSPARENT)
-			to_chat(user, "<span class='notice'>It contains:</span>")
-			if(user.can_see_reagents()) //Show each individual reagent
-				for(var/I in reagents.reagent_list)
-					var/datum/reagent/R = I
-					to_chat(user, "<span class='notice'>[R.volume] units of [R.name]</span>")
-			else //Otherwise, just show the total volume
-				if(reagents && reagents.reagent_list.len)
-					to_chat(user, "<span class='notice'>[reagents.total_volume] units of various reagents.</span>")
+			to_chat(user, SPAN_NOTICE("It contains:"))
+			var/return_value = user.can_see_reagents()
+			if(return_value == TRUE) //Show each individual reagent
+				for(var/datum/reagent/R in reagents.reagent_list)
+					to_chat(user, SPAN_NOTICE("[R.volume] units of [R.name]"))
+			/* Uncomment to check for consumer reagents also in can_see_reagents
+			else if(return_value == 2) // Check for consumer reagents
+				for(var/datum/reagent/R in reagents.reagent_list)
+					if(!(istype(R,/datum/reagent/ethanol) || istype(R,/datum/reagent/drink) || istype(R, /datum/reagent/water)))
+						//to_chat(user, SPAN_NOTICE("[R.volume] units of an unfamiliar substance")) For balance concers , don't let them know
+						continue
+					to_chat(user, SPAN_NOTICE("[R.volume] units of [R.name]"))
+			*/
+			else if(reagents && reagents.reagent_list.len)
+				to_chat(user, SPAN_NOTICE("[reagents.total_volume] units of various reagents."))
 		else
-			to_chat(user, "<span class='notice'>Nothing</span>	")
-	else if(reagent_flags & AMOUNT_VISIBLE)
-		if(reagents.total_volume)
-			to_chat(user, "<span class='notice'>It has [reagents.total_volume] unit\s left.</span>")
-		else
-			to_chat(user, "<span class='danger'>It's empty.</span>")
+			if(reagent_flags & AMOUNT_VISIBLE)
+				if(reagents.total_volume)
+					to_chat(user, SPAN_NOTICE("It has [reagents.total_volume] unit\s left."))
+				else
+					to_chat(user, SPAN_DANGER("It's empty."))
 
 	if(ishuman(user) && user.stats && user.stats.getPerk(/datum/perk/greenthumb))
 		var/datum/perk/greenthumb/P = user.stats.getPerk(/datum/perk/greenthumb)

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -145,7 +145,7 @@ Your second loyalty is to your career with Moebius corp, and to your coworkers i
 		STAT_BIO = 30
 	)
 
-	perks = list(/datum/perk/selfmedicated)
+	perks = list(/datum/perk/selfmedicated/chemist)
 
 	software_on_spawn = list(/datum/computer_file/program/chem_catalog,
 							/datum/computer_file/program/scanner)

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -255,12 +255,11 @@ var/list/flooring_types
 	//BSTs need this or they generate tons of soundspam while flying through the ship
 	if(!ishuman(M)|| M.incorporeal_move || !has_gravity(get_turf(M)))
 		return
+	var/mob/living/carbon/human/our_trippah = M
 	if(MOVING_QUICKLY(M))
-		if(prob(5))
-			M.adjustBruteLoss(5)
-			M.slip(null, 6)
-			playsound(M, 'sound/effects/bang.ogg', 50, 1)
-			to_chat(M, SPAN_WARNING("You tripped over!"))
+		if(prob(50 - our_trippah.stats.getStat(STAT_COG))) // The art of calculating the vectors required to avoid tripping on the metal beams requires big quantities of brain power
+			our_trippah.adjustBruteLoss(5)
+			our_trippah.trip(6)
 			return
 
 //============HULL PLATING=========\\

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -257,7 +257,7 @@ var/list/flooring_types
 		return
 	var/mob/living/carbon/human/our_trippah = M
 	if(MOVING_QUICKLY(M))
-		if(prob(50 - our_trippah.stats.getStat(STAT_COG))) // The art of calculating the vectors required to avoid tripping on the metal beams requires big quantities of brain power
+		if(prob(50 - our_trippah.stats.getStat(STAT_COG) * 2)) // The art of calculating the vectors required to avoid tripping on the metal beams requires big quantities of brain power
 			our_trippah.adjustBruteLoss(5)
 			our_trippah.trip(6)
 			return

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -259,7 +259,7 @@ var/list/flooring_types
 	if(MOVING_QUICKLY(M))
 		if(prob(50 - our_trippah.stats.getStat(STAT_COG) * 2)) // The art of calculating the vectors required to avoid tripping on the metal beams requires big quantities of brain power
 			our_trippah.adjustBruteLoss(5)
-			our_trippah.trip(6)
+			our_trippah.trip(src, 6)
 			return
 
 //============HULL PLATING=========\\

--- a/code/modules/clothing/glasses/science.dm
+++ b/code/modules/clothing/glasses/science.dm
@@ -1,5 +1,5 @@
 /obj/item/clothing/glasses/powered/science
-	name = "Science Goggles"
+	name = "science goggles"
 	desc = "These goggles scan the reagents within beakers, displaying them to you!"
 	off_state = "purple"
 	icon_state = "purple"

--- a/code/modules/clothing/glasses/science.dm
+++ b/code/modules/clothing/glasses/science.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/glasses/powered/science
 	name = "Science Goggles"
-	desc = "The goggles do nothing!"
+	desc = "These goggles scan the reagents within beakers , displaying them to you!"
 	off_state = "purple"
 	icon_state = "purple"
 	item_state = "glasses"

--- a/code/modules/clothing/glasses/science.dm
+++ b/code/modules/clothing/glasses/science.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/glasses/powered/science
 	name = "Science Goggles"
-	desc = "These goggles scan the reagents within beakers , displaying them to you!"
+	desc = "These goggles scan the reagents within beakers, displaying them to you!"
 	off_state = "purple"
 	icon_state = "purple"
 	item_state = "glasses"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1403,12 +1403,13 @@ var/list/rank_prefix = list(\
 /mob/living/carbon/human/trip(tripped_on, stun_duration)
 	if(buckled)
 		return FALSE
+	if(lying)
+		return FALSE // No tripping while crawling
 	stop_pulling()
 	if (tripped_on)
 		playsound(src, 'sound/effects/bang.ogg', 50, 1)
 		to_chat(src, SPAN_WARNING("You tripped over!"))
-	Stun(stun_duration)
-	Weaken(FLOOR(stun_duration * 0.5, 1))
+	Weaken(stun_duration)
 	return TRUE
 
 /mob/living/carbon/human/proc/undislocate()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1400,6 +1400,17 @@ var/list/rank_prefix = list(\
 		return 0
 	..(slipped_on,stun_duration)
 
+/mob/living/carbon/human/trip(tripped_on, stun_duration)
+	if(buckled)
+		return FALSE
+	stop_pulling()
+	if (tripped_on)
+		playsound(tripped_on, 'sound/effects/bang.ogg', 50, 1)
+		to_chat(tripped_on, SPAN_WARNING("You tripped over!"))
+	Stun(stun_duration)
+	Weaken(FLOOR(stun_duration * 0.5, 1))
+	return TRUE
+
 /mob/living/carbon/human/proc/undislocate()
 	set category = "Object"
 	set name = "Undislocate Joint"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1405,8 +1405,8 @@ var/list/rank_prefix = list(\
 		return FALSE
 	stop_pulling()
 	if (tripped_on)
-		playsound(tripped_on, 'sound/effects/bang.ogg', 50, 1)
-		to_chat(tripped_on, SPAN_WARNING("You tripped over!"))
+		playsound(src, 'sound/effects/bang.ogg', 50, 1)
+		to_chat(src, SPAN_WARNING("You tripped over!"))
 	Stun(stun_duration)
 	Weaken(FLOOR(stun_duration * 0.5, 1))
 	return TRUE

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -23,6 +23,8 @@
 		var/obj/item/clothing/glasses/powered/our_glasses = glasses
 		if(our_glasses.active)
 			return TRUE
+	if(stats.check_for_shared_perk(PERK_SHARED_SEE_REAGENTS))
+		return TRUE
 	if(stats.getStat(STAT_COG) >= HUMAN_REQ_COG_FOR_REG || stats.getStat(STAT_BIO) >= HUMAN_REQ_BIO_FOR_REG)
 		return TRUE
 	return FALSE

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -27,6 +27,10 @@
 		return TRUE
 	if(stats.getStat(STAT_COG) >= HUMAN_REQ_COG_FOR_REG || stats.getStat(STAT_BIO) >= HUMAN_REQ_BIO_FOR_REG)
 		return TRUE
+	/*
+	if(stats.check_for_shared_perk(PERK_SHARED_SEE_CONSUMER_REAGENTS))
+		return 2
+	*/
 	return FALSE
 
 /mob/living/carbon/human/can_force_feed(var/feeder, var/food, var/feedback = 1)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -18,6 +18,15 @@
 			to_chat(src, SPAN_WARNING("\The [status[2]] is in the way!"))
 	return 0
 
+/mob/living/carbon/human/can_see_reagents()
+	if(istype(glasses, /obj/item/clothing/glasses/powered/science))
+		var/obj/item/clothing/glasses/powered/our_glasses = glasses
+		if(our_glasses.active)
+			return TRUE
+	if(stats.getStat(STAT_COG) >= HUMAN_REQ_COG_FOR_REG || stats.getStat(STAT_BIO) >= HUMAN_REQ_BIO_FOR_REG)
+		return TRUE
+	return FALSE
+
 /mob/living/carbon/human/can_force_feed(var/feeder, var/food, var/feedback = 1)
 	var/list/status = can_eat_status()
 	if(status[1] == HUMAN_EATING_NO_ISSUE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -674,6 +674,9 @@ default behaviour is:
 /mob/living/proc/slip(var/slipped_on,stun_duration=8)
 	return FALSE
 
+/mob/living/proc/trip(tripped_on, stun_duration)
+	return FALSE
+
 //damage/heal the mob ears and adjust the deaf amount
 /mob/living/adjustEarDamage(damage, deaf)
 	ear_damage = max(0, ear_damage + damage)


### PR DESCRIPTION
## About The Pull Request
Trip chance is now at base 50%
Cognition reduces chance to trip
Tripping is no longer prevented by slip-preventing items such as magboots
You now need scanning googles , 35 cognition or 50 biological to recognise reagents in drinks
Adds functionality for abilities that are shared between more perks with bitflags



## Why It's Good For The Game
Forces everyone on plating to play on even ground , makes cognition count more 
Lets people actually poison drinks , which can deal to interesting plots

## Changelog
:cl:
balance: Seeing reagents inside beakers now requires scanning goggles , 35 cognition or 50 biology
balance: Tripping can no longer be prevented by anything slip-preventing
balance: Trip chance is now 50% , and gets lowered by cognition stat
code: Added bitflag handling for perks that share a common ability
balance: Buffed chemist perk and made the chemist perk also give the ability to see reagents
balance: Tripping no longer hardstuns , instead if weakens.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
