### PR TITLE
Fix resting robots

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -49,6 +49,10 @@
 		AH.unregister_alarm(src)
 	. = ..()
 
+/mob/living/silicon/lay_down()
+	resting = FALSE
+	update_lying_buckled_and_verb_status()
+
 /mob/living/silicon/proc/init_id()
 	if(idcard)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Your mining robot pressed "rest" verb and turned immobile and deaf? No more!

## Why It's Good For The Game

Fixes cool.

## Changelog
:cl:
fix: robots being able to rest
/:cl: