### PR TITLE
Ammo crafting kit no longer consumes wirecutters

### DIFF
--- a/code/datums/craft/recipes/guns.dm
+++ b/code/datums/craft/recipes/guns.dm
@@ -116,7 +116,7 @@
 	result = /obj/item/ammo_kit
 	steps = list(
 		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL),
-		list(QUALITY_CUTTING, 10 , 20),
+		list(QUALITY_CUTTING, 10, 20),
 		list(QUALITY_WELDING, 10, 20),
 		list(CRAFT_MATERIAL, 5, MATERIAL_CARDBOARD),
 		list(QUALITY_ADHESIVE, 15, 70)

--- a/code/datums/craft/recipes/guns.dm
+++ b/code/datums/craft/recipes/guns.dm
@@ -116,7 +116,7 @@
 	result = /obj/item/ammo_kit
 	steps = list(
 		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL),
-		list(QUALITY_CUTTING, 10 , 20)
+		list(QUALITY_CUTTING, 10 , 20),
 		list(QUALITY_WELDING, 10, 20),
 		list(CRAFT_MATERIAL, 5, MATERIAL_CARDBOARD),
 		list(QUALITY_ADHESIVE, 15, 70)

--- a/code/datums/craft/recipes/guns.dm
+++ b/code/datums/craft/recipes/guns.dm
@@ -115,8 +115,8 @@
 	name = "Scrap ammo kit"
 	result = /obj/item/ammo_kit
 	steps = list(
-		list(/obj/item/tool/wirecutters, 1),
 		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL),
+		list(QUALITY_CUTTING, 10 , 20)
 		list(QUALITY_WELDING, 10, 20),
 		list(CRAFT_MATERIAL, 5, MATERIAL_CARDBOARD),
 		list(QUALITY_ADHESIVE, 15, 70)


### PR DESCRIPTION

## About The Pull Request

In title

## Why It's Good For The Game

Why does each and every ammo kit need its own wirecutter? What happens to it once you use it up? Why is this a thing?

## Changelog
:cl:
tweak: tweaked a ammo crafting kit's recipe
:cl:

