### PR TITLE
Walking on plating without any form of lightning and without any form of seeing turfs will now make you trip regardless

### DIFF
--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -256,11 +256,15 @@ var/list/flooring_types
 	if(!ishuman(M)|| M.incorporeal_move || !has_gravity(get_turf(M)))
 		return
 	var/mob/living/carbon/human/our_trippah = M
+	var/turf/our_plating = get_turf(our_trippah)
+	if(our_plating.get_lumcount() < 0.3 && our_trippah.see_invisible != SEE_INVISIBLE_NOLIGHTING)
+		if(prob(60))
+			our_trippah.trip(src, 6)
+		return TRUE // Lucky if you don't trip
 	if(MOVING_QUICKLY(M))
 		if(prob(50 - our_trippah.stats.getStat(STAT_COG) * 2)) // The art of calculating the vectors required to avoid tripping on the metal beams requires big quantities of brain power
-			our_trippah.adjustBruteLoss(5)
 			our_trippah.trip(src, 6)
-			return
+			return TRUE
 
 //============HULL PLATING=========\\
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1407,6 +1407,7 @@ var/list/rank_prefix = list(\
 	if (tripped_on)
 		playsound(src, 'sound/effects/bang.ogg', 50, 1)
 		to_chat(src, SPAN_WARNING("You tripped over!"))
+	adjustBruteLoss(5)
 	Weaken(stun_duration)
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Walking on plating without any form of lightning / mesons / NVGS / etc makes you trip regardless of stats

## Why It's Good For The Game
People don't use mesons because they find no use for them , another reason is because they simply don't need lightning on turfs , this should change. Lightning should matter
THE PDA DEFAULT LIGHT IS ENOUGH TO COUNTERACT THIS.

## Changelog
:cl:
balance: You will now trip regardless of stats on plating if you don't have any form of lightning or ability to see
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
