### PR TITLE
Makes the Type42 OP (pls nerf)

### DIFF
--- a/code/modules/projectiles/guns/projectile/pistol/type42.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/type42.dm
@@ -14,8 +14,8 @@
 	mag_well = MAG_WELL_PISTOL
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	magazine_type = /obj/item/ammo_magazine/cspistol
-	damage_multiplier = 1.3
-	penetration_multiplier = 1.3
+	damage_multiplier = 1.8
+	penetration_multiplier = 1.5
 	recoil_buildup = 2.5
 	spawn_tags = SPAWN_TAG_GUN_OS
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Modifies the Type 42 One Star pistol to have 1.8x Damage modifier and 1.5x AP modifier. This change gives the pistol the following values when using regular or HV ammo: 
Damage:-
48.6(regular)/58.68(HV)
AP:-
22.5(regular)/30(HV)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Requested by Rosa and they told me that anyone who complains is having a skill issue.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The Type 42 now has 1.8x damage and 1.5xAP - this makes it actually better than a Paco now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
