### PR TITLE
Plasma firemode rework

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -790,6 +790,7 @@
 #include "code\game\objects\empulse.dm"
 #include "code\game\objects\explosion.dm"
 #include "code\game\objects\explosion_recursive.dm"
+#include "code\game\objects\heatwave.dm"
 #include "code\game\objects\items.dm"
 #include "code\game\objects\objs.dm"
 #include "code\game\objects\structures.dm"

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -26,6 +26,10 @@
 	spawn(lifetime)
 		qdel(src)
 
+/obj/effect/overlay/pulse/heatwave
+	icon_state = "sparks"
+	name = "heatwave sparks"
+
 /obj/effect/overlay/palmtree_r
 	name = "Palm tree"
 	icon = 'icons/misc/beach2.dmi'

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -29,7 +29,7 @@ proc/empulse(turf/epicenter, heavy_range, light_range, log=0, strength=1)
 	for(var/mob/M in range(heavy_range, epicenter))
 		M << 'sound/effects/EMPulse.ogg'
 
-	var/effect = max(strength,0)
+	var/effect = max(strength, 0)
 
 	for(var/atom/T in range(light_range, epicenter))
 		#ifdef EMPDEBUG

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -46,7 +46,7 @@ proc/empulse(turf/epicenter, heavy_range, light_range, log=0, strength=1)
 			else
 				T.emp_act(effect + 1)
 		else if(distance <= light_range)
-			T.emp_act(effect+1)
+			T.emp_act(effect + 1)
 		#ifdef EMPDEBUG
 		if((world.timeofday - time) >= EMPDEBUG)
 			log_and_message_admins("EMPDEBUG: [T.name] - [T.type] - took [world.timeofday - time]ds to process emp_act()!")

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -1,6 +1,6 @@
 // Uncomment this define to check for possible lengthy processing of emp_act()s.
 // If emp_act() takes more than defined deciseconds (1/10 seconds) an admin message and log is created.
-// I do not recommend having this uncommented on main server, it probably causes a bit more lag, espicially with larger EMPs.
+// I do not recommend having this uncommented on main server, it probably causes a bit more lag, especially with larger EMPs.
 
 // #define EMPDEBUG 10
 

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -44,7 +44,7 @@ proc/empulse(turf/epicenter, heavy_range, light_range, log=0, strength=1)
 			if(prob(50))
 				T.emp_act(effect)
 			else
-				T.emp_act(effect+1)
+				T.emp_act(effect + 1)
 		else if(distance <= light_range)
 			T.emp_act(effect+1)
 		#ifdef EMPDEBUG

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -4,7 +4,7 @@
 
 // #define EMPDEBUG 10
 
-proc/empulse(turf/epicenter, heavy_range, light_range, log=0)
+proc/empulse(turf/epicenter, heavy_range, light_range, log=0, strength=1)
 	if(!epicenter) return
 
 	if(!istype(epicenter, /turf))
@@ -29,6 +29,8 @@ proc/empulse(turf/epicenter, heavy_range, light_range, log=0)
 	for(var/mob/M in range(heavy_range, epicenter))
 		M << 'sound/effects/EMPulse.ogg'
 
+	var/effect = max(strength,0)
+
 	for(var/atom/T in range(light_range, epicenter))
 		#ifdef EMPDEBUG
 		var/time = world.timeofday
@@ -37,14 +39,14 @@ proc/empulse(turf/epicenter, heavy_range, light_range, log=0)
 		if(distance < 0)
 			distance = 0
 		if(distance < heavy_range)
-			T.emp_act(1)
+			T.emp_act(effect)
 		else if(distance == heavy_range)
 			if(prob(50))
-				T.emp_act(1)
+				T.emp_act(effect)
 			else
-				T.emp_act(2)
+				T.emp_act(effect+1)
 		else if(distance <= light_range)
-			T.emp_act(2)
+			T.emp_act(effect+1)
 		#ifdef EMPDEBUG
 		if((world.timeofday - time) >= EMPDEBUG)
 			log_and_message_admins("EMPDEBUG: [T.name] - [T.type] - took [world.timeofday - time]ds to process emp_act()!")

--- a/code/game/objects/heatwave.dm
+++ b/code/game/objects/heatwave.dm
@@ -1,4 +1,4 @@
-proc/heatwave(turf/epicenter, heavy_range, light_range, damage, fire_stacks, log=0)
+proc/heatwave(turf/epicenter, heavy_range, light_range, damage, fire_stacks, penetration, log=0)
 	if(!epicenter) return
 
 	if(!istype(epicenter, /turf))
@@ -44,6 +44,6 @@ proc/heatwave(turf/epicenter, heavy_range, light_range, damage, fire_stacks, log
 			var/loc_damage
 			while (burn_damage > 0)
 				burn_damage -= loc_damage = rand(0, burn_damage)
-				L.damage_through_armor(loc_damage, BURN, organ_hit, ARMOR_ENERGY)
+				L.damage_through_armor(loc_damage, BURN, organ_hit, ARMOR_ENERGY, penetration)
 				organ_hit = pickweight(list(BP_HEAD = 0.2, BP_GROIN = 0.2, BP_R_ARM = 0.1, BP_L_ARM = 0.1, BP_R_LEG = 0.1, BP_L_LEG = 0.1))  //We determine some other body parts that should be hit
 	return 1

--- a/code/game/objects/heatwave.dm
+++ b/code/game/objects/heatwave.dm
@@ -1,4 +1,4 @@
-proc/heatwave(turf/epicenter, heavy_range, light_range, damage, log=0)
+proc/heatwave(turf/epicenter, heavy_range, light_range, damage, fire_stacks, log=0)
 	if(!epicenter) return
 
 	if(!istype(epicenter, /turf))
@@ -9,37 +9,41 @@ proc/heatwave(turf/epicenter, heavy_range, light_range, damage, log=0)
 		log_game("Heatwave with size ([heavy_range], [light_range]) in area [epicenter.loc.name] ")
 
 	if(heavy_range > 1)
-		var/obj/effect/overlay/pulse = new(epicenter)
-		pulse.icon = 'icons/effects/effects.dmi'
-		pulse.icon_state = "emppulse"
-		pulse.name = "emp pulse"
-		pulse.anchored = TRUE
+		var/obj/effect/overlay/heatwave = new(epicenter)
+		heatwave.icon = 'icons/effects/effects.dmi'
+		heatwave.icon_state = "sparks"
+		heatwave.name = "heatwave"
+		heatwave.anchored = TRUE
 		spawn(20)
-			qdel(pulse)
+			qdel(heatwave)
 
 	if(heavy_range > light_range)
 		light_range = heavy_range
+	
+	for(var/atom/T in range(heavy_range, epicenter))
+		if(fire_stacks)
+			T.fire_act()
+		if(istype(T, /mob/living))
+			var/mob/living/L = T
+			L << 'sound/effects/gore/sear.ogg' // How do I replace this
 
-	for(var/mob/living/L in range(light_range, epicenter))
-		L << 'sound/effects/gore/sear.ogg' // How do I replace this
+			var/burn_damage = 0
 
-		var/burn_damage = 0
+			var/distance = get_dist(epicenter, L)
+			if(distance < 0)
+				distance = 0
+			if(distance <= heavy_range)
+				burn_damage = damage
+			else if(distance <= light_range)
+				burn_damage = damage*0.5
 
-		var/distance = get_dist(epicenter, L)
-		if(distance < 0)
-			distance = 0
-		if(distance <= heavy_range)
-			burn_damage = damage
-		else if(distance <= light_range)
-			burn_damage = damage*0.5
+			if(burn_damage && L.stat == CONSCIOUS)
+				to_chat(L, SPAN_WARNING("You feel your skin boiling!"))
 
-		if(burn_damage && L.stat == CONSCIOUS)
-			to_chat(SPAN_WARNING("You feel your skin boiling!"))
-
-		var/organ_hit = BP_CHEST //Chest is hit first
-		var/loc_damage
-		while (burn_damage > 0)
-			burn_damage -= loc_damage = rand(0, burn_damage)
-			L.damage_through_armor(loc_damage, BURN, organ_hit, ARMOR_ENERGY)
-			organ_hit = pickweight(list(BP_HEAD = 0.2, BP_GROIN = 0.2, BP_R_ARM = 0.1, BP_L_ARM = 0.1, BP_R_LEG = 0.1, BP_L_LEG = 0.1))  //We determine some other body parts that should be hit
+			var/organ_hit = BP_CHEST //Chest is hit first
+			var/loc_damage
+			while (burn_damage > 0)
+				burn_damage -= loc_damage = rand(0, burn_damage)
+				L.damage_through_armor(loc_damage, BURN, organ_hit, ARMOR_ENERGY)
+				organ_hit = pickweight(list(BP_HEAD = 0.2, BP_GROIN = 0.2, BP_R_ARM = 0.1, BP_L_ARM = 0.1, BP_R_LEG = 0.1, BP_L_LEG = 0.1))  //We determine some other body parts that should be hit
 	return 1

--- a/code/game/objects/heatwave.dm
+++ b/code/game/objects/heatwave.dm
@@ -1,0 +1,45 @@
+proc/heatwave(turf/epicenter, heavy_range, light_range, damage, log=0)
+	if(!epicenter) return
+
+	if(!istype(epicenter, /turf))
+		epicenter = get_turf(epicenter.loc)
+
+	if(log)
+		message_admins("Heatwave with size ([heavy_range], [light_range]) in area [epicenter.loc.name] ")
+		log_game("Heatwave with size ([heavy_range], [light_range]) in area [epicenter.loc.name] ")
+
+	if(heavy_range > 1)
+		var/obj/effect/overlay/pulse = new(epicenter)
+		pulse.icon = 'icons/effects/effects.dmi'
+		pulse.icon_state = "emppulse"
+		pulse.name = "emp pulse"
+		pulse.anchored = TRUE
+		spawn(20)
+			qdel(pulse)
+
+	if(heavy_range > light_range)
+		light_range = heavy_range
+
+	for(var/mob/living/L in range(light_range, epicenter))
+		L << 'sound/effects/gore/sear.ogg' // How do I replace this
+
+		var/burn_damage = 0
+
+		var/distance = get_dist(epicenter, L)
+		if(distance < 0)
+			distance = 0
+		if(distance <= heavy_range)
+			burn_damage = damage
+		else if(distance <= light_range)
+			burn_damage = damage*0.5
+
+		if(burn_damage && L.stat == CONSCIOUS)
+			to_chat(SPAN_WARNING("You feel your skin boiling!"))
+
+		var/organ_hit = BP_CHEST //Chest is hit first
+		var/loc_damage
+		while (burn_damage > 0)
+			burn_damage -= loc_damage = rand(0, burn_damage)
+			L.damage_through_armor(loc_damage, BURN, organ_hit, ARMOR_ENERGY)
+			organ_hit = pickweight(list(BP_HEAD = 0.2, BP_GROIN = 0.2, BP_R_ARM = 0.1, BP_L_ARM = 0.1, BP_R_LEG = 0.1, BP_L_LEG = 0.1))  //We determine some other body parts that should be hit
+	return 1

--- a/code/game/objects/heatwave.dm
+++ b/code/game/objects/heatwave.dm
@@ -1,4 +1,4 @@
-proc/heatwave(turf/epicenter, heavy_range, light_range, damage, fire_stacks, penetration, log=0)
+proc/heatwave(turf/epicenter, heavy_range, light_range, damage, fire_stacks, penetration, log=FALSE)
 	if(!epicenter) return
 
 	if(!istype(epicenter, /turf))

--- a/code/game/objects/heatwave.dm
+++ b/code/game/objects/heatwave.dm
@@ -5,8 +5,8 @@ proc/heatwave(turf/epicenter, heavy_range, light_range, damage, fire_stacks, pen
 		epicenter = get_turf(epicenter.loc)
 
 	if(log)
-		message_admins("Heatwave with size ([heavy_range], [light_range]) in area [epicenter.loc.name] ")
-		log_game("Heatwave with size ([heavy_range], [light_range]) in area [epicenter.loc.name] ")
+		message_admins("Heatwave with size ([heavy_range], [light_range]) in area [epicenter.loc.name]")
+		log_game("Heatwave with size ([heavy_range], [light_range]) in area [epicenter.loc.name]")
 
 	if(heavy_range > 1)
 		var/obj/effect/overlay/pulse/heatwave/HW = new(epicenter)

--- a/code/game/objects/heatwave.dm
+++ b/code/game/objects/heatwave.dm
@@ -31,7 +31,7 @@ proc/heatwave(turf/epicenter, heavy_range, light_range, damage, fire_stacks, pen
 			if(distance <= heavy_range)
 				burn_damage = damage
 			else if(distance <= light_range)
-				burn_damage = damage*0.5
+				burn_damage = damage * 0.5
 
 			if(burn_damage && L.stat == CONSCIOUS)
 				to_chat(L, SPAN_WARNING("You feel your skin boiling!"))

--- a/code/game/objects/heatwave.dm
+++ b/code/game/objects/heatwave.dm
@@ -39,7 +39,7 @@ proc/heatwave(turf/epicenter, heavy_range, light_range, damage, fire_stacks, pen
 			var/organ_hit = BP_CHEST //Chest is hit first
 			var/loc_damage
 			while (burn_damage > 0)
-				burn_damage -= loc_damage = rand(0, burn_damage)
+				burn_damage -= loc_damage = rand(1, burn_damage)
 				L.damage_through_armor(loc_damage, BURN, organ_hit, ARMOR_ENERGY, penetration)
 				organ_hit = pickweight(list(BP_HEAD = 0.2, BP_GROIN = 0.2, BP_R_ARM = 0.1, BP_L_ARM = 0.1, BP_R_LEG = 0.1, BP_L_LEG = 0.1))  //We determine some other body parts that should be hit
 	return 1

--- a/code/game/objects/heatwave.dm
+++ b/code/game/objects/heatwave.dm
@@ -21,7 +21,7 @@ proc/heatwave(turf/epicenter, heavy_range, light_range, damage, fire_stacks, pen
 			T.fire_act()
 		if(istype(T, /mob/living))
 			var/mob/living/L = T
-			L << 'sound/effects/gore/sear.ogg' // How do I replace this
+			playsound(L, 'sound/effects/gore/sear.ogg', 40, 1)
 
 			var/burn_damage = 0
 

--- a/code/game/objects/heatwave.dm
+++ b/code/game/objects/heatwave.dm
@@ -9,13 +9,9 @@ proc/heatwave(turf/epicenter, heavy_range, light_range, damage, fire_stacks, pen
 		log_game("Heatwave with size ([heavy_range], [light_range]) in area [epicenter.loc.name] ")
 
 	if(heavy_range > 1)
-		var/obj/effect/overlay/heatwave = new(epicenter)
-		heatwave.icon = 'icons/effects/effects.dmi'
-		heatwave.icon_state = "sparks"
-		heatwave.name = "heatwave"
-		heatwave.anchored = TRUE
+		var/obj/effect/overlay/pulse/heatwave/HW = new(epicenter)
 		spawn(20)
-			qdel(heatwave)
+			qdel(HW)
 
 	if(heavy_range > light_range)
 		light_range = heavy_range

--- a/code/modules/projectiles/effects.dm
+++ b/code/modules/projectiles/effects.dm
@@ -3,6 +3,7 @@
 	icon_state = "bolt"
 	layer = ABOVE_MOB_LAYER
 	var/lifetime = 3
+	mouse_opacity = 0
 
 /obj/effect/projectile/New(var/turf/location)
 	init_plane()

--- a/code/modules/projectiles/guns/energy/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma.dm
@@ -24,7 +24,7 @@
 	init_firemodes = list(
 		list(mode_name="Burn", mode_desc="A relatively light plasma round", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/energy/melt.ogg', burst=1, fire_delay=6, charge_cost=15, icon="kill", projectile_color = "#0088ff", recoil_buildup=3),
 		list(mode_name="Sear", mode_desc="A three-round burst of light plasma rounds, for dealing with unruly crowds", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/energy/melt.ogg', burst=3, fire_delay=12, charge_cost=15, icon="burst", projectile_color = "#0088ff", recoil_buildup=3),
-		list(mode_name="INCINERATE", mode_desc="A heavy armor-stripping plasma round", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/energy/incinerate.ogg', burst=1, fire_delay=12, charge_cost=60, icon="destroy", projectile_color = "#FFFFFF", recoil_buildup=8),
+		list(mode_name="INCINERATE", mode_desc="A heavy armor-stripping plasma round", projectile_type=/obj/item/projectile/plasma/aoe/heat, fire_sound='sound/weapons/energy/incinerate.ogg', burst=1, fire_delay=12, charge_cost=60, icon="destroy", projectile_color = "#FFFFFF", recoil_buildup=8),
 	)
 
 
@@ -45,7 +45,7 @@
 
 /obj/item/gun/energy/plasma/destroyer
 	name = "NT PR \"Purger\""
-	desc = "A more recent \"NeoTheology\" brand plasma rifle, focused on the superior firepower at the cost of high energy usage."
+	desc = "A more recent \"NeoTheology\" brand plasma cannon, focused on the superior firepower at the cost of high energy usage."
 	icon = 'icons/obj/guns/energy/destroyer.dmi'
 	fire_sound = 'sound/weapons/energy/incinerate.ogg'
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 8, MATERIAL_SILVER = 10, MATERIAL_URANIUM = 5)
@@ -53,8 +53,8 @@
 	charge_cost = 200
 
 	init_firemodes = list(
-		list(mode_name="DISINTEGRATE", mode_desc="Removes heresy from sight", projectile_type=/obj/item/projectile/plasma/ion/heavy, fire_sound='sound/weapons/Taser.ogg', fire_delay=20, charge_cost=200, icon="stun", projectile_color = "#FFFF00", recoil_buildup=25),
-		list(mode_name="CLEANSE", mode_desc="Cleanse the filth", mode_type = /datum/firemode/automatic, projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/energy/vaporize.ogg', fire_delay=5, charge_cost=35, icon="destroy", projectile_color = "#00AAFF", recoil_buildup=5),
+		list(mode_name="DISINTEGRATE", mode_desc="Removes heresy from sight", projectile_type=/obj/item/projectile/plasma/aoe/heat/strong, fire_sound='sound/weapons/energy/incinerate.ogg', fire_delay=20, charge_cost=300, icon="destroy", projectile_color = "#ff1212", recoil_buildup=25),
+		list(mode_name="CLEANSE", mode_desc="Cleanse the filth", mode_type = /datum/firemode/automatic, projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/energy/vaporize.ogg', fire_delay=5, charge_cost=35, icon="burst", projectile_color = "#00AAFF", recoil_buildup=5),
 	)
 
 
@@ -73,7 +73,7 @@
 
 	init_firemodes = list(
 		list(mode_name="Melt", mode_desc="A reliable plasma round, for stripping away armor", projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/energy/burn.ogg', burst=1, fire_delay=6, charge_cost=25, icon="kill", projectile_color = "#00AAFF", recoil_buildup=3),
-		list(mode_name="Pulse", mode_desc="A plasma round configured to explode violently on impact, and cause a small pulse of EMP", projectile_type=/obj/item/projectile/plasma/ion, fire_sound='sound/weapons/Taser.ogg', burst=1, fire_delay=12, charge_cost=100, icon="stun", projectile_color = "#00FFFF", recoil_buildup=15)
+		list(mode_name="Pulse", mode_desc="A plasma round configured to explode violently on impact, and cause a pulse of EMP", projectile_type=/obj/item/projectile/plasma/aoe/ion, fire_sound='sound/weapons/Taser.ogg', burst=1, fire_delay=12, charge_cost=150, icon="stun", projectile_color = "#00FFFF", recoil_buildup=15)
 	)
 
 	spawn_tags = SPAWN_TAG_FS_ENERGY
@@ -102,9 +102,9 @@
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 8, MATERIAL_PLASMA = 2, MATERIAL_SILVER = 3, MATERIAL_URANIUM = 3)
 
 	init_firemodes = list(
-		list(mode_name="Low Power", mode_desc="A relatively light plasma round", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/energy/melt.ogg', burst=1, fire_delay=8, charge_cost=15, icon="kill", projectile_color = "#0088ff", recoil_buildup=5),
+		list(mode_name="Low Power", mode_desc="A relatively light plasma round", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/energy/melt.ogg', burst=1, fire_delay=6, charge_cost=15, icon="kill", projectile_color = "#0088ff", recoil_buildup=5),
 		list(mode_name="High Power", mode_desc="A heavy armor-stripping plasma round", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/energy/incinerate.ogg', burst=1, fire_delay=18, charge_cost=60, icon="destroy", projectile_color = "#FFFFFF", recoil_buildup=10),
-		list(mode_name="Pulse", mode_desc="A plasma round configured to explode violently on impact, and cause a small pulse of EMP", projectile_type=/obj/item/projectile/plasma/ion, fire_sound='sound/weapons/Taser.ogg', burst=1, fire_delay=18, charge_cost=100, icon="stun", projectile_color = "#00FFFF", recoil_buildup=20)
+		list(mode_name="Pulse", mode_desc="A plasma round configured to cause a small pulse of EMP", projectile_type=/obj/item/projectile/plasma/aoe/ion/light, fire_sound='sound/weapons/Taser.ogg', burst=1, fire_delay=18, charge_cost=60, icon="stun", projectile_color = "#00FFFF", recoil_buildup=20)
 	)
 
 /obj/item/gun/energy/plasma/brigador/on_update_icon()

--- a/code/modules/projectiles/guns/energy/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma.dm
@@ -13,17 +13,18 @@
 	price_tag = 4500
 	fire_sound = 'sound/weapons/energy/burn.ogg'
 	suitable_cell = /obj/item/cell/medium
-	sel_mode = 2
-	charge_cost = 20 //Gives us 40 shots per high medium-sized cell
-	recoil_buildup = 1 //pulse weapons have a bit more recoil
+	sel_mode = 1
+	charge_cost = 15 //Gives us 40 shots per high medium-sized cell
+	recoil_buildup = 3 //pulse weapons have a bit more recoil
 	one_hand_penalty = 10
 	twohanded = TRUE
+	fire_delay = 6
+	charge_cost = 15
 
 	init_firemodes = list(
-		list(mode_name="Burn", mode_desc="A relatively light plasma round", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/energy/burn.ogg', burst=1, fire_delay=8, charge_cost=20, icon="stun", projectile_color = "#0000FF"),
-		list(mode_name="Melt", mode_desc="A much more potent plasma round for breaching tough opponents' hides", projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/energy/melt.ogg', burst=1, fire_delay=12, charge_cost=25, icon="kill", projectile_color = "#FF0000"),
-		list(mode_name="Sear", mode_desc="A three-round burst of plasma, for dealing with unruly crowds", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/energy/burn.ogg', burst=3, fire_delay=12, charge_cost=20, icon="burst", projectile_color = "#0000FF"),
-		list(mode_name="INCINERATE", mode_desc="An armor-stripping plasma round", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/energy/incinerate.ogg', burst=1, fire_delay=14, charge_cost=30, icon="destroy", projectile_color = "#FFFFFF"),
+		list(mode_name="Burn", mode_desc="A relatively light plasma round", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/energy/melt.ogg', burst=1, fire_delay=6, charge_cost=15, icon="kill", projectile_color = "#0088ff", recoil_buildup=3),
+		list(mode_name="Sear", mode_desc="A three-round burst of light plasma rounds, for dealing with unruly crowds", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/energy/melt.ogg', burst=3, fire_delay=12, charge_cost=15, icon="burst", projectile_color = "#0088ff", recoil_buildup=3),
+		list(mode_name="INCINERATE", mode_desc="A heavy armor-stripping plasma round", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/energy/incinerate.ogg', burst=1, fire_delay=12, charge_cost=60, icon="destroy", projectile_color = "#FFFFFF", recoil_buildup=8),
 	)
 
 
@@ -48,12 +49,12 @@
 	icon = 'icons/obj/guns/energy/destroyer.dmi'
 	fire_sound = 'sound/weapons/energy/incinerate.ogg'
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 8, MATERIAL_SILVER = 10, MATERIAL_URANIUM = 5)
-	sel_mode = 1
-	fire_delay = 15
+	fire_delay = 20
+	charge_cost = 200
 
 	init_firemodes = list(
-		list(mode_name="INCINERATE", mode_desc="Suffer not the heretic", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/energy/incinerate.ogg', fire_delay=15, charge_cost=30, icon="kill", projectile_color = "#FFFF00"),
-		list(mode_name="VAPORIZE", mode_desc="Cell-dump them to oblivion", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/energy/vaporize.ogg', fire_delay=5, charge_cost=70, icon="destroy", projectile_color = "#FF0000", recoil_buildup=3),
+		list(mode_name="DISINTEGRATE", mode_desc="Removes heresy from sight", projectile_type=/obj/item/projectile/plasma/ion/heavy, fire_sound='sound/weapons/Taser.ogg', fire_delay=20, charge_cost=200, icon="stun", projectile_color = "#FFFF00", recoil_buildup=25),
+		list(mode_name="CLEANSE", mode_desc="Cleanse the filth", mode_type = /datum/firemode/automatic, projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/energy/vaporize.ogg', fire_delay=5, charge_cost=35, icon="destroy", projectile_color = "#00AAFF", recoil_buildup=5),
 	)
 
 
@@ -65,16 +66,14 @@
 	item_state = "cassad"
 	matter = list(MATERIAL_PLASTEEL = 18, MATERIAL_PLASTIC = 8, MATERIAL_SILVER = 6, MATERIAL_URANIUM = 6)
 	fire_sound = 'sound/weapons/energy/burn.ogg'
-	sel_mode = 1
-	charge_cost = 15
-	fire_delay = 8
+	charge_cost = 25
+	fire_delay = 6
 	price_tag = 3000
 	zoom_factor = null
 
 	init_firemodes = list(
-		list(mode_name="Burn", mode_desc="A general purpose plasma round, for dealing with native fauna", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/energy/burn.ogg', burst=1, fire_delay=8, charge_cost=15, icon="stun", projectile_color = "#00FFFF"),
-		list(mode_name="Melt", mode_desc="A much more charged plasma round, for stripping away armor", projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/energy/melt.ogg', burst=1, fire_delay=12, charge_cost=20, icon="kill", projectile_color = "#00AAFF"),
-		list(mode_name="Burst", mode_desc="A three-round burst of plasma, for dealing with unruly crowds", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/Taser.ogg', burst=3, fire_delay=12, charge_cost=20, icon="burst", projectile_color = "#00FFFF")
+		list(mode_name="Melt", mode_desc="A reliable plasma round, for stripping away armor", projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/energy/burn.ogg', burst=1, fire_delay=6, charge_cost=25, icon="kill", projectile_color = "#00AAFF", recoil_buildup=3),
+		list(mode_name="Pulse", mode_desc="A plasma round configured to explode violently on impact, and cause a small pulse of EMP", projectile_type=/obj/item/projectile/plasma/ion, fire_sound='sound/weapons/Taser.ogg', burst=1, fire_delay=12, charge_cost=100, icon="stun", projectile_color = "#00FFFF", recoil_buildup=15)
 	)
 
 	spawn_tags = SPAWN_TAG_FS_ENERGY
@@ -95,11 +94,17 @@
 	suitable_cell = /obj/item/cell/small
 	projectile_type = /obj/item/projectile/plasma/light
 	projectile_color = "#00FFFF"
-	fire_sound = 'sound/weapons/energy/burn.ogg'
+	fire_sound = 'sound/weapons/energy/incinerate.ogg'
 	fire_delay = 8
 	charge_cost = 15
+	recoil_buildup = 5
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 8, MATERIAL_PLASMA = 2, MATERIAL_SILVER = 3, MATERIAL_URANIUM = 3)
-	init_firemodes = list()
+
+	init_firemodes = list(
+		list(mode_name="Low Power", mode_desc="A relatively light plasma round", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/energy/melt.ogg', burst=1, fire_delay=8, charge_cost=15, icon="kill", projectile_color = "#0088ff", recoil_buildup=5),
+		list(mode_name="High Power", mode_desc="A heavy armor-stripping plasma round", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/energy/incinerate.ogg', burst=1, fire_delay=18, charge_cost=60, icon="destroy", projectile_color = "#FFFFFF", recoil_buildup=10),
+		list(mode_name="Pulse", mode_desc="A plasma round configured to explode violently on impact, and cause a small pulse of EMP", projectile_type=/obj/item/projectile/plasma/ion, fire_sound='sound/weapons/Taser.ogg', burst=1, fire_delay=18, charge_cost=100, icon="stun", projectile_color = "#00FFFF", recoil_buildup=20)
+	)
 
 /obj/item/gun/energy/plasma/brigador/on_update_icon()
 	cut_overlays()

--- a/code/modules/projectiles/guns/energy/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma.dm
@@ -49,11 +49,14 @@
 	icon = 'icons/obj/guns/energy/destroyer.dmi'
 	fire_sound = 'sound/weapons/energy/incinerate.ogg'
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 8, MATERIAL_SILVER = 10, MATERIAL_URANIUM = 5)
+	slot_flags = SLOT_BACK
 	fire_delay = 20
 	charge_cost = 200
+	wield_delay = 0.8 SECOND
+	wield_delay_factor = 0.9 // 90 vig for instant wield
 
 	init_firemodes = list(
-		list(mode_name="DISINTEGRATE", mode_desc="Removes heresy from sight", projectile_type=/obj/item/projectile/plasma/aoe/heat/strong, fire_sound='sound/weapons/energy/incinerate.ogg', fire_delay=20, charge_cost=300, icon="destroy", projectile_color = "#ff1212", recoil_buildup=25),
+		list(mode_name="DISINTEGRATE", mode_desc="Removes heresy from sight", projectile_type=/obj/item/projectile/plasma/aoe/heat/strong, fire_sound='sound/weapons/energy/incinerate.ogg', fire_delay=15, charge_cost=200, icon="destroy", projectile_color = "#ff1212", recoil_buildup=25),
 		list(mode_name="CLEANSE", mode_desc="Cleanse the filth", mode_type = /datum/firemode/automatic, projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/energy/vaporize.ogg', fire_delay=5, charge_cost=35, icon="burst", projectile_color = "#00AAFF", recoil_buildup=5),
 	)
 

--- a/code/modules/projectiles/guns/energy/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma.dm
@@ -23,8 +23,8 @@
 
 	init_firemodes = list(
 		list(mode_name="Burn", mode_desc="A relatively light plasma round", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/energy/melt.ogg', burst=1, fire_delay=6, charge_cost=15, icon="kill", projectile_color = "#0088ff", recoil_buildup=3),
-		list(mode_name="Sear", mode_desc="A three-round burst of light plasma rounds, for dealing with unruly crowds", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/energy/melt.ogg', burst=3, fire_delay=12, charge_cost=15, icon="burst", projectile_color = "#0088ff", recoil_buildup=3),
-		list(mode_name="INCINERATE", mode_desc="A heavy armor-stripping plasma round", projectile_type=/obj/item/projectile/plasma/aoe/heat, fire_sound='sound/weapons/energy/incinerate.ogg', burst=1, fire_delay=12, charge_cost=60, icon="destroy", projectile_color = "#FFFFFF", recoil_buildup=8),
+		list(mode_name="Sear", mode_desc="A three-round burst of light plasma rounds, for dealing with unruly crowds", projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/energy/melt.ogg', burst=3, fire_delay=12, burst_delay=1, charge_cost=15, icon="burst", projectile_color = "#0088ff", recoil_buildup=3),
+		list(mode_name="INCINERATE", mode_desc="A heavy armor-stripping plasma round", projectile_type=/obj/item/projectile/plasma/aoe/heat, fire_sound='sound/weapons/energy/incinerate.ogg', burst=1, fire_delay=20, charge_cost=90, icon="destroy", projectile_color = "#FFFFFF", recoil_buildup=8),
 	)
 
 
@@ -56,7 +56,7 @@
 	wield_delay_factor = 0.9 // 90 vig for instant wield
 
 	init_firemodes = list(
-		list(mode_name="DISINTEGRATE", mode_desc="Removes heresy from sight", projectile_type=/obj/item/projectile/plasma/aoe/heat/strong, fire_sound='sound/weapons/energy/incinerate.ogg', fire_delay=15, charge_cost=200, icon="destroy", projectile_color = "#ff1212", recoil_buildup=25),
+		list(mode_name="DISINTEGRATE", mode_desc="Removes heresy from sight", projectile_type=/obj/item/projectile/plasma/aoe/heat/strong, fire_sound='sound/weapons/energy/incinerate.ogg', fire_delay=24, charge_cost=200, icon="destroy", projectile_color = "#ff1212", recoil_buildup=25),
 		list(mode_name="CLEANSE", mode_desc="Cleanse the filth", mode_type = /datum/firemode/automatic, projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/energy/vaporize.ogg', fire_delay=5, charge_cost=35, icon="burst", projectile_color = "#00AAFF", recoil_buildup=5),
 	)
 
@@ -75,7 +75,7 @@
 	zoom_factor = null
 
 	init_firemodes = list(
-		list(mode_name="Melt", mode_desc="A reliable plasma round, for stripping away armor", projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/energy/burn.ogg', burst=1, fire_delay=6, charge_cost=25, icon="kill", projectile_color = "#00AAFF", recoil_buildup=3),
+		list(mode_name="Melt", mode_desc="A reliable plasma round, for stripping away armor", projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/energy/burn.ogg', burst=1, fire_delay=8, charge_cost=25, icon="kill", projectile_color = "#00AAFF", recoil_buildup=3),
 		list(mode_name="Pulse", mode_desc="A plasma round configured to explode violently on impact, and cause a pulse of EMP", projectile_type=/obj/item/projectile/plasma/aoe/ion, fire_sound='sound/weapons/Taser.ogg', burst=1, fire_delay=12, charge_cost=150, icon="stun", projectile_color = "#00FFFF", recoil_buildup=15)
 	)
 
@@ -102,6 +102,8 @@
 	fire_delay = 8
 	charge_cost = 15
 	recoil_buildup = 5
+	one_hand_penalty = 0 // Handgun
+
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 8, MATERIAL_PLASMA = 2, MATERIAL_SILVER = 3, MATERIAL_URANIUM = 3)
 
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/energy/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma.dm
@@ -14,7 +14,7 @@
 	fire_sound = 'sound/weapons/energy/burn.ogg'
 	suitable_cell = /obj/item/cell/medium
 	sel_mode = 1
-	charge_cost = 15 //Gives us 40 shots per high medium-sized cell
+	charge_cost = 15 //Gives us 40 shots per low-tier medium-sized cell
 	recoil_buildup = 3 //pulse weapons have a bit more recoil
 	one_hand_penalty = 10
 	twohanded = TRUE

--- a/code/modules/projectiles/guns/energy/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma.dm
@@ -87,6 +87,7 @@
 	desc = "\"Moebius\" brand energy pistol, for personal overprotection."
 	icon = 'icons/obj/guns/energy/brigador.dmi'
 	icon_state = "brigador"
+	can_dual = TRUE
 	charge_meter = FALSE
 	w_class = ITEM_SIZE_NORMAL
 	twohanded = FALSE

--- a/code/modules/projectiles/projectile/plasma.dm
+++ b/code/modules/projectiles/projectile/plasma.dm
@@ -14,10 +14,12 @@
 /obj/item/projectile/plasma/light
 	name = "light plasma bolt"
 	armor_penetration = 0
+	damage_types = list(BURN = 27)
 
 /obj/item/projectile/plasma/heavy
 	name = "heavy plasma bolt"
 	armor_penetration = 50
+	damage_types = list(BURN = 55)
 
 /obj/item/projectile/plasma/stun
 	name = "stun plasma bolt"
@@ -25,6 +27,29 @@
 	agony = 30
 	damage_types = list(HALLOSS = 30,BURN = 5)
 	impact_type = /obj/effect/projectile/stun/impact
+
+/obj/item/projectile/plasma/ion
+	name = "ion-plasma bolt"
+	icon_state = "ion"
+	armor_penetration = 0
+	damage_types = list(BURN = 25)
+	var/heat_damage = 20
+
+/obj/item/projectile/plasma/ion/on_hit(atom/target)
+	empulse(target, 0, 1)
+	heatwave(target, 1, 1, damage_types[BURN])
+	..()
+
+/obj/item/projectile/plasma/ion/heavy
+	name = "heavy ion-plasma bolt"
+	armor_penetration = 50
+	damage_types = list(BURN = 30)
+	heat_damage = 40 // The AoE receives no penetration bonus
+
+/obj/item/projectile/plasma/ion/heavy/on_hit(atom/target)
+	empulse(target, 1, 2)
+	heatwave(target, 1, 2, damage_types[BURN])
+	..()
 
 /obj/item/projectile/plasma/check_penetrate(var/atom/A)
 	if(istype(A, /obj/item/shield))

--- a/code/modules/projectiles/projectile/plasma.dm
+++ b/code/modules/projectiles/projectile/plasma.dm
@@ -12,7 +12,7 @@
 
 /obj/item/projectile/plasma/light
 	name = "light plasma bolt"
-	armor_penetration = 0
+	armor_penetration = 15
 	damage_types = list(BURN = 27)
 
 /obj/item/projectile/plasma/heavy

--- a/code/modules/projectiles/projectile/plasma.dm
+++ b/code/modules/projectiles/projectile/plasma.dm
@@ -44,14 +44,14 @@
 	if(emp_strength)
 		empulse(target, aoe_strong, aoe_weak, strength=emp_strength)
 	if(heat_damage)
-		heatwave(target, aoe_strong, aoe_weak, heat_damage, fire_stacks)
+		heatwave(target, aoe_strong, aoe_weak, heat_damage, fire_stacks, armor_penetration)
 	..()
 
 /obj/item/projectile/plasma/aoe/ion
 	name = "ion-plasma bolt"
 	icon_state = "ion"
 	armor_penetration = 0
-	damage_types = list(BURN = 25)
+	damage_types = list(BURN = 27)
 
 	aoe_strong = 1
 	aoe_weak = 1
@@ -67,15 +67,15 @@
 
 	aoe_strong = 0
 	aoe_weak = 1
-	heat_damage = 0
+	heat_damage = 20
 	emp_strength = 3
 
 	fire_stacks = FALSE
 
 /obj/item/projectile/plasma/aoe/heat
 	name = "high-temperature plasma blast"
-	armor_penetration = 50 // The AoE receives no penetration bonus
-	damage_types = list(BURN = 42)
+	armor_penetration = 50
+	damage_types = list(BURN = 27)
 
 	aoe_strong = 1
 	aoe_weak = 1
@@ -86,12 +86,12 @@
 
 /obj/item/projectile/plasma/aoe/heat/strong
 	name = "high-temperature plasma blast"
-	armor_penetration = 0
-	damage_types = list(BURN = 25)
+	armor_penetration = 25
+	damage_types = list(BURN = 33)
 
 	aoe_strong = 1
 	aoe_weak = 2
-	heat_damage = 50
+	heat_damage = 30
 	emp_strength = 0
 
 	fire_stacks = TRUE

--- a/code/modules/projectiles/projectile/plasma.dm
+++ b/code/modules/projectiles/projectile/plasma.dm
@@ -7,7 +7,6 @@
 	check_armour = ARMOR_ENERGY
 	damage_types = list(BURN = 33)
 
-
 	muzzle_type = /obj/effect/projectile/plasma/muzzle
 	impact_type = /obj/effect/projectile/plasma/impact
 
@@ -28,28 +27,74 @@
 	damage_types = list(HALLOSS = 30,BURN = 5)
 	impact_type = /obj/effect/projectile/stun/impact
 
-/obj/item/projectile/plasma/ion
+/obj/item/projectile/plasma/aoe
+	name = "default plasma aoe"
+	icon_state = "ion"
+	armor_penetration = 0
+	damage_types = list(BURN = 0)
+
+	var/aoe_strong = 0
+	var/aoe_weak = 0 // Should be greater or equal to strong
+	var/heat_damage = 0 // FALSE or 0 to disable
+	var/emp_strength = 0 // Divides the effects by this amount, FALSE or 0 to disable
+
+	var/fire_stacks = FALSE
+
+/obj/item/projectile/plasma/aoe/on_hit(atom/target)
+	if(emp_strength)
+		empulse(target, aoe_strong, aoe_weak, strength=emp_strength)
+	if(heat_damage)
+		heatwave(target, aoe_strong, aoe_weak, heat_damage, fire_stacks)
+	..()
+
+/obj/item/projectile/plasma/aoe/ion
 	name = "ion-plasma bolt"
 	icon_state = "ion"
 	armor_penetration = 0
 	damage_types = list(BURN = 25)
-	var/heat_damage = 20
 
-/obj/item/projectile/plasma/ion/on_hit(atom/target)
-	empulse(target, 0, 1)
-	heatwave(target, 1, 1, damage_types[BURN])
-	..()
+	aoe_strong = 1
+	aoe_weak = 1
+	heat_damage = 20
+	emp_strength = 2
 
-/obj/item/projectile/plasma/ion/heavy
-	name = "heavy ion-plasma bolt"
+	fire_stacks = FALSE
+
+/obj/item/projectile/plasma/aoe/ion/light
+	name = "light ion-plasma bolt"
+	armor_penetration = 0
+	damage_types = list(BURN = 20)
+
+	aoe_strong = 0
+	aoe_weak = 1
+	heat_damage = 0
+	emp_strength = 3
+
+	fire_stacks = FALSE
+
+/obj/item/projectile/plasma/aoe/heat
+	name = "high-temperature plasma blast"
+	armor_penetration = 50 // The AoE receives no penetration bonus
+	damage_types = list(BURN = 37)
+
+	aoe_strong = 1
+	aoe_weak = 1
+	heat_damage = 40
+	emp_strength = 0
+
+	fire_stacks = TRUE
+
+/obj/item/projectile/plasma/aoe/heat/strong
+	name = "high-temperature plasma blast"
 	armor_penetration = 50
-	damage_types = list(BURN = 30)
-	heat_damage = 40 // The AoE receives no penetration bonus
+	damage_types = list(BURN = 37)
 
-/obj/item/projectile/plasma/ion/heavy/on_hit(atom/target)
-	empulse(target, 1, 2)
-	heatwave(target, 1, 2, damage_types[BURN])
-	..()
+	aoe_strong = 1
+	aoe_weak = 2
+	heat_damage = 50
+	emp_strength = 0
+
+	fire_stacks = TRUE
 
 /obj/item/projectile/plasma/check_penetrate(var/atom/A)
 	if(istype(A, /obj/item/shield))

--- a/code/modules/projectiles/projectile/plasma.dm
+++ b/code/modules/projectiles/projectile/plasma.dm
@@ -19,7 +19,7 @@
 /obj/item/projectile/plasma/heavy
 	name = "heavy plasma bolt"
 	armor_penetration = 50
-	damage_types = list(BURN = 55)
+	damage_types = list(BURN = 42)
 
 /obj/item/projectile/plasma/stun
 	name = "stun plasma bolt"

--- a/code/modules/projectiles/projectile/plasma.dm
+++ b/code/modules/projectiles/projectile/plasma.dm
@@ -75,19 +75,19 @@
 /obj/item/projectile/plasma/aoe/heat
 	name = "high-temperature plasma blast"
 	armor_penetration = 50 // The AoE receives no penetration bonus
-	damage_types = list(BURN = 37)
+	damage_types = list(BURN = 42)
 
 	aoe_strong = 1
 	aoe_weak = 1
-	heat_damage = 40
+	heat_damage = 20
 	emp_strength = 0
 
 	fire_stacks = TRUE
 
 /obj/item/projectile/plasma/aoe/heat/strong
 	name = "high-temperature plasma blast"
-	armor_penetration = 50
-	damage_types = list(BURN = 37)
+	armor_penetration = 0
+	damage_types = list(BURN = 25)
 
 	aoe_strong = 1
 	aoe_weak = 2

--- a/code/modules/projectiles/projectile/plasma.dm
+++ b/code/modules/projectiles/projectile/plasma.dm
@@ -75,7 +75,7 @@
 /obj/item/projectile/plasma/aoe/heat
 	name = "high-temperature plasma blast"
 	armor_penetration = 50
-	damage_types = list(BURN = 27)
+	damage_types = list(BURN = 20)
 
 	aoe_strong = 1
 	aoe_weak = 1

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -85,6 +85,9 @@
 		if(2)
 			if(prob(50))
 				qdel(src)
+		if(3)
+			if(prob(25))
+				qdel(src)
 
 
 /obj/machinery/shield/hitby(AM as mob|obj)


### PR DESCRIPTION
## About The Pull Request

Reworks plasma projectiles, adds new effects.

Dominion:
- Light projectiles, offers good firerate and has a burst-fire mode
- Alternate fire: powerful anti-armor projectile with high energy cost and firedelay

Cassad:
- Standard semi-auto with good firerate and relatively low energy cost
- Alternate fire: high-cost and high-delay shot that causes AoE damage, and a small EMP effect, allowing more tactical utility

Purger:
- Fully automatic, will rapidly release medium-powered shots at an increased energy cost
- Alternate fire: high-cost and high-delay shot that causes heavy AoE damage, and a larger EMP effect, making it ideal for destroying heretical equipment and machinery

Brigador:
- Light projectiles, with mediocre firerate
- Alternate fire 1: powerful anti-armor projectiles with massive cost and delay
- Alternate fire 2: AoE damage EMP effect projectile with massive cost and delay
- Can be dual-wielded


## Why It's Good For The Game

While the old system for plasma firemodes was creative, it didn't offer a good gameplay loop as penetration is rarely ever needed on plasma weapons.
This new system offers variety, and more utility for plasma weapons, instead of having only one single viable use, like the cassad's burst fire and the purger's incinerate mode.

## Changelog
:cl:
add: AoE EMP firemode on the cassad and purger
balance: rebalanced plasma weapon firemodes and projectiles
/:cl: