### PR TITLE
Adds a delay to going up / down stairs repeatedly

### DIFF
--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -272,6 +272,13 @@
 
 	if(!ES && !istop)
 		return
+	if(ishuman(AM))
+		to_chat(AM , SPAN_NOTICE("You start walking up the [src]"))
+		var/mob/our_guy = AM
+		if(do_after(our_guy , 1 SECOND, src))
+			our_guy.forceMove(get_turf(target))
+			try_resolve_mob_pulling(AM, ES)
+		return
 
 	AM.forceMove(get_turf(target))
 	try_resolve_mob_pulling(AM, ES)

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -273,7 +273,7 @@
 	if(!ES && !istop)
 		return
 	if(ishuman(AM))
-		to_chat(AM , SPAN_NOTICE("You start walking up the [src]"))
+		to_chat(AM , SPAN_NOTICE("You start walking [istop ? "up" : "down"] the [src]"))
 		var/mob/our_guy = AM
 		if(do_after(our_guy , 1 SECOND, src))
 			our_guy.forceMove(get_turf(target))

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -3,6 +3,7 @@
 //////////////////////////////
 
 #define STAIR_WAIT 5 SECOND // Seconds it takes after someone's forced stair delay to expire. used to preven combat around stairs
+
 /obj/structure/multiz
 	name = "ladder"
 	density = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a 1 second delay to going up or down stairs if they've been traversed by the same person in the last 5 seconds
## Why It's Good For The Game
A easy way to win against someone with vastly superior gear is to keep going up and down stairs and constantly hit them,  then switch stairs.
Shouldn't ideally happen

## Changelog
:cl:
balance : Stairs recently climbed by someone will have 1 second delay tied to climbing them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
