### PR TITLE
Remove RNG from disarming

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -285,7 +285,6 @@
 					src.unEquip(I) //finally disarm target
 					visible_message(SPAN_DANGER("[M] has disarmed [src]!"))
 					playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-					src.recoil *= 0.5 //halve all gained recoil
 					return
 
 			playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -267,8 +267,8 @@
 						return W.afterattack(target,src)
 
 			//Actually disarm them
-			var/rob_attacker = (50 / (1 + 150 / (min(1, max(0, H.stats.getStat(STAT_ROB))))) + 40) //soft capped amount of recoil that attacker deals
-			var/rob_target = max(0, min(400,stats.getStat(STAT_ROB))) //hard capped amount of recoil the target negates upon disarming. 400 - no recoil
+			var/rob_attacker = (50 / (1 + 150 / max(1, H.stats.getStat(STAT_ROB))) + 40) //soft capped amount of recoil that attacker deals
+			var/rob_target = max(0, min(400,stats.getStat(STAT_ROB))) //hard capped amount of recoil the target negates upon disarming
 			var/recoil_damage = (rob_attacker * (1 - (rob_target / 400))) //recoil itself
 			for(var/obj/item/I in holding)
 				external_recoil(recoil_damage)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -267,12 +267,12 @@
 						return W.afterattack(target,src)
 
 			//Actually disarm them
-			var/rob_attacker = (50 / (1 + 150 / (min(1, H.stats.getStat(STAT_ROB)))) + 20) //soft capped amount of recoil that attacker deals
-			var/rob_target = max(0, min(400, src.stats.getStat(STAT_ROB))) //hard capped amount of recoil the target negates upon disarming. 400 - no recoil
+			var/rob_attacker = (50 / (1 + 150 / (min(1, max(0, H.stats.getStat(STAT_ROB))))) + 20) //soft capped amount of recoil that attacker deals
+			var/rob_target = max(0, min(400,stats.getStat(STAT_ROB))) //hard capped amount of recoil the target negates upon disarming. 400 - no recoil
 			var/recoil_damage = (rob_attacker * (1 - (rob_target / 400))) //recoil itself
-			for(var/obj/item/I in holding)
-				src.external_recoil(recoil_damage)
-				if(src.recoil >= 60) //disarming
+			if(recoil >= 60) //disarming
+				for(var/obj/item/I in holding)
+					external_recoil(recoil_damage)
 					if(istype(I, /obj/item/grab)) //did M grab someone?
 						break_all_grabs(M) //See about breaking grips or pulls
 						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -270,22 +270,28 @@
 			var/rob_attacker = (50 / (1 + 150 / (min(1, max(0, H.stats.getStat(STAT_ROB))))) + 20) //soft capped amount of recoil that attacker deals
 			var/rob_target = max(0, min(400,stats.getStat(STAT_ROB))) //hard capped amount of recoil the target negates upon disarming. 400 - no recoil
 			var/recoil_damage = (rob_attacker * (1 - (rob_target / 400))) //recoil itself
-			if(recoil >= 60) //disarming
-				for(var/obj/item/I in holding)
-					external_recoil(recoil_damage)
+			for(var/obj/item/I in holding)
+				external_recoil(recoil_damage)
+				if(recoil >= 60) //disarming
 					if(istype(I, /obj/item/grab)) //did M grab someone?
 						break_all_grabs(M) //See about breaking grips or pulls
 						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 						return
 					if(I.wielded) //is the held item wielded?
-						if(!src.recoil >= 80) //if yes, we need more recoil to disarm
+						if(!recoil >= 80) //if yes, we need more recoil to disarm
 							playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 							visible_message(SPAN_WARNING("[M] attempted to disarm [src]"))
 							return
-					src.unEquip(I) //finally disarm target
-					visible_message(SPAN_DANGER("[M] has disarmed [src]!"))
-					playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-					return
+					if(istype(I, /obj/item/twohanded/offhand)) //did someone dare to switch to offhand to not get disarmed?
+						unEquip(src.get_inactive_hand()) //different proc here because
+						visible_message(SPAN_DANGER("[M] has disarmed [src]!"))
+						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+						return
+					else 
+						unEquip(I)
+						visible_message(SPAN_DANGER("[M] has disarmed [src]!"))
+						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+						return
 
 			playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 			visible_message(SPAN_WARNING("[M] attempted to disarm [src]"))

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -270,7 +270,6 @@
 			var/rob_attacker = (50 / (1 + 150 / max(1, H.stats.getStat(STAT_ROB))) + 40) //soft capped amount of recoil that attacker deals
 			var/rob_target = max(0, min(400,stats.getStat(STAT_ROB))) //hard capped amount of recoil the target negates upon disarming
 			var/recoil_damage = (rob_attacker * (1 - (rob_target / 400))) //recoil itself
-			visible_message("[recoil_damage] and [rob_attacker] and [rob_target]")
 			for(var/obj/item/I in holding)
 				external_recoil(recoil_damage)
 				if(recoil >= 60) //disarming

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -264,12 +264,13 @@
 					if(turfs.len)
 						var/turf/target = pick(turfs)
 						visible_message(SPAN_DANGER("[src]'s [W] goes off during the struggle!"))
-						return W.afterattack(target,src)
+						W.afterattack(target,src)
 
 			//Actually disarm them
 			var/rob_attacker = (50 / (1 + 150 / max(1, H.stats.getStat(STAT_ROB))) + 40) //soft capped amount of recoil that attacker deals
 			var/rob_target = max(0, min(400,stats.getStat(STAT_ROB))) //hard capped amount of recoil the target negates upon disarming
 			var/recoil_damage = (rob_attacker * (1 - (rob_target / 400))) //recoil itself
+			visible_message("[recoil_damage] and [rob_attacker] and [rob_target]")
 			for(var/obj/item/I in holding)
 				external_recoil(recoil_damage)
 				if(recoil >= 60) //disarming

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -266,24 +266,30 @@
 						visible_message(SPAN_DANGER("[src]'s [W] goes off during the struggle!"))
 						return W.afterattack(target,src)
 
-			var/randn = rand(1, 100)
-			randn = max(1, randn - H.stats.getStat(STAT_ROB))
-
-			if(randn <= 50)
-				//See about breaking grips or pulls
-				if(break_all_grabs(M))
-					playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-					return
-
-				//Actually disarm them
-				for(var/obj/item/I in holding)
-					if(I && src.unEquip(I))
-						visible_message(SPAN_DANGER("[M] has disarmed [src]!"))
+			//Actually disarm them
+			var/rob_attacker = (50 / (1 + 150 / (min(1, H.stats.getStat(STAT_ROB)))) + 20) //soft capped amount of recoil that attacker deals
+			var/rob_target = max(0, min(400, src.stats.getStat(STAT_ROB))) //hard capped amount of recoil the target negates upon disarming. 400 - no recoil
+			var/recoil_damage = (rob_attacker * (1 - (rob_target / 400))) //recoil itself
+			for(var/obj/item/I in holding)
+				src.external_recoil(recoil_damage)
+				if(src.recoil >= 60) //disarming
+					if(istype(I, /obj/item/grab)) //did M grab someone?
+						break_all_grabs(M) //See about breaking grips or pulls
 						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 						return
+					if(I.wielded) //is the held item wielded?
+						if(!src.recoil >= 80) //if yes, we need more recoil to disarm
+							playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+							visible_message(SPAN_WARNING("[M] attempted to disarm [src]"))
+							return
+					src.unEquip(I) //finally disarm target
+					visible_message(SPAN_DANGER("[M] has disarmed [src]!"))
+					playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+					src.recoil *= 0.5 //halve all gained recoil
+					return
 
 			playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-			visible_message("\red <B>[M] attempted to disarm [src]!</B>")
+			visible_message(SPAN_WARNING("[M] attempted to disarm [src]"))
 	return
 
 /mob/living/carbon/human/proc/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, inrange, params)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -267,7 +267,7 @@
 						return W.afterattack(target,src)
 
 			//Actually disarm them
-			var/rob_attacker = (50 / (1 + 150 / (min(1, max(0, H.stats.getStat(STAT_ROB))))) + 20) //soft capped amount of recoil that attacker deals
+			var/rob_attacker = (50 / (1 + 150 / (min(1, max(0, H.stats.getStat(STAT_ROB))))) + 40) //soft capped amount of recoil that attacker deals
 			var/rob_target = max(0, min(400,stats.getStat(STAT_ROB))) //hard capped amount of recoil the target negates upon disarming. 400 - no recoil
 			var/recoil_damage = (rob_attacker * (1 - (rob_target / 400))) //recoil itself
 			for(var/obj/item/I in holding)
@@ -283,7 +283,7 @@
 							visible_message(SPAN_WARNING("[M] attempted to disarm [src]"))
 							return
 					if(istype(I, /obj/item/twohanded/offhand)) //did someone dare to switch to offhand to not get disarmed?
-						unEquip(src.get_inactive_hand()) //different proc here because
+						unEquip(src.get_inactive_hand())
 						visible_message(SPAN_DANGER("[M] has disarmed [src]!"))
 						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 						return

--- a/code/modules/mob/living/recoil.dm
+++ b/code/modules/mob/living/recoil.dm
@@ -7,6 +7,12 @@
 		recoil += G.recoil_buildup
 		update_recoil()
 
+/mob/living/proc/external_recoil(var/recoil_amount) //used in human_attackhand.dm
+	deltimer(recoil_reduction_timer)
+	if(recoil_amount)
+		recoil += recoil_amount
+		update_recoil()
+
 /mob/living/proc/calc_recoil()
 
 	if(recoil >= 10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I am going to be hated for this probs, maybe needs tweaking

disarming adds recoil that scales off of ROB
your own ROB negates some of recoil damage
you need 60+ recoil to disarm
80 if item is wielded!

the CRAZY formulas, made ~~up~~ by Humon
rob_attacker = (50 / (1 + 150 / (min(1, __attacker robustness__))) + 40) - soft capped amount of recoil that attacker deals
rob_target = max(0, min(400, __target robustness__)) - hard capped amount of recoil the target negates upon disarming. 400 - no recoil
recoil_damage = (rob_attacker * (1 - (rob_target / 400))) - recoil itself
## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/49622619/145584005-e446ab11-c29c-4608-896d-3202006ac8e5.png)

## Changelog
:cl: Kegdo and Humonitarian
add: disarm deals recoil, scales off of ROB from both the attacker and target, wielding matters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
