### PR TITLE
Makes seclite attachable to operator helmet

### DIFF
--- a/code/game/objects/items/devices/lighting/toggleable/flashlight.dm
+++ b/code/game/objects/items/devices/lighting/toggleable/flashlight.dm
@@ -22,11 +22,18 @@
 	return ..()
 
 /obj/item/device/lighting/toggleable/flashlight/proc/calculate_dir(turf/old_loc)
-	if(istype(src.loc,/obj/item/storage) || istype(src.loc,/obj/structure/closet))
+	if(istype(src.loc, /obj/item/storage) || istype(src.loc, /obj/structure/closet))
 		return
-	if(istype(src.loc,/mob/living))
+	if(istype(src.loc, /mob/living))
 		var/mob/living/L = src.loc
 		set_dir(L.dir)
+	else if(istype(src.loc, /obj/item/clothing/head/armor/helmet))
+		var/obj/item/clothing/head/armor/helmet/H = src.loc
+		if(H.is_equipped())
+			var/mob/living/L = H.loc
+			set_dir(L.dir)
+		else
+			set_dir(H.dir)
 	else if(pulledby && old_loc)
 		var/x_diff = src.x - old_loc.x
 		var/y_diff = src.y - old_loc.y

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -75,6 +75,56 @@
 	desc = "Ironhammer Security gear. Protects the head from impacts."
 	icon_state = "helmet_ironhammer"
 	flags_inv = BLOCKHEADHAIR|HIDEEARS
+	var/fitting_flashlight = /obj/item/device/lighting/toggleable/flashlight/seclite
+	var/obj/item/device/lighting/toggleable/flashlight/flashlight
+
+/obj/item/clothing/head/armor/helmet/ironhammer/MouseDrop(over_object)
+	..()
+	if(flashlight && istype(over_object, /obj/screen/inventory/hand))
+		eject_item(flashlight, usr)
+		flashlight = null
+		action_button_name = null
+		on = FALSE
+		update_icon()
+		usr.update_action_buttons()
+
+/obj/item/clothing/head/armor/helmet/ironhammer/AltClick(mob/user)
+	if(flashlight)
+		flashlight.attack_self(user)
+		if(flashlight.on)
+			on = TRUE
+			ping_flashlight()
+		else
+			on = FALSE
+		update_icon()
+		return
+	..()
+
+/obj/item/clothing/head/armor/helmet/ironhammer/attackby(obj/item/I, mob/user)
+	if(istype(I, fitting_flashlight))
+		insert_item(I, user)
+		flashlight = I
+		if(flashlight.on)
+			on = TRUE
+			ping_flashlight()
+		else
+			on = FALSE
+		update_icon()
+		usr.update_action_buttons()
+		return
+	..()
+
+/obj/item/clothing/head/armor/helmet/ironhammer/proc/ping_flashlight()
+	if(flashlight && on)
+		flashlight.spot_locked = FALSE
+		flashlight.calculate_dir()
+		sleep(2)
+		.()
+
+/obj/item/clothing/head/armor/helmet/ironhammer/Destroy()
+	. = ..()
+	if(flashlight)
+		qdel(flashlight)
 
 /obj/item/clothing/head/armor/helmet/technomancer
 	name = "insulated technomancer helmet"

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -101,7 +101,7 @@
 	..()
 
 /obj/item/clothing/head/armor/helmet/ironhammer/attackby(obj/item/I, mob/user)
-	if(istype(I, fitting_flashlight))
+	if(istype(I, fitting_flashlight) && !flashlight)
 		insert_item(I, user)
 		flashlight = I
 		if(flashlight.on)


### PR DESCRIPTION
## About The Pull Request

What it says on the tin.
Attached by clicking with flashlight on the helmet.
Removed by dragging the helmet into empty hand.
Toggled by Alt-clicking the helmet.

![image](https://user-images.githubusercontent.com/65828539/148754037-174c9f85-6c8d-49cd-8267-e7e8e80f916e.png)


https://user-images.githubusercontent.com/65828539/148748442-5407cc37-7d6d-4f1f-b726-4306c4987b5f.mp4


## Why It's Good For The Game

I honestly don't know.

## Changelog
:cl:
add: ability to attach seclite to operator helmet
/:cl:


