### PR TITLE
Replace vomitol with mold in trash foods

### DIFF
--- a/code/game/objects/random/food.dm
+++ b/code/game/objects/random/food.dm
@@ -48,12 +48,14 @@
 			list("hclacid" = 20) = 2,
 			list("potassium" = 20) = 2,
 			list("iron" = 20) = 2,
+			list("water" = 20) = 2,
+			list("ethanol" = 20) = 2,
+			list("sugar" = 20) = 2,
 			list("copper" = 20) = 2,
 			list("mercury" = 20) = 2,
 			list("radium" = 20) = 2,
 			list("sacid" = 20) = 2,
 			list("tungsten" = 20) = 2,
-			list("vomitol" = 20) = 6,
 			list("mold" = 20) = 10)
 		var/list/picked_reagents = pickweight(random_reagent_list)
 		for(var/reagent in picked_reagents)

--- a/code/game/objects/random/food.dm
+++ b/code/game/objects/random/food.dm
@@ -51,12 +51,10 @@
 			list("copper" = 20) = 2,
 			list("mercury" = 20) = 2,
 			list("radium" = 20) = 2,
-			list("water" = 20) = 2,
-			list("ethanol" = 20) = 2,
-			list("sugar" = 20) = 2,
 			list("sacid" = 20) = 2,
 			list("tungsten" = 20) = 2,
-			list("vomitol" = 20) = 10)
+			list("vomitol" = 20) = 6,
+			list("mold" = 20) = 10)
 		var/list/picked_reagents = pickweight(random_reagent_list)
 		for(var/reagent in picked_reagents)
 			food.reagents.add_reagent(reagent, picked_reagents[reagent])

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -754,8 +754,12 @@
 	taste_description = "stale vomit mixed with pineapples"
 	reagent_state = LIQUID
 	color = "#467508"
-	metabolism = REM * 2
-	overdose = REAGENTS_OVERDOSE
+	metabolism = REM
+	overdose = REAGENTS_OVERDOSE/2
 	nerve_system_accumulations = 5
 	strength = 0.01
 	sanityloss = 2
+
+/datum/reagent/toxin/mold/overdose(mob/living/carbon/M, alien, effect_multiplier)
+	if(prob(10))
+		M.vomit()

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -760,6 +760,7 @@
 	strength = 0.01
 	sanityloss = 2
 
-/datum/reagent/toxin/mold/overdose(mob/living/carbon/M, alien, effect_multiplier)
-	if(prob(10))
+/datum/reagent/toxin/mold/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
+	. = ..()
+	if(prob(20 * effect_multiplier))
 		M.vomit()

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -746,3 +746,16 @@
 	color = "#140b30"
 	reagent_state = LIQUID
 	strength = 4
+
+/datum/reagent/toxin/mold
+	name = "Mold"
+	id = "mold"
+	description = "Food that went rotting for so long it liquefied. Do not consume."
+	taste_description = "stale vomit mixed with pineapples"
+	reagent_state = LIQUID
+	color = "#467508"
+	metabolism = REM * 2
+	overdose = REAGENTS_OVERDOSE
+	nerve_system_accumulations = 5
+	strength = 0.01
+	sanityloss = 2

--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -432,6 +432,11 @@
 	required_reagents = list("cryptobiolin" = 1, "inaprovaline" = 1)
 	result_amount = 2
 
+/datum/chemical_reaction/spaceacilin_mold
+	result = "spaceacilin"
+	required_reagents = list("mold" = 1, "sugar" = 1, "acetone" = 1)
+	result_amount = 6
+
 /datum/chemical_reaction/imidazoline
 	result = "imidazoline"
 	required_reagents = list("carbon" = 1, "hydrazine" = 1, "anti_toxin" = 1)

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -132,7 +132,7 @@
 		var/actual_volume = reagents.total_volume
 		for(var/datum/reagent/R in reagents.reagent_list)
 			reagents.remove_reagent(R.id,rand(0, R.volume),TRUE)
-		reagents.add_reagent("toxin", rand(0, actual_volume - reagents.total_volume))
+		reagents.add_reagent("mold", rand(0, actual_volume - reagents.total_volume))
 
 /obj/item/reagent_containers/food/snacks/make_old(low_quality_oldification)
 	.=..()


### PR DESCRIPTION
## About The Pull Request
yum!
Replaces vomitol in (most of) oldified food with mold, which damages sanity(2 per tick, spider venom deals 3, for scale) and gives a very little toxin damage(equal to pararein)
The taste is horrendous.
## Why It's Good For The Game

So, basically, homemade pararein. More potent(and common) version of vomitol, that can be extracted and added to normal drinks and foods to trol people
Vomitol, which is actually medicine, shouldn't be in old foods. So it's just a chem that you make now.
P. S. I decided to not add any warnings to the user about the mold processing and dealing sanity damage, but I can add them if needed.
## Changelog
:cl:
add: mold toxin. Mold deals sanity damage and a little bit of toxin damage.
tweak: vomitol in trash foods is replaced with mold.
/:cl:
