### PR TITLE
Add working status check for crafting station

### DIFF
--- a/code/game/machinery/crafting_station.dm
+++ b/code/game/machinery/crafting_station.dm
@@ -68,6 +68,10 @@
 	. = ..()
 
 /obj/machinery/craftingstation/attack_hand(mob/user as mob)
+	if(working)
+		to_chat(user, SPAN_NOTICE("You are already crafting something."))
+		return
+
 	var/cog_stat = user.stats.getStat(STAT_COG)
 
 	var/list/options = list(
@@ -159,7 +163,7 @@
 	flick("[initial(icon_state)]_warmup", src)
 	working = TRUE
 	START_PROCESSING(SSmachines, src)
-	if(do_after(user,work_time,src))
+	if(do_after(user, work_time, src))
 		STOP_PROCESSING(SSmachines, src)
 		working = FALSE
 		flick("[initial(icon_state)]_done", src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix a crafting exploit for the crafting station where you could spam recipes.

## Why It's Good For The Game

Exploit bad.

## Changelog
:cl: Hyperio
fix: Fix crafting station exploit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
