### PR TITLE
Make medspecs spawn with their flash resistant medhud

### DIFF
--- a/code/datums/outfits/jobs/security.dm
+++ b/code/datums/outfits/jobs/security.dm
@@ -61,6 +61,7 @@
 	pda_type = /obj/item/modular_computer/pda/forensics
 	belt = /obj/item/storage/belt/medical/emt
 	l_hand = /obj/item/storage/briefcase/crimekit
+	glasses = /obj/item/clothing/glasses/sunglasses/medhud
 	backpack_contents = list(/obj/item/gun/energy/gun/martin = 1, /obj/item/cell/small/high = 1)
 
 /decl/hierarchy/outfit/job/security/ihoper

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -147,7 +147,7 @@
 	icon_state = "sec"
 
 /obj/structure/closet/secure_closet/medspec/populate_contents()
-	new /obj/item/clothing/glasses/sunglasses/medhud(src)
+	new /obj/item/clothing/glasses/sunglasses/sechud/tactical(src)
 	new /obj/item/clothing/mask/gas/ihs(src)
 	new /obj/item/taperoll/police(src)
 	new /obj/item/clothing/under/rank/medspec(src)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The flash resistant medical HUD was a new addition to the medspec locker. Problem is that IH operatives keep breaking into the locker to steal them. Now medspecs spawn directly with these on their eyes.


## Changelog
:cl: Hyperio
del: Removed flash resistant medhud from medspec locker
tweak: Medspecs now directly spawn with their flash resistant medhud
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
