### PR TITLE
Welding tools make burn hitsounds

### DIFF
--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -60,6 +60,7 @@
 	var/switched_on = FALSE	//Curent status of tool. Dont edit this in subtypes vars, its for procs only.
 	var/switched_on_qualities	//This var will REPLACE tool_qualities when tool will be toggled on.
 	var/switched_on_force
+	var/switched_on_hitsound
 	var/switched_off_qualities	//This var will REPLACE tool_qualities when tool will be toggled off. So its possible for tool to have diferent qualities both for ON and OFF state.
 	var/create_hot_spot = FALSE	 //Set this TRUE to ignite plasma on turf with tool upon activation
 	var/glow_color	//Set color of glow upon activation, or leave it null if you dont want any light
@@ -672,6 +673,8 @@
 		to_chat(user, SPAN_NOTICE("\The [src] turns on."))
 	switched_on = TRUE
 	tool_qualities = switched_on_qualities
+	if(switched_on_hitsound)
+		hitsound = switched_on_hitsound
 	if (!isnull(switched_on_force))
 		force = switched_on_force
 		if(wielded)
@@ -689,6 +692,7 @@
 	switched_on = FALSE
 	STOP_PROCESSING(SSobj, src)
 	tool_qualities = switched_off_qualities
+	hitsound = initial(hitsound)
 	force = initial(force)
 	if(glow_color)
 		set_light(l_range = 0, l_power = 0, l_color = glow_color)

--- a/code/game/objects/items/weapons/tools/weldingtools.dm
+++ b/code/game/objects/items/weapons/tools/weldingtools.dm
@@ -31,7 +31,6 @@
 		playsound(loc, 'sound/items/welderactivate.ogg', 50, 1)
 		damtype = BURN
 		START_PROCESSING(SSobj, src)
-	//Todo: Add a better hit sound for a turned_on welder
 
 /obj/item/tool/weldingtool/turn_off(mob/user)
 	item_state = initial(item_state)

--- a/code/game/objects/items/weapons/tools/weldingtools.dm
+++ b/code/game/objects/items/weapons/tools/weldingtools.dm
@@ -27,6 +27,7 @@
 /obj/item/tool/weldingtool/turn_on(mob/user)
 	.=..()
 	if(.)
+		hitsound = 'sound/items/Welder.ogg'
 		playsound(loc, 'sound/items/welderactivate.ogg', 50, 1)
 		damtype = BURN
 		START_PROCESSING(SSobj, src)

--- a/code/game/objects/items/weapons/tools/weldingtools.dm
+++ b/code/game/objects/items/weapons/tools/weldingtools.dm
@@ -11,6 +11,7 @@
 	matter = list(MATERIAL_STEEL = 5)
 	origin_tech = list(TECH_ENGINEERING = 1)
 	switched_on_qualities = list(QUALITY_WELDING = 30, QUALITY_CAUTERIZING = 10, QUALITY_WIRE_CUTTING = 10)
+	switched_on_hitsound = 'sound/items/Welder.ogg'
 
 	sparks_on_use = TRUE
 	eye_hazard = TRUE
@@ -27,7 +28,6 @@
 /obj/item/tool/weldingtool/turn_on(mob/user)
 	.=..()
 	if(.)
-		hitsound = 'sound/items/Welder.ogg'
 		playsound(loc, 'sound/items/welderactivate.ogg', 50, 1)
 		damtype = BURN
 		START_PROCESSING(SSobj, src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

- Tools can now have different hitsounds when turned on
- Welding tools get a burn sound

## Why It's Good For The Game

Fixes "Oversight:Welding tool has the standard bashing sound when you use it to melee"

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: welding tool hitsound
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
