### PR TITLE
Make click catchers invisible

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -381,6 +381,7 @@ GLOBAL_LIST_INIT(click_catchers, create_click_catcher())
 	return QDEL_HINT_LETMELIVE
 
 /obj/screen/click_catcher/New(_name = "", mob/living/_parentmob, _icon, _icon_state)
+..()
 
 /proc/create_click_catcher()
 	. = list()

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -380,9 +380,7 @@ GLOBAL_LIST_INIT(click_catchers, create_click_catcher())
 /obj/screen/click_catcher/Destroy()
 	return QDEL_HINT_LETMELIVE
 
-/obj/screen/click_catcher/New()
-	..()
-	name = ""
+/obj/screen/click_catcher/New(_name = "", mob/living/_parentmob, _icon, _icon_state)
 
 /proc/create_click_catcher()
 	. = list()

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -380,6 +380,10 @@ GLOBAL_LIST_INIT(click_catchers, create_click_catcher())
 /obj/screen/click_catcher/Destroy()
 	return QDEL_HINT_LETMELIVE
 
+/obj/screen/click_catcher/New()
+	..()
+	name = ""
+
 /proc/create_click_catcher()
 	. = list()
 	for(var/i = 0, i<15, i++)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -381,7 +381,7 @@ GLOBAL_LIST_INIT(click_catchers, create_click_catcher())
 	return QDEL_HINT_LETMELIVE
 
 /obj/screen/click_catcher/New(_name = "", mob/living/_parentmob, _icon, _icon_state)
-..()
+	..()
 
 /proc/create_click_catcher()
 	. = list()

--- a/code/_onclick/hud/screen_objects/base_screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/base_screen_objects.dm
@@ -22,7 +22,7 @@
 	var/hideflag = 0
 	var/list/image/ovrls = list()
 
-/obj/screen/New(_name = "", mob/living/_parentmob, _icon, _icon_state)//(_name = "unnamed", _screen_loc = "7,7", mob/living/_parentmob, _icon, _icon_state)
+/obj/screen/New(_name = "unnamed", mob/living/_parentmob, _icon, _icon_state)//(_name = "unnamed", _screen_loc = "7,7", mob/living/_parentmob, _icon, _icon_state)
 	src.parentmob = _parentmob
 	src.name = _name
 //	src.screen_loc = _screen_loc

--- a/code/_onclick/hud/screen_objects/base_screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/base_screen_objects.dm
@@ -22,7 +22,7 @@
 	var/hideflag = 0
 	var/list/image/ovrls = list()
 
-/obj/screen/New(_name = "unnamed", mob/living/_parentmob, _icon, _icon_state)//(_name = "unnamed", _screen_loc = "7,7", mob/living/_parentmob, _icon, _icon_state)
+/obj/screen/New(_name = "", mob/living/_parentmob, _icon, _icon_state)//(_name = "unnamed", _screen_loc = "7,7", mob/living/_parentmob, _icon, _icon_state)
 	src.parentmob = _parentmob
 	src.name = _name
 //	src.screen_loc = _screen_loc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

after testing, I figured out that CC actually HAVE a (shitty) use, so to NOT make me experience PTSD I just turn them invisible to human eye
literally one line change btw
## Why It's Good For The Game
honestly we could just remove CC one day
## Changelog
:cl:
code: Click catchers are invisible now. One is right behind your back.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
