### PR TITLE
Old technomancer helmet

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -22,6 +22,7 @@
 	new /obj/item/device/flash(src)
 	new /obj/item/taperoll/engineering(src)
 	new /obj/item/storage/pouch/engineering_supply(src)
+	new /obj/item/clothing/head/armor/helmet/technomancer_old(src)
 
 /obj/structure/closet/secure_closet/engineering_electrical
 	name = "electrical supplies"
@@ -86,3 +87,4 @@
 	new /obj/item/clothing/glasses/powered/meson(src)
 	new /obj/item/clothing/head/armor/helmet/technomancer(src)
 	new /obj/item/clothing/suit/storage/vest/insulated(src)
+	new /obj/item/clothing/head/armor/helmet/technomancer_old(src)

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -100,6 +100,26 @@
 	. = ..()
 	icon_state = pick(list("technohelmet_visor", "technohelmet_googles"))
 
+/obj/item/clothing/head/armor/helmet/technomancer_old
+	name = "reinforced technomancer helmet"
+	desc = "Technomancer League's ballistic helmet. Comes with a built-in flashlight."
+	icon_state = "technohelmet_old"
+	body_parts_covered = HEAD|EARS|EYES|FACE
+	item_flags = THICKMATERIAL
+	flags_inv = BLOCKHEADHAIR|HIDEEARS|HIDEEYES|HIDEFACE
+	action_button_name = "Toggle Headlamp"
+	brightness_on = 4
+	armor = list(
+		melee = 35,
+		bullet = 45,
+		energy = 20,
+		bomb = 40,
+		bio = 0,
+		rad = 0
+	)
+	flash_protection = FLASH_PROTECTION_MAJOR
+	price_tag = 500
+
 /obj/item/clothing/head/armor/helmet/handmade
 	name = "handmade combat helmet"
 	desc = "It looks like it was made from a bucket and some steel. Uncomfortable and heavy but better than nothing."


### PR DESCRIPTION
## About The Pull Request

Bringing back old, cool technomancer helmet with different stat distribution.
- melee = 35,
- bullet = 45,
- energy = 20,
- bomb = 40,
- bio = 0,
- rad = 0

Will make it locked behind nanoforge printing when technomancer weapons is ready, for now it could be found in techomancer lockers.

## Why It's Good For The Game

It looks much better than the new one.
Having half-decent faction ballistic helmet may prevent technos from picking generic or IH armor.

## Changelog
:cl:
add: old techomancer helmet to engineering lockers
/:cl: