### PR TITLE
Makes the Mateba OP as it was always meant to be

### DIFF
--- a/code/modules/projectiles/guns/projectile/revolver/mateba.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/mateba.dm
@@ -9,7 +9,5 @@
 	damage_multiplier = 1.75
 	penetration_multiplier = 1.5
 	recoil_buildup = 6
-
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
-
-
+	spawn_blacklisted = TRUE

--- a/code/modules/projectiles/guns/projectile/revolver/mateba.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/mateba.dm
@@ -5,8 +5,8 @@
 	icon_state = "mateba"
 	drawChargeMeter = FALSE
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
-	price_tag = 3000 //more op and rare than miller, hits harder, but have fun with hittin anything
-	damage_multiplier = 1.35
+	price_tag = 3000 //more op and rare than miller, hits as hard as a Miller and doesn't struggle with armor, good luck finding it
+	damage_multiplier = 1.75
 	penetration_multiplier = 1.5
 	recoil_buildup = 6
 

--- a/code/modules/projectiles/guns/projectile/revolver/mateba.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/mateba.dm
@@ -9,5 +9,6 @@
 	damage_multiplier = 1.75
 	penetration_multiplier = 1.5
 	recoil_buildup = 6
+
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
-	spawn_blacklisted = TRUE
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Mateba damage modifier updated from 1.35x to 1.75x
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
OP revolver should be OP, I refuse to accept that a Consul is equally as good as a Mateba.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Mateba damage modifier changed from 1.35x to 1.75x. Good luck ever finding it though.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
