### PR TITLE
Adds Aural Dampener to carrion uplink too

### DIFF
--- a/code/datums/uplink/stealth and camouflage items.dm
+++ b/code/datums/uplink/stealth and camouflage items.dm
@@ -45,6 +45,7 @@
 	name = "Tool Upgrade: Aural Dampener"
 	item_cost = 1
 	path = /obj/item/tool_upgrade/augment/dampener
+	antag_roles = list(ROLE_TRAITOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 
 /datum/uplink_item/item/stealth_items/silencer
     name = "Silencer"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A thing I forgot to add in the previous PR

## Why It's Good For The Game

Ask FortuneMaster

## Changelog
:cl:
tweak: Aural Dampener is now also in the carrion uplink
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
