### PR TITLE
Blacklist tau cross from spawn

### DIFF
--- a/code/game/machinery/doors/holy_door.dm
+++ b/code/game/machinery/doors/holy_door.dm
@@ -23,6 +23,7 @@
 	item_state = ""	// No inhands
 	slot_flags = SLOT_ACCESSORY_BUFFER | SLOT_MASK
 	w_class = ITEM_SIZE_NORMAL // Chonky cross
+	spawn_blacklisted = TRUE
 
 /obj/machinery/door/holy/New()
 	GLOB.nt_doors += src


### PR DESCRIPTION
## About The Pull Request

What is says on the tin. That thing not meant to spawn in trash, eh.

## Why It's Good For The Game

Fixes cool.

## Changelog
:cl:
fix: tau cross spawns in trash no more
/:cl: