### PR TITLE
Fix Move Shuttle verb in Secret panel

### DIFF
--- a/code/modules/admin/secrets/admin_secrets/move_shuttle.dm
+++ b/code/modules/admin/secrets/admin_secrets/move_shuttle.dm
@@ -9,17 +9,18 @@
 	if (confirm == "Cancel")
 		return
 
-	var/shuttle_tag = input(user, "Which shuttle do you want to move?") as null|anything in SSshuttle.shuttles
+	var/shuttle_tag = input(user, "Shuttle:", "Which shuttle do you want to move?") as null|anything in SSshuttle.shuttles
 	if (!shuttle_tag) return
 
 	var/datum/shuttle/S = SSshuttle.shuttles[shuttle_tag]
 
-	var/list/destinations = list()
+	var/list/possible_d = list()
 	for(var/obj/effect/shuttle_landmark/WP in world)
-		destinations += WP
+		possible_d["[WP.name]"] = WP
 
-	var/obj/effect/shuttle_landmark/destination = input(user, "Select the destination.") as null|anything in destinations
-	if (!destination) return
+	var/D = input(user, "Destination:", "Select the destination.") as null|anything in possible_d
+	var/obj/effect/shuttle_landmark/destination = possible_d[D]
+	if (!destination || !istype(destination)) return
 
 	S.attempt_move(destination)
 	log_and_message_admins("moved the [shuttle_tag] shuttle to [destination] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[destination.x];Y=[destination.y];Z=[destination.z]'>JMP</a>)", user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Asked by Gray. Fix the Move shuttle verb in Secret panel, you can now force move shuttle from one landmark to another as long as the destination landmark is compatible, like you cannot move Hulk to a pod landmark.

## Why It's Good For The Game

Debugging of stuck shuttles should now be possible.

## Changelog
:cl: Hyperio
fix: Fixed Move Shuttle verb in Secret panel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
