### PR TITLE
Recoil cooldown change

### DIFF
--- a/code/modules/mob/living/recoil.dm
+++ b/code/modules/mob/living/recoil.dm
@@ -16,14 +16,14 @@
 	else
 		recoil = 0
 
-	if(recoil != 0) recoil_reduction_timer = addtimer(CALLBACK(src, .proc/calc_recoil), 1, TIMER_STOPPABLE)
+	if(recoil != 0) recoil_reduction_timer = addtimer(CALLBACK(src, .proc/calc_recoil), 0.1 SECONDS, TIMER_STOPPABLE)
 	else deltimer(recoil_reduction_timer)
 	update_cursor()
 
 //Called after setting recoil
 /mob/living/proc/update_recoil()
 	update_cursor()
-	recoil_reduction_timer = addtimer(CALLBACK(src, .proc/calc_recoil), 3, TIMER_STOPPABLE)
+	recoil_reduction_timer = addtimer(CALLBACK(src, .proc/calc_recoil), 0.3 SECONDS, TIMER_STOPPABLE)
 
 /mob/living/proc/update_cursor()
 	if(get_preference_value(/datum/client_preference/gun_cursor) != GLOB.PREF_YES)


### PR DESCRIPTION
## About The Pull Request

Up until now recoil was reduced to 0 one second after the last time you fired a gun.

This PR changes it to decrease by 10% every tick, with a minimum of 0.5, after 0.3 seconds. In effect, most recoil will dissipate in a single second, unless firing a lot of takeshi or similar heavy weapons. Short bursts and snapshots will decrease in recoil inbetween shots, and the recoil of most weapons can be completely negated so long the shots are spaced out enough.

(Most guns are between 1.2-1.8 recoil / shot)

## Why It's Good For The Game

Better recoil, if you shoot every 0.9 seconds recoil will now increase instead of just building up forever.

## Changelog
:cl:
balance: recoil now decreases progressively, instead of all at once
/:cl:
