### PR TITLE
Loadout cigar cases no longer start full , Advanced laptop no longer starts with an advanced network and advanced hardrive

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -305,6 +305,11 @@
 	create_reagents(15 * storage_slots)
 	update_icon()
 
+/obj/item/storage/fancy/cigar/empty
+
+/obj/item/storage/fancy/cigar/empty/populate_contents()
+	return FALSE
+
 /obj/item/storage/fancy/cigar/on_update_icon()
 	icon_state = "[initial(icon_state)][contents.len]"
 

--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -149,7 +149,7 @@
 
 /datum/gear/cigars
 	display_name = "fancy cigar case"
-	path = /obj/item/storage/fancy/cigar
+	path = /obj/item/storage/fancy/cigar/empty
 	cost = 2
 
 /datum/gear/cigarettes

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -59,7 +59,7 @@
 /datum/gear/utility/advancedlaptop
 	display_name = "high-tech laptop"
 	path = /obj/item/modular_computer/laptop/preset/custom_loadout/advanced/golden
-	cost = 5
+	cost = 4
 
 /datum/gear/utility/ducttape
 	display_name = "duct tape"

--- a/code/modules/modular_computers/computers/subtypes/preset_laptop.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_laptop.dm
@@ -20,8 +20,8 @@
 	..()
 	processor_unit = new/obj/item/computer_hardware/processor_unit(src)
 	tesla_link = new/obj/item/computer_hardware/tesla_link(src) //Only the advanced laptop gets a tesla link
-	hard_drive = new/obj/item/computer_hardware/hard_drive/advanced(src)
-	network_card = new/obj/item/computer_hardware/network_card/advanced(src)
+	hard_drive = new/obj/item/computer_hardware/hard_drive(src)
+	network_card = new/obj/item/computer_hardware/network_card(src)
 	printer = new/obj/item/computer_hardware/printer(src)
 	card_slot = new/obj/item/computer_hardware/card_slot(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Loadout cigar cases no longer start full , advanced laptop  no longer has an advanced network card and harddrive
Approved by Firefox
## Why It's Good For The Game
People use these in loadout commonly to avoid actually spending money .
## Changelog
:cl:
balance: Loadout cigar cases now start empty
balance: Loadout advanced laptop no longer has a advanced network card and an advanced harddrive.
balance: Advanced laptop now costs 4 loadout points
balance: Cigar case now costs 1 loadout point.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
