### PR TITLE
Sanctifier fix

### DIFF
--- a/code/game/objects/items/weapons/sword_of_truth.dm
+++ b/code/game/objects/items/weapons/sword_of_truth.dm
@@ -6,6 +6,7 @@
 	item_state = "nt_sword_truth"
 	slot_flags = FALSE
 	origin_tech = list(TECH_COMBAT = 5, TECH_POWER = 4, TECH_MATERIAL = 8)
+	aspects = list(SANCTIFIED)
 	price_tag = 20000
 	spawn_frequency = 0
 	spawn_blacklisted = TRUE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -45,7 +45,7 @@
 	if(ishuman(src) && isitem(used_weapon))
 		var/mob/living/carbon/human/H = src
 		var/obj/item/I = used_weapon
-		if((H.faction == "spiders" || mutations.len) && (SANCTIFIED in I.aspects))
+		if((is_carrion(H) || mutations.len) && (SANCTIFIED in I.aspects))
 			sanctified_attack = TRUE
 	//Feedback
 	//In order to show both target and everyone around that armor is actually working, we are going to send message for both of them

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -45,7 +45,7 @@
 	if(ishuman(src) && isitem(used_weapon))
 		var/mob/living/carbon/human/H = src
 		var/obj/item/I = used_weapon
-		if((H.has_organ(BP_SPCORE) || mutations.len) && (SANCTIFIED in I.aspects))
+		if((H.faction == "spiders" || mutations.len) && (SANCTIFIED in I.aspects))
 			sanctified_attack = TRUE
 	//Feedback
 	//In order to show both target and everyone around that armor is actually working, we are going to send message for both of them


### PR DESCRIPTION
## About The Pull Request

Sanctifier tool mod now burns carrions, as intended.
Sanctifier tool mod added to Sword of Truth.

## Why It's Good For The Game

Intended effect failed to hit the mark, best help it reach it's target.
If even the lowliest NT weapon comes with a sanctifier pre-installed, why not the Sword of Truth?

## Changelog
:cl:

tweak: Sanctifier added to Sword of Truth
fix: Sanctifier works against Carrions

/:cl: