### PR TITLE
Tweaks Oxycodone

### DIFF
--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -237,11 +237,11 @@
 	reagent_state = LIQUID
 	color = "#800080"
 	overdose = REAGENTS_OVERDOSE * 0.66
-	metabolism = 0.1
+	metabolism = 0.02
 	nerve_system_accumulations = 60
 
 /datum/reagent/medicine/oxycodone/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
-	M.add_chemical_effect(CE_PAINKILLER, 65)
+	M.add_chemical_effect(CE_PAINKILLER, 75)
 	M.druggy = max(M.druggy, 10)
 
 /datum/reagent/medicine/oxycodone/overdose(mob/living/carbon/M, alien)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Oxycodyne once again has the same metabolic rate as the rest of the painkillers and has 10 more pain relief, putting it on the same level as ParaTram (but still takes 20 more NSA). It was either this or make every other painkiller metabolise at the same speed as oxycodone and I took the path of least resistance.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Inconsistency isn't fun design and the painkiller that takes more effort to make shouldn't be objectively worse than its precursors. At least now it's on par with its contemporary, Tramadol, in terms of how much pain relief is provided per NSA.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Oxycodyne once again has the same metabolic rate as the rest of the painkillers and has 10 more pain relief, putting it on the same level as ParaTram (but still takes 20 more NSA).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
