### PR TITLE
Wires UI done right

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -8,18 +8,18 @@
 	wire_count = 12
 	window_y = 570
 	descriptions = list(
-		new /datum/wire_description(AIRLOCK_WIRE_IDSCAN, "This wire is connected to the ID scanning panel."),
-		new /datum/wire_description(AIRLOCK_WIRE_MAIN_POWER1, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(AIRLOCK_WIRE_MAIN_POWER2, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(AIRLOCK_WIRE_DOOR_BOLTS, "This wire runs down to the very base of the airlock."),
-		new /datum/wire_description(AIRLOCK_WIRE_BACKUP_POWER1, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(AIRLOCK_WIRE_BACKUP_POWER2, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(AIRLOCK_WIRE_OPEN_DOOR, "This wire connects to the door motors."),
-		new /datum/wire_description(AIRLOCK_WIRE_AI_CONTROL, "This wire connects to automated control systems."),
-		new /datum/wire_description(AIRLOCK_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(AIRLOCK_WIRE_SAFETY, "This wire connects to a safety override."),
-		new /datum/wire_description(AIRLOCK_WIRE_SPEED, "This wire appears to connect to the airlock's proximity detector modules."),
-		new /datum/wire_description(AIRLOCK_WIRE_LIGHT, "This wire powers the airlock's built-in lighting.")
+		new /datum/wire_description(AIRLOCK_WIRE_IDSCAN, "ID scanner"),
+		new /datum/wire_description(AIRLOCK_WIRE_MAIN_POWER1, "Main power"),
+		new /datum/wire_description(AIRLOCK_WIRE_MAIN_POWER2, "Auxiliary power"),
+		new /datum/wire_description(AIRLOCK_WIRE_DOOR_BOLTS, "Bolts"),
+		new /datum/wire_description(AIRLOCK_WIRE_BACKUP_POWER1, "Backup power"),
+		new /datum/wire_description(AIRLOCK_WIRE_BACKUP_POWER2, "Backup power"),
+		new /datum/wire_description(AIRLOCK_WIRE_OPEN_DOOR, "Motors"),
+		new /datum/wire_description(AIRLOCK_WIRE_AI_CONTROL, "Remote access"),
+		new /datum/wire_description(AIRLOCK_WIRE_ELECTRIFY, "Shock"),
+		new /datum/wire_description(AIRLOCK_WIRE_SAFETY, "Failsafe"),
+		new /datum/wire_description(AIRLOCK_WIRE_SPEED, "Proximity sensor"),
+		new /datum/wire_description(AIRLOCK_WIRE_LIGHT, "Bolt lights")
 	)
 
 var/const/AIRLOCK_WIRE_IDSCAN = 1
@@ -45,11 +45,11 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 		return 1
 	return 0
 
-/datum/wires/airlock/GetInteractWindow()
+/datum/wires/airlock/GetInteractWindow(mob/living/user)
 	var/obj/machinery/door/airlock/A = holder
 	var/haspower = A.arePowerSystemsOn() //If there's no power, then no lights will be on.
 
-	. += ..()
+	. += ..(user)
 	. += text("<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]",
 	(A.locked ? "The door bolts have fallen!" : "The door bolts look up."),
 	((A.lights && haspower) ? "The door bolt lights are on." : "The door bolt lights are off!"),

--- a/code/datums/wires/alarm.dm
+++ b/code/datums/wires/alarm.dm
@@ -2,11 +2,11 @@
 	holder_type = /obj/machinery/alarm
 	wire_count = 5
 	descriptions = list(
-		new /datum/wire_description(AALARM_WIRE_IDSCAN, "This wire is connected to the ID scanning panel."),
-		new /datum/wire_description(AALARM_WIRE_POWER, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(AALARM_WIRE_SYPHON, "This wire runs to atmospherics logic circuits of some sort."),
-		new /datum/wire_description(AALARM_WIRE_AI_CONTROL, "This wire connects to automated control systems."),
-		new /datum/wire_description(AALARM_WIRE_AALARM, "This wire gives power to the actual alarm mechanism.")
+		new /datum/wire_description(AALARM_WIRE_IDSCAN, "ID scanner"),
+		new /datum/wire_description(AALARM_WIRE_POWER, "Main power"),
+		new /datum/wire_description(AALARM_WIRE_SYPHON, "Panic mode"),
+		new /datum/wire_description(AALARM_WIRE_AI_CONTROL, "Remote access"),
+		new /datum/wire_description(AALARM_WIRE_AALARM, "Alarm trigger")
 	)
 
 var/const/AALARM_WIRE_IDSCAN = 1
@@ -22,9 +22,9 @@ var/const/AALARM_WIRE_AALARM = 16
 		return 1
 	return 0
 
-/datum/wires/alarm/GetInteractWindow()
+/datum/wires/alarm/GetInteractWindow(mob/living/user)
 	var/obj/machinery/alarm/A = holder
-	. += ..()
+	. += ..(user)
 	. += text("<br>\n[(A.locked ? "The Air Alarm is locked." : "The Air Alarm is unlocked.")]<br>\n[((A.shorted || (A.stat & (NOPOWER|BROKEN))) ? "The Air Alarm is offline." : "The Air Alarm is working properly!")]<br>\n[(A.aidisabled ? "The 'AI control allowed' light is off." : "The 'AI control allowed' light is on.")]")
 
 /datum/wires/alarm/UpdateCut(var/index, var/mended)

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -7,15 +7,15 @@
 	holder_type = /obj/machinery/power/apc
 	wire_count = 4
 	descriptions = list(
-		new /datum/wire_description(APC_WIRE_IDSCAN, "This wire is connected to the ID scanning panel."),
-		new /datum/wire_description(APC_WIRE_MAIN_POWER1, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(APC_WIRE_MAIN_POWER2, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(APC_WIRE_AI_CONTROL, "This wire connects to automated control systems.")
+		new /datum/wire_description(APC_WIRE_IDSCAN, "ID scanner"),
+		new /datum/wire_description(APC_WIRE_MAIN_POWER1, "Main power"),
+		new /datum/wire_description(APC_WIRE_MAIN_POWER2, "Backup power"),
+		new /datum/wire_description(APC_WIRE_AI_CONTROL, "Remote access")
 	)
 
-/datum/wires/apc/GetInteractWindow()
+/datum/wires/apc/GetInteractWindow(mob/living/user)
 	var/obj/machinery/power/apc/A = holder
-	. += ..()
+	. += ..(user)
 	. += text("<br>\n[(A.locked ? "The APC is locked." : "The APC is unlocked.")]<br>\n[(A.shorted ? "The APCs power has been shorted." : "The APC is working properly!")]<br>\n[(A.aidisabled ? "The 'AI control allowed' light is off." : "The 'AI control allowed' light is on.")]")
 
 

--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -3,18 +3,18 @@
 	holder_type = /obj/machinery/autolathe
 	wire_count = 6
 	descriptions = list(
-		new /datum/wire_description(AUTOLATHE_HACK_WIRE, "This wire appears to lead to an auxiliary data storage unit."),
-		new /datum/wire_description(AUTOLATHE_SHOCK_WIRE, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(AUTOLATHE_DISABLE_WIRE, "This wire is connected to the power switch.")
+		new /datum/wire_description(AUTOLATHE_HACK_WIRE, "Safety"),
+		new /datum/wire_description(AUTOLATHE_SHOCK_WIRE, "Shock"),
+		new /datum/wire_description(AUTOLATHE_DISABLE_WIRE, "Power")
 	)
 
 var/const/AUTOLATHE_HACK_WIRE = 1
 var/const/AUTOLATHE_SHOCK_WIRE = 2
 var/const/AUTOLATHE_DISABLE_WIRE = 4
 
-/datum/wires/autolathe/GetInteractWindow()
+/datum/wires/autolathe/GetInteractWindow(mob/living/user)
 	var/obj/machinery/autolathe/A = holder
-	. += ..()
+	. += ..(user)
 	. += "<BR>The red light is [A.disabled ? "off" : "on"]."
 	. += "<BR>The green light is [A.shocked ? "off" : "on"]."
 	. += "<BR>The blue light is [A.hacked ? "off" : "on"].<BR>"

--- a/code/datums/wires/camera.dm
+++ b/code/datums/wires/camera.dm
@@ -4,15 +4,15 @@
 	holder_type = /obj/machinery/camera
 	wire_count = 6
 	descriptions = list(
-		new /datum/wire_description(CAMERA_WIRE_FOCUS, "This wire runs to the camera's lens adjustment motors."),
-		new /datum/wire_description(CAMERA_WIRE_POWER, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(CAMERA_WIRE_LIGHT, "This wire seems connected to the built-in light."),
-		new /datum/wire_description(CAMERA_WIRE_ALARM, "This wire is connected to a remote signaling device of some sort.")
+		new /datum/wire_description(CAMERA_WIRE_FOCUS, "Focus"),
+		new /datum/wire_description(CAMERA_WIRE_POWER, "Power"),
+		new /datum/wire_description(CAMERA_WIRE_LIGHT, "Light"),
+		new /datum/wire_description(CAMERA_WIRE_ALARM, "Alarm")
 	)
 
-/datum/wires/camera/GetInteractWindow()
+/datum/wires/camera/GetInteractWindow(mob/living/user)
 
-	. = ..()
+	. = ..(user)
 	var/obj/machinery/camera/C = holder
 	. += "<br>\n[(C.view_range == initial(C.view_range) ? "The focus light is on." : "The focus light is off.")]"
 	. += "<br>\n[(C.can_use() ? "The power link light is on." : "The power link light is off.")]"

--- a/code/datums/wires/jukebox.dm
+++ b/code/datums/wires/jukebox.dm
@@ -14,8 +14,8 @@
 	holder_type = /obj/machinery/media/jukebox
 	wire_count = 10
 	descriptions = list(
-		new /datum/wire_description(WIRE_MAIN_POWER1, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(WIRE_POWER, "This wire seems to be carrying a heavy current."),
+		new /datum/wire_description(WIRE_MAIN_POWER1, "Shock"),
+		new /datum/wire_description(WIRE_POWER, "Power"),
 	)
 
 /datum/wires/jukebox/CanUse(mob/user)
@@ -25,9 +25,9 @@
 	return FALSE
 
 // Show the status of lights as a hint to the current state
-/datum/wires/jukebox/GetInteractWindow()
+/datum/wires/jukebox/GetInteractWindow(mob/living/user)
 	var/obj/machinery/media/jukebox/A = holder
-	. = ..()
+	. = ..(user)
 	. += "<br>\n The power light is [A.stat & (BROKEN|NOPOWER) ? "off." : "on."]"
 	. += "<br>\n The parental guidance light is [A.hacked ? "off." : "on."]"
 	. += "<br>\n The data light is [IsIndexCut(WIRE_REVERSE) ? "hauntingly dark." : "glowing softly."]"

--- a/code/datums/wires/lrange_scanner.dm
+++ b/code/datums/wires/lrange_scanner.dm
@@ -2,9 +2,10 @@
 	holder_type = /obj/machinery/power/long_range_scanner/
 	wire_count = 5
 	descriptions = list(
-		new /datum/wire_description(SCANNER_WIRE_POWER, "This wire seems to be carrying a heavy current."),//, STAT_LEVEL_EXPERT), //TODO: Hook in Eris skills here
-		new /datum/wire_description(SCANNER_WIRE_CONTROL, "This wire connects to the main control panel."),
-		new /datum/wire_description(SCANNER_WIRE_AICONTROL, "This wire connects to automated control systems.")
+		new /datum/wire_description(SCANNER_WIRE_POWER, "Power"),
+		new /datum/wire_description(SCANNER_WIRE_CONTROL, "Physical access"),
+		new /datum/wire_description(SCANNER_WIRE_AICONTROL, "Remote access"),
+		new /datum/wire_description(SCANNER_WIRE_NOTHING, "Failsafe")
 	)
 
 var/const/SCANNER_WIRE_POWER = 1			// Cut to disable power input into the scanner. Pulse does nothing. Mend to restore.

--- a/code/datums/wires/nuclearbomb.dm
+++ b/code/datums/wires/nuclearbomb.dm
@@ -2,9 +2,9 @@
 	holder_type = /obj/machinery/nuclearbomb
 	wire_count = 7
 	descriptions = list(
-		new /datum/wire_description(NUCLEARBOMB_WIRE_LIGHT, "This wire seems to connect to the small light on the device."),
-		new /datum/wire_description(NUCLEARBOMB_WIRE_TIMING, "This wire connects to the time display."),
-		new /datum/wire_description(NUCLEARBOMB_WIRE_SAFETY, "This wire connects to a safety override.")
+		new /datum/wire_description(NUCLEARBOMB_WIRE_LIGHT, "Light"),
+		new /datum/wire_description(NUCLEARBOMB_WIRE_TIMING, "Timer"),
+		new /datum/wire_description(NUCLEARBOMB_WIRE_SAFETY, "Safety")
 	)
 
 var/const/NUCLEARBOMB_WIRE_LIGHT		= 1
@@ -15,9 +15,9 @@ var/const/NUCLEARBOMB_WIRE_SAFETY		= 4
 	var/obj/machinery/nuclearbomb/N = holder
 	return N.panel_open
 
-/datum/wires/nuclearbomb/GetInteractWindow()
+/datum/wires/nuclearbomb/GetInteractWindow(mob/living/user)
 	var/obj/machinery/nuclearbomb/N = holder
-	. += ..()
+	. += ..(user)
 	. += "<BR>The device is [N.timing ? "shaking!" : "still."]<BR>"
 	. += "The device is is [N.safety ? "quiet" : "whirring"].<BR>"
 	. += "The lights are [N.lighthack ? "static" : "functional"].<BR>"

--- a/code/datums/wires/particle_accelerator.dm
+++ b/code/datums/wires/particle_accelerator.dm
@@ -2,10 +2,10 @@
 	wire_count = 5
 	holder_type = /obj/machinery/particle_accelerator/control_box
 	descriptions = list(
-		new /datum/wire_description(PARTICLE_TOGGLE_WIRE, "This wire seems to connect to the main power toggle."),
-		new /datum/wire_description(PARTICLE_STRENGTH_WIRE, "This wire connects to the primary magnets."),
-		new /datum/wire_description(PARTICLE_INTERFACE_WIRE, "This wire appears connected to the user panel."),
-		new /datum/wire_description(PARTICLE_LIMIT_POWER_WIRE, "This wire connects to the primary magnets.")
+		new /datum/wire_description(PARTICLE_TOGGLE_WIRE, "Power"),
+		new /datum/wire_description(PARTICLE_STRENGTH_WIRE, "Auxiliary power"),
+		new /datum/wire_description(PARTICLE_INTERFACE_WIRE, "Physical access"),
+		new /datum/wire_description(PARTICLE_LIMIT_POWER_WIRE, "Failsafe")
 	)
 var/const/PARTICLE_TOGGLE_WIRE = 1 // Toggles whether the PA is on or not.
 var/const/PARTICLE_STRENGTH_WIRE = 2 // Determines the strength of the PA.

--- a/code/datums/wires/radio.dm
+++ b/code/datums/wires/radio.dm
@@ -2,9 +2,9 @@
 	holder_type = /obj/item/device/radio
 	wire_count = 3
 	descriptions = list(
-		new /datum/wire_description(WIRE_SIGNAL, "This wire connects several radio components."),
-		new /datum/wire_description(WIRE_RECEIVE, "This wire runs to the radio reciever.",),
-		new /datum/wire_description(WIRE_TRANSMIT, "This wire runs to the radio transmitter.")
+		new /datum/wire_description(WIRE_SIGNAL, "Power"),
+		new /datum/wire_description(WIRE_RECEIVE, "Reciever"),
+		new /datum/wire_description(WIRE_TRANSMIT, "Transmitter")
 	)
 
 var/const/WIRE_SIGNAL = 1

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -2,11 +2,11 @@
 	holder_type = /mob/living/silicon/robot
 	wire_count = 5
 	descriptions = list(
-		new /datum/wire_description(BORG_WIRE_LAWCHECK, "This wire runs to the unit's law module."),
-		new /datum/wire_description(BORG_WIRE_MAIN_POWER, "This wire seems to be carrying a heavy current.",),
-		new /datum/wire_description(BORG_WIRE_LOCKED_DOWN, "This wire connects to the unit's safety override."),
-		new /datum/wire_description(BORG_WIRE_AI_CONTROL, "This wire connects to automated control systems."),
-		new /datum/wire_description(BORG_WIRE_CAMERA,  "This wire runs to the unit's vision modules.")
+		new /datum/wire_description(BORG_WIRE_LAWCHECK, "LawSync"),
+		new /datum/wire_description(BORG_WIRE_MAIN_POWER, "Power",),
+		new /datum/wire_description(BORG_WIRE_LOCKED_DOWN, "Failsafe"),
+		new /datum/wire_description(BORG_WIRE_AI_CONTROL, "Remote access"),
+		new /datum/wire_description(BORG_WIRE_CAMERA,  "Camera")
 	)
 
 var/const/BORG_WIRE_LAWCHECK = 1
@@ -15,9 +15,9 @@ var/const/BORG_WIRE_LOCKED_DOWN = 4
 var/const/BORG_WIRE_AI_CONTROL = 8
 var/const/BORG_WIRE_CAMERA = 16
 
-/datum/wires/robot/GetInteractWindow()
+/datum/wires/robot/GetInteractWindow(mob/living/user)
 
-	. = ..()
+	. = ..(user)
 	var/mob/living/silicon/robot/R = holder
 	. += text("<br>\n[(R.lawupdate ? "The LawSync light is on." : "The LawSync light is off.")]")
 	. += text("<br>\n[(R.connected_ai ? "The AI link light is on." : "The AI link light is off.")]")

--- a/code/datums/wires/shield_generator.dm
+++ b/code/datums/wires/shield_generator.dm
@@ -2,9 +2,9 @@
 	holder_type = /obj/machinery/power/shield_generator/
 	wire_count = 5
 	descriptions = list(
-		new /datum/wire_description(SHIELDGEN_WIRE_POWER, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(SHIELDGEN_WIRE_CONTROL, "This wire connects to the main control panel."),
-		new /datum/wire_description(SHIELDGEN_WIRE_AICONTROL, "This wire connects to automated control systems.")
+		new /datum/wire_description(SHIELDGEN_WIRE_POWER, "Main power"),
+		new /datum/wire_description(SHIELDGEN_WIRE_CONTROL, "Physical access"),
+		new /datum/wire_description(SHIELDGEN_WIRE_AICONTROL, "Remote access")
 	)
 
 var/const/SHIELDGEN_WIRE_POWER = 1			// Cut to disable power input into the generator. Pulse does nothing. Mend to restore.

--- a/code/datums/wires/smartfridge.dm
+++ b/code/datums/wires/smartfridge.dm
@@ -2,9 +2,9 @@
 	holder_type = /obj/machinery/smartfridge
 	wire_count = 3
 	descriptions = list(
-		new /datum/wire_description(SMARTFRIDGE_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(SMARTFRIDGE_WIRE_THROW, "This wire leads to the item dispensor force controls."),
-		new /datum/wire_description(SMARTFRIDGE_WIRE_IDSCAN, "This wire is connected to the ID scanning panel.")
+		new /datum/wire_description(SMARTFRIDGE_WIRE_ELECTRIFY, "Shock"),
+		new /datum/wire_description(SMARTFRIDGE_WIRE_THROW, "Failsafe"),
+		new /datum/wire_description(SMARTFRIDGE_WIRE_IDSCAN, "ID scanner")
 	)
 
 /datum/wires/smartfridge/secure
@@ -24,9 +24,9 @@ var/const/SMARTFRIDGE_WIRE_IDSCAN		= 4
 		return 1
 	return 0
 
-/datum/wires/smartfridge/GetInteractWindow()
+/datum/wires/smartfridge/GetInteractWindow(mob/living/user)
 	var/obj/machinery/smartfridge/S = holder
-	. += ..()
+	. += ..(user)
 	. += "<BR>The orange light is [S.seconds_electrified ? "off" : "on"].<BR>"
 	. += "The red light is [S.shoot_inventory ? "off" : "blinking"].<BR>"
 	. += "A [S.scan_id ? "purple" : "yellow"] light is on.<BR>"

--- a/code/datums/wires/smes.dm
+++ b/code/datums/wires/smes.dm
@@ -2,11 +2,11 @@
 	holder_type = /obj/machinery/power/smes/buildable
 	wire_count = 5
 	descriptions = list(
-		new /datum/wire_description(SMES_WIRE_RCON, "This wire runs to a remote signaling mechanism."),
-		new /datum/wire_description(SMES_WIRE_INPUT, "This seems to be the primary input."),
-		new /datum/wire_description(SMES_WIRE_OUTPUT, "This seems to be the primary output."),
-		new /datum/wire_description(SMES_WIRE_GROUNDING, "This wire appeas to connect directly to the floor."),
-		new /datum/wire_description(SMES_WIRE_FAILSAFES, "This wire appears to connect to a failsafe mechanism.")
+		new /datum/wire_description(SMES_WIRE_RCON, "Remote access"),
+		new /datum/wire_description(SMES_WIRE_INPUT, "Input"),
+		new /datum/wire_description(SMES_WIRE_OUTPUT, "Output"),
+		new /datum/wire_description(SMES_WIRE_GROUNDING, "Grounding"),
+		new /datum/wire_description(SMES_WIRE_FAILSAFES, "Failsafe")
 	)
 
 var/const/SMES_WIRE_RCON = 1		// Remote control (AI and consoles), cut to disable
@@ -23,9 +23,9 @@ var/const/SMES_WIRE_FAILSAFES = 16	// Cut to disable failsafes, mend to reenable
 	return 0
 
 
-/datum/wires/smes/GetInteractWindow()
+/datum/wires/smes/GetInteractWindow(mob/living/user)
 	var/obj/machinery/power/smes/buildable/S = holder
-	. += ..()
+	. += ..(user)
 	. += "The green light is [(S.input_cut || S.input_pulsed || S.output_cut || S.output_pulsed) ? "off" : "on"]<br>"
 	. += "The red light is [(S.safeties_enabled || S.grounding) ? "off" : "blinking"]<br>"
 	. += "The blue light is [S.RCon ? "on" : "off"]"

--- a/code/datums/wires/suit_storage_unit.dm
+++ b/code/datums/wires/suit_storage_unit.dm
@@ -2,9 +2,9 @@
 	holder_type = /obj/machinery/suit_storage_unit
 	wire_count = 3
 	descriptions = list(
-		new /datum/wire_description(SUIT_STORAGE_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(SUIT_STORAGE_WIRE_SAFETY, "This wire seems connected to a safety override"),
-		new /datum/wire_description(SUIT_STORAGE_WIRE_LOCKED, "This wire is connected to the ID scanning panel.")
+		new /datum/wire_description(SUIT_STORAGE_WIRE_ELECTRIFY, "Shock"),
+		new /datum/wire_description(SUIT_STORAGE_WIRE_SAFETY, "Failsafe"),
+		new /datum/wire_description(SUIT_STORAGE_WIRE_LOCKED, "ID scanner")
 	)
 
 var/const/SUIT_STORAGE_WIRE_ELECTRIFY	= 1
@@ -21,9 +21,9 @@ var/const/SUIT_STORAGE_WIRE_LOCKED		= 4
 		return 1
 	return 0
 
-/datum/wires/suit_storage_unit/GetInteractWindow()
+/datum/wires/suit_storage_unit/GetInteractWindow(mob/living/user)
 	var/obj/machinery/suit_storage_unit/S = holder
-	. += ..()
+	. += ..(user)
 	. += "<BR>The orange light is [S.electrified ? "off" : "on"].<BR>"
 	. += "The red light is [S.safeties ? "off" : "blinking"].<BR>"
 	. += "The yellow light is [S.locked ? "on" : "off"].<BR>"

--- a/code/datums/wires/taperecorder.dm
+++ b/code/datums/wires/taperecorder.dm
@@ -2,10 +2,10 @@
 	holder_type = /obj/item/device/taperecorder
 	wire_count = 4
 	descriptions = list(
-		new /datum/wire_description(TAPE_WIRE_STOP, "This wire runs to the Stop button."),
-		new /datum/wire_description(TAPE_WIRE_PLAY, "This wire runs to the Play button."),
-		new /datum/wire_description(TAPE_WIRE_RECORD, "This wire runs to the Record button."),
-		new /datum/wire_description(TAPE_WIRE_WIPE, "This wire runs to the Clear button."),
+		new /datum/wire_description(TAPE_WIRE_STOP, "Stop"),
+		new /datum/wire_description(TAPE_WIRE_PLAY, "Play"),
+		new /datum/wire_description(TAPE_WIRE_RECORD, "Record"),
+		new /datum/wire_description(TAPE_WIRE_WIPE, "Wipe"),
 	)
 
 var/const/TAPE_WIRE_STOP = 1

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -8,10 +8,10 @@
 	holder_type = /obj/machinery/vending
 	wire_count = 4
 	descriptions = list(
-		new /datum/wire_description(VENDING_WIRE_THROW, "This wire leads to the item dispensor force controls."),
-		new /datum/wire_description(VENDING_WIRE_CONTRABAND, "This wire appears connected to a reserve inventory compartment."),
-		new /datum/wire_description(VENDING_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(VENDING_WIRE_IDSCAN, "This wire is connected to the ID scanning panel."),
+		new /datum/wire_description(VENDING_WIRE_THROW, "Safety"),
+		new /datum/wire_description(VENDING_WIRE_CONTRABAND, "Contraband"),
+		new /datum/wire_description(VENDING_WIRE_ELECTRIFY, "Shock"),
+		new /datum/wire_description(VENDING_WIRE_IDSCAN, "ID scanner"),
 	)
 
 var/const/VENDING_WIRE_THROW = 1
@@ -29,9 +29,9 @@ var/const/VENDING_WIRE_IDSCAN = 8
 		return 1
 	return 0
 
-/datum/wires/vending/GetInteractWindow()
+/datum/wires/vending/GetInteractWindow(mob/living/user)
 	var/obj/machinery/vending/V = holder
-	. += ..()
+	. += ..(user)
 	. += "<BR>The orange light is [V.seconds_electrified ? "off" : "on"].<BR>"
 	. += "The red light is [V.shoot_inventory ? "off" : "blinking"].<BR>"
 	. += "The green light is [(V.categories & CAT_HIDDEN) ? "on" : "off"].<BR>"

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -123,7 +123,7 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 	for(var/colour in wires)
 		html += "<tr>"
 		var/datum/wire_description/wd = get_description(GetIndex(colour))
-		if(user_skill && (wd.skill_level <= user_skill))
+		if(user.stats && user.stats.getPerk(PERK_TECHNOMANCER) || user_skill && (wd.skill_level <= user_skill))
 			html += "<td[row_options1]><font color='[colour]'>[wd.description]</font></td>"
 		else
 			html += "<td[row_options1]><font color='[colour]'>[capitalize(colour)]</font></td>"

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -22,8 +22,8 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 
 	var/table_options = " align='center'"
 	var/row_options1 = " width='80px'"
-	var/row_options2 = " width='280px'"
-	var/window_x = 450
+	var/row_options2 = " width='260px'"
+	var/window_x = 370
 	var/window_y = 470
 
 	var/list/descriptions // Descriptions of wires (datum/wire_description) for use with examining.

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -90,11 +90,11 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 /datum/wires/proc/add_log_entry(mob/user, message)
 	wire_log += "\[[time_stamp()]\] [user.name] ([user.ckey]) [message]"
 
-/datum/wires/proc/Interact(var/mob/living/user)
+/datum/wires/proc/Interact(mob/living/user)
 
 	var/html = null
 	if(holder && CanUse(user))
-		html = GetInteractWindow()
+		html = GetInteractWindow(user)
 	if(html)
 		user.set_machine(holder)
 	else
@@ -108,19 +108,29 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 	popup.set_title_image(user.browse_rsc_icon(holder.icon, holder.icon_state))
 	popup.open()
 
-/datum/wires/proc/GetInteractWindow()
+/datum/wires/proc/GetInteractWindow(mob/living/user)
+	var/user_skill
 	var/html = "<div class='block'>"
 	html += "<h3>Exposed Wires</h3>"
 	html += "<table[table_options]>"
 
+	if(!user)
+		user = usr
+
+	if(istype(user))
+		user_skill = user.stats.getStat(STAT_MEC)
+
 	for(var/colour in wires)
 		html += "<tr>"
-		html += "<td[row_options1]><font color='[colour]'>[capitalize(colour)]</font></td>"
+		var/datum/wire_description/wd = get_description(GetIndex(colour))
+		if(user_skill && (wd.skill_level <= user_skill))
+			html += "<td[row_options1]><font color='[colour]'>[wd.description]</font></td>"
+		else
+			html += "<td[row_options1]><font color='[colour]'>[capitalize(colour)]</font></td>"
 		html += "<td[row_options2]>"
 		html += "<A href='?src=\ref[src];action=1;cut=[colour]'>[IsColourCut(colour) ? "Mend" :  "Cut"]</A>"
 		html += " <A href='?src=\ref[src];action=1;pulse=[colour]'>Pulse</A>"
 		html += " <A href='?src=\ref[src];action=1;attach=[colour]'>[IsAttached(colour) ? "Detach" : "Attach"] Signaller</A>"
-		html += " <A href='?src=\ref[src];action=1;examine=[colour]'>Examine</A></td></tr>"
 	html += "</table>"
 	html += "</div>"
 
@@ -178,11 +188,6 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 						Attach(colour, I)
 					else
 						to_chat(L, SPAN_WARNING("You need a remote signaller!"))
-			else if(href_list["examine"])
-				var/colour = href_list["examine"]
-				to_chat(usr, examine(GetIndex(colour), usr))
-
-
 
 		// Update Window
 			Interact(usr)

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -239,7 +239,7 @@
 			else
 				dat += "<A href='byond://?src=\ref[src];op=cellinsert'>Removed</A><BR>"
 
-			dat += wires.GetInteractWindow()
+			dat += wires.GetInteractWindow(user)
 		else
 			dat += "The bot is in maintenance mode and cannot be controlled.<BR>"
 


### PR DESCRIPTION
## About The Pull Request

Reworked version of #6820.
Removes silly examine button and authomatically shows wire function if player stats are high enough.

Default:
![image](https://user-images.githubusercontent.com/65828539/148624287-589f88fe-1c7c-4d22-8dd6-cf1947191029.png)

MEC stat over 40 or technomancer perk:
![image](https://user-images.githubusercontent.com/65828539/148624225-11b7a006-5159-4544-a789-d6310a324ad7.png)

## Why It's Good For The Game

Pressing examine a dozen times for every door sucks a lot, so here is QoL improvement.

## Changelog
:cl:
refactor: wires UI looks less shitty
/:cl:
