### PR TITLE
remove useless cleanup of /atom/var/reagents

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -32,13 +32,6 @@ would spawn and follow the beaker, even if it is carried or thrown.
 		pixel_x += rand(-random_offset,random_offset)
 		pixel_y += rand(-random_offset,random_offset)
 
-
-
-/obj/effect/Destroy()
-	if(reagents)
-		reagents.delete()
-	return ..()
-
 /datum/effect/effect/system
 	var/number = 3
 	var/cardinals = 0

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -60,6 +60,7 @@
 		SSchemistry.active_holders -= src
 
 	for(var/datum/reagent/R in reagent_list)
+		R.holder = null
 		qdel(R)
 	reagent_list.Cut()
 	reagent_list = null

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -111,12 +111,6 @@
 			total_volume += R.volume
 	return
 
-/datum/reagents/proc/delete()
-	for(var/datum/reagent/R in reagent_list)
-		R.holder = null
-	if(my_atom)
-		my_atom.reagents = null
-
 /datum/reagents/proc/handle_reactions()
 	if(SSchemistry)
 		SSchemistry.chem_mark_for_update(src)


### PR DESCRIPTION
## About The Pull Request

/datum/reagents/Destroy() does everything /datum/reagents/delete() does and more, and delete() is called only from /obj/effect/Destroy() which ITSELF is redundant with its parent /atom/movable/Destroy()

## Why It's Good For The Game

optimisation.

## Changelog
:cl:
del: removed abundant cleanup of atom/var/reagents.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
