### PR TITLE
Carrion organ eating readd (fix) (2)

### DIFF
--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -345,6 +345,11 @@
 			if(BP_IS_ROBOTIC(O))
 				to_chat(owner, SPAN_WARNING("This organ is robotic, you can't eat it."))
 				return
+			else if(istype(O, /obj/item/organ/internal/carrion))
+				owner.carrion_hunger += 3
+				geneticpointgain = 4
+				chemgain = 50
+				taste_description = "carrion organs taste heavenly, you need more!"
 			else if(istype(O, /obj/item/organ/internal))
 				var/organ_rotten = FALSE
 				if (O.status & ORGAN_DEAD)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Readds carrion internal organs granting 4 gene points  while only removing one point from the hunger meter, as well as refilling the chemical storage when eaten. this was removed by accident in https://github.com/discordia-space/CEV-Eris/pull/5795


## Why It's Good For The Game

Makes converting the entire ship less of a safe thing for carrions.

## Changelog
:cl:
tweak: carrion organs now grant more gene points when consumed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
