### PR TITLE
Fixes low yield EMP grenades being as effective as normal ones

### DIFF
--- a/code/game/objects/items/weapons/grenades/emgrenade.dm
+++ b/code/game/objects/items/weapons/grenades/emgrenade.dm
@@ -19,8 +19,10 @@
 	item_state = "empgrenade"
 	origin_tech = list(TECH_MATERIAL = 2, TECH_MAGNET = 3)
 
-/obj/item/grenade/empgrenade/low_yield/prime()
-	..()
+/obj/item/grenade/empgrenade/low_yield/prime() // Inheritance is a fuck . this made low yields as effective as normal.
+	var/turf/T = get_turf(src)
+	if(T)
+		T.hotspot_expose(700,125)
 	if(empulse(src, 4, 1))
 		icon_state = "emp_off"
 		desc = "[initial(desc)] It has already been used."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes low yield EMP grenades having the same effects as normal ones

## Why It's Good For The Game
Le buy 30 low yield emp grenades , le not spend TC for proper ones.
## Changelog
:cl:
fix: Fixed Low Yield Emp Grenades having the same effects as a normal one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
