### PR TITLE
Fix pre-spawned mines missing blink animation

### DIFF
--- a/code/game/objects/items/weapons/mine.dm
+++ b/code/game/objects/items/weapons/mine.dm
@@ -29,6 +29,10 @@
 	var/excelsior = FALSE
 	anchored = FALSE
 
+/obj/item/mine/Initialize()
+	. = ..()
+	update_icon()
+
 /obj/item/mine/excelsior
 	name = "Excelsior mine"
 	desc = "An anti-personnel mine. IFF technology grants safe passage to Excelsior agents, and a merciful brief end to others, unless they have a Pulse tool nearby."


### PR DESCRIPTION

## About The Pull Request

What it says on the tin.

https://user-images.githubusercontent.com/65828539/146677479-154e9967-a0fd-49c3-9281-301e3567bd0a.mp4


## Why It's Good For The Game

Fixes cool.

## Changelog
:cl:
fix: pre-spawned mines missing blink animation
/:cl:

