### PR TITLE
Buff excel turret

### DIFF
--- a/code/game/machinery/excelsior/ex_turret.dm
+++ b/code/game/machinery/excelsior/ex_turret.dm
@@ -145,11 +145,11 @@
 
 	if(target)
 		last_target = target
-		set_dir(get_dir(src, target))
 		for(var/i; i < burst_lenght; i++)
 			if(!ammo)
 				break
 			sleep(2)
+			set_dir(get_dir(src, target))
 			shootAt(target)
 
 		return 1

--- a/code/game/machinery/excelsior/ex_turret.dm
+++ b/code/game/machinery/excelsior/ex_turret.dm
@@ -15,7 +15,9 @@
 	var/ammo = 0 // number of bullets left.
 	var/ammo_max = 96
 	var/working_range = 30 // how far this turret operates from excelsior teleporter
+	var/burst_lenght = 8
 	health = 60
+	shot_delay = 0
 
 /obj/machinery/porta_turret/excelsior/proc/has_power_source_nearby()
 	for (var/a in excelsior_teleporters)
@@ -135,9 +137,45 @@
 	if(!(stat & BROKEN))
 		add_overlays(image("turret_gun"))
 
-/obj/machinery/porta_turret/excelsior/launch_projectile()
+
+
+/obj/machinery/porta_turret/excelsior/target(mob/living/target)
+	if(disabled)
+		return
+
+	if(target)
+		last_target = target
+		set_dir(get_dir(src, target))
+		for(var/i; i < burst_lenght; i++)
+			if(!ammo)
+				break
+			sleep(2)
+			shootAt(target)
+
+		return 1
+	return
+
+
+/obj/machinery/porta_turret/excelsior/shootAt(mob/living/target)
+	var/turf/T = get_turf(src)
+	var/turf/U = get_turf(target)
+	if(!istype(T) || !istype(U))
+		return
+
+	launch_projectile(target)
+
+
+/obj/machinery/porta_turret/excelsior/launch_projectile(mob/living/target)
 	ammo--
-	..()
+	update_icon()
+	var/obj/item/projectile/A
+	A = new eprojectile(loc)
+	playsound(loc, eshot_sound, 75, 1)
+	use_power(reqpower)
+	var/def_zone = get_exposed_defense_zone(target)
+	var/angle_offset = pick(5, 10, 20, 0, -5, -10, -20)
+	A.launch(target, def_zone, 0, 0, angle_offset)
+
 
 #undef TURRET_PRIORITY_TARGET
 #undef TURRET_SECONDARY_TARGET


### PR DESCRIPTION
## About The Pull Request

Makes excelsior turret shoot in bursts of 8 bullets, wildly inaccurate at that.
Still an easy kill, if not rushing in melee, but that's something at least.

Demonstration:
https://www.youtube.com/watch?v=cv0WPZXzpgE
UPD: Turret direction no longer lags behind and updates before each shoot instead of before each burst.

<details>
<summary>
Suggestions
</summary>

![image](https://user-images.githubusercontent.com/65828539/140688833-4df37572-a602-41d2-8067-77db1dc53ca1.png)

![image](https://user-images.githubusercontent.com/65828539/140689123-6cb67011-c813-44ef-93e1-7d3f88b4e908.png)


</details>

## Why It's Good For The Game

Considering how expensive that turret is to make (requires Maxim LMG), performance of it is laughable.

## Changelog
:cl:
balance: excelsior turret shoot in bursts of 8
/:cl: