### PR TITLE
Erismed 3.1 , adds scaling metabolization based off liver , stomach and heart efficiency

### DIFF
--- a/code/modules/organs/internal/internal_organ_processes.dm
+++ b/code/modules/organs/internal/internal_organ_processes.dm
@@ -26,7 +26,7 @@
 		for(var/organ in process_list)
 			var/obj/item/organ/internal/I = organ
 			effective_efficiency += I.get_process_eficiency(process_define)
-		
+
 	return effective_efficiency ? effective_efficiency : 1
 
 /mob/living/carbon/human/get_specific_organ_efficiency(process_define, parent_organ_tag)
@@ -41,7 +41,7 @@
 			var/obj/item/organ/internal/I = organ
 			if(process_define in I.organ_efficiency)
 				effective_efficiency += I.get_process_eficiency(process_define)
-	
+
 	return effective_efficiency ? effective_efficiency : 1
 
 /mob/living/carbon/human/proc/eye_process()
@@ -166,7 +166,7 @@
 		if(getOxyLoss() < 10)
 			adjustOxyLoss(1)
 
-	if(blood_volume > total_blood_req)	
+	if(blood_volume > total_blood_req)
 		status_flags &= ~BLEEDOUT
 
 	//Blood regeneration if there is some space


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ingested metabolization now works based off  ( stomach_eff + liver_eff + heart_eff ) / 300
Bloodstream metabolization now works based off (liver_Eff + heart_eff * 2) / 300

## Why It's Good For The Game
I put 3 hearts in me why don't i process shit faster >:(((
## Changelog
:cl:
add: Ingested reagents metabolization now scales off your stomach , liver and heart efficiency combined.
add: Bloodstream reagents metabolizatio now scales off your liver_eff  and heart efficiency
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
