### PR TITLE
Reduces face shield vision obstruction for paramedic helmet

### DIFF
--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -575,6 +575,7 @@
 	up = TRUE
 	spawn_blacklisted = TRUE
 	style = STYLE_HIGH
+	tint_down = TINT_LOW
 	var/speaker_enabled = TRUE
 	var/scan_scheduled = FALSE
 	var/scan_interval = 15 SECONDS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Knocks paramedic helmet face shield vision tint down from `TINT_MODERATE` (default value, same as Altyn) to `TINT_LOW` (same as IH "heavy operator" helmet).

It has less armor than the IH "heavy operator" helmet, even with its faceplate down - and is harder to obtain than Altyn.

## Why It's Good For The Game

Dunno. I was asked to make this PR, and so I did.

## Changelog
:cl:
balance: Reduces face shield vision obstruction for paramedic helmet
/:cl: