### PR TITLE
IH medical HUD + EMT belt for medspec

### DIFF
--- a/code/datums/outfits/jobs/security.dm
+++ b/code/datums/outfits/jobs/security.dm
@@ -59,7 +59,7 @@
 	uniform = /obj/item/clothing/under/rank/medspec
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat/medspec
 	pda_type = /obj/item/modular_computer/pda/forensics
-	belt = /obj/item/storage/belt/medical
+	belt = /obj/item/storage/belt/medical/emt
 	l_hand = /obj/item/storage/briefcase/crimekit
 	backpack_contents = list(/obj/item/gun/energy/gun/martin = 1, /obj/item/cell/small/high = 1)
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -147,7 +147,7 @@
 	icon_state = "sec"
 
 /obj/structure/closet/secure_closet/medspec/populate_contents()
-	new /obj/item/clothing/glasses/sunglasses/sechud/tactical(src)
+	new /obj/item/clothing/glasses/sunglasses/medhud(src)
 	new /obj/item/clothing/mask/gas/ihs(src)
 	new /obj/item/taperoll/police(src)
 	new /obj/item/clothing/under/rank/medspec(src)

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -29,7 +29,7 @@
 /obj/item/clothing/glasses/sunglasses/medhud
 	name = "Ironhammer medical HUD"
 	desc = "Flash-resistant goggles with inbuilt medical information."
-	icon_state = "swatgoggles"
+	icon_state = "healthhud"
 	prescription = TRUE
 
 	New()

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -26,6 +26,17 @@
 /obj/item/clothing/glasses/hud/health/process_hud(mob/M)
 	process_med_hud(M, 1)
 
+/obj/item/clothing/glasses/sunglasses/medhud
+	name = "Ironhammer medical HUD"
+	desc = "Flash-resistant goggles with inbuilt medical information."
+	icon_state = "swatgoggles"
+	prescription = TRUE
+
+	New()
+		..()
+		src.hud = new/obj/item/clothing/glasses/hud/health(src)
+		return
+
 /obj/item/clothing/glasses/hud/security
 	name = "Security HUD"
 	desc = "A heads-up display that scans the humans in view and provides accurate data about their ID status and security records."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replace Medical specialist standard medical belt by an emergency response team belt so that they can store more rescue stuff on them (such as crowbar).

Create a medical HUD with flash protection. Replace the sec HUD in Medspec lockers by one of those.

## Why It's Good For The Game

Makes Medical Specialists' life easier.

## Changelog
:cl: Hyperio
add: Added new IH medical HUD
balance: Medspec now spawns with an ERT medical belt
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
