### PR TITLE
Blight spider effect is much shorter to compensate for its high utility in combat

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/carrion/blight_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/blight_spider.dm
@@ -6,7 +6,7 @@
 /obj/item/implant/carrion_spider/blight/activate()
 	..()
 	if(wearer)
-		wearer.reagents.add_reagent("cryptobiolin", 5)
+		wearer.reagents.add_reagent("cryptobiolin", 0.05)
 		to_chat(wearer, SPAN_WARNING("You feel sick and nauseous"))
 		die()
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Blight spider injects 0.05 instead of 5 cryptobiolin.

## Why It's Good For The Game

Amount of chemical is subject to change if any reviewers fell its too harsh of a nerf, for reference with 0.05 the effect lasts a little less then 10 seconds which felt fine to me.

## Changelog
:cl:
tweak: blight spiders effect is much shorter now
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
