### PR TITLE
Removes craft of meat spikes

### DIFF
--- a/code/datums/craft/recipes/misc.dm
+++ b/code/datums/craft/recipes/misc.dm
@@ -17,17 +17,6 @@
 	)
 	related_stats = list(STAT_MEC)
 
-/datum/craft_recipe/kitchen_spike
-	name = "Meat spike"
-	result = /obj/structure/kitchenspike
-	time = WORKTIME_NORMAL
-	steps = list(
-		list(/obj/item/stack/rods, 3),
-		list(QUALITY_WELDING, 20, 50)
-	)
-	flags = CRAFT_ON_FLOOR|CRAFT_ONE_PER_TURF
-	related_stats = list(STAT_MEC)
-
 /datum/craft_recipe/metal_rod
 	name = "metal rod"
 	result = /obj/item/stack/rods


### PR DESCRIPTION
## About The Pull Request

What it says on the tin.
Allowing that thing to be crafted was a mistake.

## Why It's Good For The Game

Meat spikes only used to deny other players revival / brain extraction / respawn timer reduction.
Also array of meat spikes with humans on them makes us look like guro freaks to new players.

## Changelog
:cl:
del: meat spike craft recipe
/:cl:
