### PR TITLE
Paramedic helmet fix and "mute" feature

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -135,6 +135,9 @@ var/global/list/syndicate_access = list(access_maint_tunnels, access_syndicate, 
 //A list of slots where an item doesn't count as "worn" if it's in one of them
 var/global/list/unworn_slots = list(slot_l_hand,slot_r_hand, slot_l_store, slot_r_store,slot_robot_equip_1,slot_robot_equip_2,slot_robot_equip_3)
 
+//Names that shouldn't trigger notifications about low health
+GLOBAL_LIST_EMPTY(ignore_health_alerts_from)
+
 //////////////////////////
 /////Initial Building/////
 //////////////////////////

--- a/code/datums/repositories/crew/binary.dm
+++ b/code/datums/repositories/crew/binary.dm
@@ -1,6 +1,9 @@
 /* Binary */
 /crew_sensor_modifier/binary/process_crew_data(var/mob/living/carbon/human/H, var/obj/item/clothing/under/C, var/turf/pos, var/list/crew_data)
 	crew_data["alert"] = FALSE
+	crew_data["muted"] = FALSE
+	if(H.name in GLOB.ignore_health_alerts_from)
+		crew_data["muted"] = TRUE
 	if(!H.isSynthetic())
 		var/obj/item/organ/internal/heart/O = H.random_organ_by_process(OP_HEART)
 		if(O && BP_IS_ORGANIC(O))

--- a/code/datums/repositories/crew/binary.dm
+++ b/code/datums/repositories/crew/binary.dm
@@ -2,9 +2,11 @@
 /crew_sensor_modifier/binary/process_crew_data(var/mob/living/carbon/human/H, var/obj/item/clothing/under/C, var/turf/pos, var/list/crew_data)
 	crew_data["alert"] = FALSE
 	if(!H.isSynthetic())
-		var/pulse = H.pulse()
-		if(pulse == PULSE_NONE || pulse == PULSE_THREADY)
-			crew_data["alert"] = TRUE
+		var/obj/item/organ/internal/heart/O = H.random_organ_by_process(OP_HEART)
+		if(O && BP_IS_ORGANIC(O))
+			var/pulse = H.pulse()
+			if(pulse == PULSE_NONE || pulse == PULSE_THREADY)
+				crew_data["alert"] = TRUE
 		if(H.getOxyLoss() >= 20)
 			crew_data["alert"] = TRUE
 		if(H.getBruteLoss() >= 100)

--- a/code/datums/repositories/crew/crew.dm
+++ b/code/datums/repositories/crew/crew.dm
@@ -34,7 +34,7 @@ var/global/datum/repository/crew/crew_repository = new()
 
 	..()
 
-/datum/repository/crew/proc/health_data(var/z_level)
+/datum/repository/crew/proc/health_data(z_level, forced = FALSE)
 	var/list/crewmembers = list()
 	if(!z_level)
 		return crewmembers
@@ -44,7 +44,7 @@ var/global/datum/repository/crew/crew_repository = new()
 		cache_entry = new/datum/cache_entry
 		cache_data[num2text(z_level)] = cache_entry
 
-	if(world.time < cache_entry.timestamp)
+	if(!forced && (world.time < cache_entry.timestamp))
 		return cache_entry.data
 
 	cache_data_alert[num2text(z_level)] = FALSE

--- a/code/datums/repositories/crew/vital.dm
+++ b/code/datums/repositories/crew/vital.dm
@@ -6,7 +6,7 @@
 
 	if(!H.isSynthetic() && H.should_have_process(OP_HEART))
 		var/obj/item/organ/internal/heart/O = H.random_organ_by_process(OP_HEART)
-		if (!O || !BP_IS_ROBOTIC(O)) // Don't make medical freak out over prosthetic hearts
+		if(O && BP_IS_ORGANIC(O)) // Don't make medical freak out over prosthetic hearts
 			crew_data["true_pulse"] = H.pulse()
 			crew_data["pulse"] = H.get_pulse(1)
 			switch(crew_data["true_pulse"])
@@ -24,7 +24,7 @@
 				if(PULSE_THREADY)
 					crew_data["alert"] = TRUE
 					crew_data["pulse_span"] = "bad"
-		else if(BP_IS_ROBOTIC(O))
+		else if(O)
 			crew_data["pulse_span"] = "highlight"
 			crew_data["pulse"] = "synthetic"
 	else

--- a/code/datums/repositories/crew/vital.dm
+++ b/code/datums/repositories/crew/vital.dm
@@ -24,9 +24,6 @@
 				if(PULSE_THREADY)
 					crew_data["alert"] = TRUE
 					crew_data["pulse_span"] = "bad"
-		else if(O)
-			crew_data["pulse_span"] = "highlight"
-			crew_data["pulse"] = "synthetic"
 	else
 		crew_data["pulse_span"] = "highlight"
 		crew_data["pulse"] = "synthetic"

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -628,7 +628,7 @@
 	if(crewmembers.len)
 		for(var/i = 1, i <= crewmembers.len, i++)
 			var/list/entry = crewmembers[i]
-			if(entry["alert"])
+			if(entry["alert"] && !entry["muted"])
 				if(entry["name"] in crewmembers_recently_reported)
 					continue
 				crewmembers_recently_reported += entry["name"]

--- a/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
+++ b/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
@@ -39,7 +39,7 @@
 
 /datum/nano_module/crew_monitor/proc/has_alerts()
 	for(var/z_level in GLOB.maps_data.station_levels)
-		if (crew_repository.has_health_alert(z_level))
+		if(crew_repository.has_health_alert(z_level))
 			return TRUE
 	return FALSE
 
@@ -62,6 +62,7 @@
 					if(!T.is_tracking)
 						T.pinpoint()
 		return TOPIC_HANDLED
+
 	if(href_list["search"])
 		var/new_search = sanitize(input("Enter the value for search for.") as null|text)
 		if(!new_search || new_search == "")
@@ -70,11 +71,30 @@
 		search = new_search
 		return TOPIC_HANDLED
 
+	if(href_list["mute"])
+		var/mob/living/carbon/human/H = locate(href_list["mute"]) in SSmobs.mob_list
+		if(H)
+			GLOB.ignore_health_alerts_from.Add(H.name)
+			// Run that so UI updates right after button is pressed, without 5 second delay
+			for(var/z_level in GLOB.maps_data.station_levels)
+				// Forced update, we don't want cached entry to be returned
+				crew_repository.health_data(z_level, TRUE)
+		return TOPIC_HANDLED
+
+	if(href_list["unmute"])
+		var/mob/living/carbon/human/H = locate(href_list["unmute"]) in SSmobs.mob_list
+		if(H)
+			GLOB.ignore_health_alerts_from.Remove(H.name)
+			for(var/z_level in GLOB.maps_data.station_levels)
+				crew_repository.health_data(z_level, TRUE)
+		return TOPIC_HANDLED
 
 /datum/nano_module/crew_monitor/ui_data(mob/user)
 	var/list/data = host.initial_data()
 	var/datum/computer_file/program/host_program = host
-	data["can_track"] = (isAI(user) || (istype(host_program) && istype(host_program.computer, /obj/item/modular_computer/tablet/moebius)))
+	var/tracking_tablet_used = (istype(host_program) && istype(host_program.computer, /obj/item/modular_computer/tablet/moebius))
+	data["can_mute"] = tracking_tablet_used
+	data["can_track"] = (isAI(user) || tracking_tablet_used)
 	var/list/crewmembers = list()
 	for(var/z_level in GLOB.maps_data.station_levels)
 		crewmembers += crew_repository.health_data(z_level)

--- a/nano/templates/crew_monitor.tmpl
+++ b/nano/templates/crew_monitor.tmpl
@@ -45,6 +45,13 @@ Used In File(s): code\modules\modular_computers\file_system\programs\medical\sui
 			{{else}}
 				<td><span class="white">Area:</span> Not Available</td>
 			{{/if}}
+			{{if data.can_mute}}
+				{{if value.muted}}
+					<td class='tracking'>{{:helper.link('Unmute', null, {'unmute' : value.ref})}}</td>
+				{{else}}
+					<td class='tracking'>{{:helper.link('Mute', null, {'mute' : value.ref})}}</td>
+				{{/if}}
+			{{/if}}
 		</tr>
 		<tr class="candystripe">
 			<td>({{:value.assignment}})


### PR DESCRIPTION
## About The Pull Request

Fixed an issue with synthetic heart triggering suit sensors.
Added mute/unmute button to paramedic tablet's interface, allowing to disable paramedic helmet's notifications for specific people.

![image](https://user-images.githubusercontent.com/65828539/145702756-45e87112-7f0f-4215-b339-774bd976c01b.png)

![image](https://user-images.githubusercontent.com/65828539/145702775-96aabbb2-8b7c-4691-a06c-2d93a0986180.png)


## Why It's Good For The Game

Fixes cool.
QoL features cool too.

## Changelog
:cl:
add: mute/unmute button to paramedic tablet's interface
fix: synthetic heart no longer trigger suit sensors
/:cl:

