### PR TITLE
 makes buckshot knockback less crazy.

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -523,6 +523,19 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		looping_distance--
 	return current_turf
 
+// More complex proc that uses basic trigonometry to get a turf away from target . Accurate
+// it gets the difference between the center and target x and y axis. If they are - or + is handled without hardcode
+// The ratios are divided by their total (x + y ) and then multiplied by distance x / (x+y) * distance
+// this value is added ontop of the center coordinates , giving us our "away" turf.
+/proc/get_turf_away_from_target_complex(atom/center, atom/target, distance)
+	var/list/distance_reports = list(center.x - target.x, center.y - target.y)
+	var/distance_total = distance_reports[1] + distance_reports[2]
+	distance_reports[1] = round(distance_reports[1] / distance_total * distance)
+	distance_reports[2] = round(distance_reports[2] / distance_total * distance)
+	distance_reports[1] = center.x + distance_reports[1]
+	distance_reports[2] = center.y + distance_reports[2]
+	return locate(distance_reports[1], distance_reports[2], center.z)
+
 // returns turf relative to A in given direction at set range
 // result is bounded to map size
 // note range is non-pythagorean

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -88,7 +88,6 @@
 	var/base_spread = 90	//lower means the pellets spread more across body parts. If zero then this is considered a shrapnel explosion instead of a shrapnel cone
 	var/spread_step = 10	//higher means the pellets spread more across body parts with distance
 	var/pellet_to_knockback_ratio = 0
-	var/pellet_to_knockdown_ratio = 0
 
 /obj/item/projectile/bullet/pellet/Bumped()
 	. = ..()
@@ -132,11 +131,6 @@
 		if(knockback_calc)
 			var/target_turf = get_turf_away_from_target_complex(target_mob, starting, knockback_calc)
 			throw_at(target_turf, knockback_calc, 2, firer)
-	if(pellet_to_knockdown_ratio)
-		var/knockdown_calc = round(hits / pellet_to_knockdown_ratio)
-		if(knockdown_calc)
-			target_mob.Weaken(knockdown_calc)
-
 
 	if (hits >= total_pellets || pellets <= 0)
 		return 1

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -87,6 +87,8 @@
 	var/range_step = 2		//projectile will lose a fragment each time it travels this distance. Can be a non-integer.
 	var/base_spread = 90	//lower means the pellets spread more across body parts. If zero then this is considered a shrapnel explosion instead of a shrapnel cone
 	var/spread_step = 10	//higher means the pellets spread more across body parts with distance
+	var/pellet_to_knockback_ratio = 0
+	var/pellet_to_knockdown_ratio = 0
 
 /obj/item/projectile/bullet/pellet/Bumped()
 	. = ..()
@@ -125,6 +127,17 @@
 		def_zone = old_zone //restore the original zone the projectile was aimed at
 
 	pellets -= hits //each hit reduces the number of pellets left
+	if(pellet_to_knockback_ratio)
+		var/knockback_calc = round(hits / pellet_to_knockback_ratio)
+		if(knockback_calc)
+			var/target_turf = get_turf_away_from_target_complex(target_mob, starting, knockback_calc)
+			throw_at(target_turf, knockback_calc, 2, firer)
+	if(pellet_to_knockdown_ratio)
+		var/knockdown_calc = round(hits / pellet_to_knockdown_ratio)
+		if(knockdown_calc)
+			target_mob.Weaken(knockdown_calc)
+
+
 	if (hits >= total_pellets || pellets <= 0)
 		return 1
 	return 0

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -244,7 +244,7 @@ There are important things regarding this file:
 	icon_state = "slug"
 	damage_types = list(BRUTE = 54)
 	armor_penetration = 15
-	knockback = 2
+	knockback = 1
 	step_delay = 1.1
 
 /obj/item/projectile/bullet/shotgun/scrap
@@ -275,6 +275,7 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/shotgun/incendiary
 	damage_types = list(BRUTE = 45)
 	knockback = 0
+
 	var/fire_stacks = 4
 
 /obj/item/projectile/bullet/shotgun/incendiary/on_hit(atom/target, blocked = FALSE)
@@ -293,7 +294,8 @@ There are important things regarding this file:
 	pellets = 8
 	range_step = 1
 	spread_step = 10
-	knockback = 2
+	pellet_to_knockback_ratio = 2
+	pellet_to_knockdown_ratio = 5
 
 /obj/item/projectile/bullet/pellet/shotgun/Initialize()
 	. = ..()

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -295,7 +295,7 @@ There are important things regarding this file:
 	range_step = 1
 	spread_step = 10
 	pellet_to_knockback_ratio = 2
-	pellet_to_knockdown_ratio = 5
+	pellet_to_knockdown_ratio = 7
 
 /obj/item/projectile/bullet/pellet/shotgun/Initialize()
 	. = ..()

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -295,7 +295,6 @@ There are important things regarding this file:
 	range_step = 1
 	spread_step = 10
 	pellet_to_knockback_ratio = 2
-	pellet_to_knockdown_ratio = 7
 
 /obj/item/projectile/bullet/pellet/shotgun/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Buckshot knockback is now more sane , and is limited to 5 turfs at most with a improved algorithm which is far more accurate in determing where to throw the target

## Why It's Good For The Game
No more buckshot yeeeeeet half of the ship 

## Changelog
:cl:
fix: Crazy buckshot knockback
balance : Maximum distance a buckshot can fling you now is 5 tiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
