### PR TITLE
Penetration

### DIFF
--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -210,6 +210,7 @@
 	price_tag = 1000
 	base_block_chance = 40
 	item_flags = DRAG_AND_DROP_UNEQUIP
+	shield_integrity = 120
 	var/obj/item/storage/internal/container
 	var/storage_slots = 3
 	var/max_w_class = ITEM_SIZE_HUGE

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -34,9 +34,11 @@
 	armor = list(melee = 20, bullet = 20, energy = 20, bomb = 0, bio = 0, rad = 0)
 	var/base_block_chance = 50
 	var/slowdown_time = 1
+	var/shield_integrity = 100
 
 /obj/item/shield/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
-	if(user.incapacitated())
+
+	if((attacker && get_dist(user, attacker) > 1) || user.incapacitated())
 		return 0
 
 	//block as long as they are not directly behind us
@@ -44,6 +46,15 @@
 	if(check_shield_arc(user, bad_arc, damage_source, attacker))
 		if(prob(get_block_chance(user, damage, damage_source, attacker)))
 			user.visible_message(SPAN_DANGER("\The [user] blocks [attack_text] with \the [src]!"))
+			return 1
+	return 0
+
+/obj/item/shield/proc/block_bullet(mob/user, var/obj/item/projectile/Damage_source)
+	var/bad_arc = reverse_direction(user.dir)
+	if(check_shield_arc(user,bad_arc,Damage_source))
+		if(!Damage_source.check_penetrate(src))
+			visible_message(SPAN_DANGER("\The [user] blocks the bullet with their [Damage_source]!"))
+			qdel(Damage_source)
 			return 1
 	return 0
 
@@ -74,6 +85,7 @@
 	matter = list(MATERIAL_GLASS = 5, MATERIAL_STEEL = 5, MATERIAL_PLASTEEL = 10)
 	price_tag = 500
 	attack_verb = list("shoved", "bashed")
+	shield_integrity = 125
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 	var/picked_by_human = FALSE
 	var/mob/living/carbon/human/picking_human
@@ -148,6 +160,7 @@
 	throw_range = 6
 	matter = list(MATERIAL_STEEL = 6)
 	base_block_chance = 35
+	shield_integrity = 100
 
 
 /obj/item/shield/riot/handmade/get_block_chance(mob/user, var/damage, atom/damage_source = null, mob/attacker = null)
@@ -169,6 +182,7 @@
 	throw_range = 4
 	matter = list(MATERIAL_STEEL = 4)
 	base_block_chance = 35
+	shield_integrity = 80
 
 
 /obj/item/shield/riot/handmade/tray/get_block_chance(mob/user, var/damage, atom/damage_source = null, mob/attacker = null)
@@ -196,6 +210,7 @@
 	origin_tech = list(TECH_MATERIAL = 4, TECH_MAGNET = 3, TECH_COVERT = 4)
 	attack_verb = list("shoved", "bashed")
 	var/active = 0
+	shield_integrity = 115
 
 /obj/item/shield/energy/handle_shield(mob/user)
 	if(!active)

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -31,10 +31,10 @@
 
 /obj/item/shield
 	name = "shield"
-	armor = list(melee = 20, bullet = 20, energy = 20, bomb = 0, bio = 0, rad = 0)
 	var/base_block_chance = 50
 	var/slowdown_time = 1
 	var/shield_integrity = 100
+	var/list/protected_area = list(BP_CHEST,BP_GROIN,BP_HEAD)
 
 /obj/item/shield/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
 
@@ -49,9 +49,17 @@
 			return 1
 	return 0
 
-/obj/item/shield/proc/block_bullet(mob/user, var/obj/item/projectile/Damage_source)
+/obj/item/shield/proc/block_bullet(mob/user, var/obj/item/projectile/Damage_source, def_zone)
 	var/bad_arc = reverse_direction(user.dir)
-	if(check_shield_arc(user,bad_arc,Damage_source))
+
+	if(is_held_twohanded(user))
+		protected_area = BP_ALL_LIMBS
+	else if(user.l_hand == src)
+		protected_area.Add(BP_L_ARM)
+	else if(user.r_hand == src)
+		protected_area.Add(BP_R_ARM)
+
+	if(def_zone in protected_area && check_shield_arc(user,bad_arc,Damage_source))
 		if(!Damage_source.check_penetrate(src))
 			visible_message(SPAN_DANGER("\The [user] blocks the bullet with their [Damage_source]!"))
 			qdel(Damage_source)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -360,6 +360,7 @@
 				var/mob/living/carbon/C = A
 				for(var/obj/item/shield/S in get_both_hands(C))
 					if(S && S.block_bullet(C,src,def_zone))
+						qdel(src)
 						return
 			passthrough = !attack_mob(M, distance)
 		else

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -356,7 +356,11 @@
 				visible_message(SPAN_DANGER("\The [M] uses [G.affecting] as a shield!"))
 				if(Bump(G.affecting, TRUE))
 					return //If Bump() returns 0 (keep going) then we continue on to attack M.
-
+			if(iscarbon(A))
+				var/mob/living/carbon/C = A
+				for(var/obj/item/shield/S in get_both_hands(C))
+					if(S && S.block_bullet(C,src))
+						return
 			passthrough = !attack_mob(M, distance)
 		else
 			passthrough = FALSE //so ghosts don't stop bullets

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -359,7 +359,7 @@
 			if(iscarbon(A))
 				var/mob/living/carbon/C = A
 				for(var/obj/item/shield/S in get_both_hands(C))
-					if(S && S.block_bullet(C,src))
+					if(S && S.block_bullet(C,src,def_zone))
 						return
 			passthrough = !attack_mob(M, distance)
 		else

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -17,6 +17,16 @@
 
 	heat = 100
 
+/obj/item/projectile/beam/check_penetrate(var/atom/A)
+	if(istype(A, /obj/item/shield))
+		var/obj/item/shield/S = A
+		var/loss = 0
+		loss = min(round(armor_penetration*2/S.shield_integrity*1.8),1)
+		for(var/i in damage_types)
+			damage_types[i] *= loss
+		return 1
+	return 0
+
 /obj/item/projectile/beam/cutter
 	name = "cutting beam"
 	icon_state = "plasmablaster"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -34,7 +34,7 @@
 	return ..()
 
 /obj/item/projectile/bullet/check_penetrate(var/atom/A)
-	if(!A || !A.density) return 1 //if whatever it was got destroyed when we hit it, then I guess we can just keep going
+	if((!A || !A.density) && !istype(A, /obj/item/shield)) return 1 //if whatever it was got destroyed when we hit it, then I guess we can just keep going
 
 	if(istype(A, /mob/living/exosuit))
 		return 1 //exosuits have their own penetration handling
@@ -50,6 +50,9 @@
 	if(istype(A, /turf/simulated/wall))
 		var/turf/simulated/wall/W = A
 		chance = round(penetrating*armor_penetration*2/W.material.integrity*180)
+	else if(istype(A, /obj/item/shield))
+		var/obj/item/shield/S = A
+		chance = round(penetrating*armor_penetration*2/S.shield_integrity*180)
 	else if(istype(A, /obj/machinery/door))
 		var/obj/machinery/door/D = A
 		chance = round(penetrating*armor_penetration*2/D.maxhealth*180)
@@ -58,6 +61,7 @@
 		chance = 100
 	else if(istype(A, /obj/machinery) || istype(A, /obj/structure))
 		chance = armor_penetration*penetrating
+
 
 	if(prob(chance))
 		var/maintainedVelocity = min(chance,90)/100 //the chance to penetrate is used to calculate leftover velocity, capped at 90%

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -49,20 +49,27 @@
 	var/chance = 0
 	if(istype(A, /turf/simulated/wall))
 		var/turf/simulated/wall/W = A
-		chance = round(penetrating*damage/W.material.integrity*180)
+		chance = round(penetrating*armor_penetration*2/W.material.integrity*180)
 	else if(istype(A, /obj/machinery/door))
 		var/obj/machinery/door/D = A
-		chance = round(penetrating*damage/D.maxhealth*180)
+		chance = round(penetrating*armor_penetration*2/D.maxhealth*180)
 		if(D.glass) chance *= 2
 	else if(istype(A, /obj/structure/girder))
 		chance = 100
 	else if(istype(A, /obj/machinery) || istype(A, /obj/structure))
-		chance = damage*penetrating
+		chance = armor_penetration*penetrating
 
 	if(prob(chance))
+		var/maintainedVelocity = min(chance,90)/100 //the chance to penetrate is used to calculate leftover velocity, capped at 90%
+		armor_penetration *= maintainedVelocity
+		for(var/i in damage_types)
+			damage_types[i] *= maintainedVelocity
+		step_delay = min(step_delay/maintainedVelocity,step_delay/2)
+
 		if(A.opacity)
 			//display a message so that people on the other side aren't so confused
 			A.visible_message(SPAN_WARNING("\The [src] pierces through \the [A]!"))
+
 		return 1
 
 	return 0


### PR DESCRIPTION
## About The Pull Request

Piercing walls now uses armor_penetration instead of damage, and successfully piercing walls decreases the damage, penetration and velocity of the bullets. This will both make penetrating walls with good guns easier, but also reduce their effectiveness.
Probably a lot more interesting way to nerf thermal vision than just constantly increasing the price.

The PR also completely reworks the way shields work against bullets. The 50% block chance now no longer applies to projectiles. Instead, bullets will attempt to penetrate shields as if they were machinery, requiring "penetrating", and a good amount of armor penetration, and even if they succeed, their overall damage and armor penetration is reduced.

In effect, high-end weapons will see their effective damage output reduced by 10-20% as opposed to 50%, whereas smaller caliber weapons and rubber bullets are completely, or mostly ineffective. (Especially weapons with low multipliers, such as SMGs).
As shields now also have a list of bodyparts they protect (head+body+groin+holding hand), it is possible to use low-caliber weapons to target a shield user's legs or offhand. To combat this, when wielding a shield, it will cover the entire body.

It is hard to tell if values are anywhere balanced at the moment, playtesting might be required.

Beams are worthy of mentioning too, they will always penetrate shields, but suffer a decrease in raw damage when doing so.

## Why It's Good For The Game

Makes thermal-sniping through walls less lethal, more immersive shields no longer use RNG magic to block projectiles.

## Changelog
:cl:
balance: Piercing walls now uses armor penetration, inconsistent penetration results in loss of momentum
balance: Shields have been reworked, becoming a lot more consistent, stronger against smaller arms fire, but much less effective against high-end firearms.
tweak: Shields now only protect particular bodyparts, depending on how they are held
/:cl:
