### PR TITLE
more ammo in .35 packet

### DIFF
--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -41,10 +41,10 @@
 /obj/item/ammo_magazine/ammobox/pistol
 	name = "ammunition packet (.35 Auto)"
 	icon_state = "pistol_l"
-	matter = list(MATERIAL_STEEL = 6, MATERIAL_CARDBOARD = 1)
+	matter = list(MATERIAL_STEEL = 10, MATERIAL_CARDBOARD = 1)
 	caliber = CAL_PISTOL
 	ammo_type = /obj/item/ammo_casing/pistol
-	max_ammo = 30
+	max_ammo = 70
 	rarity_value = 10
 	spawn_tags = SPAWN_TAG_AMMO_COMMON
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
made .35 ammo packet contain 70 bullets instead of 30, so now you can fill two smg mags (previously you couldn't fill any).

## Why It's Good For The Game
every other ammo packet follow the same logic, i.e. .30 packet has 60 ammo (two AK mags), and so.

## Changelog
:cl:
tweak: .35 ammo packets now contain 70 bullets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
