### PR TITLE
Fix integration test freaking out

### DIFF
--- a/code/datums/loot_spawner.dm
+++ b/code/datums/loot_spawner.dm
@@ -337,6 +337,8 @@ the value of stock parts increases with the rating.
 	for(var/path in paths)
 		if(get_spawn_value(path) == spawn_value)
 			things += path
+	if(!things.len)
+		return
 	return pick(things)
 
 /datum/controller/subsystem/spawn_data/proc/take_tags(list/paths, list/exclude)


### PR DESCRIPTION
## About The Pull Request

Loot spawner now checking if list is empty, before trying to pick() from it, that hopefully should fix runtimes at roundstart.

## Why It's Good For The Game

Fixes cool.

## Changelog
:cl:
code: added missing check for loot spawner
/:cl:
