### PR TITLE
Fix Malf AI Roll when using AI drone or joining after roundstart

### DIFF
--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -3,8 +3,8 @@
 	flag = AI
 	department_flag = COMMAND
 	faction = "CEV Eris"
-	total_positions = 0 // Not used for AI, see is_position_available below and modules/mob/living/silicon/ai/latejoin.dm
-	spawn_positions = 1
+	total_positions = 1 // Not used for AI, see is_position_available below and modules/mob/living/silicon/ai/latejoin.dm
+	spawn_positions = 1 // |-> above message is partly true, it is used /AssignRole so we still need to set it o 1
 	selection_color = "#b5b7cb"
 	supervisors = "your laws"
 	req_admin_notify = 1

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -4,7 +4,7 @@
 	department_flag = COMMAND
 	faction = "CEV Eris"
 	total_positions = 1 // Not used for AI, see is_position_available below and modules/mob/living/silicon/ai/latejoin.dm
-	spawn_positions = 1 // |-> above message is partly true, it is used /AssignRole so we still need to set it o 1
+	spawn_positions = 1 // |-> above message is partly true, it is used by /AssignRole so we still need to set it to 1
 	selection_color = "#b5b7cb"
 	supervisors = "your laws"
 	req_admin_notify = 1

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -766,8 +766,9 @@ var/list/ai_verbs_default = list(
 
 /mob/living/silicon/ai/proc/pull_to_core()
 	if (bound_drone?.mind)  // If drone exists and AI is inside it
-		ckey = bound_drone.ckey
+		bound_drone.mind.active = 0 // We want to transfer the key manually
 		bound_drone.mind.transfer_to(src) // Pull back mind to AI core
+		key = bound_drone.key // Manually transfer the key to log them in
 
 /mob/living/silicon/ai/proc/go_into_drone()
 	// Switch to drone or spawn a new one
@@ -778,9 +779,10 @@ var/list/ai_verbs_default = list(
 			var/remaining = (drone_cooldown_time - (world.time - time_destroyed)) / 10
 			to_chat(src, SPAN_WARNING("Security routines hardcoded into your core force you to wait [remaining] seconds before creating a new AI bound drone."))
 	else if(mind)
-		bound_drone.ckey = ckey
-		bound_drone.laws = laws // Resync laws in case they have been changed
+		mind.active = 0 // We want to transfer the key manually
 		mind.transfer_to(bound_drone) // Transfer mind to drone
+		bound_drone.laws = laws // Resync laws in case they have been changed
+		bound_drone.key = key // Manually transfer the key to log them in
 
 /mob/living/silicon/ai/proc/destroy_drone()
 	if(bound_drone)

--- a/code/modules/mob/living/silicon/robot/drone/_drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/_drone.dm
@@ -376,8 +376,9 @@ var/list/mob_hat_cache = list()
 
 /mob/living/silicon/robot/drone/aibound/proc/back_to_core()
 	if(bound_ai && mind)
-		bound_ai.ckey = ckey
+		mind.active = 0 // We want to transfer the key manually
 		mind.transfer_to(bound_ai) // Transfer mind to AI core
+		bound_ai.key = key // Manually transfer the key to log them in
 	else
 		to_chat(src, SPAN_WARNING("No AI core detected."))
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -85,9 +85,10 @@
 		M.bound_drone = new_drone  // Save new drone in variable of AI
 		new_drone.real_name = M.name + " controlled drone"
 		new_drone.name = new_drone.real_name
-		new_drone.ckey = player.ckey
 		new_drone.laws = M.laws
+		M.mind.active = 0 // We want to transfer the key manually
 		M.mind.transfer_to(new_drone) // Transfer mind to drone
+		new_drone.key = player.key // Manually transfer the key to log them in
 		new_drone.master_fabricator = src
 
 	drone_progress = 0

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -247,7 +247,7 @@
 	if(rank == "AI")
 
 		character = character.AIize(move=0) // AIize the character, but don't move them yet
-
+		SSticker.minds += character.mind
 			// IsJobAvailable for AI checks that there is an empty core available in this list
 		var/obj/structure/AIcore/deactivated/C = empty_playable_ai_cores[1]
 		empty_playable_ai_cores -= C


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Malf AI roll by storyteller was broken when an AI used its remote controlled drone or when it was joining after roundstart due to some issues with the subsystem that handle player minds.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Hyperio
fix: Fix Malf AI Roll when using AI drone or joining after roundstart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
