### PR TITLE
Remove "breacher" ammo

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -269,14 +269,14 @@
 	item_cost = 3
 	antag_roles = list(ROLE_TRAITOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/storage/box/sniperammo/uranium
-
+/*
 /datum/uplink_item/item/ammo/sniperammo/breach
 	name = ".60 Anti material \"Breacher\""
 	desc = "A box full of low velocity .60 AMR breaching shells, designed not to pierce, but to destroy structures from a distance. Close-ranged shots have less destructive power. Have 5 shells inside."
 	item_cost = 3
 	antag_roles = list(ROLE_TRAITOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/storage/box/sniperammo/breach
-
+*/
 /datum/uplink_item/item/ammo/sniperammo/large
 	name = ".60 Anti material \"Penetrator\" crate"
 	desc = "A box full of .60 AMR shells. Have 30 shells inside."

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -283,7 +283,7 @@
 	new spawn_type(src)
 	for(var/obj/item/ammo_casing/temp_casing in src)
 		temp_casing.update_icon()
-
+/*
 /obj/item/storage/box/sniperammo/breach
 	name = "box of .60 \"Breacher\" Anti Material shells"
 	desc = "It has a picture of a gun and several warning symbols on the front, including an explosive hazard sign.<br>WARNING: Live breaching ammunition. Misuse may result in serious injury or death."
@@ -297,7 +297,7 @@
 	new spawn_type(src)
 	for(var/obj/item/ammo_casing/temp_casing in src)
 		temp_casing.update_icon()
-
+*/
 /obj/item/storage/box/flashbangs
 	name = "box of flashbangs"
 	desc = "A box containing 7 antipersonnel flashbang grenades.<br> WARNING: These devices are extremely dangerous and can cause blindness or deafness in repeated use."

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -265,7 +265,7 @@
 
 /obj/item/ammo_casing/antim/uranium/prespawned
 	amount = 5
-
+/*
 /obj/item/ammo_casing/antim/breach
 	name = "\"Breacher\" shell casing"
 	desc = "A .60 Anti-Material \"Breacher\" shell."
@@ -275,7 +275,7 @@
 
 /obj/item/ammo_casing/antim/breach/prespawned
 	amount = 5
-
+*/
 /obj/item/ammo_casing/antim/scrap
 	name = "shell casing"
 	desc = "An old .60 Anti-Material shell."

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -204,7 +204,7 @@ There are important things regarding this file:
 	damage_types = list(BRUTE = 65)
 	armor_penetration = 100
 	irradiate = 200
-
+/*
 /obj/item/projectile/bullet/antim/breach
 	damage_types = list(BRUTE = 20)
 	armor_penetration = 40
@@ -234,7 +234,7 @@ There are important things regarding this file:
 		playsound(target, 'sound/effects/explosion1.ogg', 100, 25, 8, 8)
 		if(!istype(target, /obj/machinery/door))
 			fragment_explosion(target, 7, /obj/item/projectile/bullet/pellet/fragment/strong, 50, 5, 1, 0)
-
+*/
 /obj/item/projectile/bullet/antim/scrap
 	damage_types = list(BRUTE = 63)
 


### PR DESCRIPTION
## About The Pull Request

That projectile under specific circumstances may create over 9000 explosions and switch server to turn-based mode or outright kill.
It should go for now.

## Why It's Good For The Game

Dead server is not fun.

## Changelog
:cl:
del: "breacher" .60 ammo
/:cl:
