### PR TITLE
Put taperoll on any door

### DIFF
--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -244,7 +244,7 @@ var/list/tape_roll_applications = list()
 	if(!proximity)
 		return
 
-	if (istype(A, /obj/machinery/door/))
+	if (istype(A, /obj/machinery/door))
 		var/turf/T = get_turf(A)
 		var/obj/item/tape/P = new tape_type(T.x,T.y,T.z)
 		P.loc = locate(T.x,T.y,T.z)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Taperoll can be putted on any door now, not only airlock.

## Why It's Good For The Game
Someone said it was bug and I fixed that

## Changelog
:cl:
fix: tape could be applied to any door
/:cl:
