### PR TITLE
Buffs technomancer auto-nanoforge , adds positive gunmods / toolmods.

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2619,6 +2619,7 @@
 #include "code\modules\sanity\sanity_lists.dm"
 #include "code\modules\sanity\sanity_mob.dm"
 #include "code\modules\sanity_grain\sanity_grain.dm"
+#include "code\modules\scrap\extra_quality.dm"
 #include "code\modules\scrap\oldificator.dm"
 #include "code\modules\scrap\scrap.dm"
 #include "code\modules\scrap\scrap_beacon.dm"

--- a/code/datums/autolathe/autolathe_datums.dm
+++ b/code/datums/autolathe/autolathe_datums.dm
@@ -160,26 +160,31 @@
 
 //Returns a new instance of the item for this design
 //This is to allow additional initialization to be performed, including possibly additional contructor arguments.
-/datum/design/proc/Fabricate(newloc, mat_efficiency, var/obj/machinery/autolathe/fabricator, oldify_result)
-    if(!build_path)
-        return
+/datum/design/proc/Fabricate(newloc, mat_efficiency, var/obj/machinery/autolathe/fabricator, oldify_result, high_quality_print)
+	if(!build_path)
+		return
 
-    var/atom/A = new build_path(newloc)
-    A.Created()
+	var/atom/A = new build_path(newloc)
+	A.Created()
 
-    if(mat_efficiency != 1 && adjust_materials)
-        for(var/obj/O in A.GetAllContents(includeSelf = TRUE))
-            if(length(O.matter))
-                for(var/i in O.matter)
-                    O.matter[i] = round(O.matter[i] * mat_efficiency, 0.01)
+	if(mat_efficiency != 1 && adjust_materials)
+		for(var/obj/O in A.GetAllContents(includeSelf = TRUE))
+			if(length(O.matter))
+				for(var/i in O.matter)
+					O.matter[i] = round(O.matter[i] * mat_efficiency, 0.01)
 
-    if(oldify_result && fabricator.low_quality_print)
-        var/obj/O = A
-        if(istype(O))
-            O.make_old(TRUE)
+	if(oldify_result && fabricator.low_quality_print)
+		var/obj/O = A
+		if(istype(O))
+			O.make_old(TRUE)
+
+	if(high_quality_print && fabricator.extra_quality_print)
+		var/obj/O = A
+		if(istype(O))
+			O.give_positive_attachment()
 
 
-    return A
+	return A
 
 /datum/design/autolathe
 	build_type = AUTOLATHE

--- a/code/game/machinery/autolathe/autolathe.dm
+++ b/code/game/machinery/autolathe/autolathe.dm
@@ -73,6 +73,8 @@
 	// If it prints high quality or bulky/deformed/debuffed items, or if it prints good items for one faction only.
 	var/low_quality_print = TRUE
 	var/list/high_quality_faction_list = list()
+	// If it prints items with positive traits
+	var/extra_quality_print = FALSE
 
 	//for nanoforge and/or artist bench
 	var/use_oddities = FALSE
@@ -927,17 +929,20 @@
 
 
 /obj/machinery/autolathe/proc/fabricate_design(datum/design/design)
-    consume_materials(design)
+	consume_materials(design)
 
-    if(disk && disk.GetComponent(/datum/component/oldficator))
-        design.Fabricate(drop_location(), mat_efficiency, src, TRUE)
-    else
-        design.Fabricate(drop_location(), mat_efficiency, src, FALSE)
+	if(disk && disk.GetComponent(/datum/component/oldficator))
+		design.Fabricate(drop_location(), mat_efficiency, src, TRUE)
+	else
+		if(extra_quality_print)
+			design.Fabricate(drop_location(), mat_efficiency, src, FALSE, TRUE)
+		else
+			design.Fabricate(drop_location(), mat_efficiency, src, FALSE,FALSE)
 
-    working = FALSE
-    current_file = null
-    print_post()
-    next_file()
+	working = FALSE
+	current_file = null
+	print_post()
+	next_file()
 
 
 /obj/machinery/autolathe/proc/insert_oddity(mob/living/user, obj/item/inserted_oddity) //Not sure if nessecary to name oddity this way. obj/item/oddity/inserted_oddity

--- a/code/game/machinery/autolathe/autolathe.dm
+++ b/code/game/machinery/autolathe/autolathe.dm
@@ -934,10 +934,7 @@
 	if(disk && disk.GetComponent(/datum/component/oldficator))
 		design.Fabricate(drop_location(), mat_efficiency, src, TRUE)
 	else
-		if(extra_quality_print)
-			design.Fabricate(drop_location(), mat_efficiency, src, FALSE, TRUE)
-		else
-			design.Fabricate(drop_location(), mat_efficiency, src, FALSE,FALSE)
+		design.Fabricate(drop_location(), mat_efficiency, src, FALSE, extra_quality_print)
 
 	working = FALSE
 	current_file = null

--- a/code/game/machinery/autolathe/nanoforge.dm
+++ b/code/game/machinery/autolathe/nanoforge.dm
@@ -32,6 +32,15 @@
 	MATERIAL_LEATHER = 0.1,
 	MATERIAL_TITANIUM = 0.6)
 
+	mat_efficiency = 0.6 // 40% more efficient than normal autolathes
+	storage_capacity = 240
+	speed = 4
+	extra_quality_print = TRUE
+
+/// Way too alien to be upgraded , according to lore.
+/obj/machinery/autolathe/nanoforge/RefreshParts()
+	return
+
 /obj/machinery/autolathe/nanoforge/proc/compress_matter(mob/user)
 	if(!inspiration || !inspiration.perk)
 		to_chat(user, SPAN_WARNING("Catalyst not found."))

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -714,7 +714,7 @@
 
 /obj/item/tool_upgrade/pai
 	name = "Integrated P-AI"
-	desc = "A P-AI integrated within the arhitecture of the tool , helping the user in utilizing it"
+	desc = "A P-AI integrated within the arhitecture of the tool, helping the user in utilizing it"
 	spawn_blacklisted = TRUE
 	price_tag = 200
 
@@ -722,8 +722,8 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.tool_upgrades = list(
-	UPGRADE_WORKSPEED = 0.5,
-	UPGRADE_PRECISION = 15
+	UPGRADE_WORKSPEED = 0.3,
+	UPGRADE_PRECISION = 10
 	)
 	I.prefix = "assisted"
 
@@ -768,14 +768,14 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.tool_upgrades = list(
-		UPGRADE_WORKSPEED = 0.2,
+		UPGRADE_WORKSPEED = 0.1,
 		UPGRADE_ITEMFLAGPLUS = SILENT
 	)
 	I.prefix = "still"
 
 /obj/item/tool_upgrade/plasma_coating
 	name = "Plasma coating"
-	desc = "This tool is infused with plasma ,granting it more durability"
+	desc = "This tool is infused with plasma, granting it more durability"
 	spawn_blacklisted = TRUE
 	price_tag = 600
 

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -730,7 +730,7 @@
 
 /obj/item/tool_upgrade/flow_mechanism
 	name = "Flowing metal system"
-	desc = "This tool makes use of liquid metal within its arhitecture."
+	desc = "This tool makes use of liquid metal within its architecture."
 	spawn_blacklisted = TRUE
 	price_tag = 300
 

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -747,7 +747,7 @@
 
 /obj/item/tool_upgrade/magni_grip
 	name = "Waved magnetic grip"
-	desc = "A wavy metallic sheet that attaches to most gloves automatically"
+	desc = "A wavy metallic sheet that attaches to most gloves automatically."
 	spawn_blacklisted = TRUE
 	price_tag = 200
 

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -711,3 +711,82 @@
 	. = ..()
 	GET_COMPONENT(comp_sanity, /datum/component/atom_sanity)
 	. += comp_sanity.affect * 100
+
+/obj/item/tool_upgrade/pai
+	name = "Integrated P-AI"
+	desc = "A P-AI integrated within the arhitecture of the tool , helping the user in utilizing it"
+	spawn_blacklisted = TRUE
+	price_tag = 200
+
+/obj/item/tool_upgrade/pai/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.tool_upgrades = list(
+	UPGRADE_WORKSPEED = 0.5,
+	UPGRADE_PRECISION = 15
+	)
+	I.prefix = "assisted"
+
+/obj/item/tool_upgrade/flow_mechanism
+	name = "Flowing metal system"
+	desc = "This tool makes use of liquid metal within its arhitecture."
+	spawn_blacklisted = TRUE
+	price_tag = 300
+
+/obj/item/tool_upgrade/flow_mechanism/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.tool_upgrades = list(
+		UPGRADE_DEGRADATION_MULT = 0.2,
+		UPGRADE_FORCE_MULT = 1.3,
+		UPGRADE_MAXUPGRADES = 2
+	)
+	I.prefix = "flowing"
+
+/obj/item/tool_upgrade/magni_grip
+	name = "Waved magnetic grip"
+	desc = "A wavy metallic sheet that attaches to most gloves automatically"
+	spawn_blacklisted = TRUE
+	price_tag = 200
+
+/obj/item/tool_upgrade/magni_grip/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.tool_upgrades = list(
+	UPGRADE_WORKSPEED = 0.2,
+	UPGRADE_PRECISION = 15
+	)
+	I.prefix = "magnetized"
+
+/obj/item/tool_upgrade/resonator
+	name = "Resonator sink"
+	desc = "A special module which keeps the tool from resonating"
+	spawn_blacklisted = TRUE
+	price_tag = 400
+
+/obj/item/tool_upgrade/resonator/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.tool_upgrades = list(
+		UPGRADE_WORKSPEED = 0.2,
+		UPGRADE_ITEMFLAGPLUS = SILENT
+	)
+	I.prefix = "still"
+
+/obj/item/tool_upgrade/plasma_coating
+	name = "Plasma coating"
+	desc = "This tool is infused with plasma ,granting it more durability"
+	spawn_blacklisted = TRUE
+	price_tag = 600
+
+/obj/item/tool_upgrade/augment/hydraulic/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.tool_upgrades = list(
+		UPGRADE_DEGRADATION_MULT = 0.1
+	)
+	I.prefix = "infused"
+
+
+#define GREAT_TOOLMODS list(/obj/item/tool_upgrade/pai, /obj/item/tool_upgrade/flow_mechanism, /obj/item/tool_upgrade/magni_grip, \
+	/obj/item/tool_upgrade/resonator, /obj/item/tool_upgrade/plasma_coating)

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -714,7 +714,7 @@
 
 /obj/item/tool_upgrade/pai
 	name = "Integrated P-AI"
-	desc = "A P-AI integrated within the arhitecture of the tool, helping the user in utilizing it"
+	desc = "A P-AI integrated within the architecture of the tool, helping the user in utilizing it."
 	spawn_blacklisted = TRUE
 	price_tag = 200
 

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -725,6 +725,7 @@
 	UPGRADE_WORKSPEED = 0.3,
 	UPGRADE_PRECISION = 10
 	)
+	I.destroy_on_removal = TRUE
 	I.prefix = "assisted"
 
 /obj/item/tool_upgrade/flow_mechanism
@@ -741,6 +742,7 @@
 		UPGRADE_FORCE_MULT = 1.3,
 		UPGRADE_MAXUPGRADES = 2
 	)
+	I.destroy_on_removal = TRUE
 	I.prefix = "flowing"
 
 /obj/item/tool_upgrade/magni_grip
@@ -756,6 +758,7 @@
 	UPGRADE_WORKSPEED = 0.2,
 	UPGRADE_PRECISION = 15
 	)
+	I.destroy_on_removal = TRUE
 	I.prefix = "magnetized"
 
 /obj/item/tool_upgrade/resonator
@@ -771,6 +774,7 @@
 		UPGRADE_WORKSPEED = 0.1,
 		UPGRADE_ITEMFLAGPLUS = SILENT
 	)
+	I.destroy_on_removal = TRUE
 	I.prefix = "still"
 
 /obj/item/tool_upgrade/plasma_coating
@@ -783,8 +787,10 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.tool_upgrades = list(
-		UPGRADE_DEGRADATION_MULT = 0.1
+		UPGRADE_DEGRADATION_MULT = 0.1,
+		UPGRADE_MAXUPGRADES = 3
 	)
+	I.destroy_on_removal = TRUE
 	I.prefix = "infused"
 
 

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -791,7 +791,7 @@
 		UPGRADE_MAXUPGRADES = 3
 	)
 	I.destroy_on_removal = TRUE
-	I.prefix = "infused"
+	I.prefix = "plasma coated"
 
 
 #define GREAT_TOOLMODS list(/obj/item/tool_upgrade/pai, /obj/item/tool_upgrade/flow_mechanism, /obj/item/tool_upgrade/magni_grip, \

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -763,7 +763,7 @@
 
 /obj/item/tool_upgrade/resonator
 	name = "Resonator sink"
-	desc = "A special module which keeps the tool from resonating"
+	desc = "A special module which prevents the tool from resonating."
 	spawn_blacklisted = TRUE
 	price_tag = 400
 

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -779,7 +779,7 @@
 
 /obj/item/tool_upgrade/plasma_coating
 	name = "Plasma coating"
-	desc = "This tool is infused with plasma, granting it more durability"
+	desc = "This tool is coated with plasma, granting it more durability."
 	spawn_blacklisted = TRUE
 	price_tag = 600
 

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -424,7 +424,7 @@
 
 /obj/item/gun_upgrade/barrel/better
 	name = "High-temperature forged barrel"
-	desc = "A barrel forged in high temperature , making the metal more resistant"
+	desc = "A barrel forged in high temperature, making the metal more resistant"
 	spawn_blacklisted = TRUE
 	price_tag = 150
 
@@ -440,7 +440,7 @@
 
 /obj/item/gun_upgrade/muzzle/better
 	name = "Resonance muzzle"
-	desc = "A high tech muzzle , made to resonate at the same frequency as the sound that comes from the gun."
+	desc = "A high tech muzzle, made to resonate at the same frequency as the sound that comes from the gun."
 	spawn_blacklisted = TRUE
 	price_tag = 150
 

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -423,7 +423,7 @@
 
 /obj/item/gun_upgrade/barrel/better
 	name = "High-temperature forged barrel"
-	desc = "A barrel forged in high temperature, making the metal more resistant"
+	desc = "A barrel forged in high temperature, making the metal more resistant."
 	spawn_blacklisted = TRUE
 	price_tag = 150
 

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -406,7 +406,92 @@
 	I.gun_loc_tag = GUN_SCOPE
 	I.removable = FALSE
 
+/obj/item/gun_upgrade/trigger/better
+	name = "Refined trigger"
+	desc = "This trigger seems to be made of durable alloys and cut to the precision of milimeters."
+	spawn_blacklisted = TRUE
+	price_tag = 100
+
+/obj/item/gun_upgrade/trigger/better/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.weapon_upgrades = list(
+		GUN_UPGRADE_FIRE_DELAY = 0.7
+	)
+	I.destroy_on_removal = TRUE
+	I.gun_loc_tag = GUN_TRIGGER
+	I.removable = FALSE
+
+/obj/item/gun_upgrade/barrel/better
+	name = "High-temperature forged barrel"
+	desc = "A barrel forged in high temperature , making the metal more resistant"
+	spawn_blacklisted = TRUE
+	price_tag = 150
+
+/obj/item/gun_upgrade/barrel/better/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.weapon_upgrades = list(
+		GUN_UPGRADE_FIRE_DELAY = 0.7
+	)
+	I.destroy_on_removal = TRUE
+	I.gun_loc_tag = GUN_BARREL
+	I.removable = FALSE
+
+/obj/item/gun_upgrade/muzzle/better
+	name = "Resonance muzzle"
+	desc = "A high tech muzzle , made to resonate at the same frequency as the sound that comes from the gun."
+	spawn_blacklisted = TRUE
+	price_tag = 150
+
+/obj/item/gun_upgrade/muzzle/better/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.weapon_upgrades = list(
+		GUN_UPGRADE_SILENCER = TRUE,
+		GUN_UPGRADE_STEPDELAY_MULT = 0.9
+	)
+	I.destroy_on_removal = TRUE
+	I.gun_loc_tag = GUN_MUZZLE
+	I.removable = FALSE
+
+/obj/item/gun_upgrade/mechanism/better
+	name = "Hydraulic mechanism"
+	desc = "A high tech mechanism that uses hydraulic pumps to keep recoil at a minimum."
+	spawn_blacklisted = TRUE
+	price_tag = 300
+
+/obj/item/gun_upgrade/mechanism/better/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.weapon_upgrades = list(
+		GUN_UPGRADE_RECOIL = 0.8,
+	)
+	I.destroy_on_removal = TRUE
+	I.gun_loc_tag = GUN_MECHANISM
+	I.removable = FALSE
+
+/obj/item/gun_upgrade/scope/better
+	name = "High-res scope"
+	desc = "A high resolution scope"
+	spawn_blacklisted = TRUE
+	price_tag = 100
+
+/obj/item/gun_upgrade/scope/better/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.weapon_upgrades = list(
+		GUN_UPGRADE_ZOOM = 2,
+	)
+	I.destroy_on_removal = TRUE
+	I.gun_loc_tag = GUN_SCOPE
+	I.removable = FALSE
+
+
 #define TRASH_GUNMODS list(/obj/item/gun_upgrade/trigger/faulty, /obj/item/gun_upgrade/barrel/faulty, \
 		/obj/item/gun_upgrade/muzzle/faulty, /obj/item/gun_upgrade/mechanism/faulty, \
 		/obj/item/gun_upgrade/scope/faulty)
+
+#define GREAT_GUNMODS list(/obj/item/gun_upgrade/trigger/better, /obj/item/gun_upgrade/barrel/better, \
+	/obj/item/gun_upgrade/muzzle/better, /obj/item/gun_upgrade/mechanism/better, /obj/item/gun_upgrade/scope/better)
 

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -420,7 +420,6 @@
 	)
 	I.destroy_on_removal = TRUE
 	I.gun_loc_tag = GUN_TRIGGER
-	I.removable = FALSE
 
 /obj/item/gun_upgrade/barrel/better
 	name = "High-temperature forged barrel"
@@ -436,7 +435,6 @@
 	)
 	I.destroy_on_removal = TRUE
 	I.gun_loc_tag = GUN_BARREL
-	I.removable = FALSE
 
 /obj/item/gun_upgrade/muzzle/better
 	name = "Resonance muzzle"
@@ -453,7 +451,6 @@
 	)
 	I.destroy_on_removal = TRUE
 	I.gun_loc_tag = GUN_MUZZLE
-	I.removable = FALSE
 
 /obj/item/gun_upgrade/mechanism/better
 	name = "Hydraulic mechanism"
@@ -469,7 +466,6 @@
 	)
 	I.destroy_on_removal = TRUE
 	I.gun_loc_tag = GUN_MECHANISM
-	I.removable = FALSE
 
 /obj/item/gun_upgrade/scope/better
 	name = "High-res scope"
@@ -485,7 +481,6 @@
 	)
 	I.destroy_on_removal = TRUE
 	I.gun_loc_tag = GUN_SCOPE
-	I.removable = FALSE
 
 
 #define TRASH_GUNMODS list(/obj/item/gun_upgrade/trigger/faulty, /obj/item/gun_upgrade/barrel/faulty, \

--- a/code/modules/scrap/extra_quality.dm
+++ b/code/modules/scrap/extra_quality.dm
@@ -1,0 +1,23 @@
+/obj/proc/give_positive_attachment()
+	return FALSE
+
+/obj/item/gun/give_positive_attachment()
+	var/list/great_mods = GREAT_GUNMODS
+	while(great_mods.len)
+		var/great_mod_path = pick_n_take(great_mods)
+		var/obj/item/great_mod = new great_mod_path
+		if(SEND_SIGNAL(great_mod, COMSIG_IATTACK, src, null))
+			break
+		QDEL_NULL(great_mod)
+
+/obj/item/tool/give_positive_attachment()
+	var/list/great_mods = GREAT_TOOLMODS
+	while(great_mods.len)
+		var/great_mod_path = pick_n_take(great_mods)
+		var/obj/item/great_mod = new great_mod_path
+		if(SEND_SIGNAL(great_mod, COMSIG_IATTACK, src, null))
+			break
+		QDEL_NULL(great_mod)
+
+/obj/item/cell/give_positive_attachment()
+	maxcharge *= 1.5 // 50% more cell capacity


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The auto-nanoforge now adds a positive gunmod / toolmod or increases the capacity of batteries printed
matter nanoforge is now 40% more efficient on materials
matter nanoforge now prints at double speed
matter nanoforge now stores twice as many materials
matter nanoforge can no longer be upgraded

## Why It's Good For The Game
It sucks , now it should be preety good to be forced to not get a oddity perk
## Changelog
:cl:
balance : Weapons / Tools printed using the nano autoforge now receive a buff attachmnt
balance: Automatter nanoforge is now 40% more efficient on materials and prints twice as fast, and stores twice as much.
balance : Automatter nanoforge can no longer be upgraded.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
