### PR TITLE
Replace blood loss paralyse with weaken

### DIFF
--- a/code/modules/organs/internal/internal_organ_processes.dm
+++ b/code/modules/organs/internal/internal_organ_processes.dm
@@ -157,7 +157,7 @@
 		eye_blurry = max(eye_blurry,6)
 		adjustOxyLoss(1)
 		if(prob(15))
-			Paralyse(rand(1,3))
+			Weaken(rand(1,3))
 			to_chat(src, SPAN_WARNING("You feel extremely [pick("dizzy","woosey","faint")]"))
 
 	else if(blood_volume < blood_safe)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

F'er ye to undesstan', matey, parahlyze makes ya drop to them ground, not bein' able to see nor talk nor piss, while them weaken makes ye just fall to them ground, effectively makin' this pr a huge QoL for them blood loss enjoyars. Prollems?

## Why It's Good For The Game

a HUGE quality of life change. you still fall and drop shit, it's just that you can now hear and talk while down.

## Changelog
:cl:
tweak: blood loss now weakens instead of paralyses(hardstun)
/:cl:

