### PR TITLE
Buff ethanol and serotrotium

### DIFF
--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -311,18 +311,7 @@
 		stop()
 		if(cooked)
 			cooked.loc = src.loc
-			convert_nutriment(cooked)
 		return
-
-/obj/machinery/microwave/proc/convert_nutriment(atom/target) //converts main types of nutriment(protein, nutriment)
-	if(target.type in blacklisted_from_buffs)	//to their cooked versions(reagents/food-Drinks.dm), which restore sanity
-		return FALSE // No buffs if food is blacklisted(only hot pockets for now)
-	var/amount = target.reagents.get_reagent_amount("nutriment")
-	target.reagents.remove_reagent("nutriment", amount)
-	target.reagents.add_reagent("cooked_nutriment", amount)
-	amount = target.reagents.get_reagent_amount("protein")
-	target.reagents.remove_reagent("protein", amount)
-	target.reagents.add_reagent("cooked_protein", amount) //other subtypes can be ignored, they are more for flavoring and do very little in terms of nutrition
 
 /obj/machinery/microwave/proc/wzhzhzh(var/seconds as num) // Whoever named this proc is fucking literally Satan. ~ Z
 	for (var/i=1 to seconds)

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -18,6 +18,9 @@
 	var/global/list/acceptable_items // List of the items you can put in
 	var/global/list/acceptable_reagents // List of the reagents you can put in
 	var/global/max_n_of_items = 0
+	var/list/blacklisted_from_buffs = list(
+	/obj/item/reagent_containers/food/snacks/donkpocket
+	)
 
 
 // see code/modules/food/recipes_microwave.dm for recipes
@@ -308,7 +311,18 @@
 		stop()
 		if(cooked)
 			cooked.loc = src.loc
+			convert_nutriment(cooked)
 		return
+
+/obj/machinery/microwave/proc/convert_nutriment(atom/target) //converts main types of nutriment(protein, nutriment)
+	if(target.type in blacklisted_from_buffs)	//to their cooked versions(reagents/food-Drinks.dm), which restore sanity
+		return FALSE // No buffs if food is blacklisted(only hot pockets for now)
+	var/amount = target.reagents.get_reagent_amount("nutriment")
+	target.reagents.remove_reagent("nutriment", amount)
+	target.reagents.add_reagent("cooked_nutriment", amount)
+	amount = target.reagents.get_reagent_amount("protein")
+	target.reagents.remove_reagent("protein", amount)
+	target.reagents.add_reagent("cooked_protein", amount) //other subtypes can be ignored, they are more for flavoring and do very little in terms of nutrition
 
 /obj/machinery/microwave/proc/wzhzhzh(var/seconds as num) // Whoever named this proc is fucking literally Satan. ~ Z
 	for (var/i=1 to seconds)
@@ -449,13 +463,13 @@
 /obj/machinery/microwave/campfire/abort()
 	..()
 	playsound(loc, 'sound/effects/flare.ogg', 50, 1)
-	icon_state = "barrelfire1"	
+	icon_state = "barrelfire1"
 
 /obj/machinery/microwave/campfire/stop()
 	..()
 	playsound(loc, 'sound/effects/flare.ogg', 50, 1)
 	icon_state = "barrelfire1"
-	
+
 /obj/machinery/microwave/campfire/dispose()
 	..()
 	playsound(loc, 'sound/effects/flare.ogg', 50, 1)

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -104,7 +104,7 @@
 	var/adj_temp = 0
 	var/targ_temp = 310
 	var/halluci = 0
-	sanity_gain_ingest = 0.5 //this defines how good eating/drinking the thing will make you feel
+	sanity_gain_ingest = 0.5 //this defines how good eating/drinking the thing will make you feel, scales off strength and strength mod(ethanol)
 	taste_tag = list()  // list the tastes the thing got there
 
 	glass_icon_state = "glass_clear"
@@ -445,7 +445,7 @@
 			L.take_damage(1, 0)
 	if(prob(5))
 		M.emote(pick("twitch", "blink_r", "shiver"))
-	
+
 /datum/reagent/sulfur
 	name = "Sulfur"
 	id = "sulfur"

--- a/code/modules/reagents/reagents/drugs.dm
+++ b/code/modules/reagents/reagents/drugs.dm
@@ -63,7 +63,7 @@
 	overdose = REAGENTS_OVERDOSE
 	addiction_threshold = 20
 	addiction_chance = 10
-	sanity_gain = 1.5
+	sanity_gain = 3 // Very hard to make
 
 /datum/reagent/drug/serotrotium/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(prob(7 * effect_multiplier))

--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -50,7 +50,7 @@
 	apply_sanity_effect(M, effect_multiplier)
 
 /datum/reagent/organic/nutriment/cnutriment
-	name = "Cooked nutriments"
+	name = "Cooked nutriment"
 	taste_description = "bliss"
 	id = "cooked_nutriment"
 	description = "The result of complex chemical reactions involved in cooking."
@@ -61,7 +61,7 @@
 
 /datum/reagent/organic/nutriment/affect_ingest(mob/living/carbon/M) //notify user about sanity restoration upon ingestion;
 	..()														//cprotein doesn't notify because there usually are both protein 
-	if(prob(10))											//and nutriment in foods. Not enough exceptions to bother
+	if(prob(3))										//and nutriment in foods. Not enough exceptions to bother
 		to_chat(M, SPAN_NOTICE("You feel goodness making its way through your system."))
 
 /datum/reagent/organic/nutriment/protein/cprotein

--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -49,30 +49,6 @@
 
 	apply_sanity_effect(M, effect_multiplier)
 
-/datum/reagent/organic/nutriment/cnutriment
-	name = "Cooked nutriment"
-	taste_description = "bliss"
-	id = "cooked_nutriment"
-	description = "The result of complex chemical reactions involved in cooking."
-	color = "#7e5b11"
-	// Gives a lot of sanity , but generally theres little of it.
-	// Metabolises faster than oddity tea(/reagents/other.dm)
-	sanity_gain_ingest = 1
-
-/datum/reagent/organic/nutriment/affect_ingest(mob/living/carbon/M) //notify user about sanity restoration upon ingestion;
-	..()														//cprotein doesn't notify because there usually are both protein 
-	if(prob(3))										//and nutriment in foods. Not enough exceptions to bother
-		to_chat(M, SPAN_NOTICE("You feel goodness making its way through your system."))
-
-/datum/reagent/organic/nutriment/protein/cprotein
-	name = "Cooked proteins"
-	taste_description = "perfection"
-	id = "cooked_protein"
-	description = "A mass of proteins which have undergone complex chemical processes. Simply put, cooked."
-	color = "#805009"
-	taste_tag = list(TASTE_SPICY)
-	sanity_gain_ingest = 0.7 //there can be a lot of protein in foods
-
 /datum/reagent/organic/nutriment/glucose
 	name = "Glucose"
 	id = "glucose"

--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -49,6 +49,30 @@
 
 	apply_sanity_effect(M, effect_multiplier)
 
+/datum/reagent/organic/nutriment/cnutriment
+	name = "Cooked nutriments"
+	taste_description = "bliss"
+	id = "cooked_nutriment"
+	description = "The result of complex chemical reactions involved in cooking."
+	color = "#7e5b11"
+	// Gives a lot of sanity , but generally theres little of it.
+	// Metabolises faster than oddity tea(/reagents/other.dm)
+	sanity_gain_ingest = 1
+
+/datum/reagent/organic/nutriment/affect_ingest(mob/living/carbon/M) //notify user about sanity restoration upon ingestion;
+	..()														//cprotein doesn't notify because there usually are both protein 
+	if(prob(10))											//and nutriment in foods. Not enough exceptions to bother
+	to_chat(M, SPAN_NOTICE("You feel goodness making its way through your system."))
+
+/datum/reagent/organic/nutriment/protein/cprotein
+	name = "Cooked proteins"
+	taste_description = "perfection"
+	id = "cooked_protein"
+	description = "A mass of proteins which have undergone complex chemical processes. Simply put, cooked."
+	color = "#805009"
+	taste_tag = list(TASTE_SPICY)
+	sanity_gain_ingest = 0.7 //there can be a lot of protein in foods
+
 /datum/reagent/organic/nutriment/glucose
 	name = "Glucose"
 	id = "glucose"

--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -62,7 +62,7 @@
 /datum/reagent/organic/nutriment/affect_ingest(mob/living/carbon/M) //notify user about sanity restoration upon ingestion;
 	..()														//cprotein doesn't notify because there usually are both protein 
 	if(prob(10))											//and nutriment in foods. Not enough exceptions to bother
-	to_chat(M, SPAN_NOTICE("You feel goodness making its way through your system."))
+		to_chat(M, SPAN_NOTICE("You feel goodness making its way through your system."))
 
 /datum/reagent/organic/nutriment/protein/cprotein
 	name = "Cooked proteins"

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -310,6 +310,9 @@
 	var/sanity_gain = E.sanity_gain_ingest
 	if(E.id == "ethanol")
 		sanity_gain /= 5
+	else if(istype(E, /datum/reagent/ethanol))
+		var/datum/reagent/ethanol/fine_drink = E
+		sanity_gain *= fine_drink.strength / 5 
 	changeLevel(sanity_gain * multiplier)
 	if(resting && E.taste_tag.len)
 		for(var/taste_tag in E.taste_tag)

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -312,7 +312,8 @@
 		sanity_gain /= 5
 	else if(istype(E, /datum/reagent/ethanol))
 		var/datum/reagent/ethanol/fine_drink = E
-		sanity_gain *= fine_drink.strength / 5 
+		if (fine_drink.strength <= 20)
+			sanity_gain *= (5 - (fine_drink.strength / 5))
 	changeLevel(sanity_gain * multiplier)
 	if(resting && E.taste_tag.len)
 		for(var/taste_tag in E.taste_tag)


### PR DESCRIPTION
## About The Pull Request

Alchohols give scaling sanity gain based on their strength
serotrotium insight gain = 3, previously - 1.5
## Why It's Good For The Game
Ciggaretes shall no longer be the king, long live throwing my wealth at alchohol at club.
## Changelog
:cl:
balance: Alcholic reagents give in general much more sanity based off their strength
balance: serotrotium insight gain increased to 3
/:cl: