### PR TITLE
Harddrives interact with rejuvenator

### DIFF
--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -32,6 +32,16 @@
 		return TRUE
 	return FALSE
 
+/obj/item/computer_hardware/hard_drive/make_young()
+	var/result = ..()
+	stored_files = list()
+	return result
+
+/obj/item/computer_hardware/hard_drive/portable/design/make_young()
+	var/result = ..()
+	license = min(license, 0)
+	return result
+
 /obj/proc/make_old(low_quality_oldification)	//low_quality_oldification changes names and colors to fit with "bad prints" instead of "very old items" asthetic
 	GET_COMPONENT(oldified, /datum/component/oldficator)
 	if(oldified)

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -32,7 +32,7 @@
 		return TRUE
 	return FALSE
 
-/obj/item
+/obj/item/make_young()
 	.=..()
 	refresh_upgrades() //should fix the problem of stacking mods
 

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -32,15 +32,17 @@
 		return TRUE
 	return FALSE
 
+/obj/item
+	.=..()
+	refresh_upgrades() //should fix the problem of stacking mods
+
 /obj/item/computer_hardware/hard_drive/make_young()
-	var/result = ..()
+	.=..()
 	stored_files = list()
-	return result
 
 /obj/item/computer_hardware/hard_drive/portable/design/make_young()
-	var/result = ..()
+	.=..()
 	license = min(license, 0)
-	return result
 
 /obj/proc/make_old(low_quality_oldification)	//low_quality_oldification changes names and colors to fit with "bad prints" instead of "very old items" asthetic
 	GET_COMPONENT(oldified, /datum/component/oldficator)

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -32,10 +32,6 @@
 		return TRUE
 	return FALSE
 
-/obj/item/make_young()
-	.=..()
-	refresh_upgrades() //should fix the problem of stacking mods
-
 /obj/item/computer_hardware/hard_drive/make_young()
 	.=..()
 	stored_files = list()


### PR DESCRIPTION
## About The Pull Request

Rejuvenator will empty harddrives from all files, including the designs within design disks. It will also reduce license to 0, if any.

## Why It's Good For The Game

Prevents rejuv from fixing up designs disks with little effort, but still allows the rejuvenation of printed items.

## Changelog
:cl:
add: rejuv clears disks
/:cl: