### PR TITLE
Cognition insight buff

### DIFF
--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -152,7 +152,7 @@
 /datum/sanity/proc/handle_Insight()
 	var/moralist_factor = 1
 	var/style_factor = owner.get_style_factor()
-	var/cognition_multiplier = 0.7 / (1 + 70 / max(1, owner.stats.getStat(STAT_COG)) + 1
+	var/cognition_multiplier = 0.7 / (1 + 70 / max(1, owner.stats.getStat(STAT_COG))) + 1
 	if(owner.stats.getPerk(PERK_MORALIST))
 		for(var/mob/living/carbon/human/H in view(owner))
 			if(H.sanity.level > 60)

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -152,11 +152,12 @@
 /datum/sanity/proc/handle_Insight()
 	var/moralist_factor = 1
 	var/style_factor = owner.get_style_factor()
+	var/cognition_multiplier = 0.7 / (1 + 70 / max(1, owner.stats.getStat(STAT_COG)) + 1
 	if(owner.stats.getPerk(PERK_MORALIST))
 		for(var/mob/living/carbon/human/H in view(owner))
 			if(H.sanity.level > 60)
 				moralist_factor += 0.02
-	give_insight(INSIGHT_GAIN(level_change) * insight_passive_gain_multiplier * moralist_factor * style_factor * life_tick_modifier)
+	give_insight(INSIGHT_GAIN(level_change) * insight_passive_gain_multiplier * moralist_factor * style_factor * life_tick_modifier * cognition_multiplier)
 	while(resting < max_resting && insight >= 100)
 		give_resting(1)
 		if(owner.stats.getPerk(PERK_ARTIST))


### PR DESCRIPTION
## About The Pull Request

Adds a diminishing insight multiplier based on the Cognition of the player.
Hard limit is +70%, but effect diminishes quickly.

- 20 Cog provides 15.5% insight,
- 30 Cog provides 21%,
- 50 provides 29%,
- 75 provides 36%,
- 100 provides 41%,
- 200 provides 52%.

## Why It's Good For The Game

Finally gives more use to Cog, and helps shut-in neets to gain insight.

## Changelog
:cl:
add: Insight gain scales with Cognition
/:cl:
