### PR TITLE
Surveillance pods

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -696,6 +696,7 @@
 #include "code\game\machinery\suit_storage_unit.dm"
 #include "code\game\machinery\supply_display.dm"
 #include "code\game\machinery\supplybeacon.dm"
+#include "code\game\machinery\surveillance_pod.dm"
 #include "code\game\machinery\teleporter.dm"
 #include "code\game\machinery\turret_control.dm"
 #include "code\game\machinery\vending.dm"

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -169,6 +169,7 @@
 //HUD element hidings flags
 #define F12_FLAG 1 // 0001
 #define TOGGLE_INVENTORY_FLAG 2 //0010
+#define TOGGLE_BOTTOM_FLAG 4 //0100
 
 // Default name for announcement system
 #define ANNOUNCER_NAME "CEV Eris System Announcer"

--- a/code/datums/datum_hud.dm
+++ b/code/datums/datum_hud.dm
@@ -1,8 +1,8 @@
 /datum/hud
 	var/name
-	var/list/HUDneed//for "active" elements (health)
+	var/list/HUDneed //for "active" elements (health)
 //	var/list/HUDprocess = list()
-	var/list/slot_data//inventory stuff (for mob variable HUDinventory)
+	var/list/slot_data //inventory stuff (for mob variable HUDinventory)
 	var/icon/icon = null //what dmi we use
 	var/list/HUDfrippery //for nice view
 	var/list/HUDoverlays //tech stuff (flash overlay, pain overlay, etc.)
@@ -123,26 +123,26 @@
 	"toxin"              = list("type" = /obj/screen/toxin,             "loc" = "EAST+1:16,BOTTOM+7:15",  "minloc" = "RIGHT:16,9:12", "background" = "back18"),
 	"internal"           = list("type" = /obj/screen/internal,          "loc" = "EAST+1,BOTTOM+8:-2",     "minloc" = "RIGHT,10:-5",   "background" = "back15"),
 //corner buttons
-	"jump"               = list("type" = /obj/screen/jump,              "loc" = "EAST+1,BOTTOM+1:-6",     "minloc" = "RIGHT,3:-6",   "background" = "back17-1"),
-	"look up"            = list("type" = /obj/screen/look_up,           "loc" = "EAST,BOTTOM+1:13",         "minloc" = "RIGHT-1,2:13", "background" = "back17-1"),
-	"throw"              = list("type" = /obj/screen/HUDthrow,          "loc" = "EAST+1,BOTTOM+1:13",       "minloc" = "RIGHT,2:13",   "background" = "back17-1"),
-	"pull"               = list("type" = /obj/screen/pull,              "loc" = "EAST-1,BOTTOM+1:13",       "minloc" = "RIGHT-2,2:13", "background" = "back17-1"),
-	"drop"               = list("type" = /obj/screen/drop,              "loc" = "EAST+1,BOTTOM+1",          "minloc" = "RIGHT,2",      "background" = "back17-1"),
-	"resist"             = list("type" = /obj/screen/resist,            "loc" = "EAST-1,BOTTOM+1",          "minloc" = "RIGHT-2,2",    "background" = "back17-1"),
-	"rest"               = list("type" = /obj/screen/rest,              "loc" = "EAST,BOTTOM+1",            "minloc" = "RIGHT-1,2",    "background" = "back17-1"),
-	"move intent"        = list("type" = /obj/screen/mov_intent,        "loc" = "EAST,BOTTOM",          "minloc" = "RIGHT-1,1",    "background" = "back1"),
-	"implant bionics"    = list("type" = /obj/screen/implant_bionics,   "loc" = "EAST-2,BOTTOM-1",        "minloc" = "12,1",         "background" = "back13"),
-	"craft menu"         = list("type" = /obj/screen/craft_menu,        "loc" = "EAST-2:16,BOTTOM",     "minloc" = "12:16,1",      "background" = "back13"),
-	"wield"              = list("type" = /obj/screen/wield,             "loc" = "EAST-2:16,BOTTOM+1",       "minloc" = "12:16,2",      "background" = "back13"),
-	"intent"             = list("type" = /obj/screen/intent,            "loc" = "EAST-1,BOTTOM",        "minloc" = "13,1",         "background" = "back1"),
-	"damage zone"        = list("type" = /obj/screen/zone_sel,          "loc" = "EAST+1,BOTTOM",        "minloc" = "RIGHT,1",      "background" = "back1"),
+	"jump"               = list("type" = /obj/screen/jump,              "loc" = "EAST+1,BOTTOM+1:-6", "minloc" = "RIGHT,3:-6",   "hideflag" = TOGGLE_BOTTOM_FLAG, "background" = "back17-1"),
+	"look up"            = list("type" = /obj/screen/look_up,           "loc" = "EAST,BOTTOM+1:13",   "minloc" = "RIGHT-1,2:13", "hideflag" = TOGGLE_BOTTOM_FLAG, "background" = "back17-1"),
+	"throw"              = list("type" = /obj/screen/HUDthrow,          "loc" = "EAST+1,BOTTOM+1:13", "minloc" = "RIGHT,2:13",   "hideflag" = TOGGLE_BOTTOM_FLAG, "background" = "back17-1"),
+	"pull"               = list("type" = /obj/screen/pull,              "loc" = "EAST-1,BOTTOM+1:13", "minloc" = "RIGHT-2,2:13", "hideflag" = TOGGLE_BOTTOM_FLAG, "background" = "back17-1"),
+	"drop"               = list("type" = /obj/screen/drop,              "loc" = "EAST+1,BOTTOM+1",    "minloc" = "RIGHT,2",      "hideflag" = TOGGLE_BOTTOM_FLAG, "background" = "back17-1"),
+	"resist"             = list("type" = /obj/screen/resist,            "loc" = "EAST-1,BOTTOM+1",    "minloc" = "RIGHT-2,2",    "hideflag" = TOGGLE_BOTTOM_FLAG, "background" = "back17-1"),
+	"rest"               = list("type" = /obj/screen/rest,              "loc" = "EAST,BOTTOM+1",      "minloc" = "RIGHT-1,2",    "hideflag" = TOGGLE_BOTTOM_FLAG, "background" = "back17-1"),
+	"move intent"        = list("type" = /obj/screen/mov_intent,        "loc" = "EAST,BOTTOM",        "minloc" = "RIGHT-1,1",    "hideflag" = TOGGLE_BOTTOM_FLAG, "background" = "back1"),
+	"implant bionics"    = list("type" = /obj/screen/implant_bionics,   "loc" = "EAST-2,BOTTOM-1",    "minloc" = "12,1",         "hideflag" = TOGGLE_BOTTOM_FLAG, "background" = "back13"),
+	"craft menu"         = list("type" = /obj/screen/craft_menu,        "loc" = "EAST-2:16,BOTTOM",   "minloc" = "12:16,1",      "hideflag" = TOGGLE_BOTTOM_FLAG, "background" = "back13"),
+	"wield"              = list("type" = /obj/screen/wield,             "loc" = "EAST-2:16,BOTTOM+1", "minloc" = "12:16,2",      "hideflag" = TOGGLE_BOTTOM_FLAG, "background" = "back13"),
+	"intent"             = list("type" = /obj/screen/intent,            "loc" = "EAST-1,BOTTOM",      "minloc" = "13,1",         "hideflag" = TOGGLE_BOTTOM_FLAG, "background" = "back1"),
+	"damage zone"        = list("type" = /obj/screen/zone_sel,          "loc" = "EAST+1,BOTTOM",      "minloc" = "RIGHT,1",      "hideflag" = TOGGLE_BOTTOM_FLAG, "background" = "back1"),
 //hand buttons
-	"equip"              = list("type" = /obj/screen/equip,             "loc" = "8,1",                "minloc" = "7,2",          "background" = "back14-l"),
-	"swap hand"          = list("type" = /obj/screen/swap,              "loc" = "8,1",                "minloc" = "7,2"),
+	"equip"              = list("type" = /obj/screen/equip,             "loc" = "8,1",                "minloc" = "7,2",          "hideflag" = TOGGLE_BOTTOM_FLAG, "background" = "back14-l"),
+	"swap hand"          = list("type" = /obj/screen/swap,              "loc" = "8,1",                "minloc" = "7,2",          "hideflag" = TOGGLE_BOTTOM_FLAG),
 	"right arm bionics"  = list("type" = /obj/screen/bionics/r_arm,     "loc" = "7:19,1",             "minloc" = "6:20,2",       "background" = "back16"),
 	"left arm bionics"   = list("type" = /obj/screen/bionics/l_arm,     "loc" = "10,1",               "minloc" = "9:-1,2",       "background" = "back16"),
 
-	"toggle inventory"    = list("type" = /obj/screen/toggle_invetory,   "loc" = "2,0",                "minloc" = "1,1",          "background" = "back1")
+	"toggle inventory"    = list("type" = /obj/screen/toggle_invetory,   "loc" = "2,0",                "minloc" = "1,1",          "hideflag" = TOGGLE_BOTTOM_FLAG, "background" = "back1")
 
 	)
 
@@ -155,20 +155,20 @@
 		"Left Ear" =        list("loc" = "4,2", "minloc" = "3,3",     "state" = "ears0",   "hideflag" = TOGGLE_INVENTORY_FLAG, "background" = "back1"),
 		"Right Ear" =        list("loc" = "4,3", "minloc" = "3,4",    "state" = "ears1",   "hideflag" = TOGGLE_INVENTORY_FLAG, "background" = "back1"),
 		"Hat" =         list("loc" = "3,3", "minloc" = "2,4",         "state" = "hair",    "hideflag" = TOGGLE_INVENTORY_FLAG, "background" = "back1"),
-		"Shoes" =        list("loc" = "3,0", "minloc" = "2,1",        "state" = "shoes", "background" = "back1"),
-		"Suit Storage" = list("loc" = "4,0", "minloc" = "3,1",        "state" = "suit-belt", "background" = "back1"),
-		"Back" =         list("loc" = "7,0", "minloc" = "6,1",        "state" = "back", "background" = "back1"),
-		"ID" =           list("loc" = "5,0", "minloc" = "4,1",        "state" = "id", "background" = "back1"),
-		"Left Pocket" =     list("loc" = "10,0", "minloc" = "9,1",    "state" = "pocket_l", "background" = "back1"),
-		"Right Pocket" =     list("loc" = "11,0", "minloc" = "10,1",  "state" = "pocket_r", "background" = "back1"),
-		"Belt" =         list("loc" = "6,0", "minloc" = "5,1",        "state" = "belt", "background" = "back1"),
-		"Left Hand" =       list("loc" = "9,0", "minloc" = "8,1",     "state" = "hand-l", "type" = /obj/screen/inventory/hand, "background" = "back1"),
-		"Right Hand" =       list("loc" = "8,0", "minloc" = "7,1",    "state" = "hand-r", "type" = /obj/screen/inventory/hand, "background" = "back1")
+		"Shoes" =        list("loc" = "3,0", "minloc" = "2,1",        "state" = "shoes",   "hideflag" = TOGGLE_BOTTOM_FLAG,    "background" = "back1"),
+		"Suit Storage" = list("loc" = "4,0", "minloc" = "3,1",        "state" = "suit-belt","hideflag" = TOGGLE_BOTTOM_FLAG,   "background" = "back1"),
+		"Back" =         list("loc" = "7,0", "minloc" = "6,1",        "state" = "back",    "hideflag" = TOGGLE_BOTTOM_FLAG,    "background" = "back1"),
+		"ID" =           list("loc" = "5,0", "minloc" = "4,1",        "state" = "id",      "hideflag" = TOGGLE_BOTTOM_FLAG,    "background" = "back1"),
+		"Left Pocket" =     list("loc" = "10,0", "minloc" = "9,1",    "state" = "pocket_l","hideflag" = TOGGLE_BOTTOM_FLAG,    "background" = "back1"),
+		"Right Pocket" =     list("loc" = "11,0", "minloc" = "10,1",  "state" = "pocket_r","hideflag" = TOGGLE_BOTTOM_FLAG,    "background" = "back1"),
+		"Belt" =         list("loc" = "6,0", "minloc" = "5,1",        "state" = "belt",    "hideflag" = TOGGLE_BOTTOM_FLAG,    "background" = "back1"),
+		"Left Hand" =       list("loc" = "9,0", "minloc" = "8,1",     "state" = "hand-l",  "hideflag" = TOGGLE_BOTTOM_FLAG, "type" = /obj/screen/inventory/hand, "background" = "back1"),
+		"Right Hand" =       list("loc" = "8,0", "minloc" = "7,1",    "state" = "hand-r",  "hideflag" = TOGGLE_BOTTOM_FLAG, "type" = /obj/screen/inventory/hand, "background" = "back1")
 		)
 
 	HUDfrippery = list(
-		list("loc" = "1,0", "icon_state" = "frame0-3", ),
-		list("loc" = "1,0", "icon_state" = "frame3-4", ),
+		list("loc" = "1,0", "icon_state" = "frame0-3", "hideflag" = TOGGLE_BOTTOM_FLAG),
+		list("loc" = "1,0", "icon_state" = "frame3-4", "hideflag" = TOGGLE_BOTTOM_FLAG),
 		list("loc" = "1,1", "icon_state" = "frame2-2",  "hideflag" = TOGGLE_INVENTORY_FLAG),
 		list("loc" = "1,2", "icon_state" = "frame2-3",  "hideflag" = TOGGLE_INVENTORY_FLAG),
 		list("loc" = "1,3", "icon_state" = "frame2-1",  "hideflag" = TOGGLE_INVENTORY_FLAG),
@@ -178,11 +178,11 @@
 		list("loc" = "5,1", "icon_state" = "frame1-2",  "hideflag" = TOGGLE_INVENTORY_FLAG),
 		list("loc" = "5,2", "icon_state" = "frame1-6",  "hideflag" = TOGGLE_INVENTORY_FLAG),
 		list("loc" = "5,3", "icon_state" = "frame1-4", "hideflag" = TOGGLE_INVENTORY_FLAG),
-		list("loc" = "8,1:13", "icon_state" = "frame1-8"),
-		list("loc" = "9,1:13", "icon_state" = "frame1-1"),
-		list("loc" = "12,0", "icon_state" = "frame3-2"),
-		list("loc" = "12,0", "icon_state" = "frame0-2"),
-		list("loc" = "12,0", "icon_state" = "frame0-3"),
+		list("loc" = "8,1:13", "icon_state" = "frame1-8", "hideflag" = TOGGLE_BOTTOM_FLAG),
+		list("loc" = "9,1:13", "icon_state" = "frame1-1", "hideflag" = TOGGLE_BOTTOM_FLAG),
+		list("loc" = "12,0", "icon_state" = "frame3-2", "hideflag" = TOGGLE_BOTTOM_FLAG),
+		list("loc" = "12,0", "icon_state" = "frame0-2", "hideflag" = TOGGLE_BOTTOM_FLAG),
+		list("loc" = "12,0", "icon_state" = "frame0-3", "hideflag" = TOGGLE_BOTTOM_FLAG),
 		list("loc" = "EAST+1,BOTTOM+2:25", "icon_state" = "frame1-1"),
 		list("loc" = "EAST+1,BOTTOM+2:25", "icon_state" = "frame3-3"),
 		list("loc" = "EAST+1,BOTTOM+2:25", "icon_state" = "frame0-4"),

--- a/code/game/machinery/surveillance_pod.dm
+++ b/code/game/machinery/surveillance_pod.dm
@@ -135,38 +135,27 @@
 	trigger(user)
 
 
-/obj/machinery/surveillance_pod/verb/activate_verb(mob/user)
-	set src in view(0)
-	set category = "Object"
-	set name = "Activate Pod"
-
-	trigger(user)
-
-
 /obj/machinery/surveillance_pod/verb/eject()
 	set src in view(1)
 	set category = "Object"
 	set name = "Eject Occupant"
 
-	if (usr.incapacitated())
-		return
-
-	eject_occupant()
+	try_eject_occupant(usr)
 	add_fingerprint(usr)
 	return
 
 
 /obj/machinery/surveillance_pod/relaymove(mob/user)
-	if(user.incapacitated())
-		return
-
-	eject_occupant()
+	try_eject_occupant(user)
 
 
 /obj/machinery/surveillance_pod/verb/move_inside()
 	set src in view(1)
 	set category = "Object"
 	set name = "Enter Pod"
+
+	if(usr.incapacitated())
+		return
 
 	try_set_occupant(usr)
 	add_fingerprint(usr)
@@ -237,9 +226,16 @@
 	update_icon()
 
 
-/obj/machinery/surveillance_pod/proc/eject_occupant()
+/obj/machinery/surveillance_pod/proc/try_eject_occupant(mob/user)
 	if(!occupant)
 		return
+
+	if(user.incapacitated())
+		return
+	
+	if(user != occupant)
+		if(isghost(user))
+			return
 
 	deactivate()
 	occupant.forceMove(loc)
@@ -251,7 +247,7 @@
 
 /obj/machinery/surveillance_pod/Destroy()
 	if(occupant)
-		occupant.ghostize(0)
+		occupant.ghostize(FALSE)
 		occupant.gib()
 
 	qdel(fake_liquid)

--- a/code/game/machinery/surveillance_pod.dm
+++ b/code/game/machinery/surveillance_pod.dm
@@ -268,7 +268,6 @@
 	..()
 
 
-// UI nuddles //
 /obj/machinery/surveillance_pod/proc/handle_occupant_UI(hide_ui)
 	if(hide_ui)
 		for(var/obj/screen/inventory/IS in occupant.HUDinventory)

--- a/code/game/machinery/surveillance_pod.dm
+++ b/code/game/machinery/surveillance_pod.dm
@@ -40,7 +40,7 @@
 	acceleration = FALSE
 
 
-/obj/machinery/surveillance_pod/New()
+/obj/machinery/surveillance_pod/Initialize(mapload)
 	..()
 	big_brother = new(src)
 	big_brother.visualnet = cameranet

--- a/code/game/machinery/surveillance_pod.dm
+++ b/code/game/machinery/surveillance_pod.dm
@@ -33,10 +33,12 @@
 		"pressure",
 		"toxin",
 		"internal"
-		) // Don't even get me started on HUDneed. This thing is required for UI hiding to work how intended
+		) // Don't even get me started on HUDneed. This thing is required for UI hiding to work
 
-/mob/observer/eye/pod
+
+/mob/observer/eye/pod // New child object to run create_UI() using it
 	acceleration = FALSE
+
 
 /obj/machinery/surveillance_pod/New()
 	..()
@@ -345,3 +347,10 @@
 			if(H.r_store)    H.r_store.screen_loc    = (inv_elem.invisibility == 101) ? null : inv_elem.screen_loc
 		if(slot_s_store)
 			if(H.s_store)    H.s_store.screen_loc    = (inv_elem.invisibility == 101) ? null : inv_elem.screen_loc
+
+
+/mob/proc/acceleration_toogle()
+	if(!eyeobj)
+		return
+
+	eyeobj.acceleration = !eyeobj.acceleration

--- a/code/game/machinery/surveillance_pod.dm
+++ b/code/game/machinery/surveillance_pod.dm
@@ -86,8 +86,8 @@
 	return TRUE
 
 
-/obj/machinery/surveillance_pod/proc/trigger()
-	if(usr.incapacitated())
+/obj/machinery/surveillance_pod/proc/trigger(mob/user)
+	if(user.incapacitated())
 		return
 
 	if(occupant)
@@ -132,15 +132,15 @@
 
 
 /obj/machinery/surveillance_pod/attack_hand(mob/user)
-	trigger()
+	trigger(user)
 
 
-/obj/machinery/surveillance_pod/verb/activate_verb()
+/obj/machinery/surveillance_pod/verb/activate_verb(mob/user)
 	set src in view(0)
 	set category = "Object"
 	set name = "Activate Pod"
 
-	trigger()
+	trigger(user)
 
 
 /obj/machinery/surveillance_pod/verb/eject()

--- a/code/game/machinery/surveillance_pod.dm
+++ b/code/game/machinery/surveillance_pod.dm
@@ -1,0 +1,243 @@
+/obj/machinery/surveillance_pod
+	name = "E.Y.E. surveillance pod"
+	desc = "A man-sized pod filled with pitch black liquid."
+	icon = 'icons/obj/Cryogenic2.dmi'
+	icon_state = "cryopod"
+	density = TRUE
+	anchored = TRUE
+
+	var/mob/living/carbon/human/occupant
+	var/mob/observer/eye/big_brother
+	var/datum/gas_mixture/environment
+
+	var/list/compatible_jumpsuits = list(
+	/obj/item/clothing/under/cyber
+	)
+
+	var/list/compatible_helmets = list(
+	/obj/item/clothing/head/armor/helmet/visor/cyberpunkgoggle,
+	/obj/item/clothing/head/armor/helmet/visor/cyberpunkgoggle/armored
+	)
+
+//	var/list/compatible_glasses = list()
+
+
+/obj/machinery/surveillance_pod/New()
+	..()
+	big_brother = new(src)
+	big_brother.visualnet = cameranet
+	environment = new/datum/gas_mixture // Pod filled with liqid
+	environment.adjust_gas_temp("carbon_dioxide", 100, 300, 1) // But alas, there is no liquids in the code!
+	update_icon()
+
+
+/obj/machinery/surveillance_pod/return_air()
+	return environment // Safe temperature and pressure, but can't breathe without internals
+
+
+/obj/machinery/surveillance_pod/check_eye(mob/user)
+	return FALSE // Don't reset view to mob's location every second
+
+
+/obj/machinery/surveillance_pod/proc/can_activate()
+	if(!occupant)
+		audible_message(SPAN_WARNING("[src] beeps: 'ERROR: Operator not found.'"))
+		return FALSE
+
+	if(occupant.stat == DEAD)
+		audible_message(SPAN_WARNING("[src] beeps: 'ERROR: Operator's brain activity below required threshold.'"))
+		return FALSE
+
+	if(!occupant.client)
+		audible_message(SPAN_WARNING("[src] beeps: 'ERROR: Operator's brain activity below required threshold.'"))
+		return FALSE
+
+	if(!(occupant.w_uniform && (occupant.w_uniform.type in compatible_jumpsuits)))
+		audible_message(SPAN_WARNING("[src] beeps: 'ERROR: Failed to establish connection with a cybersuit.'"))
+		to_chat(occupant, SPAN_WARNING("[src] beeps: 'ERROR: Failed to establish connection with a cybersuit.'"))
+		return FALSE
+
+	if(!(occupant.head && (occupant.head.type in compatible_helmets)))
+		audible_message(SPAN_WARNING("[src] beeps: 'ERROR: Failed to locate compatible visor.'"))
+		to_chat(occupant, SPAN_WARNING("[src] beeps: 'ERROR: Failed to locate compatible visor.'"))
+		return FALSE
+
+	if(stat & (BROKEN|NOPOWER))
+		return FALSE
+
+	return TRUE
+
+
+/obj/machinery/surveillance_pod/proc/activate()
+	if(!can_activate())
+		return
+
+	for(var/datum/chunk/C in big_brother.visibleChunks)
+		C.remove(big_brother)
+	big_brother.forceMove(src)
+	big_brother.owner = occupant
+	occupant.eyeobj = big_brother
+
+
+/obj/machinery/surveillance_pod/proc/deactivate()
+	if(big_brother.owner)
+		for(var/datum/chunk/C in big_brother.visibleChunks)
+			C.remove(big_brother)
+		big_brother.owner.eyeobj = null
+		big_brother.owner.reset_view()
+		big_brother.owner = null
+
+
+/obj/machinery/surveillance_pod/on_update_icon()
+	if(occupant)
+		icon_state = "[initial(icon_state)]_1"
+	else
+		icon_state = "[initial(icon_state)]_0"
+
+
+/obj/machinery/surveillance_pod/verb/activate_verb()
+	set src in view(0)
+	set category = "Object"
+	set name = "Activate Pod"
+
+	if(usr.incapacitated())
+		return
+
+	if(occupant)
+		if(occupant.eyeobj == big_brother)
+			deactivate()
+		else
+			activate()
+	return
+
+
+/obj/machinery/surveillance_pod/verb/eject()
+	set src in view(1)
+	set category = "Object"
+	set name = "Eject Occupant"
+
+	if (usr.incapacitated())
+		return
+
+	eject_occupant()
+	add_fingerprint(usr)
+	return
+
+
+/obj/machinery/surveillance_pod/relaymove(mob/user)
+	if(user.incapacitated())
+		return
+
+	eject_occupant()
+
+
+/obj/machinery/surveillance_pod/verb/move_inside()
+	set src in view(1)
+	set category = "Object"
+	set name = "Enter Pod"
+
+	try_set_occupant(usr)
+	add_fingerprint(usr)
+	return
+
+
+/obj/machinery/surveillance_pod/MouseDrop_T(mob/target, mob/user)
+	try_set_occupant(target, user)
+	add_fingerprint(user)
+	return TRUE
+
+
+/obj/machinery/surveillance_pod/affect_grab(mob/user, mob/target)
+	try_set_occupant(target, user)
+	add_fingerprint(user)
+	return TRUE
+
+
+/obj/machinery/surveillance_pod/proc/try_set_occupant(mob/target, mob/user)
+	if(!target)
+		return
+
+	if(!user)
+		user = target
+
+	if(user.incapacitated())
+		return
+
+	if(occupant)
+		to_chat(user, SPAN_WARNING("\The [src] is already occupied."))
+		return
+
+	if(!ishuman(target))
+		return
+
+	var/mob/living/carbon/human/T = target
+
+	if(T.abiotic(FALSE))
+		if(target == user)
+			to_chat(user, SPAN_WARNING("You can't fit in while holding [T.l_hand ? T.l_hand : T.r_hand]."))
+		else
+			to_chat(user, SPAN_WARNING("[target] can't fit in while holding [T.l_hand ? T.l_hand : T.r_hand]."))
+		return
+
+	if(T.wear_suit)
+		if(target == user)
+			to_chat(user, SPAN_WARNING("You can't fit in while wearing [T.wear_suit]."))
+		else
+			to_chat(user, SPAN_WARNING("[target] can't fit in while wearing [T.wear_suit]."))
+		return
+
+	if(target == user)
+		visible_message("\The [user] starts climbing into \the [src].")
+	else
+		visible_message("\The [user] starts putting [target] into \the [src].")
+
+	if(!do_after(user, 20, src) || !Adjacent(target))
+		return
+
+	if(occupant)
+		to_chat(user, SPAN_WARNING("\The [src] is already occupied."))
+		return
+
+	target.forceMove(src)
+	target.set_machine(src)
+	occupant = target
+	update_use_power(ACTIVE_POWER_USE)
+	update_icon()
+
+
+/obj/machinery/surveillance_pod/proc/eject_occupant()
+	if(!occupant)
+		return
+
+	deactivate()
+	occupant.forceMove(loc)
+	occupant.unset_machine()
+	occupant = null
+	update_use_power(IDLE_POWER_USE)
+	update_icon()
+
+
+/obj/machinery/surveillance_pod/attack_hand(mob/user)
+	if(occupant)
+		if(occupant.eyeobj == big_brother)
+			deactivate()
+		else
+			activate()
+
+
+/obj/machinery/surveillance_pod/Destroy()
+	if(occupant)
+		occupant.ghostize(0)
+		occupant.gib()
+
+	qdel(environment)
+	qdel(big_brother)
+	return ..()
+
+
+/obj/machinery/surveillance_pod/attackby(obj/item/I, mob/living/user)
+	if(default_deconstruction(I, user))
+		return
+	if(default_part_replacement(I, user))
+		return
+	..()

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -477,6 +477,18 @@
 		rad = 0
 	)
 
+/obj/item/clothing/head/armor/helmet/visor/cyberpunkgoggle/armored
+	name = "\improper Type-34 Semi-Enclosed Headwear"
+	desc = "Helmet used by certain law enforcement agencies."
+	armor = list(
+		melee = 30,
+		bullet = 30,
+		energy = 30,
+		bomb = 20,
+		bio = 0,
+		rad = 0
+	)
+
 /obj/item/clothing/head/armor/helmet/crusader
 	name = "crusader helmet"
 	desc = "May God guide you."

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -479,7 +479,7 @@
 
 /obj/item/clothing/head/armor/helmet/visor/cyberpunkgoggle/armored
 	name = "\improper Type-34 Semi-Enclosed Headwear"
-	desc = "Helmet used by certain law enforcement agencies."
+	desc = "Armored helmet used by certain law enforcement agencies. It's hard to believe there's a human somewhere behind that."
 	armor = list(
 		melee = 30,
 		bullet = 30,

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -247,6 +247,7 @@
 	flags_inv = HIDEFACE
 	body_parts_covered = 0
 	var/mob/observer/eye/aiEye/eye
+	spawn_blacklisted = TRUE
 
 /obj/item/clothing/mask/ai/Initialize(mapload, ...)
 	. = ..()

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -222,6 +222,12 @@ obj/item/clothing/under/cyber
 	icon_state = "cyber"
 	item_state = "cyber"
 
+obj/item/clothing/under/netrunner
+	name = "cybersuit"
+	desc = "Jumpsuit favored by surveillance officers and VR gamers alike. Ugly as sin. Luckily, in cyberspace no one can see your realspace clothing."
+	icon_state = "jensen"
+	item_state = "jensen"
+
 obj/item/clothing/under/genericb
 	name = "blue generic outfit"
 	desc = "A simple blue shirt with brown pants."

--- a/code/modules/mob/living/silicon/ai/ai_HUDs.dm
+++ b/code/modules/mob/living/silicon/ai/ai_HUDs.dm
@@ -63,3 +63,36 @@
 	actionPanel.setAlignment(HUD_CENTER_ALIGNMENT, HUD_VERTICAL_SOUTH_INSIDE_ALIGNMENT)
 	navigationPanel.setAlignment(HUD_HORIZONTAL_EAST_INSIDE_ALIGNMENT, HUD_VERTICAL_SOUTH_INSIDE_ALIGNMENT)
 	postBuildUI()
+
+/datum/interface/AI_Simple
+	mobtype = /mob/observer/eye/pod
+	styleName = "ErisStyle"
+
+/datum/interface/AI_Simple/buildUI()
+	// #####	CREATING LAYOUTS    #####
+	var/HUD_element/layout/vertical/navigationPanel = newUIElement("navigationPanel", /HUD_element/layout/vertical)
+	
+	// #####	CREATING LIST THAT WILL CONTAIN ELEMENTS FOR EASY ACCESS    #####
+	var/list/HUD_element/navigation = list()
+
+	// #####	CREATING UI ELEMENTS AND ASSIGNING THEM APPROPRIATE LISTS    #####
+//	navigation += newUIElement("Track With Camera", /HUD_element/button/thin/ai, list(icon = 'icons/mob/screen/silicon/AI/HUD_actionButtons.dmi',icon_state = "track"))
+	navigation += newUIElement("Crew Sensors", /HUD_element/button/thin/ai, list(icon = 'icons/mob/screen/silicon/AI/HUD_actionButtons.dmi',icon_state = "crew_sensors"))
+	navigation += newUIElement("Reset Camera", /HUD_element/button/thin/ai, list(icon = 'icons/mob/screen/silicon/AI/HUD_actionButtons.dmi',icon_state = "core"))
+	navigation += newUIElement("Move Downwards", /HUD_element/button/thin/ai, list(icon = 'icons/mob/screen/silicon/AI/HUD_actionButtons.dmi',icon_state = "down"))
+	navigation += newUIElement("Move Upwards", /HUD_element/button/thin/ai, list(icon = 'icons/mob/screen/silicon/AI/HUD_actionButtons.dmi',icon_state = "up"))
+
+	// #####	ADDING CLICK PROCS TO BUTTONS    #####
+//	getElementByID("Track With Camera").setClickProc(/mob/living/silicon/ai/proc/ai_camera_track, _observer.mob)
+	getElementByID("Crew Sensors").setClickProc(/mob/observer/eye/pod/proc/show_crew_sensors, _observer.mob)
+	getElementByID("Reset Camera").setClickProc(/mob/observer/eye/pod/proc/reset_position, _observer.mob)
+	getElementByID("Move Downwards").setClickProc(/mob/observer/eye/pod/proc/movedown, _observer.mob)
+	getElementByID("Move Upwards").setClickProc(/mob/observer/eye/pod/proc/moveup, _observer.mob)
+
+
+	// #####	ALIGNING ELEMENTS USING LAYOUTS    #####
+	navigationPanel.alignElements(HUD_NO_ALIGNMENT, HUD_VERTICAL_NORTH_INSIDE_ALIGNMENT, navigation, 0)
+
+	// #####	ALIGNING LAYOUTS TO SCREEN    #####
+	navigationPanel.setAlignment(HUD_HORIZONTAL_EAST_INSIDE_ALIGNMENT, HUD_VERTICAL_SOUTH_INSIDE_ALIGNMENT)
+	postBuildUI()

--- a/code/modules/mob/living/silicon/ai/ai_HUDs.dm
+++ b/code/modules/mob/living/silicon/ai/ai_HUDs.dm
@@ -64,6 +64,8 @@
 	navigationPanel.setAlignment(HUD_HORIZONTAL_EAST_INSIDE_ALIGNMENT, HUD_VERTICAL_SOUTH_INSIDE_ALIGNMENT)
 	postBuildUI()
 
+
+// Simplified version of AI HUD accessible to humans. Used in surveillance_pod.dm
 /datum/interface/AI_Simple
 	mobtype = /mob/observer/eye/pod
 	styleName = "ErisStyle"
@@ -77,18 +79,17 @@
 
 	// #####	CREATING UI ELEMENTS AND ASSIGNING THEM APPROPRIATE LISTS    #####
 //	navigation += newUIElement("Track With Camera", /HUD_element/button/thin/ai, list(icon = 'icons/mob/screen/silicon/AI/HUD_actionButtons.dmi',icon_state = "track"))
-	navigation += newUIElement("Crew Sensors", /HUD_element/button/thin/ai, list(icon = 'icons/mob/screen/silicon/AI/HUD_actionButtons.dmi',icon_state = "crew_sensors"))
+//	navigation += newUIElement("Crew Sensors", /HUD_element/button/thin/ai, list(icon = 'icons/mob/screen/silicon/AI/HUD_actionButtons.dmi',icon_state = "crew_sensors"))
 	navigation += newUIElement("Reset Camera", /HUD_element/button/thin/ai, list(icon = 'icons/mob/screen/silicon/AI/HUD_actionButtons.dmi',icon_state = "core"))
 	navigation += newUIElement("Move Downwards", /HUD_element/button/thin/ai, list(icon = 'icons/mob/screen/silicon/AI/HUD_actionButtons.dmi',icon_state = "down"))
 	navigation += newUIElement("Move Upwards", /HUD_element/button/thin/ai, list(icon = 'icons/mob/screen/silicon/AI/HUD_actionButtons.dmi',icon_state = "up"))
 
 	// #####	ADDING CLICK PROCS TO BUTTONS    #####
 //	getElementByID("Track With Camera").setClickProc(/mob/living/silicon/ai/proc/ai_camera_track, _observer.mob)
-	getElementByID("Crew Sensors").setClickProc(/mob/observer/eye/pod/proc/show_crew_sensors, _observer.mob)
-	getElementByID("Reset Camera").setClickProc(/mob/observer/eye/pod/proc/reset_position, _observer.mob)
-	getElementByID("Move Downwards").setClickProc(/mob/observer/eye/pod/proc/movedown, _observer.mob)
-	getElementByID("Move Upwards").setClickProc(/mob/observer/eye/pod/proc/moveup, _observer.mob)
-
+//	getElementByID("Crew Sensors").setClickProc(/mob/proc/show_crew_sensors, _observer.mob)
+	getElementByID("Reset Camera").setClickProc(/mob/proc/reset_view, _observer.mob)
+	getElementByID("Move Downwards").setClickProc(/mob/proc/zMoveDown, _observer.mob)
+	getElementByID("Move Upwards").setClickProc(/mob/proc/zMoveUp, _observer.mob)
 
 	// #####	ALIGNING ELEMENTS USING LAYOUTS    #####
 	navigationPanel.alignElements(HUD_NO_ALIGNMENT, HUD_VERTICAL_NORTH_INSIDE_ALIGNMENT, navigation, 0)

--- a/code/modules/mob/living/silicon/ai/ai_HUDs.dm
+++ b/code/modules/mob/living/silicon/ai/ai_HUDs.dm
@@ -80,6 +80,7 @@
 	// #####	CREATING UI ELEMENTS AND ASSIGNING THEM APPROPRIATE LISTS    #####
 //	navigation += newUIElement("Track With Camera", /HUD_element/button/thin/ai, list(icon = 'icons/mob/screen/silicon/AI/HUD_actionButtons.dmi',icon_state = "track"))
 //	navigation += newUIElement("Crew Sensors", /HUD_element/button/thin/ai, list(icon = 'icons/mob/screen/silicon/AI/HUD_actionButtons.dmi',icon_state = "crew_sensors"))
+	navigation += newUIElement("Toogle Acceleration", /HUD_element/button/thin/ai, list(icon = 'icons/mob/screen/silicon/AI/HUD_actionButtons.dmi',icon_state = "camera_light"))
 	navigation += newUIElement("Reset Camera", /HUD_element/button/thin/ai, list(icon = 'icons/mob/screen/silicon/AI/HUD_actionButtons.dmi',icon_state = "core"))
 	navigation += newUIElement("Move Downwards", /HUD_element/button/thin/ai, list(icon = 'icons/mob/screen/silicon/AI/HUD_actionButtons.dmi',icon_state = "down"))
 	navigation += newUIElement("Move Upwards", /HUD_element/button/thin/ai, list(icon = 'icons/mob/screen/silicon/AI/HUD_actionButtons.dmi',icon_state = "up"))
@@ -87,6 +88,7 @@
 	// #####	ADDING CLICK PROCS TO BUTTONS    #####
 //	getElementByID("Track With Camera").setClickProc(/mob/living/silicon/ai/proc/ai_camera_track, _observer.mob)
 //	getElementByID("Crew Sensors").setClickProc(/mob/proc/show_crew_sensors, _observer.mob)
+	getElementByID("Toogle Acceleration").setClickProc(/mob/proc/acceleration_toogle, _observer.mob)
 	getElementByID("Reset Camera").setClickProc(/mob/proc/reset_view, _observer.mob)
 	getElementByID("Move Downwards").setClickProc(/mob/proc/zMoveDown, _observer.mob)
 	getElementByID("Move Upwards").setClickProc(/mob/proc/zMoveUp, _observer.mob)

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -89,6 +89,12 @@
 	to_chat(src, SPAN_NOTICE("You lack a means of z-travel in that direction."))
 	return FALSE
 
+/mob/proc/zMoveUp()
+	return zMove(UP)
+
+/mob/proc/zMoveDown()
+	return zMove(DOWN)
+
 /mob/living/zMove(direction)
 	if (is_ventcrawling)
 		var/obj/machinery/atmospherics/pipe/zpipe/P = loc

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -332,10 +332,14 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/security/armory)
 "aba" = (
-/obj/structure/closet/l3closet/security,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/closet,
+/obj/item/clothing/under/netrunner,
+/obj/item/clothing/under/netrunner,
+/obj/item/clothing/head/armor/helmet/visor/cyberpunkgoggle/armored,
+/obj/item/clothing/head/armor/helmet/visor/cyberpunkgoggle/armored,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/security/armory)
 "abb" = (
@@ -1550,6 +1554,10 @@
 /area/eris/security/armory)
 "adQ" = (
 /obj/structure/table/rack,
+/obj/item/tank/emergency_oxygen/double,
+/obj/item/tank/emergency_oxygen/double,
+/obj/item/tank/emergency_oxygen/double,
+/obj/item/tank/emergency_oxygen/double,
 /obj/item/tank/emergency_oxygen/double,
 /obj/item/tank/emergency_oxygen/double,
 /turf/simulated/floor/tiled/dark/cargo,
@@ -100714,6 +100722,12 @@
 /obj/effect/shuttle_landmark/merc/southwest,
 /turf/space,
 /area/space)
+"eGL" = (
+/obj/machinery/surveillance_pod{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/cargo,
+/area/eris/security/armory)
 "eGV" = (
 /mob/living/simple_animal/cow{
 	name = "Beatriz"
@@ -101261,6 +101275,10 @@
 	},
 /turf/simulated/floor/grass,
 /area/eris/crew_quarters/hydroponics/garden)
+"fvm" = (
+/obj/structure/cryofeed,
+/turf/simulated/floor/tiled/dark/cargo,
+/area/eris/security/armory)
 "fzU" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 4
@@ -105147,6 +105165,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/atmos)
+"uHR" = (
+/obj/machinery/surveillance_pod,
+/turf/simulated/floor/tiled/dark/cargo,
+/area/eris/security/armory)
 "uLw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -105902,6 +105924,12 @@
 /obj/spawner/scrap/sparse,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5starboard)
+"xqY" = (
+/obj/structure/cryofeed{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/cargo,
+/area/eris/security/armory)
 "xuA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -126991,7 +127019,7 @@ ade
 adm
 aeo
 aec
-abS
+xqY
 aaR
 aaa
 aaa
@@ -127193,7 +127221,7 @@ adf
 adO
 aep
 aeQ
-abS
+eGL
 aaR
 aaa
 aaa
@@ -127395,7 +127423,7 @@ eoq
 adP
 aeq
 aeU
-abS
+uHR
 aaR
 aaa
 aaa
@@ -127597,7 +127625,7 @@ abS
 abS
 aer
 aeU
-abS
+fvm
 aaR
 aaa
 aaa

--- a/maps/submaps/deepmaint_rooms/core/ai_core.dmm
+++ b/maps/submaps/deepmaint_rooms/core/ai_core.dmm
@@ -26,15 +26,15 @@
 "af" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating/under,
 /area/deepmaint)
 "ag" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -184,10 +184,10 @@
 /area/deepmaint)
 "aF" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/deepmaint)
@@ -197,9 +197,9 @@
 /area/deepmaint)
 "aH" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/deepmaint)
@@ -213,8 +213,8 @@
 /area/deepmaint)
 "aJ" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/wall/r_wall,
 /area/deepmaint)
@@ -247,8 +247,8 @@
 "aP" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plating/under,
@@ -349,22 +349,22 @@
 /area/deepmaint)
 "bh" = (
 /obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 4
+	dir = 4;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/deepmaint)
 "bi" = (
 /obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 8
+	dir = 8;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/deepmaint)
 "bj" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-s";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/structure/catwalk,
 /obj/machinery/light{
@@ -380,15 +380,15 @@
 /area/deepmaint)
 "bl" = (
 /obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 4
+	dir = 4;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/deepmaint)
 "bm" = (
 /obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 8
+	dir = 8;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/deepmaint)

--- a/maps/submaps/deepmaint_rooms/core/ai_core.dmm
+++ b/maps/submaps/deepmaint_rooms/core/ai_core.dmm
@@ -26,15 +26,15 @@
 "af" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	icon_state = "pipe-s";
+	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/deepmaint)
 "ag" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	icon_state = "pipe-s";
+	dir = 4
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -184,10 +184,10 @@
 /area/deepmaint)
 "aF" = (
 /obj/structure/railing{
-	anchored = 1;
-	dir = 4;
+	tag = "icon-railing0 (EAST)";
 	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
+	dir = 4;
+	anchored = 1
 	},
 /turf/simulated/floor/plating/under,
 /area/deepmaint)
@@ -197,9 +197,9 @@
 /area/deepmaint)
 "aH" = (
 /obj/structure/railing{
-	dir = 8;
+	tag = "icon-railing0 (WEST)";
 	icon_state = "railing0";
-	tag = "icon-railing0 (WEST)"
+	dir = 8
 	},
 /turf/simulated/floor/plating/under,
 /area/deepmaint)
@@ -213,8 +213,8 @@
 /area/deepmaint)
 "aJ" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	icon_state = "pipe-s";
+	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/deepmaint)
@@ -247,8 +247,8 @@
 "aP" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	icon_state = "pipe-s";
+	dir = 4
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plating/under,
@@ -349,22 +349,22 @@
 /area/deepmaint)
 "bh" = (
 /obj/item/modular_computer/console/preset/command{
-	dir = 4;
-	icon_state = "console"
+	icon_state = "console";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/deepmaint)
 "bi" = (
 /obj/item/modular_computer/console/preset/command{
-	dir = 8;
-	icon_state = "console"
+	icon_state = "console";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/deepmaint)
 "bj" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	icon_state = "pipe-s";
+	dir = 4
 	},
 /obj/structure/catwalk,
 /obj/machinery/light{
@@ -380,15 +380,15 @@
 /area/deepmaint)
 "bl" = (
 /obj/item/modular_computer/console/preset/command{
-	dir = 4;
-	icon_state = "console"
+	icon_state = "console";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/deepmaint)
 "bm" = (
 /obj/item/modular_computer/console/preset/command{
-	dir = 8;
-	icon_state = "console"
+	icon_state = "console";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/deepmaint)


### PR DESCRIPTION
## About The Pull Request

Added a surveillance pod, stationary version of old "camera MIU" mask used by Bay12's ninja antagonist.
Mask have been spawning in trash until now.
Pods have same functionality as "camera MIU", minus constant runtimes and plus UI buttons.
To use it, player should have empty suit slot, internals, special jumpsuit and headgear.

Compatible headgear:
Type-34C (cyberpunkish helmet from loadout)
Type-34 (same helmet with armor stats slightly lower than on operator's helmet. Two of those found in the armory.)

Compatible jumpsuits:
Augmented jumpsuit (from loadout)
Cybersuit ("new" jumpsuit with sprite of black HoS uniform. Two of those found in the armory.)

<details>
  <summary>
    Screenshots
  </summary>

![image](https://user-images.githubusercontent.com/65828539/139855368-a00e0ad8-8a8d-497d-9869-6527aa611b59.png)
![image](https://user-images.githubusercontent.com/65828539/139855397-9ccdf0e8-ead4-496b-b603-472631c5764b.png)

</details>



## Why It's Good For The Game

Cool feature.

## Changelog
:cl:
add: armored version of type-34 helmet
add: surveillance pods, stationary version of camera MIU
tweak: armory have 6 oxygen tanks instead of 2
tweak: camera MIU blacklisted from spawn
/:cl: