### PR TITLE
Ship's nuke sets the alert to delta when armed

### DIFF
--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -20,7 +20,7 @@ var/bomb_set
 	var/lastentered
 	use_power = NO_POWER_USE
 	unacidable = 1
-	var/previous_level = ""
+	var/previous_level = "" // For resetting alert level to where it was before the nuke was armed
 	var/datum/wires/nuclearbomb/wires = null
 
 	var/eris_ship_bomb = FALSE           // if TRUE (1 in map editor), then Heads will get parts of code for this bomb. Obviously used in map editor. Single mapped bomb supported.
@@ -283,6 +283,10 @@ var/bomb_set
 					timing = 1
 					log_and_message_admins("engaged a nuclear bomb")
 					bomb_set++ //There can still be issues with this resetting when there are multiple bombs. Not a big deal though for Nuke/N
+					if(eris_ship_bomb)
+						var/decl/security_state/security_state = decls_repository.get_decl(GLOB.maps_data.security_state)
+						previous_level = security_state.current_security_level
+						security_state.set_security_level(security_state.severe_security_level)
 					update_icon()
 				else
 					secure_device()
@@ -320,6 +324,8 @@ var/bomb_set
 	bomb_set--
 	timing = 0
 	timeleft = CLAMP(timeleft, 120, 600)
+	var/decl/security_state/security_state = decls_repository.get_decl(GLOB.maps_data.security_state)
+	security_state.set_security_level(previous_level)
 	update_icon()
 
 /obj/machinery/nuclearbomb/ex_act(severity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When the ship's nuke is armed (read: any nuke with `eris_ship_bomb = TRUE`), the alert level will be set to Delta.
If the nuke is disarmed/safed, the alert will drop to what it was before the nuke was armed.
 
Fixes https://github.com/discordia-space/CEV-Eris/issues/1858

## Why It's Good For The Game

Big ol' alarm for when the nuke is angry.

## Changelog
:cl:
add: The ship's nuke now sets the alert level to Delta when armed, and back to the original level when disarmed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
