### PR TITLE
Fix EMP projectile not working sometimes

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -475,6 +475,8 @@ var/list/turret_icons
 	var/damage = Proj.get_structure_damage()
 
 	if(!damage)
+		if(istype(Proj, /obj/item/projectile/ion))
+			Proj.on_hit(loc)
 		return
 
 	if(enabled)

--- a/code/modules/hivemind/machines.dm
+++ b/code/modules/hivemind/machines.dm
@@ -254,6 +254,8 @@
 
 /obj/machinery/hivemind_machine/bullet_act(obj/item/projectile/Proj)
 	take_damage(Proj.get_structure_damage())
+	if(istype(Proj, /obj/item/projectile/ion))
+		Proj.on_hit(loc)
 	. = ..()
 
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -328,7 +328,12 @@
 	..(icon_gib,1)
 
 /mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
-	if(!Proj || Proj.nodamage)
+	if(!Proj)
+		return
+
+	if(Proj.nodamage)
+		if(istype(Proj, /obj/item/projectile/ion))
+			Proj.on_hit(loc)
 		return
 
 	adjustBruteLoss(Proj.get_total_damage())


### PR DESCRIPTION
## About The Pull Request

Remember when you shot a turret or hivemind's mob or machine with ion beam and zero fuck was given? Well, no more.
Don't have to target walls anymore.

## Why It's Good For The Game

Fixes cool.

## Changelog
:cl:
fix: EMP projectile not creating EMP when hit a turret, hivemind structure or simple_mob
/:cl:
