### PR TITLE
Biosyphon update

### DIFF
--- a/code/game/objects/items/devices/biosyphon.dm
+++ b/code/game/objects/items/devices/biosyphon.dm
@@ -1,6 +1,6 @@
 /obj/item/biosyphon
 	name = "Bluespace Biosyphon"
-	desc = "Hunts on flora and fauna that sometimes populates bluespace, and use them to produce donuts endlessly."
+	desc = "Hunts on flora and fauna that sometimes populates bluespace, and use them to produce donuts endlessly. May also produce rare and powerful donuts when fed with the meat of non-bluespace fauna."
 	icon = 'icons/obj/faction_item.dmi'
 	icon_state = "biosyphon"
 	item_state = "biosyphon"
@@ -16,6 +16,18 @@
 	spawn_blacklisted = TRUE
 	var/last_produce = 0
 	var/cooldown = 15 MINUTES
+	var/donut_points = 0
+	var/production_cost = 100
+	var/common_meat_value = 8
+	var/uncommon_meat_value = 40
+	var/rare_meat_value = 200
+	var/special_donuts = list(
+		/obj/item/reagent_containers/food/snacks/donut/stat_buff/mec,
+		/obj/item/reagent_containers/food/snacks/donut/stat_buff/cog, 
+		/obj/item/reagent_containers/food/snacks/donut/stat_buff/rob, 
+		/obj/item/reagent_containers/food/snacks/donut/stat_buff/tgh, 
+		/obj/item/reagent_containers/food/snacks/donut/stat_buff/bio, 
+		/obj/item/reagent_containers/food/snacks/donut/stat_buff/vig)
 
 /obj/item/biosyphon/Initialize()
 	. = ..()
@@ -35,8 +47,25 @@
 		var/obj/item/storage/box/donut/D = new /obj/item/storage/box/donut(get_turf(src))
 		visible_message(SPAN_NOTICE("[name] drop [D]."))
 		last_produce = world.time
+	if(donut_points >= production_cost)
+		donut_points -= production_cost
+		var/specialdonut = pick(special_donuts)
+		var/obj/item/reagent_containers/food/snacks/donut/stat_buff/G = new specialdonut(get_turf(src))
+		visible_message(SPAN_NOTICE("[name] drop [G]."))
 
 /obj/item/biosyphon/attackby(obj/item/I, mob/living/user, params)
 	if(nt_sword_attack(I, user))
 		return
+	if(istype(I, /obj/item/reagent_containers/food/snacks/meat/roachmeat/fuhrer))
+		donut_points += uncommon_meat_value 
+		to_chat(user, "You insert [I] into the [src]. It produces a whirring noise.")
+		qdel(I)
+	else if(istype(I, /obj/item/reagent_containers/food/snacks/meat/roachmeat/kaiser))
+		donut_points += rare_meat_value
+		to_chat(user, SPAN_NOTICE("You insert [I] into the [src]. It emits a loud humming sound!"))
+		qdel(I)
+	else if(istype(I, /obj/item/reagent_containers/food/snacks/meat/roachmeat) || istype(I, /obj/item/reagent_containers/food/snacks/meat/spider))
+		donut_points += common_meat_value
+		to_chat(user, "You insert [I] into the [src]. It softly beeps.")
+		qdel(I)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The biosyphon now actually serves a purpose, as it produces stat boosting donuts when fed with enough maint fauna meat, with more rare types of meat (fuhrer and kaiser) producing donuts faster. The donuts only raise one stat by 10 points for 20 minutes and do not stack, so this should not be a balance concern (nobody will use it anyways other than antags who steal it for memes)

## Why It's Good For The Game

This update will thoroughly break the maintenance economy by making all of these items rarer, it also has literally no reason to exist and ironhammer mains will demand katanas to be mapped into the armory for "butchering purposes"

## Changelog
:cl:
tweak: the biosyphon can now be fed maint fauna meat to produce masterpiece donuts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
