### PR TITLE
Removes water-pot explosion reaction , replaces it with fire

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -491,7 +491,7 @@ steam.start() -- spawns the effect
 
 /datum/effect/effect/system/pottasium_sparkle_explosion/start()
 	started = world.time + duration
-	looping_fire(fire_stacks)
+	looping_fire()
 
 /datum/effect/effect/system/pottasium_sparkle_explosion/proc/looping_fire()
 	var/particles_to_throw = amount_rating / 50 // 10 big particles in the worst case that break into 30

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -490,11 +490,10 @@ steam.start() -- spawns the effect
 	src.light_range = light_range
 
 /datum/effect/effect/system/pottasium_sparkle_explosion/start()
-	var/fire_stacks = amount_rating / 100
 	started = world.time + duration
 	looping_fire(fire_stacks)
 
-/datum/effect/effect/system/pottasium_sparkle_explosion/proc/looping_fire(fire_stack)
+/datum/effect/effect/system/pottasium_sparkle_explosion/proc/looping_fire()
 	var/particles_to_throw = amount_rating / 50 // 10 big particles in the worst case that break into 30
 	var/list/turf/affectable = RANGE_TURFS(light_range, location)
 	var/list/obj/fire/fires = list()

--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -601,15 +601,8 @@
 	mix_message = null
 
 /datum/chemical_reaction/explosion_potassium/on_reaction(var/datum/reagents/holder, var/created_volume)
-	var/datum/effect/effect/system/reagents_explosion/e = new()
-	e.set_up(round (created_volume/45, 1), holder.my_atom, 0, 0) // 600/45 = 13.3 , 13/3 = 4-3 light-range , slightly weaker than a cracker.
-	if(isliving(holder.my_atom))
-		e.amount *= 0.5
-		var/mob/living/L = holder.my_atom
-		if(L.stat != DEAD)
-			if(e.amount >= 6)
-				L.gib()
-			e.amount *= 1.5
+	var/datum/effect/effect/system/pottasium_sparkle_explosion/e = new()
+	e.set_up(created_volume, get_turf(holder.my_atom), created_volume / 50 SECOND, created_volume / 200 , created_volume / 100)
 	e.start()
 	holder.clear_reagents()
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Water and pot no longer explode , but instead create a area denying fire of weak intensity with a low chance to actually ignite anyone
## Why It's Good For The Game
We nerfed water pot into the ground , might as well make it have a more sparky role with area-denial role instead of an useless explosion

## Changelog
:cl:
balance: water-pot no longer creates a explosion , it now creates a fire with duration  and range scaling off amount.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
