### PR TITLE
Gun assembly moved to guns crafting category

### DIFF
--- a/code/datums/craft/recipes/guns.dm
+++ b/code/datums/craft/recipes/guns.dm
@@ -3,6 +3,14 @@
 	time = 25
 	related_stats = list(STAT_MEC)
 
+/datum/craft_recipe/gun/guns_craft_frame
+	name = "Gun assembly"
+	result = /obj/item/craft_frame/guns
+	steps = list(
+		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTEEL, "time" = 30),
+		list(QUALITY_WELDING, 10, 10)
+	)
+
 /datum/craft_recipe/gun/pistol
 	name = "Handmade gun"
 	result = /obj/item/gun/projectile/handmade_pistol

--- a/code/datums/craft/recipes/misc.dm
+++ b/code/datums/craft/recipes/misc.dm
@@ -292,11 +292,3 @@
 	name = "Makeshift prosthetic right arm"
 	result = /obj/item/organ/external/robotic/makeshift/r_arm
 
-/datum/craft_recipe/guns_craft_frame
-	name = "Gun assembly"
-	result = /obj/item/craft_frame/guns
-	steps = list(
-		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTEEL, "time" = 30),
-		list(QUALITY_WELDING, 10, 10)
-	)
-	related_stats = list(STAT_MEC)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/59490776/145896082-917892e1-d3fc-452d-a9be-2045c2b1a917.png)
Moves the gun assembly from misc to guns.

## Why It's Good For The Game

Think its better to have a gun related crafting assembly to be in the guns category, rather than at the bottom of misc

## Changelog
:cl:
tweak: Moved gun assembly craft recipe to the "guns" category from "misc"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
