### PR TITLE
Biomatter sheets now stack at 120

### DIFF
--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -353,7 +353,6 @@
 	singular_name = "biomatter sheet"
 	icon_state = "sheet-biomatter"
 	default_type = MATERIAL_BIOMATTER
-	max_amount = 60
 	price_tag = 10
 	var/biomatter_in_sheet = BIOMATTER_PER_SHEET // defined in solidifier.dm
 

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -363,7 +363,7 @@
 	rarity_value = 10
 
 /obj/item/stack/material/biomatter/full
-	amount = 60
+	amount = 120
 
 /obj/item/stack/material/compressed
 	name = "compressed matter"


### PR DESCRIPTION
## About The Pull Request
Increases the maximum amount a biomatter stack can hold from 60 to 120

In a revolutionary breakthrough, through the divine guidance of the Angels, a research team employed at His Divine Grace's Applied Thaumaturgy Laboratory has successfully synthesized a novel form of biomatter showing 200% stability compared to the standard. The potential applications of this novel material will surely be wide-reaching.

## Why It's Good For The Game
Biomatter is the only stackable material that maxes at a value other than 120, with no clear reason for this. 

## Changelog
:cl:
tweak: Biomatter max_amount changed from 60 to 120
/:cl: