### PR TITLE
Breakable splints

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -68,7 +68,7 @@
 		if(ishuman(src) && def_zone)
 			var/mob/living/carbon/human/H = src
 			var/obj/item/organ/external/o = H.get_organ(def_zone)
-			if (o && o.status & ORGAN_SPLINTED && effective_damage > 20)
+			if (o && o.status & ORGAN_SPLINTED && effective_damage >= 20)
 				visible_message(SPAN_WARNING("The splints break off [src] after being hit!"),
 						SPAN_WARNING("Your splints break off after being hit!"))
 				o.status &= ~ORGAN_SPLINTED
@@ -85,7 +85,7 @@
 		//Actual part of the damage that passed through armor
 		var/actual_damage = round ( ( effective_damage * ( 100 - armor_effectiveness ) ) / 100 )
 		apply_damage(actual_damage, damagetype, def_zone, sharp, edge, used_weapon)
-		if(ishuman(src) && def_zone && actual_damage > 20)
+		if(ishuman(src) && def_zone && actual_damage >= 20)
 			var/mob/living/carbon/human/H = src
 			var/obj/item/organ/external/o = H.get_organ(def_zone)
 			if (o && o.status & ORGAN_SPLINTED)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -65,6 +65,13 @@
 	//No armor? Damage as usual
 	if(armor_effectiveness == 0)
 		apply_damage(effective_damage, damagetype, def_zone, sharp, edge, used_weapon)
+		if(ishuman(src) && def_zone)
+			var/mob/living/carbon/human/H = src
+			var/obj/item/organ/external/o = H.get_organ(def_zone)
+			if (o && o.status & ORGAN_SPLINTED && effective_damage > 20)
+				visible_message(SPAN_WARNING("The splints break off [src] after being hit!"),
+						SPAN_WARNING("Your splints break off after being hit!"))
+				o.status &= ~ORGAN_SPLINTED
 		if(sanctified_attack)
 			apply_damage(effective_damage / 2, BURN, def_zone, sharp, edge, used_weapon)
 	//Here we split damage in two parts, where armor value will determine how much damage will get through
@@ -78,11 +85,17 @@
 		//Actual part of the damage that passed through armor
 		var/actual_damage = round ( ( effective_damage * ( 100 - armor_effectiveness ) ) / 100 )
 		apply_damage(actual_damage, damagetype, def_zone, sharp, edge, used_weapon)
+		if(ishuman(src) && def_zone && actual_damage > 20)
+			var/mob/living/carbon/human/H = src
+			var/obj/item/organ/external/o = H.get_organ(def_zone)
+			if (o && o.status & ORGAN_SPLINTED)
+				visible_message(SPAN_WARNING("The splints break off [src] after being hit!"),
+						SPAN_WARNING("Your splints break off after being hit!"))
+				o.status &= ~ORGAN_SPLINTED
 		if(sanctified_attack)
 			apply_damage(actual_damage / 2, BURN, def_zone, sharp, edge, used_weapon)
 		return actual_damage
 	return effective_damage
-
 
 //if null is passed for def_zone, then this should return something appropriate for all zones (e.g. area effect damage)
 /mob/living/proc/getarmor(var/def_zone, var/type)


### PR DESCRIPTION

## About The Pull Request

spcr made a salt pr and then closed it without fleshing it out, I decided that the idea is good so I stole his code and tweaked it.

splints fall off after getting more than 20 damage. For scale, wielded untoolmodded crowbar deals 19.5, unwielded untoolmodded butcher cleaver deals 20.
## Why It's Good For The Game

"No longer you can combat pre-splint to avoid a major part of the medical system and balance"

## Changelog
:cl:
balance: splints break and fall off after being hit, 20+ damage to break them.
/:cl:

