### PR TITLE
Reduces overall pain by 10% , reduces oxyloss pain by 40%, pain slowdown is now linear instead of stage-based.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -40,7 +40,7 @@
 			tally += shoes.slowdown
 
 	//tally += min((shock_stage / 100) * 3, 3) //Scales from 0 to 3 over 0 to 100 shock stage
-	tally += min(get_dynamic_pain() / 25, 3) // Scales from 0 to 3,
+	tally += min((get_dynamic_pain() - get_painkiller()) / 40, 3) // Scales from 0 to 3,
 
 	if (bodytemperature < 283.222)
 		tally += (283.222 - bodytemperature) / 10 * 1.75

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -39,7 +39,8 @@
 		if(shoes)
 			tally += shoes.slowdown
 
-	tally += min((shock_stage / 100) * 3, 3) //Scales from 0 to 3 over 0 to 100 shock stage
+	//tally += min((shock_stage / 100) * 3, 3) //Scales from 0 to 3 over 0 to 100 shock stage
+	tally += min(get_dynamic_pain() / 25, 3) // Scales from 0 to 3,
 
 	if (bodytemperature < 283.222)
 		tally += (283.222 - bodytemperature) / 10 * 1.75
@@ -47,7 +48,7 @@
 
 	if(slowdown)
 		tally += 1
-	
+
 	tally += (r_hand?.slowdown_hold + l_hand?.slowdown_hold)
 
 	return tally

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -29,8 +29,8 @@
 		hard_crit_threshold += 20
 
 	. = 						\
-	1	* get_limb_damage() + 	\
-	1	* getOxyLoss() + 		\
+	0.9	* get_limb_damage() + 	\
+	0.6	* getOxyLoss() + 		\
 	0.5	* getToxLoss() + 		\
 	1.5	* getCloneLoss()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces pain gained from limb damage by 10%
Reduces pain from oxyloss by 40%
Pain slowdown is now based on (halloss * 1.33 ) / 25 , instead of shock_stage / 100 
## Why It's Good For The Game
People get far too much slowdown from a few shots.
## Changelog
:cl:
balance: Reduced overall agony from limb damage by 10%
balance : Reduced overall agony from oxyloss by 40%
balance : Pain induced slowdown is now linear and based on dynamic pain instead of shock stage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
