### PR TITLE
Armor stacking with fall-off and fractional multiplication

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -166,7 +166,7 @@ meteor_act
 	var/protection = 0
 	var/list/protective_gear = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes)
 	if(def_zone.armor)
-		protection = 100 - (100 - def_zone.armor.getRating(type)) * (100 - protection) * 0.0001 // Converts armor into multiplication form, stacks them, then converts them back
+		protection = 100 - (100 - def_zone.armor.getRating(type)) * (100 - protection) * 0.01 // Converts armor into multiplication form, stacks them, then converts them back
 
 	for(var/gear in protective_gear)
 		if(gear && istype(gear ,/obj/item/clothing))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -137,11 +137,11 @@ meteor_act
 				armorval += getarmor_organ(organ, type) * weight
 				total += weight
 	
-	armorval =/ max(total, 1)
+	armorval = armorval/max(total, 1)
 
 	if (armorval > 75) // reducing the risks from powergaming
 		switch (type)
-			if (ARMOR_MELEE,ARMOR_BULLET,ARMOR_ENERGY) armoval = (75+armorval/2)
+			if (ARMOR_MELEE,ARMOR_BULLET,ARMOR_ENERGY) armorval = (75+armorval/2)
 			else return armorval
 
 	return armorval

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -172,7 +172,7 @@ meteor_act
 		if(gear && istype(gear ,/obj/item/clothing))
 			var/obj/item/clothing/C = gear
 			if(istype(C) && C.body_parts_covered & def_zone.body_part && C.armor)
-				protection = 100 - (100 - C.armor.vars[type]) * (100 - protection) * 0.0001 // Same as above
+				protection = 100 - (100 - C.armor.vars[type]) * (100 - protection) * 0.01 // Same as above
 
 	var/obj/item/shield/shield = has_shield()
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -136,7 +136,15 @@ meteor_act
 				var/weight = organ_rel_size[organ_name]
 				armorval += getarmor_organ(organ, type) * weight
 				total += weight
-	return (armorval/max(total, 1))
+	
+	armorval =/ max(total, 1)
+
+	if (armorval > 75) // reducing the risks from powergaming
+		switch (type)
+			if (ARMOR_MELEE,ARMOR_BULLET,ARMOR_ENERGY) armoval = (75+armorval/2)
+			else return armorval
+
+	return armorval
 
 //this proc returns the Siemens coefficient of electrical resistivity for a particular external organ.
 /mob/living/carbon/human/proc/get_siemens_coefficient_organ(obj/item/organ/external/def_zone)
@@ -158,20 +166,23 @@ meteor_act
 	var/protection = 0
 	var/list/protective_gear = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes)
 	if(def_zone.armor)
-		if(def_zone.armor.getRating(type) > protection)
-			protection = def_zone.armor.getRating(type)
+		protection = 100 - (100 - def_zone.armor.getRating(type)) * (100 - protection) * 0.0001 // Converts armor into multiplication form, stacks them, then converts them back
 
 	for(var/gear in protective_gear)
 		if(gear && istype(gear ,/obj/item/clothing))
 			var/obj/item/clothing/C = gear
 			if(istype(C) && C.body_parts_covered & def_zone.body_part && C.armor)
-				if(C.armor.vars[type] > protection)
-					protection = C.armor.vars[type]
+				protection = 100 - (100 - C.armor.vars[type]) * (100 - protection) * 0.0001 // Same as above
 
 	var/obj/item/shield/shield = has_shield()
 
 	if(shield)
 		protection += shield.armor[type]
+	
+	if (protection > 75) // reducing the risks from powergaming
+		switch (type)
+			if (ARMOR_MELEE,ARMOR_BULLET,ARMOR_ENERGY) protection = (75+protection/2)
+			else return protection
 
 	return protection
 


### PR DESCRIPTION
## About The Pull Request

Pretty radical change, makes armor stack multiplicatively (eg. 60% bulletproof with 10% rockerboy jumpsuit becomes 64% bullet protection). There are other safety features in mind, such as any armor against melee, bullet and energy is averaged with 75 once above 75. (eg. 80 armor becomes (75+80)/2)

_**Do not merge**_
Until properly tested.

## Why It's Good For The Game

Armor will make a lot more sense now, limbs will be able to take armor from organs and from being robotic, generally just a lot more pleasant to make features for.

## Changelog
:cl:
balance: armor stacks
/:cl: