### PR TITLE
Lowers pistol wield delay and wield factor in general

### DIFF
--- a/code/modules/projectiles/guns/projectile/pistol/colt.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/colt.dm
@@ -16,9 +16,8 @@
 	recoil_buildup = 4
 	gun_tags = list(GUN_GILDABLE)
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
-	wield_delay = 0.3 SECOND
-	wield_delay_factor = 0.2 // 20 vig
-
+	wield_delay = 0.1 SECOND
+	wield_delay_factor = 0.05 // 5 vig
 
 /obj/item/gun/projectile/colt/on_update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/pistol/giskard.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/giskard.dm
@@ -20,8 +20,8 @@
 	penetration_multiplier = 0.8
 	recoil_buildup = 2
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
-	wield_delay = 0.2 SECOND
-	wield_delay_factor = 0.2 // 20 vig
+	wield_delay = 0.1 SECOND
+	wield_delay_factor = 0.05 // 5 vig
 
 /obj/item/gun/projectile/giskard/on_update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/pistol/handmade.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/handmade.dm
@@ -19,8 +19,8 @@
 	var/chamber_open = FALSE
 	var/jammed = FALSE
 	var/jam_chance = 15
-	wield_delay = 0.2 SECOND
-	wield_delay_factor = 0.1 // 10 vig
+	wield_delay = 0.1 SECOND
+	wield_delay_factor = 0.05 // 5 vig
 
 /obj/item/gun/projectile/handmade_pistol/New()
 	..()

--- a/code/modules/projectiles/guns/projectile/pistol/mandella.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mandella.dm
@@ -22,8 +22,8 @@
 	damage_multiplier = 1.2
 	penetration_multiplier = 1.7
 	recoil_buildup = 2
-	wield_delay = 0.3 SECOND
-	wield_delay_factor = 0.3 // 30 vig
+	wield_delay = 0.2 SECOND
+	wield_delay_factor = 0.1 // 10 vig
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
 

--- a/code/modules/projectiles/guns/projectile/pistol/mk58.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mk58.dm
@@ -16,8 +16,8 @@
 	damage_multiplier = 1.3
 	penetration_multiplier = 1.3
 	recoil_buildup = 3
-	wield_delay = 0.2 SECOND
-	wield_delay_factor = 0.2 // 20 vig
+	wield_delay = 0.1 SECOND
+	wield_delay_factor = 0.05 // 5 vig
 
 /obj/item/gun/projectile/mk58/on_update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
@@ -22,8 +22,8 @@
 		)
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
-	wield_delay = 0.2 SECOND
-	wield_delay_factor = 0.2 // 20 vig
+	wield_delay = 0.1 SECOND
+	wield_delay_factor = 0.05 // 5 vig
 
 /obj/item/gun/projectile/olivaw/on_update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/pistol/paco.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/paco.dm
@@ -23,7 +23,7 @@
 	recoil_buildup = 3
 	gun_tags = list(GUN_SILENCABLE)
 	wield_delay = 0.2 SECOND
-	wield_delay_factor = 0.3 // 30 vig
+	wield_delay_factor = 0.1 // 10 vig
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
 

--- a/code/modules/projectiles/guns/projectile/pistol/selfload.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/selfload.dm
@@ -27,8 +27,9 @@
 		FULL_AUTO_800
 		)
 
-	wield_delay = 0.2 SECOND
-	wield_delay_factor = 0.2 // 20 vig
+	wield_delay = 0.1 SECOND
+	wield_delay_factor = 0.05 // 5 vig
+
 	//spawn_tags = SPAWN_TAG_FS_PROJECTILE
 
 /obj/item/gun/projectile/selfload/on_update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Most pistols are reduced to 5 vigilance and 0.1 second

## Why It's Good For The Game

Should only have a delay if you're negative on vigilance

## Changelog
:cl:
balance: Most pistols now have their wield delay lowered and wield factor halved.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
