### PR TITLE
INFECTION carrion spiders don't work in prosthetic limbs

### DIFF
--- a/code/game/objects/items/weapons/implant/implant.dm
+++ b/code/game/objects/items/weapons/implant/implant.dm
@@ -66,6 +66,10 @@
 			to_chat(user, SPAN_WARNING("[src] cannot be implanted in this limb."))
 			return
 
+		if(is_carrion(user) && BP_IS_ROBOTIC(affected))
+			to_chat(user, SPAN_WARNING("[src] cannot be implanted in a prosthetic limb."))
+			return
+
 	if(!can_install(target, affected))
 		to_chat(user, SPAN_WARNING("You can't install [src]."))
 		return

--- a/code/game/objects/items/weapons/implant/implant.dm
+++ b/code/game/objects/items/weapons/implant/implant.dm
@@ -66,10 +66,6 @@
 			to_chat(user, SPAN_WARNING("[src] cannot be implanted in this limb."))
 			return
 
-		if(is_carrion(user) && BP_IS_ROBOTIC(affected))
-			to_chat(user, SPAN_WARNING("[src] cannot be implanted in a prosthetic limb."))
-			return
-
 	if(!can_install(target, affected))
 		to_chat(user, SPAN_WARNING("You can't install [src]."))
 		return

--- a/code/game/objects/items/weapons/implant/implants/carrion/infection_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/infection_spider.dm
@@ -7,6 +7,9 @@
 
 /obj/item/implant/carrion_spider/infection/activate()
 	..()
+	if(BP_IS_ROBOTIC(affected))
+		to_chat(user, SPAN_WARNING("[src] cannot be implanted in a prosthetic limb."))
+		return
 	if(!wearer)
 		to_chat(owner_mob, SPAN_WARNING("[src] doesn't have a host"))
 		return

--- a/code/game/objects/items/weapons/implant/implants/carrion/infection_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/infection_spider.dm
@@ -19,9 +19,9 @@
 	if(is_neotheology_disciple(wearer))
 		to_chat(owner_mob, SPAN_WARNING("[wearer]'s cruciform prevents activation"))
 		return
-	var/obj/item/organ/external/affected = wearer.organs_by_name[pick(list(BP_HEAD, BP_CHEST))]
+	var/obj/item/organ/external/affected = wearer.organs_by_name[BP_HEAD || BP_CHEST]
 	if(BP_IS_ROBOTIC(affected))
-		to_chat(owner_mob, SPAN_WARNING("[src] cannot be implanted in a prosthetic limb."))
+		to_chat(owner_mob, SPAN_WARNING("[src] cannot be activated in a prosthetic limb."))
 		return
 
 	if(is_carrion(wearer))

--- a/code/game/objects/items/weapons/implant/implants/carrion/infection_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/infection_spider.dm
@@ -7,9 +7,6 @@
 
 /obj/item/implant/carrion_spider/infection/activate()
 	..()
-	if(BP_IS_ROBOTIC(affected))
-		to_chat(user, SPAN_WARNING("[src] cannot be implanted in a prosthetic limb."))
-		return
 	if(!wearer)
 		to_chat(owner_mob, SPAN_WARNING("[src] doesn't have a host"))
 		return
@@ -21,6 +18,10 @@
 		return
 	if(is_neotheology_disciple(wearer))
 		to_chat(owner_mob, SPAN_WARNING("[wearer]'s cruciform prevents activation"))
+		return
+	var/obj/item/organ/external/affected = wearer.organs_by_name[pick(list(BP_HEAD, BP_CHEST))]
+	if(BP_IS_ROBOTIC(affected))
+		to_chat(owner_mob, SPAN_WARNING("[src] cannot be implanted in a prosthetic limb."))
 		return
 
 	if(is_carrion(wearer))


### PR DESCRIPTION
## About The Pull Request

fokken no idea who made this oversight, but JNFECTION carrion spiders could work in prosthetic limbs, effectively making it possible to infect and convert a FBP
yes, carrion in a steel body, bad fucking idea

## Why It's Good For The Game
carrion nerf
muh realism
## Changelog
:cl:
fix: infection spiders don't work in prosthetic limbs
/:cl: