### PR TITLE
Meat spike rebalance and readd of crafting

### DIFF
--- a/code/datums/craft/recipes/misc.dm
+++ b/code/datums/craft/recipes/misc.dm
@@ -17,6 +17,17 @@
 	)
 	related_stats = list(STAT_MEC)
 
+/datum/craft_recipe/kitchen_spike
+	name = "Meat spike"
+	result = /obj/structure/kitchenspike
+	time = WORKTIME_NORMAL
+	steps = list(
+		list(/obj/item/stack/rods, 3),
+		list(QUALITY_WELDING, 20, 50)
+	)
+	flags = CRAFT_ON_FLOOR|CRAFT_ONE_PER_TURF
+	related_stats = list(STAT_MEC)
+
 /datum/craft_recipe/metal_rod
 	name = "metal rod"
 	result = /obj/item/stack/rods

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -7,10 +7,12 @@
 	desc = "A spike for collecting meat from animals."
 	density = TRUE
 	anchored = TRUE
+	var/mob/living/occupant = null
 	var/meat = 0
-	var/occupied
+	var/occupied = 0
 	var/meat_type
 	var/victim_name = "corpse"
+	var/tearing
 
 /obj/structure/kitchenspike/affect_grab(mob/user, mob/living/target, state)
 	if(occupied)
@@ -19,15 +21,24 @@
 	if(state != GRAB_KILL)
 		to_chat(user, SPAN_NOTICE("You need to grab \the [target] by the neck!"))
 		return FALSE
-	if(spike(target))
-		visible_message(SPAN_DANGER("[user] has forced [target] onto \the [src], killing them instantly!"))
-		for(var/obj/item/thing in target)
-			if(thing.is_equipped())
-				target.drop_from_inventory(thing)
-		qdel(target)
-		return TRUE
-	to_chat(user, SPAN_DANGER("They are too big for \the [src], try something smaller!"))
-	return FALSE
+	var/mob/living/carbon/human/H = target
+	var/list/damaged = H.get_damaged_organs(1, 0)
+	for(var/obj/item/organ/external/chest/G in damaged)
+		if(G.brute_dam > 200)
+			to_chat(user, "[H] is too badly damaged to hold onto the meat spike.")
+			return 
+	visible_message(SPAN_DANGER("[user] is trying to force \the [target] onto \the [src]!"))
+	if(do_after(user, 80))	
+		if(spike(target))
+			visible_message(SPAN_DANGER("[user] has forced [target] onto \the [src], killing them instantly!"))
+			target.damage_through_armor (201, BRUTE, BP_CHEST)
+			for(var/obj/item/thing in target)
+				if(thing.is_equipped())
+					target.drop_from_inventory(thing)
+			return TRUE
+	else
+		return FALSE
+
 
 /obj/structure/kitchenspike/proc/spike(mob/living/victim)
 
@@ -40,8 +51,9 @@
 		icon_state = "spike_[H.species.name]"
 	else
 		return FALSE
-
+	victim.loc = src
 	victim_name = victim.name
+	occupant = victim
 	occupied = TRUE
 	meat = 5
 	return TRUE
@@ -49,24 +61,50 @@
 /obj/structure/kitchenspike/attack_hand(mob/living/carbon/human/user)
 	if(..() || !occupied)
 		return
-	meat--
-	new meat_type(get_turf(src))
-	if(meat > 1)
-		to_chat(user, "You remove some meat from \the [victim_name].")
-	else if(meat == 1)
-		to_chat(user, "You remove the last piece of meat from \the [victim_name]!")
-		icon_state = initial(icon_state)
-		occupied = 0
-	if(meat_type == user.species.meat_type)
-		user.sanity.changeLevel(-(15*((user.nutrition ? user.nutrition : 1)/user.max_nutrition))) // The more hungry the less sanity damage.
-		to_chat(user, SPAN_NOTICE("You feel your [user.species.name]ity dismantling as you cut a slab off \the [src]")) // Human-ity , Monkey-ity , Slime-Ity
+	to_chat(user, "You start to remove [victim_name] from \the [src].")	
+	if(!do_after(user, 40))
+		return 0
+	occupant.loc = (get_turf(src))
+	occupied = FALSE
+	meat = 0
+	meat_type = initial(meat_type)
+	to_chat(user, "You remove [victim_name] from \the [src].")	
+	icon_state = initial(icon_state)
 
-
-/obj/structure/kitchenspike/attackby(obj/item/I, mob/user)
-	var/list/usable_qualities = list(QUALITY_BOLT_TURNING)
+/obj/structure/kitchenspike/attackby(obj/item/I, mob/living/carbon/human/user)
+	var/list/usable_qualities = list(QUALITY_BOLT_TURNING, QUALITY_CUTTING)
 	var/tool_type = I.get_tool_type(user, usable_qualities, src)
+	if(tearing)
+		return
 
-	if (tool_type == QUALITY_BOLT_TURNING)
+	if(tool_type == QUALITY_CUTTING)
+		if(!occupied)
+			return
+		tearing = TRUE
+		if(do_after(user, 20))
+			tearing = FALSE
+			var/cut_damage
+			var/organ_damaged
+			organ_damaged = pickweight(list(BP_HEAD = 0.1, BP_GROIN = 0.2, BP_R_ARM = 0.2, BP_L_ARM = 0.2, BP_R_LEG = 0.2, BP_L_LEG = 0.2))
+			cut_damage = rand(15, 25)
+			occupant.apply_damage(cut_damage, BRUTE, organ_damaged)
+			playsound(src, 'sound/weapons/bladeslice.ogg', 50, 1)
+			if(meat < 1)
+				to_chat(user, "There is no more meat on \the [victim_name].")
+				return
+			meat--
+			new meat_type(get_turf(src))
+			if(meat > 1)
+				to_chat(user, "You remove some meat from \the [victim_name].")
+			else if(meat == 1)
+				to_chat(user, "You remove the last piece of meat from \the [victim_name]!")
+			if(meat_type == user.species.meat_type)
+				user.sanity.changeLevel(-(15*((user.nutrition ? user.nutrition : 1)/user.max_nutrition))) // The more hungry the less sanity damage.
+				to_chat(user, SPAN_NOTICE("You feel your [user.species.name]ity dismantling as you cut a slab off \the [src]")) // Human-ity , Monkey-ity , Slime-Ity
+		else
+			tearing = FALSE
+	
+	else if (tool_type == QUALITY_BOLT_TURNING)
 		if (!occupied)
 			if(I.use_tool(user, src, WORKTIME_NORMAL, tool_type, FAILCHANCE_EASY, required_stat = STAT_MEC))
 				user.visible_message(SPAN_NOTICE("\The [user] dismantles \the [src]."),SPAN_NOTICE("You dismantle \the [src]."))
@@ -74,10 +112,11 @@
 				qdel(src)
 			return
 		else
-			to_chat(user, SPAN_DANGER(" \The [src] has something on it, finish collecting its meat first!"))
+			to_chat(user, SPAN_DANGER(" \The [src] has something on it, remove it first!"))
 			return
 
-	return ..()
+	else 
+		return ..()
 
 /obj/structure/kitchenspike/examine(mob/user, distance, infix, suffix)
 	if(distance < 4)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

readds meatspike crafting
you can now remove people from meatspikes again (use an empty hand on the spike)
forcing someone onto a meatspike now takes a considerable amount of time to do.
you now need to use a sharp item to remove meat from something on a meat spike, and you cannot put the same person on a meatspike again after they've been removed, unless their corpse is somehow healed.

## Why It's Good For The Game

I ded plz buff
everyone loves barely-tested shitcoded balance updates

## Changelog
:cl:
balance: readds meatspike crafting, meatspikes no longer delete people, and assorted updates to meatspikes. (did I mention meatspikes?)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
