### PR TITLE
Speedloaders in uplinks come in a box of 2 also price changes

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -81,14 +81,14 @@
 
 /datum/uplink_item/item/ammo/slpistol
 	name = ".35 Auto SL box"
-	desc = "Contains 2 standard .35 Auto speed loader, loaded with lethal ammunition. Can fit 6 bullets."
+	desc = "Contains 2 standard .35 Auto speed loaders, loaded with lethal ammunition. Can fit 6 bullets."
 	item_cost = 1
 	antag_roles = list(ROLE_TRAITOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/storage/box/syndie_kit/slpistol
 
 /datum/uplink_item/item/ammo/slpistol/highvelocity
 	name = ".35 Auto HV SL"
-	desc = "Contains 2 standard .35 Auto speed loader, loaded with high-velocity ammunition. Can fit 6 bullets."
+	desc = "Contains 2 standard .35 Auto speed loaders, loaded with high-velocity ammunition. Can fit 6 bullets."
 	item_cost = 2
 	antag_roles = list(ROLE_TRAITOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/storage/box/syndie_kit/slpistol/hv

--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -73,39 +73,39 @@
 /datum/uplink_item/item/ammo/magnum/msmg/hv
 	name = "SMG .40 HV magazine"
 	desc = "SMG .40 magazine, loaded with high velocity ammunition. Can fit 25 bullets."
-	item_cost = 4
+	item_cost = 5
 	antag_roles = list(ROLE_TRAITOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/ammo_magazine/msmg/hv
 
 ///// .35 and .40 revolvers////
 
 /datum/uplink_item/item/ammo/slpistol
-	name = ".35 Auto SL"
-	desc = "Standard .35 Auto speed loader, loaded with lethal ammunition. Can fit 6 bullets."
+	name = ".35 Auto SL box"
+	desc = "Contains 2 standard .35 Auto speed loader, loaded with lethal ammunition. Can fit 6 bullets."
 	item_cost = 1
 	antag_roles = list(ROLE_TRAITOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/ammo_magazine/slpistol
+	path = /obj/item/storage/box/syndie_kit/slpistol
 
 /datum/uplink_item/item/ammo/slpistol/highvelocity
 	name = ".35 Auto HV SL"
-	desc = "Standard .35 Auto speed loader, loaded with high-velocity ammunition. Can fit 6 bullets."
+	desc = "Contains 2 standard .35 Auto speed loader, loaded with high-velocity ammunition. Can fit 6 bullets."
 	item_cost = 2
 	antag_roles = list(ROLE_TRAITOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/ammo_magazine/slpistol/hv
+	path = /obj/item/storage/box/syndie_kit/slpistol/hv
 
 /datum/uplink_item/item/ammo/slmagnum
-	name = ".40 magnum SL"
-	desc = ".40 magnum speed loader, loaded with lethal ammunition. Can fit 6 bullets."
+	name = ".40 magnum SL box"
+	desc = "Contains 2 .40 magnum speed loaders, loaded with lethal ammunition. Can fit 6 bullets."
 	item_cost = 1
 	antag_roles = list(ROLE_TRAITOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/ammo_magazine/slmagnum
+	path = /obj/item/storage/box/syndie_kit/slmagnum
 
 /datum/uplink_item/item/ammo/slmagnum/highvelocity
-	name = ".40 magnum HV SL"
-	desc = ".40 magnum HV speed loader, loaded with high velocity ammunition. Can fit 6 bullets."
+	name = ".40 magnum HV SL box"
+	desc = "Contains 2 .40 magnum HV speed loaders, loaded with high velocity ammunition. Can fit 6 bullets."
 	item_cost = 4
 	antag_roles = list(ROLE_TRAITOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/ammo_magazine/slmagnum/highvelocity
+	path = /obj/item/storage/box/syndie_kit/slmagnum/highvelocity
 
 
 /////.20 . 25 .30 Rifles/////
@@ -192,7 +192,7 @@
 /datum/uplink_item/item/ammo/magnum_hv
 	name = ".40 Magnum HV ammo packet"
 	desc = ".40 ammo packet with high velocity ammunition. Contain 30 bullets."
-	item_cost = 5
+	item_cost = 6
 	antag_roles = list(ROLE_TRAITOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/ammo_magazine/ammobox/magnum/hv
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -357,4 +357,33 @@
 	new /obj/item/soap/syndie(src)
 	new /obj/item/bodybag/expanded(src)
 	new /obj/item/grenade/chem_grenade/cleaner(src)
-	new /obj/item/reagent_containers/spray/cleaner(src) 
+	new /obj/item/reagent_containers/spray/cleaner(src)
+/obj/item/storage/box/syndie_kit/slmagnum
+	name = ".40 leathal speedloader box"
+	desc = "Contains 2 .40 leathal speedloaders."
+
+/obj/item/storage/box/syndie_kit/slmagnum/populate_contents()
+	new /obj/item/ammo_magazine/slmagnum(src)
+	new /obj/item/ammo_magazine/slmagnum(src)
+/obj/item/storage/box/syndie_kit/slmagnum/highvelocity
+	name = ".40 HV high velocity speedloader box"
+	desc = "Contains 2 .40 HV high velocity speedloaders."
+
+/obj/item/storage/box/syndie_kit/slmagnum/highvelocity/populate_contents()
+	new /obj/item/ammo_magazine/slmagnum/highvelocity(src)
+	new /obj/item/ammo_magazine/slmagnum/highvelocity(src)
+/obj/item/storage/box/syndie_kit/slpistol
+	name = ".35 leathal speedloader box"
+	desc = "Contains 2 .35 leathal speedloaders speedloaders."
+
+/obj/item/storage/box/syndie_kit/slpistol/populate_contents()
+	new /obj/item/ammo_magazine/slpistol(src)
+	new /obj/item/ammo_magazine/slpistol(src)
+/obj/item/storage/box/syndie_kit/slpistol/hv
+	name = ".35 HV high velocity speedloaders box"
+	desc = "Contains 2 .35 HV high velocity speedloaders."
+
+/obj/item/storage/box/syndie_kit/slpistol/hv/populate_contents()
+	new /obj/item/ammo_magazine/slpistol/hv(src)
+	new /obj/item/ammo_magazine/slpistol/hv(src)
+

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -359,29 +359,29 @@
 	new /obj/item/grenade/chem_grenade/cleaner(src)
 	new /obj/item/reagent_containers/spray/cleaner(src)
 /obj/item/storage/box/syndie_kit/slmagnum
-	name = ".40 leathal speedloader box"
-	desc = "Contains 2 .40 leathal speedloaders."
+	name = ".40 lethal speedloader box"
+	desc = "Contains 2 .40 lethal speedloaders."
 
 /obj/item/storage/box/syndie_kit/slmagnum/populate_contents()
 	new /obj/item/ammo_magazine/slmagnum(src)
 	new /obj/item/ammo_magazine/slmagnum(src)
 /obj/item/storage/box/syndie_kit/slmagnum/highvelocity
-	name = ".40 HV high velocity speedloader box"
-	desc = "Contains 2 .40 HV high velocity speedloaders."
+	name = ".40 HV speedloader box"
+	desc = "Contains 2 .40 HV speedloaders."
 
 /obj/item/storage/box/syndie_kit/slmagnum/highvelocity/populate_contents()
 	new /obj/item/ammo_magazine/slmagnum/highvelocity(src)
 	new /obj/item/ammo_magazine/slmagnum/highvelocity(src)
 /obj/item/storage/box/syndie_kit/slpistol
-	name = ".35 leathal speedloader box"
-	desc = "Contains 2 .35 leathal speedloaders speedloaders."
+	name = ".35 lethal speedloader box"
+	desc = "Contains 2 .35 lethal speedloaders."
 
 /obj/item/storage/box/syndie_kit/slpistol/populate_contents()
 	new /obj/item/ammo_magazine/slpistol(src)
 	new /obj/item/ammo_magazine/slpistol(src)
 /obj/item/storage/box/syndie_kit/slpistol/hv
-	name = ".35 HV high velocity speedloaders box"
-	desc = "Contains 2 .35 HV high velocity speedloaders."
+	name = ".35 HV speedloaders box"
+	desc = "Contains 2 .35 HV speedloaders."
 
 /obj/item/storage/box/syndie_kit/slpistol/hv/populate_contents()
 	new /obj/item/ammo_magazine/slpistol/hv(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -358,6 +358,7 @@
 	new /obj/item/bodybag/expanded(src)
 	new /obj/item/grenade/chem_grenade/cleaner(src)
 	new /obj/item/reagent_containers/spray/cleaner(src)
+
 /obj/item/storage/box/syndie_kit/slmagnum
 	name = ".40 lethal speedloader box"
 	desc = "Contains 2 .40 lethal speedloaders."
@@ -365,6 +366,7 @@
 /obj/item/storage/box/syndie_kit/slmagnum/populate_contents()
 	new /obj/item/ammo_magazine/slmagnum(src)
 	new /obj/item/ammo_magazine/slmagnum(src)
+
 /obj/item/storage/box/syndie_kit/slmagnum/highvelocity
 	name = ".40 HV speedloader box"
 	desc = "Contains 2 .40 HV speedloaders."
@@ -372,6 +374,7 @@
 /obj/item/storage/box/syndie_kit/slmagnum/highvelocity/populate_contents()
 	new /obj/item/ammo_magazine/slmagnum/highvelocity(src)
 	new /obj/item/ammo_magazine/slmagnum/highvelocity(src)
+
 /obj/item/storage/box/syndie_kit/slpistol
 	name = ".35 lethal speedloader box"
 	desc = "Contains 2 .35 lethal speedloaders."
@@ -379,6 +382,7 @@
 /obj/item/storage/box/syndie_kit/slpistol/populate_contents()
 	new /obj/item/ammo_magazine/slpistol(src)
 	new /obj/item/ammo_magazine/slpistol(src)
+
 /obj/item/storage/box/syndie_kit/slpistol/hv
 	name = ".35 HV speedloaders box"
 	desc = "Contains 2 .35 HV speedloaders."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

.35 and .40 speedloaders very horribly overpriced compared to other .35 and .40 ammo, this fixes that problem.

## Why It's Good For The Game

Traitors are encouraged not to just buy .35 and .40 ammo from mags and put it in speedloaders and instantly reloading revolvers with that tactic.

## Changelog
:cl:
tweak: both .35 and .40 speedloaders lethal and HV variant now come in a box of 2
tweak: .40 SMG HV cost increased from 4 to 5, .40 HV ammo packet cost increased from 5 to 6
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
