### PR TITLE
Prosthetic surgery tweak

### DIFF
--- a/code/modules/surgery/robotic.dm
+++ b/code/modules/surgery/robotic.dm
@@ -95,8 +95,8 @@
 
 /datum/surgery_step/robotic/remove_item/end_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool, atom/movable/target)
 	user.visible_message(
-		SPAN_NOTICE("[user] pries something out of [organ.get_surgery_name()] with \the [tool]."),
-		SPAN_NOTICE("You pry [target] out of [organ.get_surgery_name()] with \the [tool].")
+		SPAN_NOTICE("[user] extracts something out of [organ.get_surgery_name()] with \the [tool]."),
+		SPAN_NOTICE("You extract [target] out of [organ.get_surgery_name()] with \the [tool].")
 	)
 	organ.remove_item(target, user)
 


### PR DESCRIPTION
## About The Pull Request

Makes surgery on robotic limbs use pliers/hemostat instead of a crowbar.

![image](https://user-images.githubusercontent.com/65828539/137836989-1b4d8fe2-8876-4926-94a8-c842391ee319.png)

## Why It's Good For The Game

Imagine taking out nerves/shrapnel/brain/whatever with a crowbar.
Pliers make much more sense for that procedure and easy to obtain.

## Changelog
:cl:
tweak: organ removal on robotic limb require "clamping" instead of "prying" tool quality
/:cl:
