### PR TITLE
REMOVE melee and throw dodging, fix missing buckled mobs, fix division by zero in throwing knives

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -276,7 +276,7 @@
 	if(istype(item, /obj/item/stack/throwing_knife))
 		var/obj/item/stack/throwing_knife/V = item
 		var/ROB_throwing_damage = stats.getStat(STAT_ROB)
-		V.throwforce = 35 / (1 + 100 / ROB_throwing_damage) + 10 //soft cap; This would result in knives doing 10 damage at 0 rob, 20 at 50 ROB, 25 at 100 etc.
+		V.throwforce = 35 / (1 + 100 / ROB_throwing_damage + 1) + 10 //soft cap; This would result in knives doing 10 damage at 0 rob, 20 at 50 ROB, 25 at 100 etc. + 1 is here to avoid division by zero
 		if(V.amount == 1)
 			drop_from_inventory(V)
 			V.throw_at(target, item.throw_range, item.throw_speed, src)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -275,8 +275,8 @@
 
 	if(istype(item, /obj/item/stack/throwing_knife))
 		var/obj/item/stack/throwing_knife/V = item
-		var/ROB_throwing_damage = stats.getStat(STAT_ROB)
-		V.throwforce = 35 / (1 + 100 / ROB_throwing_damage + 1) + 10 //soft cap; This would result in knives doing 10 damage at 0 rob, 20 at 50 ROB, 25 at 100 etc. + 1 is here to avoid division by zero
+		var/ROB_throwing_damage = max(stats.getStat(STAT_ROB), 1)
+		V.throwforce = 35 / (1 + 100 / ROB_throwing_damage + 10) //soft cap; This would result in knives doing 10 damage at 0 rob, 20 at 50 ROB, 25 at 100 etc.
 		if(V.amount == 1)
 			drop_from_inventory(V)
 			V.throw_at(target, item.throw_range, item.throw_speed, src)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -187,9 +187,6 @@
 
 					And after that, we subtract AGI stat from chance to hit different organ.
 					General miss chance also depends on AGI.
-
-					Note: We don't use get_zone_with_miss_chance() here since the chances
-						  were made for projectiles.
 					TODO: proc for melee combat miss chances depending on organ?
 				*/
 				if(prob(50 - H.stats.getStat(STAT_ROB)))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -343,7 +343,7 @@ meteor_act
 		if (!(zone in base_miss_chance))//does the target even have that bodypart?
 			return
 		var/dodge = (max(src.stats.getStat(STAT_ROB), 1))//handled differently in living_defense
-		var/miss_chance = (base_miss_chance[zone] * (10 / (1 + 100 / dodge ) + 10)) /10//soft cap that takes base_miss_chance into account, base_miss_chance in mob_helpers
+		var/miss_chance = ((base_miss_chance[zone] * (10 / (1 + 100 / dodge ) + 10)) / 10)//soft cap that takes base_miss_chance into account, base_miss_chance in mob_helpers
 		// we cannot miss if the target is prone or restrained
 		if(src.buckled || src.lying)
 			miss_chance = 0

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -211,25 +211,7 @@ meteor_act
 	if(check_attack_throat(I, user))
 		return null
 
-	if(user == src) // Attacking yourself can't miss
-		return target_zone
 	var/hit_zone = check_zone(target_zone)
-	//check if we hit
-	var/dodge = max(src.stats.getStat(STAT_ROB), 1)//handled differently in living_defense
-	var/miss_chance = ((base_miss_chance[hit_zone] * (5 /(1 + 100 / dodge) + 10)) / 10)//soft cap that takes base_miss_chance into account, base_miss_chance in mob_helpers
-	if(prob(miss_chance))
-		hit_zone = null
-	// you cannot miss if your target is prone or restrained
-	if(src.buckled || src.lying)
-		return hit_zone
-	// if your target is being grabbed aggressively by someone you cannot miss either
-	for(var/obj/item/grab/G in src.grabbed_by)
-		if(G.state >= GRAB_AGGRESSIVE)
-			return hit_zone
-	if(!hit_zone)
-		visible_message(SPAN_DANGER("\The [user] misses [src] with \the [I]!"))
-		return null
-
 	if(check_shields(I.force, I, user, target_zone, "the [I.name]"))
 		return null
 
@@ -339,29 +321,12 @@ meteor_act
 			zone = check_zone(L.targeted_organ)
 		else
 			zone = ran_zone(BP_CHEST, 75)//Hits a random part of the body, geared towards the chest
-		//check if we hit
-		if (!(zone in base_miss_chance))//does the target even have that bodypart?
-			return
-		var/dodge = (max(src.stats.getStat(STAT_ROB), 1))//handled differently in living_defense
-		var/miss_chance = ((base_miss_chance[zone] * (10 / (1 + 100 / dodge ) + 10)) / 10)//soft cap that takes base_miss_chance into account, base_miss_chance in mob_helpers
-		// we cannot miss if the target is prone or restrained
-		if(src.buckled || src.lying)
-			miss_chance = 0
-		// if the target is being grabbed aggressively by someone we cannot miss either
-		for(var/obj/item/grab/G in src.grabbed_by)
-			if(G.state >= GRAB_AGGRESSIVE)
-				miss_chance = 0
-		if(prob(miss_chance))
-			zone = null		
 		if(zone && O.thrower != src) //does the target have a shield?
 			var/shield_check = check_shields(throw_damage, O, thrower, zone, "[O]")
 			if(shield_check == PROJECTILE_FORCE_MISS)
 				zone = null
 			else if(shield_check)
 				return
-		if(!zone)//we missed!
-			visible_message(SPAN_NOTICE("\The [O] misses [src] narrowly!"))
-			return
 
 		O.throwing = 0//it hit, so stop moving
 		/// Get hit with glass shards , your fibers are on them now, or with a rod idk.

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -215,10 +215,10 @@ meteor_act
 		return target_zone
 	var/hit_zone = check_zone(target_zone)
 	//check if we hit
-	var/dodge = src.stats.getStat(STAT_ROB)
-	var/miss_chance = ((base_miss_chance[hit_zone] / 4) + (20 / (1 + 100 / (dodge + 1)) + 10)) //soft cap, minumum 10 at rob 0, 16.5 at 50, 20 at 100, 22 at 150,
+	var/dodge = max(src.stats.getStat(STAT_ROB), 1)
+	var/miss_chance = (20 / (1 + 100 / dodge) + 10) //soft cap, minumum 10 at rob 0, 16.5 at 50, 20 at 100, 22 at 150,
 	if(prob(miss_chance))																//max - ~24, ignoring the base_miss_chance that adds a bit more
-		hit_zone = null																//+ 1 is there to avoid division by zero
+		hit_zone = null
 	// you cannot miss if your target is prone or restrained
 	if(src.buckled || src.lying)
 		return hit_zone
@@ -342,8 +342,8 @@ meteor_act
 		//check if we hit
 		if (!(zone in base_miss_chance))//does the target even have that bodypart?
 			return
-		var/dodge = src.stats.getStat(STAT_ROB)
-		var/miss_chance = ((base_miss_chance[zone] / 3) + (25 / (1 + 100 / (dodge + 1)) + 10)) //soft cap, minumum 10 at rob 0, 18 at 50, 22 at 100, 25 at 150, + 1 is there to avoid division by zero
+		var/dodge = (max(src.stats.getStat(STAT_ROB), 1))
+		var/miss_chance = (25 / (1 + 100 / dodge) + 10) //soft cap, minumum 10 at rob 0, 18 at 50, 22 at 100, 25 at 150
 		// we cannot miss if the target is prone or restrained								//max - ~27 ignoring the base_miss_chance that adds some more(listed in mob_helpers.dm)
 		if(src.buckled || src.lying)
 			miss_chance = 0

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -217,7 +217,7 @@ meteor_act
 	//check if we hit
 	var/dodge = max(src.stats.getStat(STAT_ROB), 1)
 	var/miss_chance = (20 / (1 + 100 / dodge) + 10) //soft cap, minumum 10 at rob 0, 16.5 at 50, 20 at 100, 22 at 150,
-	if(prob(miss_chance))																//max - ~24, ignoring the base_miss_chance that adds a bit more
+	if(prob(miss_chance))
 		hit_zone = null
 	// you cannot miss if your target is prone or restrained
 	if(src.buckled || src.lying)
@@ -344,7 +344,7 @@ meteor_act
 			return
 		var/dodge = (max(src.stats.getStat(STAT_ROB), 1))
 		var/miss_chance = (25 / (1 + 100 / dodge) + 10) //soft cap, minumum 10 at rob 0, 18 at 50, 22 at 100, 25 at 150
-		// we cannot miss if the target is prone or restrained								//max - ~27 ignoring the base_miss_chance that adds some more(listed in mob_helpers.dm)
+		// we cannot miss if the target is prone or restrained
 		if(src.buckled || src.lying)
 			miss_chance = 0
 		// if the target is being grabbed aggressively by someone we cannot miss either

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -215,8 +215,8 @@ meteor_act
 		return target_zone
 	var/hit_zone = check_zone(target_zone)
 	//check if we hit
-	var/dodge = max(src.stats.getStat(STAT_ROB), 1)
-	var/miss_chance = (20 / (1 + 100 / dodge) + 10) //soft cap, minumum 10 at rob 0, 16.5 at 50, 20 at 100, 22 at 150,
+	var/dodge = max(src.stats.getStat(STAT_ROB), 1)//handled differently in living_defense
+	var/miss_chance = ((base_miss_chance[hit_zone] * (5 /(1 + 100 / dodge) + 10)) / 10)//soft cap that takes base_miss_chance into account, base_miss_chance in mob_helpers
 	if(prob(miss_chance))
 		hit_zone = null
 	// you cannot miss if your target is prone or restrained
@@ -342,8 +342,8 @@ meteor_act
 		//check if we hit
 		if (!(zone in base_miss_chance))//does the target even have that bodypart?
 			return
-		var/dodge = (max(src.stats.getStat(STAT_ROB), 1))
-		var/miss_chance = (25 / (1 + 100 / dodge) + 10) //soft cap, minumum 10 at rob 0, 18 at 50, 22 at 100, 25 at 150
+		var/dodge = (max(src.stats.getStat(STAT_ROB), 1))//handled differently in living_defense
+		var/miss_chance = (base_miss_chance[zone] * (10 / (1 + 100 / dodge ) + 10)) /10//soft cap that takes base_miss_chance into account, base_miss_chance in mob_helpers
 		// we cannot miss if the target is prone or restrained
 		if(src.buckled || src.lying)
 			miss_chance = 0

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -101,7 +101,6 @@ var/list/global/organ_rel_size = list(
 
 // Returns zone with a certain probability. If the probability fails, or no zone is specified, then a random body part is chosen.
 // Do not use this if someone is intentionally trying to hit a specific body part.
-// Use get_zone_with_miss_chance() for that.
 /proc/ran_zone(zone, probability)
 	if (zone)
 		zone = check_zone(zone)
@@ -121,33 +120,6 @@ var/list/global/organ_rel_size = list(
 		)
 
 	return ran_zone
-
-// Emulates targetting a specific body part, and miss chances
-// May return null if missed
-// miss_chance_mod may be negative.
-/proc/get_zone_with_miss_chance(zone, var/mob/target, var/miss_chance_mod = 0, var/ranged_attack=0)
-	zone = check_zone(zone)
-
-	if(!ranged_attack)
-		// you cannot miss if your target is prone or restrained
-		if(target.buckled || target.lying)
-			return zone
-		// if your target is being grabbed aggressively by someone you cannot miss either
-		for(var/obj/item/grab/G in target.grabbed_by)
-			if(G.state >= GRAB_AGGRESSIVE)
-				return zone
-
-	var/miss_chance = 10
-	if (zone in base_miss_chance)
-		miss_chance = base_miss_chance[zone]
-	miss_chance = max(miss_chance + miss_chance_mod, 0)
-	if(prob(miss_chance))
-		if(prob(70))
-			return null
-		return pick(base_miss_chance)
-	return zone
-
-
 
 //Replaces some of the characters with *, used in whispers. pr = probability of no star.
 //Will try to preserve HTML formatting. re_encode controls whether the returned text is HTML encoded outside tags.

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -119,7 +119,6 @@
 			continue
 
 		//pellet hits spread out across different zones, but 'aim at' the targeted zone with higher probability
-		//whether the pellet actually hits the def_zone or a different zone should still be determined by the parent using get_zone_with_miss_chance().
 		var/old_zone = def_zone
 		def_zone = ran_zone(def_zone, spread)
 		if (..()) hits++


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
removes the old ass bay12 leftover get_zone_with_missing_chance proc, that overwrote some given vars and did useless checking + was calculating missing buckled mobs incorrectly. It was also removed to implement stat-based dodging.
dodging melee formula: __((base_miss_chance[hit_zone] * (5 /(1 + 100 / dodge) + 10))__ //soft cap
dodging  the thrown items formula: __(base_miss_chance[zone] * (10 / (1 + 100 / dodge ) + 10)) /10__ //soft cap
## Why It's Good For The Game
more ROB scaling, better dodge, fixes cool, bay leftover bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: dodging melee attacks and thrown items scales off ROB
del: bay leftover get_zone proc
fix: missing buckled mobs with thrown items
fix: division by zero in throwing knives code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
