### PR TITLE
Ghetto chem tools spawn in maint

### DIFF
--- a/code/modules/reagents/machinery/centrifuge.dm
+++ b/code/modules/reagents/machinery/centrifuge.dm
@@ -229,6 +229,7 @@
 	icon_state = "centrifuge_makeshift"
 	matter = list(MATERIAL_STEEL = 4)
 	rarity_value = 50
+	spawn_tags = SPAWN_TAG_JUNKTOOL
 	var/obj/item/reagent_containers/mainBeaker
 	var/list/obj/item/reagent_containers/separationBeakers = list()
 	var/beakerSlots = 2

--- a/code/modules/reagents/machinery/electrolyzer.dm
+++ b/code/modules/reagents/machinery/electrolyzer.dm
@@ -215,6 +215,7 @@
 	rarity_value = 50
 	starting_cell = FALSE
 	suitable_cell = /obj/item/cell/small
+	spawn_tags = SPAWN_TAG_JUNKTOOL
 	var/on = FALSE
 	var/tick_cost = 3
 	var/obj/item/reagent_containers/beaker

--- a/code/modules/reagents/machinery/grinder.dm
+++ b/code/modules/reagents/machinery/grinder.dm
@@ -341,6 +341,7 @@
 	rarity_value = 25
 	spawn_tags = SPAWN_TAG_ITEM_UTILITY
 	reagent_flags = REFILLABLE | DRAINABLE
+	spawn_tags = SPAWN_TAG_JUNKTOOL
 	var/amount_per_transfer_from_this = 10
 	var/possible_transfer_amounts = list(5,10,30,60)
 


### PR DESCRIPTION


## About The Pull Request
Add ghetto chem tools to the junktool spawning pool
## Why It's Good For The Game
now you can actually find ghetto tools in ghetto rooms
## Changelog
:cl:
tweak: you can find ghetto chem tools in maintenance now
/:cl: