### PR TITLE
Remove admin warnings from opening firedoors

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -315,9 +315,6 @@
 			return //needs power to open unless it was forced
 		else
 			use_power(360)
-	else if (usr)
-		log_admin("[usr]([usr.ckey]) has forced open an emergency shutter.")
-//		message_admins("[usr]([usr.ckey]) has forced open an emergency shutter.")
 
 	if(checkAlarmed())
 		spawn(150)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -317,7 +317,7 @@
 			use_power(360)
 	else if (usr)
 		log_admin("[usr]([usr.ckey]) has forced open an emergency shutter.")
-		message_admins("[usr]([usr.ckey]) has forced open an emergency shutter.")
+//		message_admins("[usr]([usr.ckey]) has forced open an emergency shutter.")
 
 	if(checkAlarmed())
 		spawn(150)


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. ~It's still logged, but no admin messages pop up.~

## Why It's Good For The Game

Admeme asked for this.

## Changelog
:cl:
admin: admins no longer messaged about firedoors being opened
/:cl:
