### PR TITLE
Fixes breacher ammo , makes it be angled the other way from where it was fired , fixes a oopsie in get_target_away_complex

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -529,7 +529,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 // this value is added ontop of the center coordinates , giving us our "away" turf.
 /proc/get_turf_away_from_target_complex(atom/center, atom/target, distance)
 	var/list/distance_reports = list(center.x - target.x, center.y - target.y)
-	var/distance_total = distance_reports[1] + distance_reports[2]
+	var/distance_total = abs(distance_reports[1]) + abs(distance_reports[2])
 	distance_reports[1] = round(distance_reports[1] / distance_total * distance)
 	distance_reports[2] = round(distance_reports[2] / distance_total * distance)
 	distance_reports[1] = center.x + distance_reports[1]

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -135,3 +135,21 @@ proc/fragment_explosion(var/turf/epicenter, var/range, var/f_type, var/f_amount 
 		if (prob(same_turf_hit_chance))
 			for(var/mob/living/M in epicenter)
 				P.attack_mob(M, 0, 100)
+
+
+// This is made to mimic the explosion that would happen when something gets pierced by a bullet ( a tank by a anti-armor shell , a armoured car by an .60 AMR,  etc, creates flying shrapnel on the other side!)
+proc/fragment_explosion_angled(atom/epicenter, turf/origin , projectile_type, projectile_amount)
+	// Long story short , this gets the turfs between 3 dots ,hopefully works all the time
+	// it works by getting the turfs bettween boundry_one and boundry_two , then getting each turf towards them with get_step from epicenter
+	var/turf/turf_t = get_turf_away_from_target_complex(get_turf(epicenter), origin, 3)
+	var/list/hittable_turfs  = RANGE_TURFS(1, turf_t)
+	var/proj_amount = projectile_amount
+	while(proj_amount)
+		proj_amount--
+		var/obj/item/projectile/pew_thingie = new projectile_type(epicenter)
+		pew_thingie.firer = epicenter
+		pew_thingie.launch(pick(hittable_turfs))
+
+
+
+

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -139,8 +139,6 @@ proc/fragment_explosion(var/turf/epicenter, var/range, var/f_type, var/f_amount 
 
 // This is made to mimic the explosion that would happen when something gets pierced by a bullet ( a tank by a anti-armor shell , a armoured car by an .60 AMR,  etc, creates flying shrapnel on the other side!)
 proc/fragment_explosion_angled(atom/epicenter, turf/origin , projectile_type, projectile_amount)
-	// Long story short , this gets the turfs between 3 dots ,hopefully works all the time
-	// it works by getting the turfs bettween boundry_one and boundry_two , then getting each turf towards them with get_step from epicenter
 	var/turf/turf_t = get_turf_away_from_target_complex(get_turf(epicenter), origin, 3)
 	var/list/hittable_turfs  = RANGE_TURFS(1, turf_t)
 	var/proj_amount = projectile_amount

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -226,14 +226,20 @@ There are important things regarding this file:
 
 /obj/item/projectile/bullet/antim/breach/on_hit(atom/target, blocked = FALSE)
 	. = ..()
-	if(iscarbon(target))
-		var/mob/living/carbon/H = target
+/*
+	if(ismob(target))
 		spawn(1 SECONDS)
-		fragment_explosion(H, 7, /obj/item/projectile/bullet/pellet/fragment/strong, 50, 4, 1, 5)
-	if(!iscarbon(target))
+			fragment_explosion(target, 7, /obj/item/projectile/bullet/pellet/fragment/strong, 20, 4, 1, 5)
+	else
 		playsound(target, 'sound/effects/explosion1.ogg', 100, 25, 8, 8)
 		if(!istype(target, /obj/machinery/door))
-			fragment_explosion(target, 7, /obj/item/projectile/bullet/pellet/fragment/strong, 50, 5, 1, 0)
+			fragment_explosion(target, 7, /obj/item/projectile/bullet/pellet/fragment/strong, 20, 5, 1, 0)
+		*/
+	fragment_explosion_angled(target, starting ,/obj/item/projectile/bullet/pellet/fragment/strong, 5)
+	playsound(target, 'sound/effects/explosion1.ogg', 100, 25, 8, 8)
+
+
+
 
 /obj/item/projectile/bullet/antim/scrap
 	damage_types = list(BRUTE = 63)

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -226,15 +226,6 @@ There are important things regarding this file:
 
 /obj/item/projectile/bullet/antim/breach/on_hit(atom/target, blocked = FALSE)
 	. = ..()
-/*
-	if(ismob(target))
-		spawn(1 SECONDS)
-			fragment_explosion(target, 7, /obj/item/projectile/bullet/pellet/fragment/strong, 20, 4, 1, 5)
-	else
-		playsound(target, 'sound/effects/explosion1.ogg', 100, 25, 8, 8)
-		if(!istype(target, /obj/machinery/door))
-			fragment_explosion(target, 7, /obj/item/projectile/bullet/pellet/fragment/strong, 20, 5, 1, 0)
-		*/
 	fragment_explosion_angled(target, starting ,/obj/item/projectile/bullet/pellet/fragment/strong, 5)
 	playsound(target, 'sound/effects/explosion1.ogg', 100, 25, 8, 8)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes breacher ammo being broken and lagging the server to a halt
Fixes a oopsie in get_target_complex that would cause it bogus results
Makes breacher ammo send shrapnel only on the other side of where it penetrates ( behaviour similar to a tank getting penetrated by a anti-tank shell and shrapnel being thrown on the inside)
## Why It's Good For The Game
Breacher rounds are kinda cool , wallbanging people with deadly shrapnel couldn't ever be more balanced!

## Changelog
:cl:
fix:Breacher rounds now work properly and don't lag the server to death
fix:Coding fuckup in get_turf_away_from_target_complex
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
