### PR TITLE
Add Follow verb in context menu

### DIFF
--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -308,9 +308,15 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	stop_following()
 	usr.forceMove(pick(L))
 
-/mob/observer/ghost/verb/follow(input in getmobs())
+/mob/observer/ghost/verb/Follow(atom/A as mob|obj in view(usr.client)) ////// Follow verb in context menu
+	if(following)
+		stop_following()
+	var/target = A
+	ManualFollow(target)
+
+/mob/observer/ghost/verb/follow_mob(input in getmobs()) ////// Follow verb in Ghost tab
 	set category = "Ghost"
-	set name = "Follow" // "Haunt"
+	set name = "Follow mob" // "Haunt"
 	set desc = "Follow and haunt a mob."
 
 	var/target = getmobs()[input]


### PR DESCRIPTION
## About The Pull Request

adds the follow verb in context menu(right mouse button menu thingy(only for ghosts))

## Why It's Good For The Game

comfy QoL

## Changelog
:cl:
add: now possible to use Follow verb via context menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
