### PR TITLE
Diving patch

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -197,7 +197,13 @@
 		//cap projectile damage so that there's still a minimum number of hits required to break the door
 			take_damage(min(damage, 100))
 
-
+/obj/machinery/door/proc/hit_by_living(var/mob/living/M)
+	var/body_part = pick(BP_HEAD, BP_CHEST, BP_GROIN)
+	visible_message(SPAN_DANGER("[M] slams against \the [src]!"))
+	if(prob(30))
+		M.Weaken(1)
+	M.damage_through_armor(8, BRUTE, body_part, ARMOR_MELEE)
+	take_damage(M.mob_size)
 
 /obj/machinery/door/hitby(AM as mob|obj, var/speed=5)
 
@@ -207,8 +213,8 @@
 		var/obj/item/O = AM
 		damage = O.throwforce
 	else if (istype(AM, /mob/living))
-		var/mob/living/M = AM
-		damage = M.mob_size
+		hit_by_living(AM)
+		return
 	take_damage(damage)
 	return
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -193,6 +193,11 @@
 
 /obj/structure/window/hitby(AM as mob|obj)
 	..()
+
+	if(isliving(AM))
+		hit_by_living(AM)
+		return
+
 	visible_message(SPAN_DANGER("[src] was hit by [AM]."))
 	var/tforce = 0
 	if(ismob(AM))
@@ -278,6 +283,20 @@
 	sleep(5) //Allow a littleanimating time
 	return TRUE
 
+/obj/structure/window/proc/hit_by_living(var/mob/living/M)
+	var/body_part = pick(BP_HEAD, BP_CHEST, BP_GROIN)
+	visible_message(SPAN_DANGER("[M] slams against \the [src]!"))
+	if(prob(30))
+		M.Weaken(1)
+	M.damage_through_armor(8, BRUTE, body_part, ARMOR_MELEE)
+
+	var/tforce = 15
+	if(reinf) tforce *= 0.25
+	if(health - tforce <= 7 && !reinf)
+		set_anchored(FALSE)
+		step(src, get_dir(M, src))
+	hit(tforce)
+	mount_check()
 
 /obj/structure/window/attackby(obj/item/I, mob/user)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -618,7 +618,7 @@ default behaviour is:
 
 	if(resting && unstack)
 		unstack = FALSE
-		if((livmomentum <= 0) && do_after(src, (src.stats.getPerk(PERK_PARKOUR) ? 0.3 SECONDS : 0.7 SECONDS), null, 0, 1, INCAPACITATION_DEFAULT, immobile = 0))
+		if((livmomentum <= 0) && do_after(src, (src.stats.getPerk(PERK_PARKOUR) ? 0.4 SECONDS : 1 SECOND), null, 0, 1, INCAPACITATION_DEFAULT, immobile = 0))
 			resting = FALSE
 			unstack = TRUE
 			to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"].</span>")
@@ -639,7 +639,7 @@ default behaviour is:
 			var/is_jump = FALSE
 			if(istype(get_step(H, dir), /turf/simulated/open))
 				is_jump = TRUE
-			H.throw_at(get_edge_target_turf(H, dir), 2 + is_jump, 1)// "Diving"; if you dive over a table, your momentum is set to 0. If you dive over space, you are thrown a tile further.
+			H.throw_at(get_edge_target_turf(H, dir), 1 + is_jump, 1)// "Diving"; if you dive over a table, your momentum is set to 0. If you dive over space, you are thrown a tile further.
 			update_lying_buckled_and_verb_status()
 			pass_flags -= PASSTABLE // Jumpn't over them anymore!
 			H.allow_spin = TRUE
@@ -663,7 +663,7 @@ default behaviour is:
 mob/living/carbon/human/verb/stopSliding()
 	set hidden = 1
 	set instant = 1
-	src.livmomentum = 0
+	livmomentum = 0
 
 /mob/living/proc/cannot_use_vents()
 	return "You can't fit into that vent."


### PR DESCRIPTION
## About The Pull Request

Reduces diving range, increased standup length, adds injury to diving into windows.

## Why It's Good For The Game

No more prisoners breaking out with their heads (uninjured), sliding is no longer superior to running (exception: parkour perk).

## Changelog
:cl:
balance: diving range decreased
balance: Titanfall removed
balance: diving into windows and doors takes longer to break them, damages the jumper
/:cl:
