### PR TITLE
Reduces Techno-Tribalism Enforcer(cube) cooldown to something more manageable

### DIFF
--- a/code/game/objects/items/devices/techno_tribalism.dm
+++ b/code/game/objects/items/devices/techno_tribalism.dm
@@ -9,10 +9,10 @@
 	spawn_frequency = 0
 	spawn_blacklisted = TRUE
 	var/list/oddity_stats = list(STAT_MEC = 0, STAT_COG = 0, STAT_BIO = 0, STAT_ROB = 0, STAT_TGH = 0, STAT_VIG = 0)
-	var/last_produce = -30 MINUTES
+	var/last_produce = -20 MINUTES
 	var/items_count = 0
 	var/max_count = 5
-	var/cooldown = 30 MINUTES
+	var/cooldown = 20 MINUTES
 
 /obj/item/device/techno_tribalism/New()
 	..()


### PR DESCRIPTION

## About The Pull Request

Gives cube a cooldown thats more in line with its power.

## Why It's Good For The Game

People were complaining about only being able to use the cube a few times per round, less then they had hoped to.

## Changelog
:cl:
tweak: cube cooldown is now 20 instead of 30 minutes
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
