### PR TITLE
Action button for scope

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -579,6 +579,7 @@
 			action = new /obj/screen/item_action/top_bar/gun/scope
 			action.owner = src
 			hud_actions += action
+			action_button_name = "Toggle Scope"
 			if(ismob(loc))
 				var/mob/user = loc
 				user.client?.screen += action
@@ -587,6 +588,7 @@
 			var/mob/user = loc
 			user.client?.screen -= action
 		hud_actions -= action
+		action_button_name = null
 		qdel(action)
 
 /obj/item/gun/proc/add_firemode(list/firemode)

--- a/code/modules/projectiles/gun_hud_actions.dm
+++ b/code/modules/projectiles/gun_hud_actions.dm
@@ -45,6 +45,12 @@
 	icon_state = "info"
 
 /obj/item/gun/ui_action_click(mob/living/user, action_name)
+	if(!action_name)
+		action_name = "scope" // For classic action button that pass nothing
+
+	if(!user)
+		user = usr
+
 	switch(action_name)
 		if("fire mode")
 			toggle_firemode(user)


### PR DESCRIPTION
## About The Pull Request

Makes action button appear when gun have a scope installed.

## Why It's Good For The Game

Have been asked to make it, so I assume it is useful for someone.

## Changelog
:cl:
add: action button for guns with scope installed
/:cl: