### PR TITLE
Pipebomb change, shiv DLC

### DIFF
--- a/code/datums/craft/recipes/weapon.dm
+++ b/code/datums/craft/recipes/weapon.dm
@@ -315,12 +315,12 @@
 	steps = list(
 		list(/obj/item/cell/medium/high, 1),
 		list(QUALITY_SAWING, 10),
-		list(QUALITY_DRILLING, 10, "time" = 40),
+		list(QUALITY_DRILLING, 5, "time" = 40),
 		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTEEL),
 		list(QUALITY_WELDING, 10, "time" = 30),
 		list(CRAFT_MATERIAL, 2, MATERIAL_PLASMA), //similary to the makeshift landmine, as explosive, frags come from the shell itself
 		list(QUALITY_WELDING, 10, "time" = 30),
-		list(QUALITY_DRILLING, 10, "time" = 40),
+		list(QUALITY_DRILLING, 5, "time" = 40),
 		list(/obj/item/device/assembly/igniter, 1),
 		list(QUALITY_SCREW_DRIVING, 10, "time" = 30),
 		list(/obj/item/stack/cable_coil, 5),

--- a/code/game/objects/items/weapons/tools/knives.dm
+++ b/code/game/objects/items/weapons/tools/knives.dm
@@ -307,7 +307,9 @@
 /obj/item/tool/knife/shiv
 	name = "shiv"
 	desc = "A pointy piece of glass, abraded to an edge and wrapped in tape for a handle. Could become a decent tool or weapon with right tool mods."
+	icon = 'icons/obj/tools.dmi'
 	icon_state = "impro_shiv"
+	item_state = "shiv"
 	worksound = WORKSOUND_HARD_SLASH
 	matter = list(MATERIAL_GLASS = 1)
 	sharp = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces drill requirement to 5, so you can use a shiv

Also makes the shiv actually show up, 2 fucking lines come on people and no one noticed a invisible shiv
![image](https://user-images.githubusercontent.com/59490776/147616314-88f3fa87-9f2e-4b65-a56c-7b02501b487c.png)


## Why It's Good For The Game

More pipebombs, Go full Ted Kaczynski
![image](https://user-images.githubusercontent.com/59490776/147615099-8ce5075f-9264-4260-af85-1c2bc953ba74.png)

## Changelog
:cl:
tweak: drill quality requirement for pipebomb, reduced to 5, you can now use a shiv/knife/etc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
