### PR TITLE
Caliber names for bullet projectiles

### DIFF
--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -11,7 +11,7 @@ There are important things regarding this file:
 */
 //Low-caliber pistols and SMGs .35
 /obj/item/projectile/bullet/pistol
-	name = ".35 bullet"
+	name = ".35 caliber bullet"
 	damage_types = list(BRUTE = 28)
 	armor_penetration = 10
 	can_ricochet = TRUE
@@ -48,7 +48,7 @@ There are important things regarding this file:
 // .20 rifle
 
 /obj/item/projectile/bullet/srifle
-	name = ".20 bullet"
+	name = ".20 caliber bullet"
 	damage_types = list(BRUTE = 25)
 	armor_penetration = 25
 	penetrating = 1
@@ -86,7 +86,7 @@ There are important things regarding this file:
 // .25 caseless rifle
 
 /obj/item/projectile/bullet/clrifle
-	name = ".25 bullet"
+	name = ".25 caliber bullet"
 	damage_types = list(BRUTE = 27)
 	armor_penetration = 15
 	penetrating = 1
@@ -124,7 +124,7 @@ There are important things regarding this file:
 // .30 rifle
 
 /obj/item/projectile/bullet/lrifle
-	name = ".30 bullet"
+	name = ".30 caliber bullet"
 	damage_types = list(BRUTE = 28)
 	armor_penetration = 20
 	penetrating = 1
@@ -158,7 +158,7 @@ There are important things regarding this file:
 
 //Revolvers and high-caliber pistols .40
 /obj/item/projectile/bullet/magnum
-	name = " .40 magnum bullet"
+	name = " .40 caliber bullet"
 	damage_types = list(BRUTE = 34)
 	armor_penetration = 15
 	can_ricochet = TRUE
@@ -192,7 +192,7 @@ There are important things regarding this file:
 
 //Sniper rifles .60
 /obj/item/projectile/bullet/antim
-	name = ".60 bullet"
+	name = ".60 caliber bullet"
 	damage_types = list(BRUTE = 70)
 	armor_penetration = 50
 	penetrating = 1

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -11,6 +11,7 @@ There are important things regarding this file:
 */
 //Low-caliber pistols and SMGs .35
 /obj/item/projectile/bullet/pistol
+	name = ".35 bullet"
 	damage_types = list(BRUTE = 28)
 	armor_penetration = 10
 	can_ricochet = TRUE
@@ -47,6 +48,7 @@ There are important things regarding this file:
 // .20 rifle
 
 /obj/item/projectile/bullet/srifle
+	name = ".20 bullet"
 	damage_types = list(BRUTE = 25)
 	armor_penetration = 25
 	penetrating = 1
@@ -84,6 +86,7 @@ There are important things regarding this file:
 // .25 caseless rifle
 
 /obj/item/projectile/bullet/clrifle
+	name = ".25 bullet"
 	damage_types = list(BRUTE = 27)
 	armor_penetration = 15
 	penetrating = 1
@@ -121,6 +124,7 @@ There are important things regarding this file:
 // .30 rifle
 
 /obj/item/projectile/bullet/lrifle
+	name = ".30 bullet"
 	damage_types = list(BRUTE = 28)
 	armor_penetration = 20
 	penetrating = 1
@@ -154,6 +158,7 @@ There are important things regarding this file:
 
 //Revolvers and high-caliber pistols .40
 /obj/item/projectile/bullet/magnum
+	name = " .40 magnum bullet"
 	damage_types = list(BRUTE = 34)
 	armor_penetration = 15
 	can_ricochet = TRUE
@@ -187,6 +192,7 @@ There are important things regarding this file:
 
 //Sniper rifles .60
 /obj/item/projectile/bullet/antim
+	name = ".60 bullet"
 	damage_types = list(BRUTE = 70)
 	armor_penetration = 50
 	penetrating = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Now lethal and HV bullet __projectiles__ are named after its caliber.
Made mostly for #6793, can also be a QoL of sorts? For compendium stories?
These two prs aren't really related so I decided to break them into two.
## Why It's Good For The Game

QoL of sorts? For compendium stories?

## Changelog
:cl:
tweak: now lethal and HV bullet projectiles are named after it's caliber.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
