### PR TITLE
Blacklists of most of the hastily added armor disks try 2

### DIFF
--- a/code/game/objects/items/weapons/design_disks/ironhammer.dm
+++ b/code/game/objects/items/weapons/design_disks/ironhammer.dm
@@ -34,7 +34,7 @@
 	disk_name = "Ironhammer Combat Equipment - Bulletproof Armor"
 	icon_state = "ironhammer"
 	spawn_tags = SPAWN_TAG_DESIGN_ADVANCED_COMMON
-	spawn_blacklisted = TRUE
+	spawn_blacklisted = TRUE // Is too easy to acquire and changing the rarity value didn't help much when tested
 	rarity_value = 15 // about as rare as a advanced tool disk - remember that this takes from the 'advanced' pool (which is rare) instead of the 'common' pool like the normal armor disk does
 	license = 4 // 4 pieces, or 2 sets
 	designs = list(
@@ -47,7 +47,7 @@
 	disk_name = "Ironhammer Combat Equipment - Laserproof Armor"
 	icon_state = "ironhammer"
 	spawn_tags = SPAWN_TAG_DESIGN_ADVANCED_COMMON
-	spawn_blacklisted = TRUE
+	spawn_blacklisted = TRUE // Is too easy to acquire and changing the rarity value didn't help much when tested
 	rarity_value = 16 // slightly rarer than bulletproof gear
 	license = 4 // 4 pieces, or 2 sets
 	designs = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Blacklists all expect generic armor disks from the game.

## Why It's Good For The Game

They were added on a whim of ex-delegate who is now gone, they are an idea thats plain bad especially with how common they were, and with everyone running with full bulletproofs other cloths are neglected, the armors from those disks can still be acquired using other ways.

## Changelog
:cl:
tweak: Blacklists all expect generic armor disks, the armors in them can still be acquired with other means like junking, guild, etc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
