### PR TITLE
Makes Expanded fuel tank mod actually attainable to common folk

### DIFF
--- a/code/datums/craft/recipes/tools.dm
+++ b/code/datums/craft/recipes/tools.dm
@@ -186,7 +186,7 @@
 
 	steps = list(
 		list(CRAFT_MATERIAL, 8, MATERIAL_PLASTEEL),
-		list(QUALITY_WELDING, 10, 50)
+		list(QUALITY_WELDING, 10, 50),
 		list(QUALITY_HAMMERING, 10, 100),
 		list(/obj/item/stack/rods, 2, 30),
 		list(QUALITY_WELDING, 10, 100),

--- a/code/datums/craft/recipes/tools.dm
+++ b/code/datums/craft/recipes/tools.dm
@@ -185,9 +185,13 @@
 	result = /obj/item/tool_upgrade/augment/fuel_tank
 
 	steps = list(
-		list(/obj/item/weldpack, 1, "time" = 30),
-		list(QUALITY_SAWING, 10, "time" = 120),//Disassemble the backpack
-		list(QUALITY_BOLT_TURNING, 10, 40), //And open some valves
+		list(CRAFT_MATERIAL, 8, MATERIAL_PLASTEEL),
+		list(QUALITY_WELDING, 10, 50)
+		list(QUALITY_HAMMERING, 10, 100),
+		list(/obj/item/stack/rods, 2, 30),
+		list(QUALITY_WELDING, 10, 100),
+		list(QUALITY_BOLT_TURNING, 10, 40), 
+		list(QUALITY_ADHESIVE, 20, 30)
 	)
 
 /datum/craft_recipe/tool/makeshift_centrifuge


### PR DESCRIPTION
## About The Pull Request
Tweaks recipe for arguably one of the most useful toolmods out there to still be mildly time consuming to craft but without requiring welder pack, which iirc can't be even printed or anything, and hardly ahs place in game regardless.

## Why It's Good For The Game

Crafting good, crafting using rare nd useless legacy items bad, simple as!

## Changelog
:cl:
tweak:Expanded fuel tank recipe
/:cl:
