### PR TITLE
Remove "platinumsolidification" recipe

### DIFF
--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -615,15 +615,6 @@
 	new /obj/item/stack/material/silver(get_turf(holder.my_atom), created_volume)
 	return
 
-/datum/chemical_reaction/platinumsolidification
-	result = null
-	required_reagents = list("iron" = 5, "frostoil" = 5, "platinum" = 20)
-	result_amount = 1
-
-/datum/chemical_reaction/platinumsolidification/on_reaction(var/datum/reagents/holder, var/created_volume)
-	new /obj/item/stack/material/platinum(get_turf(holder.my_atom), created_volume)
-	return
-
 /datum/chemical_reaction/plastication
 	result = null
 	required_reagents = list("pacid" = 1, "plasticide" = 2)


### PR DESCRIPTION
## About The Pull Request

Fixes `## ERROR: recipe /datum/chemical_reaction/platinumsolidification created incorectly,[required_reagents] reagent with id "platinum" does not exist.` introduced in #6893, by removing the recipe.
Better than adding more reagents that will be used maybe in one of hundreds rounds, if at all.

## Why It's Good For The Game

Errors bad, all my hommies hate errors.

## Changelog
:cl:
del: platinum solidification recipe
/:cl:

