### PR TITLE
Add preference for keeping hotkeys always on

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -102,6 +102,10 @@
 		last_activity = world.time
 	if(new_character.client)
 		new_character.client.create_UI(new_character.type)
+	if(new_character.client.get_preference_value(/datum/client_preference/stay_in_hotkey_mode) == GLOB.PREF_YES)
+		winset(new_character.client, null, "mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true input.background-color=#F0F0F0")
+		if(istype(new_character, /mob/living/silicon/robot))
+			winset(src, null, "mainwindow.macro=borgmacro")
 
 /datum/mind/proc/store_memory(new_text)
 	memory += "[new_text]<BR>"

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -222,7 +222,7 @@ var/list/_client_preferences_by_type
 		preference_mob.update_music()
 
 /datum/client_preference/stay_in_hotkey_mode
-	description ="Keep hotkeys on mob change"
+	description = "Keep hotkeys on mob change"
 	key = "KEEP_HOTKEY_MODE"
 	default_value = GLOB.PREF_NO
 

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -221,6 +221,11 @@ var/list/_client_preferences_by_type
 	else
 		preference_mob.update_music()
 
+/datum/client_preference/stay_in_hotkey_mode
+	description ="Keep hotkeys on mob change"
+	key = "KEEP_HOTKEY_MODE"
+	default_value = GLOB.PREF_NO
+
 /********************
 * General Staff Preferences *
 ********************/

--- a/code/modules/mob/living/silicon/robot/login.dm
+++ b/code/modules/mob/living/silicon/robot/login.dm
@@ -5,6 +5,10 @@
 	show_laws(0)
 
 	winset(src, null, "mainwindow.macro=borgmacro hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5")
+	if(client.get_preference_value(/datum/client_preference/stay_in_hotkey_mode) == GLOB.PREF_YES)
+		winset(client, null, "mainwindow.macro=borgmacro hotkey_toggle.is-checked=true mapwindow.map.focus=true input.background-color=#F0F0F0")
+	else
+		winset(client, null, "mainwindow.macro=borgmacro hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5")
 
 	// Forces synths to select an icon relevant to their module
 	if(!icon_selected)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -50,7 +50,10 @@
 		client.perspective = MOB_PERSPECTIVE
 
 	//set macro to normal incase it was overriden (like cyborg currently does)
-	winset(src, null, "mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5")
+	if(client.get_preference_value(/datum/client_preference/stay_in_hotkey_mode) == GLOB.PREF_YES)
+		winset(client, null, "mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true input.background-color=#F0F0F0")
+	else
+		winset(client, null, "mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5")
 
 	if (client)
 		if(client.UI)


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. If new preference is set to "Yes", on login or mob change (spawning, ghosting, detaching as a spider core, being borged, etc.) player will have hotkey mode enabled, instead of if being reset.

## Why It's Good For The Game

QoL feature.
Prevents situations where player can't move precisely at a time they have to. Like when spider core / borer detaching.

## Changelog
:cl:
add: preference for keeping hotkeys always on
/:cl: