### PR TITLE
makes hydraulic circuits hydraulic again

### DIFF
--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -783,7 +783,7 @@
 	spawn_blacklisted = TRUE
 	price_tag = 600
 
-/obj/item/tool_upgrade/augment/hydraulic/New()
+/obj/item/tool_upgrade/plasma_coating/New()
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.tool_upgrades = list(


### PR DESCRIPTION
## About The Pull Request
makes an overwriting definition of hydraulic circuits actually refer to the plasma coating
## Why It's Good For The Game
i miss hydraulics bro
## Changelog
:cl:
fix: Hydraulic circuits have returned to increasing tool speed, and not coating tools in plasma.
/:cl: