### PR TITLE
Fix phantom gun after crafting

### DIFF
--- a/code/datums/craft/step.dm
+++ b/code/datums/craft/step.dm
@@ -202,6 +202,7 @@
 			else if(req_amount > 1)
 				. = IN_PROGRESS
 
+			user.drop_from_inventory(I)
 			qdel(I)
 
 	if(target)


### PR DESCRIPTION
## About The Pull Request

Crafting Embedded SMG with a Slaught-o-Matic no longer break player's hands. Hopefully.

## Why It's Good For The Game

Fixes cool.

## Changelog
:cl:
fix: phantom gun after crafting embedded SMG
/:cl:
