### PR TITLE
Makes splints fall off when the limb gets shot

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -977,7 +977,15 @@ var/list/rank_prefix = list(\
 /mob/living/carbon/human/proc/handle_embedded_objects()
 
 	for(var/obj/item/organ/external/organ in organs)
-		if(organ.status & ORGAN_SPLINTED) //Splints prevent movement.
+		if(organ.status & ORGAN_SPLINTED) //Splints prevent damage , but not pain
+			for(var/obj/item/O in organ.implants)
+				var/mob/living/carbon/human/H = organ.owner
+				if(prob(10) && is_sharp(O) && !MOVING_DELIBERATELY(H))
+					if(!organ.can_feel_pain())
+						to_chat(src, SPAN_WARNING("You feel [O] moving inside your [organ.name]."))
+						continue
+					to_chat(src, SPAN_WARNING("You feel a weak wave of pain as \the [O] inside your [organ.name] jostles"))
+					H.adjustHalLoss(2)
 			continue
 
 		for(var/obj/item/O in organ.implants)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -978,14 +978,6 @@ var/list/rank_prefix = list(\
 
 	for(var/obj/item/organ/external/organ in organs)
 		if(organ.status & ORGAN_SPLINTED) //Splints prevent damage , but not pain
-			for(var/obj/item/O in organ.implants)
-				var/mob/living/carbon/human/H = organ.owner
-				if(prob(10) && is_sharp(O) && !MOVING_DELIBERATELY(H))
-					if(!organ.can_feel_pain())
-						to_chat(src, SPAN_WARNING("You feel [O] moving inside your [organ.name]."))
-						continue
-					to_chat(src, SPAN_WARNING("You feel a weak wave of pain as \the [O] inside your [organ.name] jostles"))
-					H.adjustHalLoss(2)
 			continue
 
 		for(var/obj/item/O in organ.implants)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -977,7 +977,7 @@ var/list/rank_prefix = list(\
 /mob/living/carbon/human/proc/handle_embedded_objects()
 
 	for(var/obj/item/organ/external/organ in organs)
-		if(organ.status & ORGAN_SPLINTED) //Splints prevent damage , but not pain
+		if(organ.status & ORGAN_SPLINTED) //Splints prevent movement
 			continue
 
 		for(var/obj/item/O in organ.implants)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -123,8 +123,12 @@
 		return
 
 	for (var/obj/item/organ/external/E in organs)
-		if(!E || !(E.functions & BODYPART_GRASP) || (E.status & ORGAN_SPLINTED))
+		if(!E || !(E.functions & BODYPART_GRASP))
 			continue
+
+		if(E.status & ORGAN_SPLINTED)
+			if(prob(70))
+				continue
 
 		if(E.is_broken() || E.is_dislocated() || E.limb_efficiency <= 50)
 			switch(E.body_part)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -123,12 +123,8 @@
 		return
 
 	for (var/obj/item/organ/external/E in organs)
-		if(!E || !(E.functions & BODYPART_GRASP))
+		if(!E || !(E.functions & BODYPART_GRASP) || if(E.status & ORGAN_SPLINTED))
 			continue
-
-		if(E.status & ORGAN_SPLINTED)
-			if(prob(70))
-				continue
 
 		if(E.is_broken() || E.is_dislocated() || E.limb_efficiency <= 50)
 			switch(E.body_part)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -123,7 +123,7 @@
 		return
 
 	for (var/obj/item/organ/external/E in organs)
-		if(!E || !(E.functions & BODYPART_GRASP) || if(E.status & ORGAN_SPLINTED))
+		if(!E || !(E.functions & BODYPART_GRASP) || (E.status & ORGAN_SPLINTED))
 			continue
 
 		if(E.is_broken() || E.is_dislocated() || E.limb_efficiency <= 50)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -68,8 +68,8 @@
 		if(ishuman(src) && def_zone)
 			var/mob/living/carbon/human/H = src
 			var/obj/item/organ/external/o = H.get_organ(def_zone)
-			if (o && o.status & ORGAN_SPLINTED)
-				visible_message("The splints break off [src] as they get hit")
+			if (o && o.status & ORGAN_SPLINTED && effective_damage > 4)
+				visible_message("The splints break off [src] as it gets hit")
 				o.status &= ~ORGAN_SPLINTED
 		if(sanctified_attack)
 			apply_damage(effective_damage / 2, BURN, def_zone, sharp, edge, used_weapon)
@@ -84,11 +84,11 @@
 		//Actual part of the damage that passed through armor
 		var/actual_damage = round ( ( effective_damage * ( 100 - armor_effectiveness ) ) / 100 )
 		apply_damage(actual_damage, damagetype, def_zone, sharp, edge, used_weapon)
-		if(ishuman(src) && def_zone)
+		if(ishuman(src) && def_zone && effective_damage > 4)
 			var/mob/living/carbon/human/H = src
 			var/obj/item/organ/external/o = H.get_organ(def_zone)
 			if (o && o.status & ORGAN_SPLINTED)
-				visible_message("The splints break off [src] as they get hit")
+				visible_message("The splints break off [src] as it gets hit")
 				o.status &= ~ORGAN_SPLINTED
 		if(sanctified_attack)
 			apply_damage(actual_damage / 2, BURN, def_zone, sharp, edge, used_weapon)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -65,6 +65,12 @@
 	//No armor? Damage as usual
 	if(armor_effectiveness == 0)
 		apply_damage(effective_damage, damagetype, def_zone, sharp, edge, used_weapon)
+		if(ishuman(src) && def_zone)
+			var/mob/living/carbon/human/H = src
+			var/obj/item/organ/external/o = H.get_organ(def_zone)
+			if (o && o.status & ORGAN_SPLINTED)
+				visible_message("The splints break off [src] as they get hit")
+				o.status &= ~ORGAN_SPLINTED
 		if(sanctified_attack)
 			apply_damage(effective_damage / 2, BURN, def_zone, sharp, edge, used_weapon)
 	//Here we split damage in two parts, where armor value will determine how much damage will get through
@@ -78,6 +84,12 @@
 		//Actual part of the damage that passed through armor
 		var/actual_damage = round ( ( effective_damage * ( 100 - armor_effectiveness ) ) / 100 )
 		apply_damage(actual_damage, damagetype, def_zone, sharp, edge, used_weapon)
+		if(ishuman(src) && def_zone)
+			var/mob/living/carbon/human/H = src
+			var/obj/item/organ/external/o = H.get_organ(def_zone)
+			if (o && o.status & ORGAN_SPLINTED)
+				visible_message("The splints break off [src] as they get hit")
+				o.status &= ~ORGAN_SPLINTED
 		if(sanctified_attack)
 			apply_damage(actual_damage / 2, BURN, def_zone, sharp, edge, used_weapon)
 		return actual_damage


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Splints will fall off when the limb they affect is  shot
## Why It's Good For The Game
No longer you can combat pre-splint to avoid a major part of the medical system and balance

## Changelog
:cl:
balance: splints now fall off when the limb they are applied to gets shot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
