### PR TITLE
Mobility Stage 1: Diving, Sliding

### DIFF
--- a/code/datums/perks/oddity.dm
+++ b/code/datums/perks/oddity.dm
@@ -63,7 +63,7 @@
 
 /datum/perk/oddity/parkour
 	name = "Parkour"
-	desc = "You can climb tables and ladders faster. Also clings to railings and low walls."
+	desc = "You cling to railings and low walls, climb faster, and get up after diving or sliding sooner."
 	icon_state = "parkour" //https://game-icons.net/1x1/delapouite/jump-across.html
 
 /datum/perk/oddity/parkour/assign(mob/living/carbon/human/H)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -637,11 +637,12 @@ default behaviour is:
 			pass_flags -= PASSTABLE //jumpn't over them anymore!
 			src.allow_spin = TRUE
 			sleep(3)
-			while(livmomentum > 0)
+            src.client.mloop = 1
+			while(livmomentum > 0 && src.client.true_dir)
 				src.Move(get_step(src.loc, dir),dir)
-				src.client.move_loop()
 				livmomentum = (livmomentum - speed)
 				sleep(world.tick_lag + 1)
+			src.client.mloop = 0
 		else
 			to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"].</span>")
 			update_lying_buckled_and_verb_status()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -637,7 +637,7 @@ default behaviour is:
 			pass_flags -= PASSTABLE //jumpn't over them anymore!
 			src.allow_spin = TRUE
 			sleep(3)
-            src.client.mloop = 1
+			src.client.mloop = 1
 			while(livmomentum > 0 && src.client.true_dir)
 				src.Move(get_step(src.loc, dir),dir)
 				livmomentum = (livmomentum - speed)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -623,26 +623,31 @@ default behaviour is:
 			unstack = TRUE
 			to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"].</span>")
 			update_lying_buckled_and_verb_status()
+		else
+			unstack = TRUE
 	else if (!resting)
+		var/client/C = src.client
 		var/speed = movement_delay()
 		resting = TRUE
-		var/dir = src.client.true_dir
-		if(ishuman(src) && (dir))//if true_dir = 0(src isn't moving), doesn't proc
-			livmomentum = 5 //set momentum value as soon as possible for stopSliding to work better
-			to_chat(src, SPAN_NOTICE("You dive onwards!"))
-			pass_flags += PASSTABLE //jump over them!
-			src.allow_spin = FALSE
-			src.throw_at(get_edge_target_turf(src, dir), 2, 1)//"Diving"; if you dive over a table, your momentum is set to 0
+		var/dir = C.true_dir
+		if(ishuman(src) && (dir))// If true_dir = 0(src isn't moving), doesn't proc
+			var/mob/living/carbon/human/H = src
+			livmomentum = 5 // Set momentum value as soon as possible for stopSliding to work better
+			to_chat(H, SPAN_NOTICE("You dive onwards!"))
+			pass_flags += PASSTABLE // Jump over them!
+			H.allow_spin = FALSE
+			H.throw_at(get_edge_target_turf(H, dir), 1, 1)// "Diving"; if you dive over a table, your momentum is set to 0
 			update_lying_buckled_and_verb_status()
-			pass_flags -= PASSTABLE //jumpn't over them anymore!
-			src.allow_spin = TRUE
-			sleep(3)
-			src.client.mloop = 1
-			while(livmomentum > 0 && src.client.true_dir)
-				src.Move(get_step(src.loc, dir),dir)
+			pass_flags -= PASSTABLE // Jumpn't over them anymore!
+			H.allow_spin = TRUE
+			sleep(2)
+			C.mloop = 1
+			while(livmomentum > 0 && C.true_dir)
+				H.Move(get_step(H.loc, dir),dir)
 				livmomentum = (livmomentum - speed)
+				H.regen_slickness(0.75) // The longer you slide, the more stylish it is
 				sleep(world.tick_lag + 1)
-			src.client.mloop = 0
+			C.mloop = 0
 		else
 			to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"].</span>")
 			update_lying_buckled_and_verb_status()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -636,7 +636,10 @@ default behaviour is:
 			to_chat(H, SPAN_NOTICE("You dive onwards!"))
 			pass_flags += PASSTABLE // Jump over them!
 			H.allow_spin = FALSE
-			H.throw_at(get_edge_target_turf(H, dir), 1, 1)// "Diving"; if you dive over a table, your momentum is set to 0
+			var/is_jump = FALSE
+			if(istype(get_step(H, dir), /turf/simulated/open))
+				is_jump = TRUE
+			H.throw_at(get_edge_target_turf(H, dir), 2 + is_jump, 1)// "Diving"; if you dive over a table, your momentum is set to 0. If you dive over space, you are thrown a tile further.
 			update_lying_buckled_and_verb_status()
 			pass_flags -= PASSTABLE // Jumpn't over them anymore!
 			H.allow_spin = TRUE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -645,7 +645,7 @@ default behaviour is:
 			while(livmomentum > 0 && C.true_dir)
 				H.Move(get_step(H.loc, dir),dir)
 				livmomentum = (livmomentum - speed)
-				H.regen_slickness(0.75) // The longer you slide, the more stylish it is
+				H.regen_slickness(0.25) // The longer you slide, the more stylish it is
 				sleep(world.tick_lag + 1)
 			C.mloop = 0
 		else

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -638,15 +638,10 @@ default behaviour is:
 			src.allow_spin = TRUE
 			sleep(3)
 			while(livmomentum > 0)
-				visible_message("slide procced!")
 				src.Move(get_step(src.loc, dir),dir)
 				src.client.move_loop()
 				livmomentum = (livmomentum - speed)
 				sleep(world.tick_lag + 1)
-				//ADD COOLDOWN!!
-			//add stage 2
-			//get devstaff
-			//also buff suplex and perks, preferably better than a number change
 		else
 			to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"].</span>")
 			update_lying_buckled_and_verb_status()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -616,50 +616,50 @@ default behaviour is:
 	set name = "Rest"
 	set category = "IC"
 
-	var/state_changed = FALSE
-	if(resting && can_stand_up())
-		if(do_after(src, 0.5 SECONDS, null, 0, 1, INCAPACITATION_DEFAULT, immobile = 0))
+	if(resting && unstack)
+		unstack = FALSE
+		if((livmomentum <= 0) && do_after(src, (src.stats.getPerk(PERK_PARKOUR) ? 0.3 SECONDS : 0.7 SECONDS), null, 0, 1, INCAPACITATION_DEFAULT, immobile = 0))
 			resting = FALSE
-			state_changed = TRUE
+			unstack = TRUE
+			to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"].</span>")
+			update_lying_buckled_and_verb_status()
 	else if (!resting)
-		if(ishuman(src))
-			var/obj/item/bedsheet/BS = locate(/obj/item/bedsheet) in get_turf(src)
-			// If there is unrolled bedsheet roll and unroll it to get in bed like a proper adult does
-			if(BS && !BS.rolled && !BS.folded)
-				resting = TRUE
-				BS.toggle_roll(src, no_message = TRUE)
-				BS.toggle_roll(src)
-			else
-				resting = TRUE
-			state_changed = TRUE
+		var/speed = movement_delay()
+		resting = TRUE
+		var/dir = src.client.true_dir
+		if(ishuman(src) && (dir))//if true_dir = 0(src isn't moving), doesn't proc
+			livmomentum = 5 //set momentum value as soon as possible for stopSliding to work better
+			to_chat(src, SPAN_NOTICE("You dive onwards!"))
+			pass_flags += PASSTABLE //jump over them!
+			src.allow_spin = FALSE
+			src.throw_at(get_edge_target_turf(src, dir), 2, 1)//"Diving"; if you dive over a table, your momentum is set to 0
+			update_lying_buckled_and_verb_status()
+			pass_flags -= PASSTABLE //jumpn't over them anymore!
+			src.allow_spin = TRUE
+			sleep(3)
+			while(livmomentum > 0)
+				visible_message("slide procced!")
+				src.Move(get_step(src.loc, dir),dir)
+				src.client.move_loop()
+				livmomentum = (livmomentum - speed)
+				sleep(world.tick_lag + 1)
+				//ADD COOLDOWN!!
+			//add stage 2
+			//get devstaff
+			//also buff suplex and perks, preferably better than a number change
 		else
-			resting = TRUE
-			state_changed = TRUE
-	if(state_changed)
-		to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"]</span>")
-		update_lying_buckled_and_verb_status()
-
-/mob/living/proc/can_stand_up()
-	var/no_blankets = FALSE
-	no_blankets = unblanket()
-
-	if(no_blankets)
-		return TRUE
-	else
-		to_chat(src, SPAN_WARNING("You can't stand up, bedsheets are in the way and you struggle to get rid of them."))
-		return FALSE
-
-//used to push away bedsheets in order to stand up, only humans will roll them (see overriden human proc)
-/mob/living/proc/unblanket()
-	var/obj/item/bedsheet/blankets = (locate(/obj/item/bedsheet) in loc)
-	if (blankets && !blankets.rolled && !blankets.folded)
-		return blankets.toggle_roll(src)
-	return TRUE
+			to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"].</span>")
+			update_lying_buckled_and_verb_status()
 
 /mob/living/simple_animal/spiderbot/is_allowed_vent_crawl_item(var/obj/item/carried_item)
 	if(carried_item == held_item)
 		return FALSE
 	return ..()
+
+mob/living/carbon/human/verb/stopSliding()
+	set hidden = 1
+	set instant = 1
+	src.livmomentum = 0
 
 /mob/living/proc/cannot_use_vents()
 	return "You can't fit into that vent."

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -39,7 +39,8 @@
 	var/mob_swap_flags = 0
 	var/mob_push_flags = 0
 	var/mob_always_swap = 0
-	var/move_to_delay = 4 //delay for the automated movement.
+	var/livmomentum = 0 //Used for advanced movement options.
+	var/move_to_delay = 4 //Delay for the automated movement.
 	var/can_burrow = FALSE //If true, this mob can travel around using the burrow network.
 	//When this mob spawns at roundstart, a burrow will be created near it if it can't find one
 
@@ -48,6 +49,7 @@
 	var/step_count = 0
 
 	var/update_slimes = 1
+	var/unstack = 1 //prevent stacking of certain actions, like resting/diving
 	var/silent 		// Can't talk. Value goes down every life proc.
 	var/on_fire = 0 //The "Are we on fire?" var
 	var/fire_stacks

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -325,7 +325,7 @@
 		if(istype(rig))
 			rig.force_rest(src)
 	else
-		if(resting && can_stand_up())
+		if(resting)
 			resting = FALSE
 		else if (!resting)
 			resting = TRUE

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -626,7 +626,7 @@
 /mob/living/simple_animal/lay_down()
 	set name = "Rest"
 	set category = "Abilities"
-	if(resting && can_stand_up())
+	if(resting)
 		wake_up()
 	else if (!resting)
 		fall_asleep()

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -1,5 +1,10 @@
 /obj/item/var/list/center_of_mass = list("x"=16, "y"=16) //can be null for no exact placement behaviour
 /obj/structure/table/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	if(isliving(mover))
+		var/mob/living/L = mover
+		L.livmomentum = 0
+		if(L.weakened)
+			return 1
 	if(air_group || (height==0)) return 1
 	if(istype(mover,/obj/item/projectile))
 		return (check_cover(mover,target))
@@ -17,9 +22,6 @@
 //checks if projectile 'P' from turf 'from' can hit whatever is behind the table. Returns 1 if it can, 0 if bullet stops.
 /obj/structure/table/proc/check_cover(obj/item/projectile/P, turf/from)
 	var/turf/cover
-	if(isliving(src))
-		var/mob/living/L = src
-		L.livmomentum = 0
 	if(flipped==1)
 		cover = get_turf(src)
 	else if(flipped==0)

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -17,6 +17,9 @@
 //checks if projectile 'P' from turf 'from' can hit whatever is behind the table. Returns 1 if it can, 0 if bullet stops.
 /obj/structure/table/proc/check_cover(obj/item/projectile/P, turf/from)
 	var/turf/cover
+	if(isliving(src))
+		var/mob/living/L = src
+		L.livmomentum = 0
 	if(flipped==1)
 		cover = get_turf(src)
 	else if(flipped==0)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -672,6 +672,12 @@ macro "hotkeymode"
 	elem 
 		name = "CTRL+Y"
 		command = "Activate-Held-Object"
+	elem
+		name = "C"
+		command = "rest"
+	elem
+		name = "C+UP"
+		command = "stopSliding"
 	elem 
 		name = "Z"
 		command = "Activate-Held-Object"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tactical Combat design doc PR stage 1
Rest hotkey - C
Can't stack resting action anymore
You can dive and dodge now, based on rest(more info in the video in discord, too big to post here)
Removed bay leftover SHEET ROLLING PROC
Parkour perk reduces the time it takes to stand up
Diving is a 1-tile JUMP(you can bridge gaps!) which lets you pass over tables, so you can vault over a table and cover. Press C(rest) while moving. You may continue to hold down C after a dive to preserve your momentum and slide. This will allow you to close a few extra tiles at an increased speed until you run out of momentum, and dodge unaimed projectiles. Being faster increases the maximum range of sliding.
## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/49622619/151409441-cb81c572-e474-4f5b-a4c2-7dc13cef2432.png)

For the time being tables and short walls exist as hard to pass obstacles, players having to spend significantly longer climbing onto them than walking around.
This mechanic was an important aspect in the old codebases of Space Station, preventing players from stealing key items such as the Head of Personnel’s ID, or a security officer’s stunbaton.

However, in our case guns almost completely nullify this issue, allowing us to better utilize the new purpose for tables.
This would be equally useful for both those in and without armor, but still give those faster more utility.
By replacing the climbing timer, and instead forcing a player into rest, they can instantly jump on tables, crawling down with zero delay to avoid gunfire. This move cannot be used offensively, as standing up is now bound by a timer, making them vulnerable to anyone on the other side, or close enough to the table to simply shoot over it.
"The Perk that increases the speed of vaulting would halve the time it takes to stand up, allowing you to recover from a vault much more quickly, and better utilize cover."

## Changelog
:cl:
add: diving, sliding, rest while moving, hold rest to move
add: resting hotkey - C
tweak: parkour perk reduces the time it takes to stand up
tweak: can't stack resting action anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
