### PR TITLE
Vapour

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -566,7 +566,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/voltage = 0
 	var/quality_multiplier = 1
 
-	var/charge_per_use = 0.5
+	var/charge_per_use = 0.2
 	var/obj/item/cell/cell
 	var/suitable_cell = /obj/item/cell/small
 

--- a/tools/hooks/Install.bat
+++ b/tools/hooks/Install.bat
@@ -1,2 +1,0 @@
-@call "%~dp0\..\bootstrap\python" -m hooks.install %*
-@pause


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the charge use from .5 to .2. Turns the basic battery use from 10 units to 25 units per charge. 200 unit batteries will use the whole amount of reagents inside now instead of requiring 500 units of charge to use the whole mask.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Masks cant be used for smoking desires due to code issues I cant fixed. Time to make them a slow chem delivery systems, theyre good with space drugs and you need to know how to modify them but theyre good for pain chem delivery that lets you cut it off hen you want to instead of measuring pill size or liquid amounts. Balanced by the fact you cant use internals with it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: changed the amount of power to use the vapour mask fully from 500 units to 200 units.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
