### PR TITLE
Food/drink sanity gain adjustments

### DIFF
--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -82,6 +82,7 @@
 	taste_description = "sweetness"
 	nutriment_factor = 4
 	color = "#FFFF00"
+	sanity_gain_ingest = 0.5 //tasty
 	taste_tag = list(TASTE_SWEET,TASTE_SLIMEY)
 
 /datum/reagent/organic/nutriment/flour
@@ -107,6 +108,7 @@
 	taste_mult = 1.3
 	reagent_state = SOLID
 	nutriment_factor = 2
+	sanity_gain_ingest = 0.5 // endorphins
 	color = "#302000"
 	taste_tag = list(TASTE_SWEET,TASTE_SLIMEY)
 
@@ -150,6 +152,7 @@
 	taste_mult = 1.3
 	reagent_state = LIQUID
 	nutriment_factor = 0.4
+	sanity_gain_ingest = 0.5
 	color = "#801E28"
 	taste_tag = list(TASTE_SLIMEY)
 
@@ -188,8 +191,10 @@
 	taste_mult = 2
 	reagent_state = LIQUID
 	nutriment_factor = 0.8
+	sanity_gain_ingest = 0 //Yucky
 	color = "#899613"
 	taste_tag = list(TASTE_SOUR)
+
 /datum/reagent/organic/nutriment/sprinkles
 	name = "Sprinkles"
 	id = "sprinkles"
@@ -227,6 +232,7 @@
 	description = "A salt made of sodium chloride. Commonly used to season food."
 	taste_description = "salt"
 	reagent_state = SOLID
+	sanity_gain_ingest = 0.05 //seasoning
 	color = "#FFFFFF"
 	overdose = REAGENTS_OVERDOSE
 
@@ -236,8 +242,9 @@
 	description = "A powder ground from peppercorns. Used in many medicinal and beauty products."
 	taste_description = "pepper"
 	reagent_state = SOLID
+	sanity_gain_ingest = 0.05 //ditto
 	color = "#000000"
-	taste_tag = list(TASTE_SPICY,)
+	taste_tag = list(TASTE_SPICY)
 
 /datum/reagent/organic/enzyme
 	name = "Universal Enzyme"
@@ -275,6 +282,7 @@
 	taste_description = "hot peppers"
 	taste_mult = 1.5
 	reagent_state = LIQUID
+	nutriment_factor = 0.8
 	color = "#B31008"
 	var/agony_dose = 5
 	var/agony_amount = 2
@@ -387,6 +395,7 @@
 	id = "drink"
 	description = "Uh, some kind of drink."
 	reagent_state = LIQUID
+	sanity_gain_ingest = 0.2 //Less effective than alcohol but more obtainable and no downsides (usually)
 	color = "#E78108"
 	var/nutrition = 0 // Per metabolism tick
 	var/adj_dizzy = 0 // Per metabolism tick
@@ -622,6 +631,7 @@
 	id = "tea"
 	description = "Tasty black tea. Contains caffeine."
 	taste_description = "tart black tea"
+	sanity_gain_ingest = 0.25 //calming
 	color = "#AC3700"
 	adj_dizzy = -2
 	adj_drowsy = -1
@@ -747,6 +757,7 @@
 	id = "cafe_latte"
 	description = "A nice, strong and tasty beverage while you are reading."
 	taste_description = "bitter cream"
+	sanity_gain_ingest = 0.25
 	color = "#664300" // rgb: 102, 67, 0
 	adj_temp = 5
 	taste_tag = list(TASTE_BITTER)
@@ -767,6 +778,7 @@
 	description = "A heated drink consisting melted chocolate and heated milk."
 	taste_description = "creamy chocolate"
 	reagent_state = LIQUID
+	sanity_gain_ingest = 0.25
 	color = "#403010"
 	nutrition = 2
 	adj_temp = 5
@@ -1021,6 +1033,7 @@
 	description = "A gulp a day keeps the MediBot away. That's probably for the best."
 	taste_description = "homely fruit"
 	reagent_state = LIQUID
+	sanity_gain_ingest = 0.5 //Delightful
 	color = "#FF8CFF"
 	nutrition = 1
 	taste_tag = list(TASTE_SWEET)
@@ -1048,6 +1061,7 @@
 	taste_description = "dry and cheap noodles"
 	reagent_state = SOLID
 	nutrition = 1
+	sanity_gain_ingest = 0.1
 	color = "#302000"
 	taste_tag = list(TASTE_SLIMEY)
 
@@ -1057,6 +1071,7 @@
 	description = "The noodles are boiled, the flavors are artificial, just like being back in school."
 	taste_description = "wet and cheap noodles"
 	reagent_state = LIQUID
+	sanity_gain_ingest = 0.3
 	color = "#302000"
 	nutrition = 5
 	adj_temp = 5
@@ -1068,6 +1083,7 @@
 	description = "The noodles are boiled, the flavors are artificial, just like being back in school."
 	taste_description = "wet and cheap noodles on fire"
 	reagent_state = LIQUID
+	sanity_gain_ingest = 0.3
 	color = "#302000"
 	nutrition = 5
 	taste_tag = list(TASTE_SLIMEY,TASTE_SPICY)
@@ -1083,6 +1099,7 @@
 	taste_description = "ice"
 	taste_mult = 1.5
 	reagent_state = SOLID
+	sanity_gain_ingest = 0 //it's just water
 	color = "#619494"
 	adj_temp = -5
 	taste_tag = list(TASTE_REFRESHING)
@@ -1097,6 +1114,7 @@
 	id = "nothing"
 	description = "Absolutely nothing."
 	taste_description = "nothing"
+	sanity_gain_ingest = 0 //Nothing
 
 	glass_unique_appearance = TRUE
 	glass_icon_state = "nothing"

--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -529,6 +529,7 @@
 	id = "poisonberryjuice"
 	description = "A tasty juice blended from various kinds of very deadly and toxic berries."
 	taste_description = "berries"
+	sanity_gain_ingest = 0 //bad for you
 	color = "#863353"
 	strength = 5
 
@@ -738,6 +739,7 @@
 	id = "soy_latte"
 	description = "A coffee drink made with espresso and steamed soy milk."
 	taste_description = "creamy coffee"
+	sanity_gain_ingest = 0.25
 	color = "#664300"
 	adj_temp = 5
 	taste_tag = list(TASTE_BITTER)

--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -529,7 +529,7 @@
 	id = "poisonberryjuice"
 	description = "A tasty juice blended from various kinds of very deadly and toxic berries."
 	taste_description = "berries"
-	sanity_gain_ingest = 0 //bad for you
+	sanity_gain_ingest = 0.8 //Bad for your health but good for your mental state
 	color = "#863353"
 	strength = 5
 
@@ -2142,6 +2142,7 @@
 	id = "pwine"
 	description = "Is this even wine? Toxic! Hallucinogenic! Probably consumed in boatloads by your superiors!"
 	taste_description = "purified alcoholic death"
+	sanity_gain_ingest = 2 // With risk comes reward 
 	color = "#000000"
 	strength = 1
 	druggy = 50

--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -282,7 +282,6 @@
 	taste_description = "hot peppers"
 	taste_mult = 1.5
 	reagent_state = LIQUID
-	nutriment_factor = 0.8
 	color = "#B31008"
 	var/agony_dose = 5
 	var/agony_amount = 2
@@ -294,6 +293,7 @@
 	M.adjustToxLoss(0.05 * effect_multiplier)
 
 /datum/reagent/organic/capsaicin/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
+	M.adjustNutrition(0.8 * effect_multiplier)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.species && (H.species.flags & (NO_PAIN)))

--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -191,7 +191,7 @@
 	taste_mult = 2
 	reagent_state = LIQUID
 	nutriment_factor = 0.8
-	sanity_gain_ingest = 0 //Yucky
+	sanity_gain_ingest = -0.3 //Yucky
 	color = "#899613"
 	taste_tag = list(TASTE_SOUR)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Drinks now provide sanity, less than half of that of alcohol on average, and some forms of nutriment are now better for your mind than others. 
Minor alteration to capascin oil to satisfy nutrition (on par with soy sauce). *Technically* buffs pepperspray as an improvised food source but go ahead, drink your pepper spray - I dare you. Virus food, ice and Nothing on the flipside provides no sanity benefit.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives most drinks a purpose beyond being a prerequisite for cocktails. _This change does not make them valid for satisfying desires, the drink desire explicitly requires ethanol or a subtype of it._
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Capascin provide nutrition, on par with soy sauce. Some nutriments are now more pleasing than others.
balance: Drinks now provide sanity benefit. Salt and pepper are *ever so* slightly good for your sanity now. Poisonberry juice and wine is 4x better for sanity as their counterparts, if you're willing to bear the side effects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
