### PR TITLE
Randomise wiring, add examine wire, examining wires scales off MEC

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -7,7 +7,6 @@
 	holder_type = /obj/machinery/door/airlock
 	wire_count = 12
 	window_y = 570
-	random = 1
 	descriptions = list(
 		new /datum/wire_description(AIRLOCK_WIRE_IDSCAN, "This wire is connected to the ID scanning panel."),
 		new /datum/wire_description(AIRLOCK_WIRE_MAIN_POWER1, "This wire seems to be carrying a heavy current."),

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -1,13 +1,27 @@
 // Wires for airlocks
 
 /datum/wires/airlock/secure
-	random = 1
 	wire_count = 14
 
 /datum/wires/airlock
 	holder_type = /obj/machinery/door/airlock
 	wire_count = 12
 	window_y = 570
+	random = 1
+	descriptions = list(
+		new /datum/wire_description(AIRLOCK_WIRE_IDSCAN, "This wire is connected to the ID scanning panel."),
+		new /datum/wire_description(AIRLOCK_WIRE_MAIN_POWER1, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(AIRLOCK_WIRE_MAIN_POWER2, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(AIRLOCK_WIRE_DOOR_BOLTS, "This wire runs down to the very base of the airlock."),
+		new /datum/wire_description(AIRLOCK_WIRE_BACKUP_POWER1, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(AIRLOCK_WIRE_BACKUP_POWER2, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(AIRLOCK_WIRE_OPEN_DOOR, "This wire connects to the door motors."),
+		new /datum/wire_description(AIRLOCK_WIRE_AI_CONTROL, "This wire connects to automated control systems."),
+		new /datum/wire_description(AIRLOCK_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(AIRLOCK_WIRE_SAFETY, "This wire connects to a safety override."),
+		new /datum/wire_description(AIRLOCK_WIRE_SPEED, "This wire appears to connect to the airlock's proximity detector modules."),
+		new /datum/wire_description(AIRLOCK_WIRE_LIGHT, "This wire powers the airlock's built-in lighting.")
+	)
 
 var/const/AIRLOCK_WIRE_IDSCAN = 1
 var/const/AIRLOCK_WIRE_MAIN_POWER1 = 2

--- a/code/datums/wires/alarm.dm
+++ b/code/datums/wires/alarm.dm
@@ -1,6 +1,13 @@
 /datum/wires/alarm
 	holder_type = /obj/machinery/alarm
 	wire_count = 5
+	descriptions = list(
+		new /datum/wire_description(AALARM_WIRE_IDSCAN, "This wire is connected to the ID scanning panel."),
+		new /datum/wire_description(AALARM_WIRE_POWER, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(AALARM_WIRE_SYPHON, "This wire runs to atmospherics logic circuits of some sort."),
+		new /datum/wire_description(AALARM_WIRE_AI_CONTROL, "This wire connects to automated control systems."),
+		new /datum/wire_description(AALARM_WIRE_AALARM, "This wire gives power to the actual alarm mechanism.")
+	)
 
 var/const/AALARM_WIRE_IDSCAN = 1
 var/const/AALARM_WIRE_POWER = 2

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -1,11 +1,17 @@
-/datum/wires/apc
-	holder_type = /obj/machinery/power/apc
-	wire_count = 4
-
 #define APC_WIRE_IDSCAN 1
 #define APC_WIRE_MAIN_POWER1 2
 #define APC_WIRE_MAIN_POWER2 4
 #define APC_WIRE_AI_CONTROL 8
+
+/datum/wires/apc
+	holder_type = /obj/machinery/power/apc
+	wire_count = 4
+	descriptions = list(
+		new /datum/wire_description(APC_WIRE_IDSCAN, "This wire is connected to the ID scanning panel."),
+		new /datum/wire_description(APC_WIRE_MAIN_POWER1, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(APC_WIRE_MAIN_POWER2, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(APC_WIRE_AI_CONTROL, "This wire connects to automated control systems.")
+	)
 
 /datum/wires/apc/GetInteractWindow()
 	var/obj/machinery/power/apc/A = holder

--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -2,6 +2,11 @@
 
 	holder_type = /obj/machinery/autolathe
 	wire_count = 6
+	descriptions = list(
+		new /datum/wire_description(AUTOLATHE_HACK_WIRE, "This wire appears to lead to an auxiliary data storage unit."),
+		new /datum/wire_description(AUTOLATHE_SHOCK_WIRE, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(AUTOLATHE_DISABLE_WIRE, "This wire is connected to the power switch.")
+	)
 
 var/const/AUTOLATHE_HACK_WIRE = 1
 var/const/AUTOLATHE_SHOCK_WIRE = 2

--- a/code/datums/wires/camera.dm
+++ b/code/datums/wires/camera.dm
@@ -1,9 +1,14 @@
 // Wires for cameras.
 
 /datum/wires/camera
-	random = 1
 	holder_type = /obj/machinery/camera
 	wire_count = 6
+	descriptions = list(
+		new /datum/wire_description(CAMERA_WIRE_FOCUS, "This wire runs to the camera's lens adjustment motors."),
+		new /datum/wire_description(CAMERA_WIRE_POWER, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(CAMERA_WIRE_LIGHT, "This wire seems connected to the built-in light."),
+		new /datum/wire_description(CAMERA_WIRE_ALARM, "This wire is connected to a remote signaling device of some sort.")
+	)
 
 /datum/wires/camera/GetInteractWindow()
 

--- a/code/datums/wires/jukebox.dm
+++ b/code/datums/wires/jukebox.dm
@@ -13,6 +13,10 @@
 	random = TRUE
 	holder_type = /obj/machinery/media/jukebox
 	wire_count = 10
+	descriptions = list(
+		new /datum/wire_description(WIRE_MAIN_POWER1, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(WIRE_POWER, "This wire seems to be carrying a heavy current."),
+	)
 
 /datum/wires/jukebox/CanUse(mob/user)
 	var/obj/machinery/media/jukebox/A = holder

--- a/code/datums/wires/mulebot.dm
+++ b/code/datums/wires/mulebot.dm
@@ -1,5 +1,4 @@
 /datum/wires/mulebot
-	random = 1
 	holder_type = /obj/machinery/bot/mulebot
 	wire_count = 10
 

--- a/code/datums/wires/nuclearbomb.dm
+++ b/code/datums/wires/nuclearbomb.dm
@@ -1,7 +1,11 @@
 /datum/wires/nuclearbomb
 	holder_type = /obj/machinery/nuclearbomb
-	random = 1
 	wire_count = 7
+	descriptions = list(
+		new /datum/wire_description(NUCLEARBOMB_WIRE_LIGHT, "This wire seems to connect to the small light on the device."),
+		new /datum/wire_description(NUCLEARBOMB_WIRE_TIMING, "This wire connects to the time display."),
+		new /datum/wire_description(NUCLEARBOMB_WIRE_SAFETY, "This wire connects to a safety override.")
+	)
 
 var/const/NUCLEARBOMB_WIRE_LIGHT		= 1
 var/const/NUCLEARBOMB_WIRE_TIMING		= 2

--- a/code/datums/wires/particle_accelerator.dm
+++ b/code/datums/wires/particle_accelerator.dm
@@ -1,7 +1,12 @@
 /datum/wires/particle_acc/control_box
 	wire_count = 5
 	holder_type = /obj/machinery/particle_accelerator/control_box
-
+	descriptions = list(
+		new /datum/wire_description(PARTICLE_TOGGLE_WIRE, "This wire seems to connect to the main power toggle."),
+		new /datum/wire_description(PARTICLE_STRENGTH_WIRE, "This wire connects to the primary magnets."),
+		new /datum/wire_description(PARTICLE_INTERFACE_WIRE, "This wire appears connected to the user panel."),
+		new /datum/wire_description(PARTICLE_LIMIT_POWER_WIRE, "This wire connects to the primary magnets.")
+	)
 var/const/PARTICLE_TOGGLE_WIRE = 1 // Toggles whether the PA is on or not.
 var/const/PARTICLE_STRENGTH_WIRE = 2 // Determines the strength of the PA.
 var/const/PARTICLE_INTERFACE_WIRE = 4 // Determines the interface showing up.

--- a/code/datums/wires/radio.dm
+++ b/code/datums/wires/radio.dm
@@ -1,6 +1,11 @@
 /datum/wires/radio
 	holder_type = /obj/item/device/radio
 	wire_count = 3
+	descriptions = list(
+		new /datum/wire_description(WIRE_SIGNAL, "This wire connects several radio components."),
+		new /datum/wire_description(WIRE_RECEIVE, "This wire runs to the radio reciever.",),
+		new /datum/wire_description(WIRE_TRANSMIT, "This wire runs to the radio transmitter.")
+	)
 
 var/const/WIRE_SIGNAL = 1
 var/const/WIRE_RECEIVE = 2

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -1,10 +1,16 @@
 /datum/wires/robot
-	random = 1
 	holder_type = /mob/living/silicon/robot
 	wire_count = 5
+	descriptions = list(
+		new /datum/wire_description(BORG_WIRE_LAWCHECK, "This wire runs to the unit's law module."),
+		new /datum/wire_description(BORG_WIRE_MAIN_POWER, "This wire seems to be carrying a heavy current.", SKILL_EXPERIENCED),
+		new /datum/wire_description(BORG_WIRE_LOCKED_DOWN, "This wire connects to the unit's safety override."),
+		new /datum/wire_description(BORG_WIRE_AI_CONTROL, "This wire connects to automated control systems."),
+		new /datum/wire_description(BORG_WIRE_CAMERA,  "This wire runs to the unit's vision modules.")
+	)
 
 var/const/BORG_WIRE_LAWCHECK = 1
-var/const/BORG_WIRE_MAIN_POWER = 2 // The power wires do nothing whyyyyyyyyyyyyy
+var/const/BORG_WIRE_MAIN_POWER = 2 // The power wires do nothing whyyyyyyyyyyyyy //  then fix itttttt
 var/const/BORG_WIRE_LOCKED_DOWN = 4
 var/const/BORG_WIRE_AI_CONTROL = 8
 var/const/BORG_WIRE_CAMERA = 16

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -3,14 +3,14 @@
 	wire_count = 5
 	descriptions = list(
 		new /datum/wire_description(BORG_WIRE_LAWCHECK, "This wire runs to the unit's law module."),
-		new /datum/wire_description(BORG_WIRE_MAIN_POWER, "This wire seems to be carrying a heavy current.", SKILL_EXPERIENCED),
+		new /datum/wire_description(BORG_WIRE_MAIN_POWER, "This wire seems to be carrying a heavy current.",),
 		new /datum/wire_description(BORG_WIRE_LOCKED_DOWN, "This wire connects to the unit's safety override."),
 		new /datum/wire_description(BORG_WIRE_AI_CONTROL, "This wire connects to automated control systems."),
 		new /datum/wire_description(BORG_WIRE_CAMERA,  "This wire runs to the unit's vision modules.")
 	)
 
 var/const/BORG_WIRE_LAWCHECK = 1
-var/const/BORG_WIRE_MAIN_POWER = 2 // The power wires do nothing whyyyyyyyyyyyyy //  then fix itttttt
+var/const/BORG_WIRE_MAIN_POWER = 2 // The power wires do nothing whyyyyyyyyyyyyy
 var/const/BORG_WIRE_LOCKED_DOWN = 4
 var/const/BORG_WIRE_AI_CONTROL = 8
 var/const/BORG_WIRE_CAMERA = 16

--- a/code/datums/wires/shield_generator.dm
+++ b/code/datums/wires/shield_generator.dm
@@ -2,7 +2,7 @@
 	holder_type = /obj/machinery/power/shield_generator/
 	wire_count = 5
 	descriptions = list(
-		new /datum/wire_description(SHIELDGEN_WIRE_POWER, "This wire seems to be carrying a heavy current."),//, STAT_LEVEL_EXPERT), //TODO: Hook in Eris skills here
+		new /datum/wire_description(SHIELDGEN_WIRE_POWER, "This wire seems to be carrying a heavy current."),
 		new /datum/wire_description(SHIELDGEN_WIRE_CONTROL, "This wire connects to the main control panel."),
 		new /datum/wire_description(SHIELDGEN_WIRE_AICONTROL, "This wire connects to automated control systems.")
 	)

--- a/code/datums/wires/smartfridge.dm
+++ b/code/datums/wires/smartfridge.dm
@@ -1,9 +1,13 @@
 /datum/wires/smartfridge
 	holder_type = /obj/machinery/smartfridge
 	wire_count = 3
+	descriptions = list(
+		new /datum/wire_description(SMARTFRIDGE_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(SMARTFRIDGE_WIRE_THROW, "This wire leads to the item dispensor force controls."),
+		new /datum/wire_description(SMARTFRIDGE_WIRE_IDSCAN, "This wire is connected to the ID scanning panel.")
+	)
 
 /datum/wires/smartfridge/secure
-	random = 1
 	wire_count = 4
 
 var/const/SMARTFRIDGE_WIRE_ELECTRIFY	= 1

--- a/code/datums/wires/smes.dm
+++ b/code/datums/wires/smes.dm
@@ -1,6 +1,13 @@
 /datum/wires/smes
 	holder_type = /obj/machinery/power/smes/buildable
 	wire_count = 5
+	descriptions = list(
+		new /datum/wire_description(SMES_WIRE_RCON, "This wire runs to a remote signaling mechanism."),
+		new /datum/wire_description(SMES_WIRE_INPUT, "This seems to be the primary input."),
+		new /datum/wire_description(SMES_WIRE_OUTPUT, "This seems to be the primary output."),
+		new /datum/wire_description(SMES_WIRE_GROUNDING, "This wire appeas to connect directly to the floor."),
+		new /datum/wire_description(SMES_WIRE_FAILSAFES, "This wire appears to connect to a failsafe mechanism.")
+	)
 
 var/const/SMES_WIRE_RCON = 1		// Remote control (AI and consoles), cut to disable
 var/const/SMES_WIRE_INPUT = 2		// Input wire, cut to disable input, pulse to disable for 60s

--- a/code/datums/wires/suit_storage_unit.dm
+++ b/code/datums/wires/suit_storage_unit.dm
@@ -1,6 +1,11 @@
 /datum/wires/suit_storage_unit
 	holder_type = /obj/machinery/suit_storage_unit
 	wire_count = 3
+	descriptions = list(
+		new /datum/wire_description(SUIT_STORAGE_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(SUIT_STORAGE_WIRE_SAFETY, "This wire seems connected to a safety override"),
+		new /datum/wire_description(SUIT_STORAGE_WIRE_LOCKED, "This wire is connected to the ID scanning panel.")
+	)
 
 var/const/SUIT_STORAGE_WIRE_ELECTRIFY	= 1
 var/const/SUIT_STORAGE_WIRE_SAFETY		= 2

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -7,6 +7,12 @@
 /datum/wires/vending
 	holder_type = /obj/machinery/vending
 	wire_count = 4
+	descriptions = list(
+		new /datum/wire_description(VENDING_WIRE_THROW, "This wire leads to the item dispensor force controls."),
+		new /datum/wire_description(VENDING_WIRE_CONTRABAND, "This wire appears connected to a reserve inventory compartment."),
+		new /datum/wire_description(VENDING_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(VENDING_WIRE_IDSCAN, "This wire is connected to the ID scanning panel."),
+	)
 
 var/const/VENDING_WIRE_THROW = 1
 var/const/VENDING_WIRE_CONTRABAND = 2

--- a/code/datums/wires/wire_description.dm
+++ b/code/datums/wires/wire_description.dm
@@ -1,7 +1,7 @@
 /datum/wire_description
 	var/index
 	var/description
-	var/skill_level = STAT_LEVEL_PROF //STAT_LEVEL_PROF //TODO: Hook eris skills here
+	var/skill_level = STAT_LEVEL_EXPERT //40 pts
 
 /datum/wire_description/New(index, description, skill_level)
 	src.index = index

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -22,7 +22,7 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 
 	var/table_options = " align='center'"
 	var/row_options1 = " width='80px'"
-	var/row_options2 = " width='320px'"
+	var/row_options2 = " width='280px'"
 	var/window_x = 450
 	var/window_y = 470
 

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -11,7 +11,7 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 
 /datum/wires
 
-	var/random = 0 // Will the wires be different for every single instance.
+	var/random = 1 // Will the wires be different for every single instance.
 	var/atom/holder = null // The holder
 	var/holder_type = null // The holder type; used to make sure that the holder is the correct type.
 	var/wire_count = 0 // Max is 16
@@ -22,8 +22,8 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 
 	var/table_options = " align='center'"
 	var/row_options1 = " width='80px'"
-	var/row_options2 = " width='260px'"
-	var/window_x = 370
+	var/row_options2 = " width='320px'"
+	var/window_x = 450
 	var/window_y = 470
 
 	var/list/descriptions // Descriptions of wires (datum/wire_description) for use with examining.
@@ -71,15 +71,15 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 		src.wires[colour] = index
 		//wires = shuffle(wires)
 
-/datum/wires/proc/examine(index, mob/user)
+/datum/wires/proc/examine(index, mob/user,)
 	. = "You aren't sure what this wire does."
+	var/mec_stat = user.stats.getStat(STAT_MEC)
 
 	var/datum/wire_description/wd = get_description(index)
 	if(!wd)
 		return
-	//TODO: Port bay wires fully and integrate eris' skill system
-	//if(wd.skill_level && !user.skill_check(SKILL_ELECTRICAL, wd.skill_level))
-		//return
+	if(wd.skill_level > mec_stat)
+		return
 	return wd.description
 
 /datum/wires/proc/get_description(index)
@@ -119,12 +119,10 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 		html += "<td[row_options2]>"
 		html += "<A href='?src=\ref[src];action=1;cut=[colour]'>[IsColourCut(colour) ? "Mend" :  "Cut"]</A>"
 		html += " <A href='?src=\ref[src];action=1;pulse=[colour]'>Pulse</A>"
-		html += " <A href='?src=\ref[src];action=1;attach=[colour]'>[IsAttached(colour) ? "Detach" : "Attach"] Signaller</A></td></tr>"
+		html += " <A href='?src=\ref[src];action=1;attach=[colour]'>[IsAttached(colour) ? "Detach" : "Attach"] Signaller</A>"
+		html += " <A href='?src=\ref[src];action=1;examine=[colour]'>Examine</A></td></tr>"
 	html += "</table>"
 	html += "</div>"
-
-	if (random)
-		html += "<i>\The [holder] appears to have tamper-resistant electronics installed.</i><br><br>" //maybe this could be more generic?
 
 	return html
 
@@ -180,7 +178,9 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 						Attach(colour, I)
 					else
 						to_chat(L, SPAN_WARNING("You need a remote signaller!"))
-
+			else if(href_list["examine"])
+				var/colour = href_list["examine"]
+				to_chat(usr, examine(GetIndex(colour), usr))
 
 
 

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -71,7 +71,7 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 		src.wires[colour] = index
 		//wires = shuffle(wires)
 
-/datum/wires/proc/examine(index, mob/user,)
+/datum/wires/proc/examine(index, mob/user)
 	. = "You aren't sure what this wire does."
 	var/mec_stat = user.stats.getStat(STAT_MEC)
 

--- a/code/modules/clothing/spacesuits/rig/rig_wiring.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_wiring.dm
@@ -1,5 +1,4 @@
 /datum/wires/rig
-	random = 1
 	holder_type = /obj/item/rig
 	wire_count = 5
 


### PR DESCRIPTION
## About The Pull Request

All machinery(code/datums/wires/) has randomised wiring.
You can examine wires.
If your MEC is >= 40, you can figure out what the wire does.
![image](https://user-images.githubusercontent.com/49622619/143909373-b9eb6749-a2c8-4f0f-b1db-18c1f439f4fb.png)

## Why It's Good For The Game
Now MEC is actually useful besides gun crafting. ~~Come on, lynch me, I dare you.~~

This was in FortuneMaster's design doc. Also known as "Rope Bunny Boy" on discord.

## Changelog
:cl:
tweak: all wires in machinery are randomised now.
add: you can now examine(MEC >= 40) wires to figure out what each does.
/:cl:
