### PR TITLE
Very slight Organ Efficiency changes and bugfixes

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -315,7 +315,7 @@ proc/blood_splatter(var/target,var/datum/reagent/organic/blood/source,var/large)
 				pulse_mod *= 1.1
 			if(PULSE_2FAST, PULSE_THREADY)
 				pulse_mod *= 1.25
-		blood_volume *= max(0.3, (1-((100 - heart_efficiency) / 100))) * pulse_mod
+		blood_volume *= max(0.3, (heart_efficiency / 100)) * pulse_mod
 
 	if(!open_check && chem_effects[CE_BLOODCLOT])
 		blood_volume *= max(0, 1-chem_effects[CE_BLOODCLOT])

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -335,8 +335,9 @@
 		. += 0.5
 
 	var/muscle_eff = owner.get_specific_organ_efficiency(OP_MUSCLE, organ_tag)
-	muscle_eff = muscle_eff - (muscle_eff/(owner.get_specific_organ_efficiency(OP_NERVE, organ_tag)/100)) //Need more nerves to control those new muscles
-	. += max(-(muscle_eff/ 100)/4, MAX_MUSCLE_SPEED)
+	var/nerve_eff = max(owner.get_specific_organ_efficiency(OP_NERVE, organ_tag),1)
+	muscle_eff = (muscle_eff/100) - (muscle_eff/nerve_eff) //Need more nerves to control those new muscles
+	. += max(-(muscle_eff), MAX_MUSCLE_SPEED)
 
 	. += tally
 

--- a/code/modules/organs/external/damage.dm
+++ b/code/modules/organs/external/damage.dm
@@ -21,8 +21,8 @@
 			var/obj/item/organ/internal/I = pick(internal_organs)
 			I.take_damage(brute / 2)
 			brute -= brute / 2
-
-	if(brute_dam > min_broken_damage && prob(brute_dam + brute))
+	var/bone_efficiency = owner.get_specific_organ_efficiency(OP_BONE, organ_tag)
+	if(brute_dam > (min_broken_damage * (bone_efficiency / 100)) && prob(brute_dam + brute))
 		fracture()
 
 	if(status & ORGAN_BROKEN && prob(40) && brute)

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -55,7 +55,7 @@
 	for(var/proc_path in owner_verbs)
 		verbs |= proc_path
 
-/obj/item/organ/internal/proc/get_process_eficiency(process_define)
+/obj/item/organ/internal/proc/get_process_efficiency(process_define)
 	return organ_efficiency[process_define] - (organ_efficiency[process_define] * (damage / max_damage))
 
 /obj/item/organ/internal/take_damage(amount, silent)	//Deals damage to the organ itself

--- a/code/modules/organs/internal/internal_organ_processes.dm
+++ b/code/modules/organs/internal/internal_organ_processes.dm
@@ -25,7 +25,7 @@
 	if(process_list && process_list.len)
 		for(var/organ in process_list)
 			var/obj/item/organ/internal/I = organ
-			effective_efficiency += I.get_process_eficiency(process_define)
+			effective_efficiency += I.get_process_efficiency(process_define)
 
 	return effective_efficiency ? effective_efficiency : 1
 
@@ -40,7 +40,7 @@
 		for(var/organ in parent_organ.internal_organs)
 			var/obj/item/organ/internal/I = organ
 			if(process_define in I.organ_efficiency)
-				effective_efficiency += I.get_process_eficiency(process_define)
+				effective_efficiency += I.get_process_efficiency(process_define)
 
 	return effective_efficiency ? effective_efficiency : 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

General tweaking with the organ efficiency system. Mirror of a near-identical PR I did on Sojourn

## Why It's Good For The Game
Makes Reinforced Bones work like it should

Improves code efficiency in calculating organ efficiency

Increases readability

## Changelog
:cl:
spellcheck: Fixes some variable typos for get_process_efficiency

tweak: Changes the heart's blood volume equation to an identical one that is easier to look at.

tweak: Changes the get_tally() function to include nerve and muscle efficiency. Only thing changed between this equation and the old equation is a .25 modifier on muscle efficiency. So minor it won't be noticed. (it still doesn't do much)

fix: Changed the take_damage function to account for bone efficiency when deciding whether or not to fracture a bone, like it does when an organ takes internal damage. This makes reinforced bones function better.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
