### PR TITLE
Bullet Nerf and laser/RPG buff

### DIFF
--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/guns/projectile/heavysniper.dmi'
 	icon_state = "heavysniper"
 	item_state = "heavysniper"
-	damage_multiplier = 0.9
+	damage_multiplier = 1
 	w_class = ITEM_SIZE_HUGE
 	force = WEAPON_FORCE_PAINFUL
 	slot_flags = SLOT_BACK

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -76,7 +76,7 @@
 	var/contractor = FALSE //Check if it's a contractor psychic beam
 	damage_types = list(PSY = 30)
 	armor_penetration = 100
-	style_damage = 110 //I don't honestly think this should be dodgeable since it's not really lethal.
+	style_damage = 60 //It's magic brain beams, deal with it.
 
 	muzzle_type = /obj/effect/projectile/psychic_laser_heavy/muzzle
 	tracer_type = /obj/effect/projectile/psychic_laser_heavy/tracer

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -10,6 +10,7 @@
 	var/frequency = 1
 	hitscan = 1
 	invisibility = 101	//beam projectiles are invisible as they are rendered by the effect engine
+	style_damage = 30 //hitscan, light speed projectiles? Be glad its easier to dodge than a revolver.
 
 	muzzle_type = /obj/effect/projectile/laser/muzzle
 	tracer_type = /obj/effect/projectile/laser/tracer
@@ -62,6 +63,7 @@
 	icon_state = "heavylaser"
 	damage_types = list(BURN = 50)
 	armor_penetration = 20
+	style_damage = 60 //it's a slow firing beam weapon, this is probably fair.
 
 	muzzle_type = /obj/effect/projectile/laser_heavy/muzzle
 	tracer_type = /obj/effect/projectile/laser_heavy/tracer
@@ -74,6 +76,7 @@
 	var/contractor = FALSE //Check if it's a contractor psychic beam
 	damage_types = list(PSY = 30)
 	armor_penetration = 100
+	style_damage = 110 //I don't honestly think this should be dodgeable since it's not really lethal.
 
 	muzzle_type = /obj/effect/projectile/psychic_laser_heavy/muzzle
 	tracer_type = /obj/effect/projectile/psychic_laser_heavy/tracer
@@ -187,6 +190,7 @@
 	damage_types = list(BURN = 60)
 	armor_penetration = 50
 	stutter = 3
+	style_damage = 70 //it's the laser AMR.
 
 	muzzle_type = /obj/effect/projectile/xray/muzzle
 	tracer_type = /obj/effect/projectile/xray/tracer

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -307,7 +307,7 @@ There are important things regarding this file:
 	icon_state = "birdshot-[rand(1,4)]"
 
 /obj/item/projectile/bullet/pellet/shotgun/scrap
-	damage_types = list(BRUTE = 9)
+	damage_types = list(BRUTE = 7)
 
 //Miscellaneous
 /obj/item/projectile/bullet/blank

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -12,13 +12,13 @@ There are important things regarding this file:
 //Low-caliber pistols and SMGs .35
 /obj/item/projectile/bullet/pistol
 	name = ".35 caliber bullet"
-	damage_types = list(BRUTE = 25)
+	damage_types = list(BRUTE = 26)
 	armor_penetration = 10
 	can_ricochet = TRUE
 	penetrating = 1
 
 /obj/item/projectile/bullet/pistol/hv
-	damage_types = list(BRUTE = 29)
+	damage_types = list(BRUTE = 30)
 	armor_penetration = 20
 	step_delay = 0.75
 
@@ -41,7 +41,7 @@ There are important things regarding this file:
 	sharp = FALSE
 
 /obj/item/projectile/bullet/pistol/scrap
-	damage_types = list(BRUTE = 22)
+	damage_types = list(BRUTE = 23)
 
 //Carbines and rifles
 
@@ -49,7 +49,7 @@ There are important things regarding this file:
 
 /obj/item/projectile/bullet/srifle
 	name = ".20 caliber bullet"
-	damage_types = list(BRUTE = 20)
+	damage_types = list(BRUTE = 21)
 	armor_penetration = 25
 	penetrating = 1
 	can_ricochet = TRUE
@@ -67,7 +67,7 @@ There are important things regarding this file:
 	can_ricochet = FALSE
 
 /obj/item/projectile/bullet/srifle/hv
-	damage_types = list(BRUTE = 25)
+	damage_types = list(BRUTE = 26)
 	armor_penetration = 30
 	step_delay = 0.75
 
@@ -81,13 +81,13 @@ There are important things regarding this file:
 	sharp = FALSE
 
 /obj/item/projectile/bullet/srifle/scrap
-	damage_types = list(BRUTE = 17)
+	damage_types = list(BRUTE = 18)
 
 // .25 caseless rifle
 
 /obj/item/projectile/bullet/clrifle
 	name = ".25 caliber bullet"
-	damage_types = list(BRUTE = 22)
+	damage_types = list(BRUTE = 23)
 	armor_penetration = 15
 	penetrating = 1
 	sharp = TRUE
@@ -103,7 +103,7 @@ There are important things regarding this file:
 	can_ricochet = FALSE
 
 /obj/item/projectile/bullet/clrifle/hv
-	damage_types = list(BRUTE = 27)
+	damage_types = list(BRUTE = 28)
 	armor_penetration = 20
 	step_delay = 0.75
 	can_ricochet = TRUE
@@ -119,13 +119,13 @@ There are important things regarding this file:
 	can_ricochet = TRUE
 
 /obj/item/projectile/bullet/clrifle/scrap
-	damage_types = list(BRUTE = 19)
+	damage_types = list(BRUTE = 20)
 
 // .30 rifle
 
 /obj/item/projectile/bullet/lrifle
 	name = ".30 caliber bullet"
-	damage_types = list(BRUTE = 23)
+	damage_types = list(BRUTE = 24)
 	armor_penetration = 20
 	penetrating = 1
 	can_ricochet = TRUE
@@ -140,7 +140,7 @@ There are important things regarding this file:
 	can_ricochet = FALSE
 
 /obj/item/projectile/bullet/lrifle/hv
-	damage_types = list(BRUTE = 28)
+	damage_types = list(BRUTE = 29)
 	armor_penetration = 30
 	step_delay = 0.75
 
@@ -154,12 +154,12 @@ There are important things regarding this file:
 	sharp = FALSE
 
 /obj/item/projectile/bullet/lrifle/scrap
-	damage_types = list(BRUTE = 20)
+	damage_types = list(BRUTE = 21)
 
 //Revolvers and high-caliber pistols .40
 /obj/item/projectile/bullet/magnum
 	name = " .40 caliber bullet"
-	damage_types = list(BRUTE = 28)
+	damage_types = list(BRUTE = 31)
 	armor_penetration = 15
 	can_ricochet = TRUE
 	penetrating = 1
@@ -175,7 +175,7 @@ There are important things regarding this file:
 	can_ricochet = FALSE
 
 /obj/item/projectile/bullet/magnum/hv
-	damage_types = list(BRUTE = 33)
+	damage_types = list(BRUTE = 35)
 	armor_penetration = 20
 	step_delay = 0.75
 
@@ -189,12 +189,12 @@ There are important things regarding this file:
 	sharp = FALSE
 
 /obj/item/projectile/bullet/magnum/scrap
-	damage_types = list(BRUTE = 25)
+	damage_types = list(BRUTE = 28)
 
 //Sniper rifles .60
 /obj/item/projectile/bullet/antim
 	name = ".60 caliber bullet"
-	damage_types = list(BRUTE = 70)
+	damage_types = list(BRUTE = 65)
 	armor_penetration = 50
 	penetrating = 1
 	hitscan = TRUE //so the PTR isn't useless as a sniper weapon
@@ -209,7 +209,7 @@ There are important things regarding this file:
 	empulse(target, 0, 0)
 
 /obj/item/projectile/bullet/antim/uranium
-	damage_types = list(BRUTE = 65)
+	damage_types = list(BRUTE = 60)
 	armor_penetration = 100
 	irradiate = 200
 
@@ -247,14 +247,14 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/shotgun
 	name = "slug"
 	icon_state = "slug"
-	damage_types = list(BRUTE = 43)
+	damage_types = list(BRUTE = 48)
 	armor_penetration = 15
 	knockback = 1
 	step_delay = 1.1
 	style_damage = 25
 
 /obj/item/projectile/bullet/shotgun/scrap
-	damage_types = list(BRUTE = 38)
+	damage_types = list(BRUTE = 42)
 
 /obj/item/projectile/bullet/shotgun/beanbag
 	name = "beanbag"
@@ -279,7 +279,7 @@ There are important things regarding this file:
 	knockback = 0
 
 /obj/item/projectile/bullet/shotgun/incendiary
-	damage_types = list(BRUTE = 36)
+	damage_types = list(BRUTE = 38)
 	knockback = 0
 
 	var/fire_stacks = 4

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -12,13 +12,13 @@ There are important things regarding this file:
 //Low-caliber pistols and SMGs .35
 /obj/item/projectile/bullet/pistol
 	name = ".35 caliber bullet"
-	damage_types = list(BRUTE = 28)
+	damage_types = list(BRUTE = 25)
 	armor_penetration = 10
 	can_ricochet = TRUE
 	penetrating = 1
 
 /obj/item/projectile/bullet/pistol/hv
-	damage_types = list(BRUTE = 32)
+	damage_types = list(BRUTE = 29)
 	armor_penetration = 20
 	step_delay = 0.75
 
@@ -41,7 +41,7 @@ There are important things regarding this file:
 	sharp = FALSE
 
 /obj/item/projectile/bullet/pistol/scrap
-	damage_types = list(BRUTE = 25)
+	damage_types = list(BRUTE = 22)
 
 //Carbines and rifles
 
@@ -49,7 +49,7 @@ There are important things regarding this file:
 
 /obj/item/projectile/bullet/srifle
 	name = ".20 caliber bullet"
-	damage_types = list(BRUTE = 25)
+	damage_types = list(BRUTE = 20)
 	armor_penetration = 25
 	penetrating = 1
 	can_ricochet = TRUE
@@ -67,7 +67,7 @@ There are important things regarding this file:
 	can_ricochet = FALSE
 
 /obj/item/projectile/bullet/srifle/hv
-	damage_types = list(BRUTE = 30)
+	damage_types = list(BRUTE = 25)
 	armor_penetration = 30
 	step_delay = 0.75
 
@@ -81,13 +81,13 @@ There are important things regarding this file:
 	sharp = FALSE
 
 /obj/item/projectile/bullet/srifle/scrap
-	damage_types = list(BRUTE = 22)
+	damage_types = list(BRUTE = 17)
 
 // .25 caseless rifle
 
 /obj/item/projectile/bullet/clrifle
 	name = ".25 caliber bullet"
-	damage_types = list(BRUTE = 27)
+	damage_types = list(BRUTE = 22)
 	armor_penetration = 15
 	penetrating = 1
 	sharp = TRUE
@@ -103,7 +103,7 @@ There are important things regarding this file:
 	can_ricochet = FALSE
 
 /obj/item/projectile/bullet/clrifle/hv
-	damage_types = list(BRUTE = 32)
+	damage_types = list(BRUTE = 27)
 	armor_penetration = 20
 	step_delay = 0.75
 	can_ricochet = TRUE
@@ -119,13 +119,13 @@ There are important things regarding this file:
 	can_ricochet = TRUE
 
 /obj/item/projectile/bullet/clrifle/scrap
-	damage_types = list(BRUTE = 24)
+	damage_types = list(BRUTE = 19)
 
 // .30 rifle
 
 /obj/item/projectile/bullet/lrifle
 	name = ".30 caliber bullet"
-	damage_types = list(BRUTE = 28)
+	damage_types = list(BRUTE = 23)
 	armor_penetration = 20
 	penetrating = 1
 	can_ricochet = TRUE
@@ -140,7 +140,7 @@ There are important things regarding this file:
 	can_ricochet = FALSE
 
 /obj/item/projectile/bullet/lrifle/hv
-	damage_types = list(BRUTE = 30)
+	damage_types = list(BRUTE = 28)
 	armor_penetration = 30
 	step_delay = 0.75
 
@@ -154,12 +154,12 @@ There are important things regarding this file:
 	sharp = FALSE
 
 /obj/item/projectile/bullet/lrifle/scrap
-	damage_types = list(BRUTE = 25)
+	damage_types = list(BRUTE = 20)
 
 //Revolvers and high-caliber pistols .40
 /obj/item/projectile/bullet/magnum
 	name = " .40 caliber bullet"
-	damage_types = list(BRUTE = 34)
+	damage_types = list(BRUTE = 28)
 	armor_penetration = 15
 	can_ricochet = TRUE
 	penetrating = 1
@@ -175,7 +175,7 @@ There are important things regarding this file:
 	can_ricochet = FALSE
 
 /obj/item/projectile/bullet/magnum/hv
-	damage_types = list(BRUTE = 39)
+	damage_types = list(BRUTE = 33)
 	armor_penetration = 20
 	step_delay = 0.75
 
@@ -189,7 +189,7 @@ There are important things regarding this file:
 	sharp = FALSE
 
 /obj/item/projectile/bullet/magnum/scrap
-	damage_types = list(BRUTE = 30)
+	damage_types = list(BRUTE = 25)
 
 //Sniper rifles .60
 /obj/item/projectile/bullet/antim
@@ -247,14 +247,14 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/shotgun
 	name = "slug"
 	icon_state = "slug"
-	damage_types = list(BRUTE = 54)
+	damage_types = list(BRUTE = 43)
 	armor_penetration = 15
 	knockback = 1
 	step_delay = 1.1
 	style_damage = 25
 
 /obj/item/projectile/bullet/shotgun/scrap
-	damage_types = list(BRUTE = 48)
+	damage_types = list(BRUTE = 38)
 
 /obj/item/projectile/bullet/shotgun/beanbag
 	name = "beanbag"
@@ -279,7 +279,7 @@ There are important things regarding this file:
 	knockback = 0
 
 /obj/item/projectile/bullet/shotgun/incendiary
-	damage_types = list(BRUTE = 45)
+	damage_types = list(BRUTE = 36)
 	knockback = 0
 
 	var/fire_stacks = 4
@@ -296,7 +296,7 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/pellet/shotgun
 	name = "shrapnel"
 	icon_state = "birdshot-1"
-	damage_types = list(BRUTE = 10)
+	damage_types = list(BRUTE = 8)
 	pellets = 8
 	range_step = 1
 	spread_step = 10

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -297,6 +297,7 @@ There are important things regarding this file:
 	name = "shrapnel"
 	icon_state = "birdshot-1"
 	damage_types = list(BRUTE = 8)
+	armor_penetration = 60
 	pellets = 8
 	range_step = 1
 	spread_step = 10

--- a/code/modules/projectiles/projectile/plasma.dm
+++ b/code/modules/projectiles/projectile/plasma.dm
@@ -5,7 +5,7 @@
 	hitsound_wall = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	armor_penetration = 25
 	check_armour = ARMOR_ENERGY
-	damage_types = list(BURN = 26)
+	damage_types = list(BURN = 27)
 
 	muzzle_type = /obj/effect/projectile/plasma/muzzle
 	impact_type = /obj/effect/projectile/plasma/impact
@@ -13,12 +13,12 @@
 /obj/item/projectile/plasma/light
 	name = "light plasma bolt"
 	armor_penetration = 15
-	damage_types = list(BURN = 22)
+	damage_types = list(BURN = 23)
 
 /obj/item/projectile/plasma/heavy
 	name = "heavy plasma bolt"
 	armor_penetration = 50
-	damage_types = list(BURN = 33)
+	damage_types = list(BURN = 34)
 
 /obj/item/projectile/plasma/stun
 	name = "stun plasma bolt"
@@ -51,7 +51,7 @@
 	name = "ion-plasma bolt"
 	icon_state = "ion"
 	armor_penetration = 0
-	damage_types = list(BURN = 22)
+	damage_types = list(BURN = 23)
 
 	aoe_strong = 1
 	aoe_weak = 1
@@ -63,7 +63,7 @@
 /obj/item/projectile/plasma/aoe/ion/light
 	name = "light ion-plasma bolt"
 	armor_penetration = 0
-	damage_types = list(BURN = 18)
+	damage_types = list(BURN = 19)
 
 	aoe_strong = 0
 	aoe_weak = 1
@@ -75,7 +75,7 @@
 /obj/item/projectile/plasma/aoe/heat
 	name = "high-temperature plasma blast"
 	armor_penetration = 50
-	damage_types = list(BURN = 18)
+	damage_types = list(BURN = 19)
 
 	aoe_strong = 1
 	aoe_weak = 1
@@ -87,7 +87,7 @@
 /obj/item/projectile/plasma/aoe/heat/strong
 	name = "high-temperature plasma blast"
 	armor_penetration = 25
-	damage_types = list(BURN = 26)
+	damage_types = list(BURN = 27)
 
 	aoe_strong = 1
 	aoe_weak = 2

--- a/code/modules/projectiles/projectile/plasma.dm
+++ b/code/modules/projectiles/projectile/plasma.dm
@@ -5,7 +5,7 @@
 	hitsound_wall = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	armor_penetration = 25
 	check_armour = ARMOR_ENERGY
-	damage_types = list(BURN = 33)
+	damage_types = list(BURN = 26)
 
 	muzzle_type = /obj/effect/projectile/plasma/muzzle
 	impact_type = /obj/effect/projectile/plasma/impact
@@ -13,12 +13,12 @@
 /obj/item/projectile/plasma/light
 	name = "light plasma bolt"
 	armor_penetration = 15
-	damage_types = list(BURN = 27)
+	damage_types = list(BURN = 22)
 
 /obj/item/projectile/plasma/heavy
 	name = "heavy plasma bolt"
 	armor_penetration = 50
-	damage_types = list(BURN = 42)
+	damage_types = list(BURN = 33)
 
 /obj/item/projectile/plasma/stun
 	name = "stun plasma bolt"
@@ -51,7 +51,7 @@
 	name = "ion-plasma bolt"
 	icon_state = "ion"
 	armor_penetration = 0
-	damage_types = list(BURN = 27)
+	damage_types = list(BURN = 22)
 
 	aoe_strong = 1
 	aoe_weak = 1
@@ -63,7 +63,7 @@
 /obj/item/projectile/plasma/aoe/ion/light
 	name = "light ion-plasma bolt"
 	armor_penetration = 0
-	damage_types = list(BURN = 20)
+	damage_types = list(BURN = 18)
 
 	aoe_strong = 0
 	aoe_weak = 1
@@ -75,7 +75,7 @@
 /obj/item/projectile/plasma/aoe/heat
 	name = "high-temperature plasma blast"
 	armor_penetration = 50
-	damage_types = list(BURN = 20)
+	damage_types = list(BURN = 18)
 
 	aoe_strong = 1
 	aoe_weak = 1
@@ -87,7 +87,7 @@
 /obj/item/projectile/plasma/aoe/heat/strong
 	name = "high-temperature plasma blast"
 	armor_penetration = 25
-	damage_types = list(BURN = 33)
+	damage_types = list(BURN = 26)
 
 	aoe_strong = 1
 	aoe_weak = 2

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -24,8 +24,9 @@
 /obj/item/projectile/bullet/rocket
 	name = "high explosive rocket"
 	icon_state = "rocket"
-	damage_types = list(BRUTE = 70)
+	damage_types = list(BRUTE = 50)
 	armor_penetration = 100
+	style_damage = 110 //single shot, incredibly powerful. If you get direct hit with this you deserve it, if you dodge the direct shot you're protected from the explosion.
 	check_armour = ARMOR_BULLET
 	penetrating = -5
 

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -26,7 +26,7 @@
 	icon_state = "rocket"
 	damage_types = list(BRUTE = 50)
 	armor_penetration = 100
-	style_damage = 110 //single shot, incredibly powerful. If you get direct hit with this you deserve it, if you dodge the direct shot you're protected from the explosion.
+	style_damage = 101 //single shot, incredibly powerful. If you get direct hit with this you deserve it, if you dodge the direct shot you're protected from the explosion.
 	check_armour = ARMOR_BULLET
 	penetrating = -5
 


### PR DESCRIPTION
## About The Pull Request

Reduces most bullet damages by 20%, with some mercy shown towards .35. Also increases style damage on lasers and the RPG.

## Why It's Good For The Game

Let me first start off by blaming all of this on humon, they came to my house and threatened to release my ERP logs if I didn't comply.

Jokes aside, I've been asked to do this in the past by several people. Bullet damage is believed to be a little too high, and while bullets are still going to be substantially powerful, this should lower TTK a bit, making fire hit advantage a bit less deadly and making lighter armors less dangerous. This also applies to plasma projectiles but not lasers, as in general most people consider them to be underperforming and they have less damage and no AP on average.

As for the style damage thing, I think lasers were forgotten since I'm the only one who cares about lasers. Also the RPG was definitely forgotten because there's no way you should be directly dodging it.

Buffs buckshot specifically to have 60 AP. I know this sounds bad, but it already suffers due to GDR. On 60% armor with this change, buckshot will be reduced to dealing 16 damage to people right next to you, while at 30% it'll deal 40 damage. It's not going to be unbalanced.

I removed the damage mod on AMR but I also nerfed its bullets a bit. It adds up to the same stats, with 1-2 extra points of damage.

## Changelog
:cl:
balance: Reduces the damage on ballistic and plasma projectiles. On average it's a 20% reduction, with some tweaks up or down.
balance: Increased style damage on RPG rockets and lasers.
balance: gives buckshot AP to help it deal with the Eris armor system.
balance: removes -0.1 damage mod on AMR. It's ammo was nerfed so it's about the same.
/:cl: