### PR TITLE
Fixes a typo in crafting_station.dm

### DIFF
--- a/code/game/machinery/crafting_station.dm
+++ b/code/game/machinery/crafting_station.dm
@@ -2,7 +2,7 @@
 #define DONE "done"
 
 /obj/machinery/craftingstation
-	name = "crafting ctation"
+	name = "crafting station"
 	desc = "Makeshift fabrication station for home-made munitions and components of firearms and armor."
 	icon = 'icons/obj/machines/crafting_station.dmi'
 	icon_state = "craft"


### PR DESCRIPTION
## About The Pull Request

Fixes "crafting ctation", now it's properly named to "crafting station".

## Why It's Good For The Game
Typo fix, immersion intact

## Changelog
:cl: Xoxeyos
spellcheck: Fixes "crafting ctation", now it's properly named to "crafting station".
/:cl:
