### PR TITLE
Redoes lense code , Thermal lenses no longer provide night vision , Adds in explosive lenses

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -1496,6 +1496,7 @@
 #include "code\modules\clothing\accessories\armband.dm"
 #include "code\modules\clothing\accessories\badges.dm"
 #include "code\modules\clothing\accessories\holster.dm"
+#include "code\modules\clothing\accessories\lenses.dm"
 #include "code\modules\clothing\accessories\lockets.dm"
 #include "code\modules\clothing\glasses\glasses.dm"
 #include "code\modules\clothing\glasses\hud.dm"

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -105,13 +105,14 @@
 #define COMSIG_ATTACKBY "attack_by"										//from /mob/ClickOn():
 #define COMSIG_APPVAL "apply_values"									//from /atom/refresh_upgrades(): (/src) Called to upgrade specific values
 #define COMSIG_ADDVAL "add_values" 										//from /atom/refresh_upgrades(): (/src) Called to add specific things to the /src, called before COMSIG_APPVAL
-#define COMSIG_REMOVE "uninstall"	
+#define COMSIG_REMOVE "uninstall"
 #define COMSIG_ITEM_DROPPED	"item_dropped"					//from  /obj/item/tool/attackby(): Called to remove an upgrade
 #define COMSIG_ITEM_PICKED "item_picked"
 
 // /obj/item/clothing signals
 #define COMSIG_CLOTH_DROPPED "cloths_missing"
 #define COMSIG_CLOTH_EQUIPPED "cloths_recovered"
+#define COMSIG_GLASS_LENSES_REMOVED "lenses_removed" // lenses.dm
 
 // /obj/item/implant signals
 

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -42,7 +42,7 @@
 	name = "Heavy Armor Vest"
 	item_cost = 6
 	path = /obj/item/clothing/suit/storage/vest/merc
-	
+
 /datum/uplink_item/item/tools/full_heavy_vest
 	name = "Fullbody Heavy Armor Vest"
 	item_cost = 12
@@ -89,7 +89,7 @@
 /datum/uplink_item/item/tools/thermal_lens
 	name = "Thermal Imaging Lenses"
 	item_cost = 12
-	path = /obj/item/clothing/glasses/powered/thermal/lens
+	path = /obj/item/clothing/glasses/attachable_lenses
 
 /datum/uplink_item/item/tools/powersink
 	name = "Powersink (DANGER!)"

--- a/code/datums/uplink/stealthy and inconspicuous weapons.dm
+++ b/code/datums/uplink/stealthy and inconspicuous weapons.dm
@@ -23,6 +23,12 @@
 	name = "\"Glass Widow\" radiation infuser"
 	item_cost = 2
 	path = /obj/item/gun_upgrade/mechanism/glass_widow
+
+/datum/uplink_item/item/stealthy_weapons/eye_banger
+	name = "\"Sparkly clean\" explosive lenses"
+	item_cost = 5
+	path = /obj/item/clothing/glasses/attachable_lenses/explosive
+
 /*
 /datum/uplink_item/item/stealthy_weapons/assassin_dagger
 	name = "Assassin's Dagger"

--- a/code/modules/clothing/accessories/lenses.dm
+++ b/code/modules/clothing/accessories/lenses.dm
@@ -1,0 +1,90 @@
+/obj/item/clothing/glasses/attachable_lenses
+	name = "Thermal lenses"
+	desc = "lenses for glasses, you can see red people through walls with them."
+	icon_state = "thermal_lens"
+	body_parts_covered = FALSE
+	slot_flags = FALSE
+	see_invisible = FALSE
+	vision_flags = SEE_MOBS
+	flash_protection = FLASH_PROTECTION_REDUCED
+	origin_tech = list(TECH_COVERT = 3)
+	/// Saves the overlay of the last goggles converted , just for the sake of not deleting it
+	var/saved_last_overlay = FALSE
+
+	spawn_blacklisted = TRUE
+// Yep , we have to do it in new , because global.
+/obj/item/clothing/glasses/attachable_lenses/New()
+	..()
+	overlay = global_hud.thermal
+
+/obj/item/clothing/glasses/verb/detach_lenses()
+	set name = "Detach lenses"
+	set category = "Object"
+	set src in view(1)
+
+	if (have_lenses)
+		flash_protection = initial(protection)
+		see_invisible = initial(see_invisible)
+		vision_flags = initial(vision_flags)
+		origin_tech = initial(origin_tech)
+		overlay = saved_last_overlay
+		saved_last_overlay = FALSE
+		to_chat(usr, "You detach \the [have_lenses] from \the [src]");
+		usr.put_in_hands(have_lenses)
+		SEND_SIGNAL(src, COMSIG_GLASS_LENSES_REMOVED, usr, src)
+
+	else
+		to_chat(usr, "You haven't got any lenses in \the [src]");
+
+
+/obj/item/clothing/glasses/attachable_lenses/proc/handle_insertion(obj/item/clothing/glasses/target, mob/living/carbon/human/inserter)
+	if(overlay)
+		saved_last_overlay = target.overlay
+		target.overlay = overlay
+	if(vision_flags) // Don/t override if we don't have it set.
+		target.vision_flags = vision_flags
+	if(see_invisible)
+		target.see_invisible = see_invisible
+	if(flash_protection)
+		target.protection = flash_protection
+		target.flash_protection = flash_protection
+	if(origin_tech)
+		target.origin_tech.Add(origin_tech)
+	to_chat(inserter, "You attached \the [src] to \the [target]")
+	target.have_lenses = src
+	inserter.drop_item(src)
+	forceMove(target)
+
+/obj/item/clothing/glasses/attachable_lenses/explosive
+	name = "Explosive lenses"
+	desc = "lenses for glasses, these ones explode when someone wears goggles containing them. Awful."
+	icon_state = "thermal_lens"
+	vision_flags = FALSE
+	flash_protection = FALSE
+	origin_tech = list(TECH_COVERT = 3, TECH_COMBAT = 2 , TECH_ENGINEERING = 5)
+	var/charge_exploded = FALSE
+
+/obj/item/clothing/glasses/attachable_lenses/explosive/handle_insertion(obj/item/clothing/glasses/target, mob/living/carbon/human/inserter)
+	..()
+	RegisterSignal(target, COMSIG_CLOTH_EQUIPPED, .proc/handle_boom)
+	RegisterSignal(target, COMSIG_GLASS_LENSES_REMOVED, .proc/handle_removal)
+
+/obj/item/clothing/glasses/attachable_lenses/explosive/proc/handle_boom(mob/living/carbon/human/unfortunate_man)
+	visible_message(SPAN_DANGER("You feel a jet of molten slag pierce your skull as \the [loc] explodes"),
+	SPAN_DANGER("[unfortunate_man]'s skull is blown apart as a jet of molten slag pierces through his eye from
+[loc]"), SPAN_DANGER("You hear a small explosion than the violent fizzle of flesh"))
+	playsound()
+	unfortunate_man.adjustBrainLoss(200)
+	for(var/obj/organ/internal/organ in unfortunate_man.head)
+		organ.take_damage(200)
+	// F
+	handle_removal()
+
+/obj/item/clothing/glasses/attachable_lenses/explosive/proc/handle_removal()
+	var/obj/item/clothing/glasses/current_loc = loc
+	UnregisterSignal(current_loc, COMSIG_CLOTH_EQUIPPED)
+	UnregisterSignal(current_loc, COMSIG_GLASS_LENSES_REMOVED)
+
+
+
+

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -46,3 +46,8 @@
 	..()
 	if(((toggleable || hud) && prescription) && (user.disabilities&NEARSIGHTED) && (slot == slot_glasses))
 		to_chat(user, SPAN_NOTICE("[src] optical matrix automatically adjust to your poor prescription."))
+
+/obj/item/clothing/glasses/attackby(obj/item/Z, mob/user)
+	if(istype(Z,/obj/item/clothing/glasses/attachable_lenses))
+		var/obj/item/clothing/glasses/attachable_lenses/lenses = Z
+		lenses.handle_insertion(src, user)

--- a/code/modules/clothing/glasses/thermal.dm
+++ b/code/modules/clothing/glasses/thermal.dm
@@ -80,48 +80,4 @@
 	icon_state = "thermalimplants"
 	item_state = "syringe_kit"
 
-/obj/item/clothing/glasses/powered/thermal/lens
-	name = "Thermal lenses"
-	desc = "Lenses for glasses."
-	toggleable = FALSE
-	icon_state = "thermal_lens"
-	body_parts_covered = 0
-	slot_flags = 0
-	spawn_blacklisted = TRUE
-
-
-/obj/item/clothing/glasses/attackby(obj/item/Z, mob/user)
-
-	if (istype(Z,/obj/item/clothing/glasses/powered/thermal/lens))
-		overlay = global_hud.thermal
-		vision_flags = SEE_MOBS
-		see_invisible = SEE_INVISIBLE_NOLIGHTING
-		protection = flash_protection
-		flash_protection = FLASH_PROTECTION_REDUCED
-		origin_tech = list(TECH_COVERT = 3)
-		to_chat(usr, "You attached your lenses to your glasses")
-		have_lenses = 1
-		qdel(Z)
-
-/obj/item/clothing/glasses/powered/thermal/attackby(obj/item/C, mob/user)
-	if(istype(C, /obj/item/clothing/glasses/powered/thermal/lens))
-		to_chat(usr, "This glasses already have thermal implant")
-	..()
-
-/obj/item/clothing/glasses/verb/detach_lenses()
-	set name = "Detach lenses"
-	set category = "Object"
-	set src in view(1)
-
-	if (have_lenses == 1)
-		flash_protection = protection;
-		see_invisible = -1;
-		vision_flags = 0;
-		origin_tech = 0;
-		have_lenses = 0;
-		overlay = 0;
-		to_chat(usr, "You detach lenses from your glasses");
-		var/obj/item/clothing/glasses/powered/thermal/lens/THL = new()
-		usr.put_in_hands(THL)
-	else to_chat(usr, "You haven't got any lenses in your glasses");
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Redid all of lense related code for modularity
added in explosive lenses , 5 TC , explodes upon being worn in the glasses slot. Very effective and stealthy
Thermal lenses no longer provide NV , they are not xrays

## Why It's Good For The Game
General balance , more traitor stuff for gimmicks (FILL ALL THE MEDHUDS WITH EXPLOSIVE LENSES), code quality
## Changelog
:cl:
add: Explosive lenses , 5 TC , lenses that explode upon being worn on the glasses slot and killing their victim
balance: Thermal lenses no longer provide NV
code: Lense code is now a whole lot more modular and easy to add onto
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
