### PR TITLE
guild profit calculations

### DIFF
--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -64,7 +64,6 @@ SUBSYSTEM_DEF(supply)
 	for(var/A in exports)
 		var/datum/export/E = A
 		var/export_text = E.total_printout()
-		GLOB.supply_profit += E.cost
 		if(!export_text)
 			continue
 
@@ -112,7 +111,6 @@ SUBSYSTEM_DEF(supply)
 
 		var/datum/supply_order/SO = S
 		var/datum/supply_pack/SP = SO.object
-		GLOB.supply_profit -= SP.cost
 		var/obj/A = new SP.containertype(pickedloc)
 		A.name = "[SP.name][SO.reason ? " ([SO.reason])":"" ]"
 

--- a/code/game/gamemodes/scores.dm
+++ b/code/game/gamemodes/scores.dm
@@ -154,6 +154,11 @@ GLOBAL_VAR_INIT(score_technomancer_faction_item_loss, 0)
 	var/obj/item/cell/large/high/HC = /obj/item/cell/large/high
 	var/min_charge = initial(HC.maxcharge) * 0.6
 
+	//calculate guild profits in a sane way
+	var/ending_balance = get_account_credits(department_accounts[DEPARTMENT_GUILD])
+	GLOB.supply_profit = ending_balance - 7500
+
+
 	//Check station's power levels
 	for(var/area/A in ship_areas)
 		if(A.fire || A.atmosalm)

--- a/code/game/jobs/department.dm
+++ b/code/game/jobs/department.dm
@@ -123,6 +123,9 @@
 		He recieves no funding, infact later he will pay guild fees out of his earnings
 	*/
 	account_initial_balance = 7500
+	/* if you want to change this remember to do so in code\game\gamemodes\score.dm as well,
+	if you manage to get this variable refferenced there you're a better man than me. godspeed
+	*/
 	funding_type = FUNDING_NONE
 
 /datum/department/offship //So we can pay the Club without giving them independant money


### PR DESCRIPTION

## About The Pull Request

makes guild profits calculated from the delta-credits in the guild account from round end to round start rather than the delta-credits from exported and imported goods

## Why It's Good For The Game

gives guild merchants and members a more representative value of how much they earned in the round,
and means that running the store creates profit from selling imported goods, the way it was before. if the captain
ordered crates for 10k and gave the guild 100k, the game would logg it as a -10k without taking into account the 100k paid by the captain.

## Changelog
:cl:
tweak: tweaked how guild profit scores are calculated
/:cl:

