### PR TITLE
removes redundant code in the gyroscopic stabilizer

### DIFF
--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -353,10 +353,6 @@
 		)
 	I.gun_loc_tag = GUN_GRIP
 	I.req_gun_tags = list(GUN_PROJECTILE, GUN_GRIP)
-
-/obj/item/tool_upgrade/refinement/stabilized_grip/New()
-	..()
-	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.tool_upgrades = list(
 	UPGRADE_PRECISION = 10,
 	UPGRADE_HEALTH_THRESHOLD = 10)

--- a/tools/hooks/Install.bat
+++ b/tools/hooks/Install.bat
@@ -1,2 +1,0 @@
-@call "%~dp0\..\bootstrap\python" -m hooks.install %*
-@pause


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
the gyroscopic stabilizer can now be used as a toolmod and gunmod again.

## Why It's Good For The Game

fixes good.

## Changelog
:cl:
fix: the gyroscopic stabilizer can now be used as a toolmod and gunmod again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
