### PR TITLE
Heal limbs directly

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1038,6 +1038,22 @@ Note that amputating the affected organ does in fact remove the infection from t
 			)
 			conditions_list.Add(list(condition))
 
+		if(brute_dam > 0)
+			condition = list(
+				"name" = "Damaged tissue",
+				"fix_name" = "Treat",
+				"step" = /datum/surgery_step/fix_brute
+			)
+			conditions_list.Add(list(condition))
+
+		if(burn_dam > 0)
+			condition = list(
+				"name" = "Severe burning",
+				"fix_name" = "Salve",
+				"step" = /datum/surgery_step/fix_burn
+			)
+			conditions_list.Add(list(condition))
+
 	return conditions_list
 
 /obj/item/organ/external/attackby(obj/item/A, mob/user, params)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1048,7 +1048,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 		if(burn_dam > 0)
 			condition = list(
-				"name" = "Severe burning",
+				"name" = "Severe burns",
 				"fix_name" = "Salve",
 				"step" = /datum/surgery_step/fix_burn
 			)

--- a/code/modules/surgery/organic_damage.dm
+++ b/code/modules/surgery/organic_damage.dm
@@ -154,3 +154,93 @@
 			SPAN_WARNING("Your hand slips, making a deep gash on [organ.get_surgery_name()] with \the [tool]!")
 		)
 	organ.take_damage(60, 0, sharp=TRUE, edge=TRUE)
+
+/datum/surgery_step/fix_brute
+		allowed_tools = list(
+			/obj/item/stack/medical/advanced/bruise_pack = 100,
+			/obj/item/stack/medical/advanced/bruise_pack/nt = 100,
+		)
+		difficulty = FAILCHANCE_HARD
+		duration = 100
+
+/datum/surgery_step/fix_brute/require_tool_message(mob/living/user)
+	to_chat(user, SPAN_WARNING("You need an advanced trauma kit to complete this step."))
+
+/datum/surgery_step/fix_brute/proc/get_tool_name(obj/item/stack/tool)
+	var/tool_name = "\the regenerative membrane"
+	return tool_name
+
+/datum/surgery_step/fix_brute/can_use(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
+	if(organ.brute_dam <= 0)
+		to_chat(user, SPAN_NOTICE("This limb is undamaged!"))
+		return SURGERY_FAILURE
+	return TRUE
+
+/datum/surgery_step/fix_brute/begin_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
+	user.visible_message(
+		SPAN_NOTICE("[user] begins to treat damage to [organ.get_surgery_name()]'s subcutaneous tissue with \the [tool]."),
+		SPAN_NOTICE("You begin to treat damage to [organ.get_surgery_name()]'s subcutaneous tissue with \the [tool].")
+	)
+
+/datum/surgery_step/fix_brute/end_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
+	user.visible_message(
+		SPAN_NOTICE("[user] finishes treating damage to [organ.get_surgery_name()] with \the [tool]."),
+		SPAN_NOTICE("You finish treating damage to [organ.get_surgery_name()] with \the [tool].")
+	)
+	if(istype(tool, /obj/item/stack/medical/advanced/bruise_pack) || istype(tool, /obj/item/stack/medical/advanced/bruise_pack/nt))
+		var/obj/item/stack/S = tool
+		S.use(1)
+	organ.heal_damage(25, 0, TRUE)
+
+/datum/surgery_step/fix_brute/fail_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
+	user.visible_message(
+		SPAN_WARNING("[user]'s hand slips, damaging the subcutaneous tissue of [organ.get_surgery_name()] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, damaging the subcutaneous tissue of [organ.get_surgery_name()] with \the [tool]!")
+	)
+	organ.take_damage(rand(5, 10), 0)
+
+/datum/surgery_step/fix_burn
+		allowed_tools = list(
+			/obj/item/stack/medical/advanced/ointment = 100,
+			/obj/item/stack/medical/advanced/ointment/nt = 100,
+		)
+		difficulty = FAILCHANCE_HARD
+		duration = 100
+
+/datum/surgery_step/fix_burn/require_tool_message(mob/living/user)
+	to_chat(user, SPAN_WARNING("You need an advanced burn kit to complete this step."))
+
+/datum/surgery_step/fix_burn/proc/get_tool_name(obj/item/stack/tool)
+	var/tool_name = "\the regenerative membrane"
+	return tool_name
+
+/datum/surgery_step/fix_burn/can_use(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
+	if(organ.burn_dam <= 0)
+		to_chat(user, SPAN_NOTICE("This limb is undamaged!"))
+		return SURGERY_FAILURE
+
+	return TRUE
+
+
+/datum/surgery_step/fix_burn/begin_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
+	user.visible_message(
+		SPAN_NOTICE("[user] begins to treat damage to [organ.get_surgery_name()]'s subcutaneous tissue with \the [tool]."),
+		SPAN_NOTICE("You begin to treat damage to [organ.get_surgery_name()]'s subcutaneous tissue with \the [tool].")
+	)
+
+/datum/surgery_step/fix_burn/end_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
+	user.visible_message(
+		SPAN_NOTICE("[user] finishes treating damage to [organ.get_surgery_name()] with \the [tool]."),
+		SPAN_NOTICE("You finish treating damage to [organ.get_surgery_name()] with \the [tool].")
+	)
+	if(istype(tool, /obj/item/stack/medical/advanced/ointment) || istype(tool, /obj/item/stack/medical/advanced/ointment/nt))
+		var/obj/item/stack/S = tool
+		S.use(1)
+	organ.heal_damage(0, 25, TRUE)
+
+/datum/surgery_step/fix_burn/fail_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
+	user.visible_message(
+		SPAN_WARNING("[user]'s hand slips, damaging the subcutaneous tissue of [organ.get_surgery_name()] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, damaging the subcutaneous tissue of [organ.get_surgery_name()] with \the [tool]!")
+	)
+	organ.take_damage(0, rand(5, 10))


### PR DESCRIPTION
## About The Pull Request

Adds two buttons to the surgery menu: Treat damage to tissue and salve burns. Requires the respected advanced kits, takes a long time, has an increased chance to fail. Heals 25 damage.
![image](https://user-images.githubusercontent.com/49622619/140984450-523067f7-91f8-40b4-adb9-e423e22fc77b.png)



## Why It's Good For The Game
The year is 2577, we can convince our immunity system to not reject chunks of steel glued to our flesh, while also being able to fix(heal) the prosthetics on the go, but can't heal the flesh itself? dislike and unsub
/////
no more waiting for tricord to make the bone mendable. I decided to make this instead of just removing the damage threshold.
## Changelog
:cl:
add: It's now possible to heal limbs directly via surgery.
/:cl:
