### PR TITLE
Catwalk smoothing

### DIFF
--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -21,6 +21,15 @@
 			update_icon()
 			redraw_nearby_catwalks()
 
+/obj/structure/catwalk/Initialize()
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/structure/catwalk/LateInitialize()
+	..()
+	update_icon()
+	redraw_nearby_catwalks()
+
 /obj/structure/catwalk/Destroy()
 	if (istype(loc, /turf/simulated/open))
 		var/turf/simulated/open/T = loc
@@ -34,30 +43,39 @@
 			var/obj/structure/catwalk/L = locate(/obj/structure/catwalk, get_step(src, direction))
 			L.update_icon() //so siding get updated properly
 
+/obj/structure/catwalk/proc/test_connect(var/turf/T)
+	if(locate(/obj/structure/catwalk, T))
+		return TRUE
+	else if(T.is_wall)
+		return TRUE
+	else if (istype(T, /turf/simulated/floor))
+		var/turf/simulated/floor/t = T
+		if(!t.flooring.is_plating || istype(t.flooring, /decl/flooring/reinforced/plating/hull)) //Caution stripes go where elevation would change, eg, stepping down onto underplating 
+			return TRUE
 
 /obj/structure/catwalk/on_update_icon()
 	var/connectdir = 0
 	for(var/direction in cardinal)
-		if(locate(/obj/structure/catwalk, get_step(src, direction)))
+		if(test_connect(get_step(src, direction)))
 			connectdir |= direction
 
 	//Check the diagonal connections for corners, where you have, for example, connections both north and east. In this case it checks for a north-east connection to determine whether to add a corner marker or not.
 	var/diagonalconnect = 0 //1 = NE; 2 = SE; 4 = NW; 8 = SW
 	//NORTHEAST
 	if(connectdir & NORTH && connectdir & EAST)
-		if(locate(/obj/structure/catwalk, get_step(src, NORTHEAST)))
+		if(test_connect(get_step(src, NORTHEAST)))
 			diagonalconnect |= 1
 	//SOUTHEAST
 	if(connectdir & SOUTH && connectdir & EAST)
-		if(locate(/obj/structure/catwalk, get_step(src, SOUTHEAST)))
+		if(test_connect(get_step(src, SOUTHEAST)))
 			diagonalconnect |= 2
 	//NORTHWEST
 	if(connectdir & NORTH && connectdir & WEST)
-		if(locate(/obj/structure/catwalk, get_step(src, NORTHWEST)))
+		if(test_connect(get_step(src, NORTHWEST)))
 			diagonalconnect |= 4
 	//SOUTHWEST
 	if(connectdir & SOUTH && connectdir & WEST)
-		if(locate(/obj/structure/catwalk, get_step(src, SOUTHWEST)))
+		if(test_connect(get_step(src, SOUTHWEST)))
 			diagonalconnect |= 8
 
 	icon_state = "catwalk[connectdir]-[diagonalconnect]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Catwalks now only show caution strips when bordering plating/underplating (implied elevation difference)

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/95113773/146602819-7f6a4b0b-88c3-41ed-bc53-bf38f953f903.png)

## Changelog
:cl:
tweak: Catwalk smoothing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
