### PR TITLE
Fix ammo names in vendors (again)

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -25,7 +25,7 @@
 
 	var/obj/tmp = path
 
-	if(istype(tmp, /obj/item/ammo_magazine))
+	if(ispath(tmp, /obj/item/ammo_magazine))
 		// On New() magazine gets a proper name assigned
 		var/obj/item/ammo_magazine/AM = new tmp
 		product_name = AM.name


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/65828539/150668159-c5f569d9-2c3e-44d0-b2d2-4e16539cac6e.png)

Apparently last PR fixed only part of the issue, my bad.

![image](https://user-images.githubusercontent.com/65828539/150668071-90abe706-9161-4638-bc7c-f92f7daa9a57.png)

![image](https://user-images.githubusercontent.com/65828539/150668073-80cf86b6-66b3-44ad-bbaf-17c4e3ae71a6.png)


## Why It's Good For The Game

Fixes cool.

## Changelog
:cl:
fix: ammo names in vendor, this time for real
/:cl: