### PR TITLE
Unlink disposal and trunk when deconstructed

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1349,6 +1349,13 @@
 	update()
 	return
 
+/obj/structure/disposalpipe/trunk/Destroy()
+	// Unlink trunk and disposal so that objets are not sent to nullspace
+	var/obj/machinery/disposal/D = linked
+	D.trunk = null
+	linked = null
+	return ..()
+
 /obj/structure/disposalpipe/trunk/proc/getlinked()
 	linked = null
 	var/obj/machinery/disposal/D = locate() in src.loc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disposal bin and trunk were not unlinked when the trunk was deconstructed so items put into the disposal bin were sent to nullspace since that's where the trunk is after its deconstruction.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Hyperio
fix: Fix disposal sending items to nullspace
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
