### PR TITLE
Fixes exosuits ignoring move disruptions via strafe

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -370,7 +370,7 @@
 	name = "mech gun electrical component"
 	desc = "An electrical component for exosuit energy guns."
 	icon_state = "m_st"
-	maxcharge = 1000
+	maxcharge = 700
 	bad_type = /obj/item/cell/medium/mech
 	matter = list()
 	spawn_blacklisted = TRUE

--- a/code/modules/mechs/_mech_defines.dm
+++ b/code/modules/mechs/_mech_defines.dm
@@ -21,9 +21,10 @@
 #define MECH_SOFTWARE_ENGINEERING			"advanced engineering systems"	// RCD.
 
 // EMP damage points before various effects occur.
-#define EMP_HUD_DISRUPT 					5								// 1 ion rifle shot == 8.
-#define EMP_MOVE_DISRUPT 					10								// 2 shots.
-#define EMP_ATTACK_DISRUPT 					20								// 3 shots.
+#define EMP_HUD_DISRUPT 					5								// 1 ion rifle shot == 4.5ish, w/ combat armor.
+#define EMP_MOVE_DISRUPT 					10								// 3 shots.
+#define EMP_ATTACK_DISRUPT 					20								// 5 shots.
+#define EMP_STRAFE_DISABLE					12								// 3 shots.
 
 //About components
 #define MECH_COMPONENT_DAMAGE_UNDAMAGED		1

--- a/code/modules/mechs/_mech_defines.dm
+++ b/code/modules/mechs/_mech_defines.dm
@@ -21,10 +21,10 @@
 #define MECH_SOFTWARE_ENGINEERING			"advanced engineering systems"	// RCD.
 
 // EMP damage points before various effects occur.
-#define EMP_HUD_DISRUPT 					5								// 1 ion rifle shot == 4.5ish, w/ combat armor.
+#define EMP_HUD_DISRUPT 					5								// 2 ion rifle shots //1 ion rifle shot == 4.5ish emp_damage w/ combat armor.
 #define EMP_MOVE_DISRUPT 					10								// 3 shots.
-#define EMP_ATTACK_DISRUPT 					20								// 5 shots.
 #define EMP_STRAFE_DISABLE					12								// 3 shots.
+#define EMP_ATTACK_DISRUPT 					20								// 5 shots.
 
 //About components
 #define MECH_COMPONENT_DAMAGE_UNDAMAGED		1

--- a/code/modules/mechs/_mech_defines.dm
+++ b/code/modules/mechs/_mech_defines.dm
@@ -23,7 +23,7 @@
 // EMP damage points before various effects occur.
 #define EMP_HUD_DISRUPT 					5								// 2 ion rifle shots //1 ion rifle shot == 4.5ish emp_damage w/ combat armor.
 #define EMP_MOVE_DISRUPT 					10								// 3 shots.
-#define EMP_STRAFE_DISABLE					12								// 3 shots.
+#define EMP_STRAFE_DISABLE					10								// 3 shots.
 #define EMP_ATTACK_DISRUPT 					20								// 5 shots.
 
 //About components

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -15,7 +15,7 @@
 	restricted_hardpoints = list(HARDPOINT_LEFT_HAND, HARDPOINT_RIGHT_HAND)
 	restricted_software = list(MECH_SOFTWARE_WEAPONS)
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 3)
-	matter = list(MATERIAL_PLASTEEL = 24, MATERIAL_PLASTIC = 10, MATERIAL_SILVER = 3)
+	matter = list(MATERIAL_PLASTEEL = 25, MATERIAL_PLASTIC = 10, MATERIAL_SILVER = 10)
 
 /obj/item/gun/energy/taser/carbine/mounted
 	bad_type = /obj/item/gun/energy/taser/carbine/mounted
@@ -38,7 +38,7 @@
 	desc = "An exosuit-mounted ion rifle. Handle with care."
 	icon_state = "mech_ionrifle"
 	holding_type = /obj/item/gun/energy/ionrifle/mounted/mech
-	matter = list(MATERIAL_PLASTEEL = 24, MATERIAL_SILVER = 10)
+	matter = list(MATERIAL_PLASTEEL = 25, MATERIAL_PLASTIC = 10, MATERIAL_SILVER = 10)
 	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 4)
 
 /obj/item/gun/energy/ionrifle/mounted
@@ -59,7 +59,7 @@
 	desc = "An exosuit-mounted laser rifle. Handle with care."
 	icon_state = "mech_lasercarbine"
 	holding_type = /obj/item/gun/energy/laser/mounted/mech
-	matter = list(MATERIAL_PLASTEEL = 26, MATERIAL_SILVER = 5)
+	matter = list(MATERIAL_PLASTEEL = 25, MATERIAL_PLASTIC = 10, MATERIAL_SILVER = 10)
 	origin_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 3)
 
 /obj/item/gun/energy/laser/mounted
@@ -74,6 +74,7 @@
 	twohanded = FALSE
 	charge_cost = MECH_WEAPON_POWER_COST
 	burst = 2
+	init_firemodes = list()
 	burst_delay = 1.5
 	matter = list()
 	cell_type = /obj/item/cell/medium/mech
@@ -118,13 +119,13 @@
 
 /obj/item/mech_equipment/mounted_system/ballistic/pk
 	name = "SA \"VJP\""
-	desc = "A reverse engineered Pulemyot Kalashnikova fitted for mech use. Fires in 15 round bursts. Horribly inaccurate, but packs quite a punch."
+	desc = "A reverse engineered Pulemyot Kalashnikova fitted for mech use. Fires in 5 round bursts. Horribly inaccurate, but packs quite a punch."
 	icon_state = "mech_pk"
 	holding_type = /obj/item/gun/projectile/automatic/lmg/pk/mounted/mech
 	restricted_hardpoints = list(HARDPOINT_LEFT_HAND, HARDPOINT_RIGHT_HAND)
 	restricted_software = list(MECH_SOFTWARE_WEAPONS)
 	origin_tech = list(TECH_COMBAT = 5, TECH_MAGNET = 3)
-	matter = list(MATERIAL_PLASTEEL = 60)
+	matter = list(MATERIAL_PLASTEEL = 50, MATERIAL_GOLD = 8, MATERIAL_SILVER = 5) // Gold and silver for it's ammo-regeneration electronics
 	spawn_blacklisted = TRUE
 
 /obj/item/gun/projectile/automatic/lmg/pk/mounted
@@ -136,7 +137,7 @@
 	restrict_safety = TRUE
 	twohanded = FALSE
 	init_firemodes = list(
-		list(mode_name="spit fire",  burst=5, burst_delay=0.8, move_delay=5,  icon="burst")
+		list(mode_name="spit fire",  burst=5, burst_delay=0.8, move_delay=5, one_hand_penalty=15, icon="burst")
 		)
 	spawn_tags = null
 	matter = list()

--- a/code/modules/mechs/interface/screen_objects.dm
+++ b/code/modules/mechs/interface/screen_objects.dm
@@ -275,7 +275,10 @@
 	name = "toggle strafing"
 	icon_state = "strafe"
 
-/obj/screen/movable/exosuit/toggle/strafe/toggled()
+/obj/screen/movable/exosuit/toggle/strafe/toggled() // Prevents exosuits from strafing when EMP'd enough
+	if(owner.emp_damage >= EMP_STRAFE_DISABLE)
+		to_chat(usr, SPAN_WARNING("Error: Coordination systems are unable to synchronize. Contact an authorised exo-electrician immediately."))
+		return
 	owner.strafing = ..()
 	to_chat(usr, SPAN_NOTICE("Strafing [owner.strafing ? "enabled" : "disabled"]."))
 

--- a/code/modules/mechs/mech_movement.dm
+++ b/code/modules/mechs/mech_movement.dm
@@ -67,6 +67,9 @@
 	var/mob/living/exosuit/exosuit = host
 	var/moving_dir = direction
 
+	if(exosuit.emp_damage >= EMP_STRAFE_DISABLE && exosuit.strafing == TRUE) //Stops a heavily EMP'd exosuit from strafing
+		exosuit.strafing = FALSE
+
 	var/failed = FALSE
 	if(exosuit.emp_damage >= EMP_MOVE_DISRUPT && prob(30))
 		failed = TRUE


### PR DESCRIPTION
## About The Pull Request

This fixes exosuits being able to mostly ignore movement disruptions from EMP damage by disabling a mech's strafe if its emp_damage reaches a threshold. 

## Why It's Good For The Game

A few people complained exosuits were able to 'soak up EMPs before running off to repair', this should fix that. It'll still be able to waddle back, but should be far easier to finish off now.

Also, changes the mech's laser gun to fire in 2-round bursts now, this was an intended feature that didn't work, rebalances a few mech parts costs, and makes the mech PK a tad more accurate.

## Changelog
:cl:
balance: fixes mechs running at full speed when EMP'd, changes costs of a few mech guns, reduces the the internal mag for exosuit energy guns
fix: fixes mech's move disruption being functionally useless, makes the immolator fire in bursts
/:cl:
