### PR TITLE
Autopsy scanner error formula change

### DIFF
--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -50,9 +50,9 @@
 		if(!W.pretend_weapon)
 			var/error_chance = (user.stats.getStat(STAT_BIO) * 4) //always success at BIO 25
 			if(prob(error_chance))
-				W.pretend_weapon = pick("mechanical toolbox", "wirecutters", "revolver", "crowbar", "fire extinguisher", "tomato soup", "oxygen tank", "emergency oxygen tank", "laser", "bullet")
-			else
 				W.pretend_weapon = W.weapon
+			else
+				W.pretend_weapon = pick("mechanical toolbox", "wirecutters", "revolver", "crowbar", "fire extinguisher", "tomato soup", "oxygen tank", "emergency oxygen tank", "laser", "bullet")
 
 
 		var/datum/autopsy_data_scanner/D = wdata[V]

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -48,8 +48,8 @@
 		var/datum/autopsy_data/W = O.autopsy_data[V]
 
 		if(!W.pretend_weapon)
-			// 5% chance for the device to bug out
-			if(prob(5))
+			var/error_chance = (user.stat.getStat(STAT_BIO) * 4) //always success at BIO 25+
+			if(prob(error_chance))
 				W.pretend_weapon = pick("mechanical toolbox", "wirecutters", "revolver", "crowbar", "fire extinguisher", "tomato soup", "oxygen tank", "emergency oxygen tank", "laser", "bullet")
 			else
 				W.pretend_weapon = W.weapon

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -48,7 +48,7 @@
 		var/datum/autopsy_data/W = O.autopsy_data[V]
 
 		if(!W.pretend_weapon)
-			var/error_chance = (user.stat.getStat(STAT_BIO) * 4) //always success at BIO 25+
+			var/error_chance = (user.stats.getStat(STAT_BIO) * 4) //always success at BIO 25
 			if(prob(error_chance))
 				W.pretend_weapon = pick("mechanical toolbox", "wirecutters", "revolver", "crowbar", "fire extinguisher", "tomato soup", "oxygen tank", "emergency oxygen tank", "laser", "bullet")
 			else

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -48,16 +48,11 @@
 		var/datum/autopsy_data/W = O.autopsy_data[V]
 
 		if(!W.pretend_weapon)
-			/*
-			// the more hits, the more likely it is that we get the right weapon type
-			if(prob(50 + W.hits * 10 + W.damage))
-			*/
-
-			// Buffing this stuff up for now!
-			if(prob(min(20 + (user.stats.getMult(STAT_BIO, STAT_LEVEL_EXPERT) * 100 ), 100)))
-				W.pretend_weapon = W.weapon
-			else
+			// 5% chance for the device to bug out
+			if(prob(5))
 				W.pretend_weapon = pick("mechanical toolbox", "wirecutters", "revolver", "crowbar", "fire extinguisher", "tomato soup", "oxygen tank", "emergency oxygen tank", "laser", "bullet")
+			else
+				W.pretend_weapon = W.weapon
 
 
 		var/datum/autopsy_data_scanner/D = wdata[V]
@@ -189,7 +184,7 @@
 		src.wdata = list()
 		src.chemtraces = list()
 		src.timeofdeath = null
-		to_chat(user, SPAN_NOTICE("A new patient has been registered.. Purging data for previous patient."))
+		to_chat(user, SPAN_NOTICE("A new patient has been registered. Purging data for previous patient."))
 
 	src.timeofdeath = M.timeofdeath
 


### PR DESCRIPTION
## About The Pull Request

~~how the FUCK can a device in 5577 BUG OUT depending on HOW YOU HOLD IT???!!!~~ <-- I am still salty about this
formula itself: (BIO_STAT) * 4, always success at BIO 25+
## Why It's Good For The Game

you will be seeing those OPs who died to "tomato soup" and "oxygen tank" while being full of high-velocity pistol bullets far less often
## Changelog
:cl:
tweak: autopsy scanning error formula changed to BIO_STAT * 4
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
