### PR TITLE
[TESTING REQUIRED]Remove #2811 click catchers 

### DIFF
--- a/code/__DEFINES/_planes+layers.dm
+++ b/code/__DEFINES/_planes+layers.dm
@@ -51,8 +51,6 @@ What is the naming convention for planes or layers?
 //Defines for atom layers and planes
 //KEEP THESE IN A NICE ACSCENDING ORDER, PLEASE
 
-#define CLICKCATCHER_PLANE -99
-
 #define PLANE_SPACE -95
 #define PLANE_SPACE_PARALLAX -80
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -366,46 +366,6 @@
 	set_dir(ndir)
 	return 1
 
-
-
-GLOBAL_LIST_INIT(click_catchers, create_click_catcher())
-
-/obj/screen/click_catcher
-	icon = 'icons/mob/screen_gen.dmi'
-	icon_state = "click_catcher"
-	plane = CLICKCATCHER_PLANE
-	mouse_opacity = 2
-	screen_loc = "CENTER-7,CENTER-7"
-
-/obj/screen/click_catcher/Destroy()
-	return QDEL_HINT_LETMELIVE
-
-/proc/create_click_catcher()
-	. = list()
-	for(var/i = 0, i<15, i++)
-		for(var/j = 0, j<15, j++)
-			var/obj/screen/click_catcher/CC = new()
-			CC.screen_loc = "NORTH-[i],EAST-[j]"
-			. += CC
-
-/obj/screen/click_catcher/Click(location, control, params)
-	var/list/modifiers = params2list(params)
-	if(modifiers["middle"] && istype(usr, /mob/living/carbon))
-		var/mob/living/carbon/C = usr
-		C.swap_hand()
-	else
-		var/turf/T = screen_loc2turf(screen_loc, get_turf(usr))
-		if(T)
-			usr.client.Click(T, location, control, params)
-			//T.Click(location, control, params)
-			//Bay system doesnt use client.click, not sure if better
-
-	. = 1
-
-/obj/screen/click_catcher/proc/resolve(var/mob/user)
-	var/turf/T = screen_loc2turf(screen_loc, get_turf(user))
-	return T
-
 /mob/living/carbon/human/proc/absolute_grab(mob/living/carbon/human/T)
 	if(!ishuman(T))
 		return

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -344,10 +344,3 @@ datum/hud/New(mob/owner)
 	hud_used.hidden_inventory_update()
 	hud_used.persistant_inventory_update()*/
 	update_action_buttons()
-
-
-/mob/proc/add_click_catcher()
-	client.screen |= GLOB.click_catchers
-
-/mob/new_player/add_click_catcher()
-	return

--- a/code/datums/datum_click_handlers.dm
+++ b/code/datums/datum_click_handlers.dm
@@ -57,11 +57,6 @@
 //If its not valid, null will be returned
 //In the case of click catchers, we resolve and return the turf under it
 /datum/click_handler/proc/resolve_world_target(var/a)
-
-	if (istype(a, /obj/screen/click_catcher))
-		var/obj/screen/click_catcher/CC = a
-		return CC.resolve(owner.mob)
-
 	if (istype(a, /turf))
 		return a
 

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -60,7 +60,6 @@
 			client.UI.show()
 		else
 			client.create_UI(src.type)
-		add_click_catcher()
 		client.CAN_MOVE_DIAGONALLY = FALSE
 
 	SEND_SIGNAL(src, COMSIG_MOB_LOGIN)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

the said click catchers spawn on every tile on your screen(like hud does), only to catch your clicks. Now, what does click catching do?
well, if you click on it with LMB/RMB, it calls the Click proc.
And if you click on it with MMB, it swaps your hand. That's it.
We have the MiddleClickOn proc for that.
![image](https://user-images.githubusercontent.com/49622619/144869773-3112531c-9a7f-4a80-876a-15dc8df4c308.png)
Ergo it doesn't do anything but just... exist here. The fact that it is called "unnamed" terrifies me when I test stuff on local.


(also I am currently sleep deprived so it may break some shit but I am 59% sure it won't)
## Why It's Good For The Game
probably huge optimisation. And some QoL, you will never wonder 'what's that "unnamed" thing' any more.
## Changelog
:cl:
del: click catchers that catched your clicks only to swap your hand
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
