### PR TITLE
Insight no longer stacks, doubled capacity instead

### DIFF
--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -53,13 +53,13 @@
 
 	var/insight
 	var/max_insight = INFINITY
-	var/insight_passive_gain_multiplier = 1
+	var/insight_passive_gain_multiplier = 0.5
 	var/insight_gain_multiplier = 1
 	var/insight_rest = 0
 	var/max_insight_rest = INFINITY
 	var/insight_rest_gain_multiplier = 1
 	var/resting = 0
-	var/max_resting = INFINITY
+	var/max_resting = 1
 
 	var/list/valid_inspirations = list(/obj/item/oddity)
 	var/list/desires = list()
@@ -240,13 +240,13 @@
 
 	var/stat_pool = resting * 15
 	while(stat_pool--)
-		LAZYAPLUS(stat_change, pick(ALL_STATS), 1)
+		LAZYAPLUS(stat_change, pick(ALL_STATS), 3)
 
 	for(var/stat in stat_change)
 		owner.stats.changeStat(stat, stat_change[stat])
 
 	if(!owner.stats.getPerk(PERK_ARTIST))
-		INVOKE_ASYNC(src, .proc/oddity_stat_up, resting)
+		INVOKE_ASYNC(src, .proc/oddity_stat_up, resting*2)
 
 	if(owner.stats.getPerk(PERK_ARTIST))
 		to_chat(owner, SPAN_NOTICE("You have created art and improved your stats."))


### PR DESCRIPTION
## About The Pull Request

Insight now fills up half as fast, but provides double the stats from oddities, and triple the stats passively (to make up for any missed insight). Insight also no longer stacks, requiring players to rest occassionally. Active insight sources (objectives and breakdowns) were unaffected, effectively doubling how much insight they provide.

## Why It's Good For The Game

BarRP, completing objectives. Most of the time people can still rely on smoking, maint and drugs to fill rest, albeit having to do so more regularly instead of once every ten insight. In some cases however, if both desires are unique they might have to hit up the bar to fill their insight, or miss out on it.

## Changelog
:cl:
balance: Insight levels no longer stack, fill up half as fast, but provide more than double the benefits
balance: Completing objectives and breakdowns now provides double the insight
/:cl: