### PR TITLE
Splits shared and Preacher exclusive NT litanies into separate lists

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -11,8 +11,17 @@
 	category = "Priest"
 
 /datum/ritual/cruciform/priest/acolyte
+	name = "acolyte"
+	phrase = null
+	desc = ""
+	category = "Acolyte"
 
 /datum/ritual/targeted/cruciform/priest/acolyte
+	name = "acolyte targeted"
+	phrase = null
+	desc = ""
+	category = "Acolyte"
+
 
 /datum/ritual/cruciform/priest/acolyte/epiphany
 	name = "Epiphany"


### PR DESCRIPTION
## About The Pull Request

It's finally time, as NT development moves on more and more litanies have been added into the Preacher list. This PR makes the split between shared litanies and Preacher exclusive litanies.

## Why It's Good For The Game

Two short lists are far easier to navigate than one bloated list.

## Changelog
:cl:
add: Litanies shared between the Acolytes and the Preacher have been separated into their own list.
/:cl:

