### PR TITLE
Fix Integration tests, again

### DIFF
--- a/code/modules/maps/tg/reader.dm
+++ b/code/modules/maps/tg/reader.dm
@@ -91,7 +91,8 @@ var/global/use_preloader = FALSE
 		// (1,1,1) = {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
 		else if(dmmRegex.group[3]) // Coords
 			if(!key_len)
-				throw EXCEPTION("Coords before model definition in DMM")
+				//throw EXCEPTION("Coords before model definition in DMM")
+				return
 
 			var/xcrdStart = text2num(dmmRegex.group[3]) + x_offset - 1
 			//position of the currently processed square


### PR DESCRIPTION
## About The Pull Request

This PR silences "Coords before model definition in DMM" exception in reader.dm in attempt to get rid of failing tests.
Currently integration tests fail with roughly 50% chance due to reader.dm detecting some flaw in our map file.
It doesn't seem to affect actual gameplay, however, and finding what's wrong in a file with 300000+ lines is not that simple.

## Why It's Good For The Game

I don't like red crosses. Nobody does.

## Changelog
:cl:
code: changed some code
/:cl: