### PR TITLE
Paramedic armor slowdown rework

### DIFF
--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -60,7 +60,7 @@
 		if(AB_ITEM)
 			if(target)
 				var/obj/item/item = target
-				item.ui_action_click()
+				item.ui_action_click(usr, name)
 		//if(AB_SPELL)
 		//	if(target)
 		//		var/obj/effect/proc_holder/spell = target

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -587,7 +587,7 @@
 	var/speed_boost_ready = TRUE
 	var/speed_boost_active = FALSE
 	var/speed_boost_power = -0.5
-	var/speed_boost_length = 15 SECONDS
+	var/speed_boost_length = 30 SECONDS
 	var/speed_boost_cooldown = 5 MINUTES
 	var/matching_helmet = /obj/item/clothing/head/armor/faceshield/paramedic
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -568,7 +568,9 @@
 		MATERIAL_PLASTEEL = 10,
 		MATERIAL_STEEL = 5,
 		MATERIAL_PLASTIC = 5,
-		MATERIAL_PLATINUM = 3
+		MATERIAL_PLATINUM = 3,
+		MATERIAL_URANIUM = 4,
+		MATERIAL_SILVER = 2
 		)
 	armor = list(
 		melee = 30,
@@ -581,4 +583,52 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	spawn_blacklisted = TRUE
 	style = STYLE_HIGH
-	slowdown = -0.3
+	action_button_name = "Toggle Acceleration"
+	var/speed_boost_ready = TRUE
+	var/speed_boost_active = FALSE
+	var/speed_boost_power = -0.5
+	var/speed_boost_length = 15 SECONDS
+	var/speed_boost_cooldown = 5 MINUTES
+	var/matching_helmet = /obj/item/clothing/head/armor/faceshield/paramedic
+
+
+/obj/item/clothing/suit/armor/paramedic/ui_action_click(mob/living/user, action_name)
+	if(..())
+		return TRUE
+
+	trigger_speed_boost(user)
+
+
+/obj/item/clothing/suit/armor/paramedic/proc/trigger_speed_boost(mob/living/carbon/human/user)
+	if(!istype(user))
+		return
+
+	if(!speed_boost_ready)
+		if(user.head && istype(user.head, matching_helmet))
+			if(speed_boost_active)
+				to_chat(usr, SPAN_WARNING("[user.head] beeps: 'Acceleration protocol active.'"))
+			else
+				to_chat(usr, SPAN_WARNING("[user.head] beeps: 'Acceleration protocol failture. Insufficient capacitor charge.'"))
+		return
+
+	speed_boost_ready = FALSE
+	speed_boost_active = TRUE
+	slowdown = speed_boost_power
+
+	if(user.head && istype(user.head, matching_helmet))
+		to_chat(usr, SPAN_WARNING("[user.head] beeps: 'Acceleration protocol initiated.'"))
+
+	spawn(speed_boost_length)
+		if(QDELETED(src))
+			return
+		slowdown = initial(slowdown)
+		speed_boost_active = FALSE
+		if(user.head && istype(user.head, matching_helmet))
+			to_chat(usr, SPAN_WARNING("[user.head] beeps: 'Capacitors discharged. Acceleration protocol aborted.'"))
+
+		spawn(speed_boost_cooldown)
+			if(QDELETED(src))
+				return
+			speed_boost_ready = TRUE
+			if(user.head && istype(user.head, matching_helmet))
+				to_chat(usr, SPAN_WARNING("[user.head] beeps: 'Capacitors have been recharged.'"))


### PR DESCRIPTION
## About The Pull Request

Replaced constant 0.3 speed boost of paramedic's armor with 0.5, that can be active for ~15~ 30 seconds and have a cooldown of 5 minutes.
Added materials of medium atomcell to armor cost.
If paramedic helmet is equipped, there will be notifications on activation, deactivation and cooldown end.

## Why It's Good For The Game

People are salty over constant speed boost, probably that will work out better.

## Changelog
:cl:
tweak: paramedic armor's constant 0.3 speed boost replaced with 0.5, that can be active for 30 seconds and have a cooldown of 5 minutes
/:cl: