### PR TITLE
Armor buff

### DIFF
--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -518,7 +518,7 @@
 		melee = 50,
 		bullet = 50,
 		energy = 50,
-		bomb = 20,
+		bomb = 25,
 		bio = 0,
 		rad = 0
 	)

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -26,9 +26,9 @@
 	desc = "Standard Security gear. Protects the head from impacts."
 	icon_state = "helmet"
 	armor = list(
-		melee = 35,
-		bullet = 30,
-		energy = 30,
+		melee = 30,
+		bullet = 40,
+		energy = 40,
 		bomb = 20,
 		bio = 0,
 		rad = 0
@@ -49,7 +49,7 @@
 	)
 
 /obj/item/clothing/head/armor/helmet/merchelm
-	name = "Heavy Armour Helmet"
+	name = "Mercenary Armour Helmet"
 	desc = "A high-quality helmet in a fetching tan. Very durable"
 	icon_state = "merchelm"
 	body_parts_covered = HEAD | EARS | EYES | FACE
@@ -90,7 +90,7 @@
 	brightness_on = 4
 	armor = list(
 		melee = 35,
-		bullet = 25,
+		bullet = 30,
 		energy = 40,
 		bomb = 20,
 		bio = 0,
@@ -115,8 +115,8 @@
 	brightness_on = 4
 	armor = list(
 		melee = 35,
-		bullet = 40,
-		energy = 20,
+		bullet = 50,
+		energy = 30,
 		bomb = 40,
 		bio = 0,
 		rad = 0
@@ -130,10 +130,10 @@
 	desc = "It looks like it was made from a bucket and some steel. Uncomfortable and heavy but better than nothing."
 	icon_state = "helmet_handmade"
 	armor = list(
-		melee = 35,
-		bullet = 25,
-		energy = 20,
-		bomb = 10,
+		melee = 30,
+		bullet = 30,
+		energy = 30,
+		bomb = 20,
 		bio = 0,
 		rad = 0
 	)
@@ -154,9 +154,9 @@
 	body_parts_covered = HEAD | EARS | EYES | FACE
 	armor = list(
 		melee = 30,
-		bullet = 55,
-		energy = 25,
-		bomb = 25,
+		bullet = 60,
+		energy = 30,
+		bomb = 20,
 		bio = 0,
 		rad = 0
 	)
@@ -249,14 +249,6 @@
 	name = "full ballistic helmet"
 	desc = "Standard-issue Ironhammer ballistic helmet with a basic HUD included, covers the operator's entire face."
 	icon_state = "ironhammer_full"
-	armor = list(
-		melee = 30,
-		bullet = 60,
-		energy = 25,
-		bomb = 25,
-		bio = 0,
-		rad = 0
-	)
 	item_flags = THICKMATERIAL | COVER_PREVENT_MANIPULATION
 	price_tag = 500
 	matter = list(
@@ -273,8 +265,8 @@
 	flags_inv = HIDEEARS | HIDEEYES
 	armor = list(
 		melee = 30,
-		bullet = 25,
-		energy = 75,
+		bullet = 30,
+		energy = 65,
 		bomb = 0,
 		bio = 0,
 		rad = 0
@@ -383,7 +375,7 @@
 
 	body_parts_covered = HEAD|FACE|EARS
 	armor = list(
-		melee = 50,
+		melee = 65,
 		bullet = 50,
 		energy = 40,
 		bomb = 35,
@@ -456,7 +448,7 @@
 	name = "steelpot helmet"
 	desc = "A titanium helmet of serbian origin. Still widely used despite being discontinued."
 	icon_state = "steelpot"
-	armor = list(melee = 40, bullet = 35, energy = 0, bomb = 30, bio = 0, rad = 0) // slightly buffed IHS helmet minus energy resistance
+	armor = list(melee = 40, bullet = 40, energy = 30, bomb = 30, bio = 0, rad = 0) // slightly buffed IHS helmet minus energy resistance
 	flags_inv = BLOCKHEADHAIR
 	body_parts_covered = HEAD|EARS
 	siemens_coefficient = 1
@@ -465,8 +457,8 @@
 	name = "altyn helmet"
 	desc = "A titanium helmet of serbian origin. Still widely used despite being discontinued."
 	icon_state = "altyn"
-	armor_up = list(melee = 20, bullet = 15, energy = 0, bomb = 15, bio = 0, rad = 0)
-	armor_down = list(melee = 40, bullet = 40, energy = 0, bomb = 35, bio = 0, rad = 0)
+	armor_up = list(melee = 20, bullet = 20, energy = 10, bomb = 15, bio = 0, rad = 0)
+	armor_down = list(melee = 40, bullet = 50, energy = 30, bomb = 35, bio = 0, rad = 0)
 	siemens_coefficient = 1
 	up = TRUE
 
@@ -480,7 +472,7 @@
 	name = "maska helmet"
 	desc = "\"I do not know who I am, I don\'t know why I\'m here. All I know is that I must kill.\""
 	icon_state = "maska"
-	armor_down = list(melee = 55, bullet = 55, energy = 0, bomb = 45, bio = 0, rad = 0) // best what you can get, unless you face lasers
+	armor_down = list(melee = 55, bullet = 60, energy = 30, bomb = 45, bio = 0, rad = 0) // superior ballistic protection, mediocre laser protection.
 
 /obj/item/clothing/head/armor/faceshield/altyn/maska/tripoloski
 	name = "striped maska helmet"
@@ -508,8 +500,8 @@
 	desc = "Armored helmet used by certain law enforcement agencies. It's hard to believe there's a human somewhere behind that."
 	armor = list(
 		melee = 30,
-		bullet = 30,
-		energy = 30,
+		bullet = 40,
+		energy = 40,
 		bomb = 20,
 		bio = 0,
 		rad = 0
@@ -523,10 +515,10 @@
 	flags_inv = HIDEEARS|HIDEEYES|BLOCKHAIR
 	matter = list(MATERIAL_BIOMATTER = 15, MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 5, MATERIAL_GOLD = 1)
 	armor = list(
-		melee = 70,
+		melee = 50,
 		bullet = 50,
 		energy = 50,
-		bomb = 30,
+		bomb = 20,
 		bio = 0,
 		rad = 0
 	)
@@ -577,18 +569,18 @@
 		MATERIAL_PLATINUM = 2
 		)
 	armor_up = list(
-		melee = 25,
-		bullet = 25,
+		melee = 20,
+		bullet = 20,
 		energy = 20,
 		bomb = 10,
 		bio = 100,
 		rad = 50
 		)
 	armor_down = list(
-		melee = 35,
-		bullet = 35,
+		melee = 30,
+		bullet = 30,
 		energy = 30,
-		bomb = 15,
+		bomb = 10,
 		bio = 100,
 		rad = 50)
 	up = TRUE

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -578,9 +578,9 @@
 		)
 	armor_down = list(
 		melee = 30,
-		bullet = 30,
-		energy = 30,
-		bomb = 10,
+		bullet = 40,
+		energy = 40,
+		bomb = 20,
 		bio = 100,
 		rad = 50)
 	up = TRUE

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -67,7 +67,7 @@
 	armor = list(
 		melee = 50,
 		bullet = 40,
-		energy = 340,
+		energy = 40,
 		bomb = 90,
 		bio = 100,
 		rad = 100

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -8,9 +8,9 @@
 	icon_state = "security_rig"
 	suit_type = "combat hardsuit"
 	armor = list(
-		melee = 45,
-		bullet = 45,
-		energy = 45,
+		melee = 50,
+		bullet = 50,
+		energy = 50,
 		bomb = 50,
 		bio = 100,
 		rad = 50
@@ -65,9 +65,9 @@
 	desc = "A Security hardsuit designed for prolonged EVA in dangerous environments."
 	icon_state = "hazard_rig"
 	armor = list(
-		melee = 35,
-		bullet = 35,
-		energy = 35,
+		melee = 50,
+		bullet = 40,
+		energy = 340,
 		bomb = 90,
 		bio = 100,
 		rad = 100

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -10,8 +10,8 @@
 	suit_type = "crimson hardsuit"
 	armor = list(
 		melee = 50,
-		bullet = 45,
-		energy = 30,
+		bullet = 60,
+		energy = 40,
 		bomb = 75,
 		bio = 100,
 		rad = 50

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -32,8 +32,8 @@
 	icon_state = "engineering_rig"
 	armor = list(
 		melee = 50,
-		bullet = 40,
-		energy = 10,
+		bullet = 50,
+		energy = 20,
 		bomb = 25,
 		bio = 100,
 		rad = 90
@@ -312,4 +312,3 @@ Technomancer RIG
 		/obj/item/rig_module/device/healthscanner,
 		/obj/item/rig_module/vision/medhud
 		)
- 

--- a/code/modules/clothing/spacesuits/void/anomaly_suit.dm
+++ b/code/modules/clothing/spacesuits/void/anomaly_suit.dm
@@ -8,7 +8,7 @@
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	armor = list(
 		melee = 30,
-		bullet = 25,
+		bullet = 30,
 		energy = 40,
 		bomb = 50,
 		bio = 100,
@@ -26,7 +26,7 @@
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	armor = list(
 		melee = 30,
-		bullet = 25,
+		bullet = 30,
 		energy = 40,
 		bomb = 50,
 		bio = 100,

--- a/code/modules/clothing/spacesuits/void/excelsior.dm
+++ b/code/modules/clothing/spacesuits/void/excelsior.dm
@@ -13,9 +13,9 @@
 	)
 
 	armor = list(
-		melee = 35,
+		melee = 40,
 		bullet = 40,
-		energy = 30,
+		energy = 50,
 		bomb = 25,
 		bio = 100,
 		rad = 75
@@ -74,9 +74,9 @@
 	slowdown = 0.2
 	w_class = ITEM_SIZE_NORMAL
 	armor = list(
-		melee = 35,
+		melee = 40,
 		bullet = 40,
-		energy = 30,
+		energy = 50,
 		bomb = 25,
 		bio = 100,
 		rad = 75

--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -50,8 +50,8 @@
 	item_state = "syndiehelm"
 	armor = list(
 		melee = 50,
-		bullet = 40,
-		energy = 40,
+		bullet = 50,
+		energy = 50,
 		bomb = 50,
 		bio = 100,
 		rad = 75
@@ -77,8 +77,8 @@
 	item_state = "syndie_voidsuit"
 	armor = list(
 		melee = 50,
-		bullet = 40,
-		energy = 40,
+		bullet = 50,
+		energy = 50,
 		bomb = 50,
 		bio = 100,
 		rad = 75

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -135,7 +135,7 @@
 		)
 	armor = list(
 		melee = 50,
-		bullet = 35,
+		bullet = 30,
 		energy = 30,
 		bomb = 25,
 		bio = 100,
@@ -150,7 +150,7 @@
 	icon_state = "miner_suit"
 	armor = list(
 		melee = 50,
-		bullet = 35,
+		bullet = 30,
 		energy = 30,
 		bomb = 25,
 		bio = 100,
@@ -172,7 +172,7 @@
 	armor = list(
 		melee = 30,
 		bullet = 10,
-		energy = 35,
+		energy = 40,
 		bomb = 25,
 		bio = 100,
 		rad = 75
@@ -218,8 +218,8 @@
 
 	armor = list(
 		melee = 35,
-		bullet = 45,
-		energy = 35,
+		bullet = 40,
+		energy = 40,
 		bomb = 25,
 		bio = 100,
 		rad = 75
@@ -235,8 +235,8 @@
 	item_state = "ihvoidsuit"
 	armor = list(
 		melee = 35,
-		bullet = 45,
-		energy = 35,
+		bullet = 40,
+		energy = 40,
 		bomb = 25,
 		bio = 100,
 		rad = 75
@@ -306,8 +306,8 @@
 	price_tag = 200
 	armor = list(
 		melee = 40,
-		bullet = 40,
-		energy = 55,
+		bullet = 50,
+		energy = 60,
 		bomb = 40,
 		bio = 100,
 		rad = 75
@@ -358,8 +358,8 @@
 	)
 	armor = list(
 		melee = 40,
-		bullet = 40,
-		energy = 55,
+		bullet = 50,
+		energy = 60,
 		bomb = 40, //platinum price justifies bloated stats
 		bio = 100,
 		rad = 75
@@ -400,7 +400,7 @@
 
 	armor = list(
 		melee = 20,
-		bullet = 15,
+		bullet = 20,
 		energy = 20,
 		bomb = 25,
 		bio = 100,
@@ -416,7 +416,7 @@
 	item_state = "makeshift_void"
 	siemens_coefficient = 0.4
 	armor = list(
-		melee = 10,
+		melee = 20,
 		bullet = 20,
 		energy = 20,
 		bomb = 25,
@@ -438,8 +438,8 @@
 	flags_inv = BLOCKHAIR
 	armor = list(
 		melee = 40,
-		bullet = 30,
-		energy = 30,
+		bullet = 40,
+		energy = 40,
 		bomb = 30,
 		bio = 100,
 		rad = 50
@@ -458,8 +458,8 @@
 	flags_inv = HIDEGLOVES|HIDEJUMPSUIT|HIDETAIL
 	armor = list(
 	    melee = 40,
-		bullet = 30,
-		energy = 30,
+		bullet = 40,
+		energy = 40,
 		bomb = 30,
 		bio = 100,
 		rad = 50

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -135,7 +135,7 @@
 		)
 	armor = list(
 		melee = 50,
-		bullet = 30,
+		bullet = 40,
 		energy = 30,
 		bomb = 25,
 		bio = 100,
@@ -150,7 +150,7 @@
 	icon_state = "miner_suit"
 	armor = list(
 		melee = 50,
-		bullet = 30,
+		bullet = 40,
 		energy = 30,
 		bomb = 25,
 		bio = 100,
@@ -218,7 +218,7 @@
 
 	armor = list(
 		melee = 35,
-		bullet = 40,
+		bullet = 50,
 		energy = 40,
 		bomb = 25,
 		bio = 100,
@@ -235,7 +235,7 @@
 	item_state = "ihvoidsuit"
 	armor = list(
 		melee = 35,
-		bullet = 40,
+		bullet = 50,
 		energy = 40,
 		bomb = 25,
 		bio = 100,
@@ -399,9 +399,9 @@
 	slowdown = 2
 
 	armor = list(
-		melee = 20,
-		bullet = 20,
-		energy = 20,
+		melee = 30,
+		bullet = 30,
+		energy = 30,
 		bomb = 25,
 		bio = 100,
 		rad = 0
@@ -416,9 +416,9 @@
 	item_state = "makeshift_void"
 	siemens_coefficient = 0.4
 	armor = list(
-		melee = 20,
-		bullet = 20,
-		energy = 20,
+		melee = 30,
+		bullet = 30,
+		energy = 30,
 		bomb = 25,
 		bio = 100,
 		rad = 0

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -603,9 +603,9 @@
 		)
 	armor = list(
 		melee = 30,
-		bullet = 30,
-		energy = 30,
-		bomb = 10,
+		bullet = 40,
+		energy = 40,
+		bomb = 20,
 		bio = 100,
 		rad = 50
 	)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -161,7 +161,7 @@
 	item_state = "armor"
 	blood_overlay_type = "armor"
 	armor = list(
-		melee = 40,
+		melee = 30,
 		bullet = 50,
 		energy = 30,
 		bomb = 30,
@@ -241,8 +241,8 @@
 	armor = list(
 		melee = 40,
 		bullet = 50,
-		energy = 30,
-		bomb = 30,
+		energy = 40,
+		bomb = 20,
 		bio = 0,
 		rad = 0
 	)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -29,9 +29,9 @@
 	blood_overlay_type = "armor"
 	armor = list(
 		melee = 30,
-		bullet = 30,
-		energy = 30,
-		bomb = 10,
+		bullet = 40,
+		energy = 40,
+		bomb = 20,
 		bio = 0,
 		rad = 0
 	)
@@ -92,9 +92,9 @@
 	icon_state = "armor_handmade"
 	armor = list(
 		melee = 30,
-		bullet = 25,
-		energy = 15,
-		bomb = 10,
+		bullet = 30,
+		energy = 30,
+		bomb = 20,
 		bio = 0,
 		rad = 0
 	)
@@ -126,9 +126,9 @@
 	style_coverage = COVERS_TORSO|COVERS_UPPER_ARMS|COVERS_UPPER_LEGS
 	armor = list(
 		melee = 30,
-		bullet = 35,
-		energy = 30,
-		bomb = 15,
+		bullet = 40,
+		energy = 40,
+		bomb = 20,
 		bio = 0,
 		rad = 0
 	)
@@ -161,10 +161,10 @@
 	item_state = "armor"
 	blood_overlay_type = "armor"
 	armor = list(
-		melee = 35,
-		bullet = 35,
-		energy = 0,
-		bomb = 20,
+		melee = 40,
+		bullet = 50,
+		energy = 30,
+		bomb = 30,
 		bio = 0,
 		rad = 0
 	)
@@ -195,9 +195,9 @@
 	slowdown = 0.15
 	armor = list(
 		melee = 25,
-		bullet = 55,
-		energy = 25,
-		bomb = 10,
+		bullet = 60,
+		energy = 30,
+		bomb = 20,
 		bio = 0,
 		rad = 0
 	)
@@ -226,14 +226,6 @@
 			This one has been done in Ironhammer Security colors."
 	icon_state = "bulletproof_ironhammer"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	armor = list(
-		melee = 25,
-		bullet = 60,
-		energy = 25,
-		bomb = 10,
-		bio = 0,
-		rad = 0
-	)
 	matter = list(
 		MATERIAL_STEEL = 15, // fullbody suit, so it costs a lot of steel compared to the non-ih one
 		MATERIAL_PLASTEEL = 3,
@@ -247,10 +239,10 @@
 	item_state = "armor"
 	blood_overlay_type = "armor"
 	armor = list(
-		melee = 25,
+		melee = 40,
 		bullet = 50,
-		energy = 0,
-		bomb = 0,
+		energy = 30,
+		bomb = 30,
 		bio = 0,
 		rad = 0
 	)
@@ -297,10 +289,10 @@
 	style_coverage = COVERS_TORSO|COVERS_UPPER_ARMS|COVERS_UPPER_LEGS
 	blood_overlay_type = "armor"
 	armor = list(
-		melee = 25,
-		bullet = 25,
-		energy = 75,
-		bomb = 0,
+		melee = 20,
+		bullet = 30,
+		energy = 65,
+		bomb = 10,
 		bio = 0,
 		rad = 0
 	)
@@ -314,7 +306,7 @@
 	slowdown = LIGHT_SLOWDOWN
 	stiffness = LIGHT_STIFFNESS
 	//spawn_blacklisted = TRUE//antag_item_targets-crafteable?
-
+/*
 /obj/item/clothing/suit/armor/laserproof/handle_shield(mob/user, damage, atom/damage_source = null, mob/attacker = null, def_zone = null, attack_text = "the attack") //TODO: Refactor this all into humandefense
 	if(istype(damage_source, /obj/item/projectile/energy) || istype(damage_source, /obj/item/projectile/beam))
 		var/obj/item/projectile/P = damage_source
@@ -334,7 +326,7 @@
 			P.redirect(new_x, new_y, curloc, user)
 
 			return PROJECTILE_CONTINUE // complete projectile permutation
-
+*/
 /obj/item/clothing/suit/storage/greatcoat/german_overcoat
 	name = "Oberth Republic uniform overcoat"
 	desc = "A black overcoat made out of special materials that will protect against energy projectiles. Probably surplus."
@@ -343,8 +335,8 @@
 	armor = list(
 		melee = 30,
 		bullet = 30,
-		energy = 45,
-		bomb = 15,
+		energy = 50,
+		bomb = 20,
 		bio = 0,
 		rad = 0
 	)
@@ -368,8 +360,8 @@
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	armor = list(
-		melee = 45, //massive slowdown justifies
-		bullet = 45,
+		melee = 65, //massive slowdown justifies
+		bullet = 50,
 		energy = 40,
 		bomb = 30,
 		bio = 0,
@@ -441,9 +433,9 @@
 	price_tag = 250 //Normal vest is worth 200, this one is worth 250 because it also has storage space
 	armor = list( //Same stats as the standard vest only difference is that this one has storage
 		melee = 30,
-		bullet = 30,
-		energy = 30,
-		bomb = 10,
+		bullet = 40,
+		energy = 40,
+		bomb = 20,
 		bio = 0,
 		rad = 0
 	)
@@ -476,7 +468,7 @@
 
 //Provides the protection of a merc voidsuit, but only covers the chest/groin, and also takes up a suit slot. In exchange it has no slowdown and provides storage.
 /obj/item/clothing/suit/storage/vest/merc
-	name = "heavy armor vest"
+	name = "mercenary armor vest"
 	desc = "A high-quality armor vest in a fetching tan. It is surprisingly flexible and light, even with the added webbing and armor plating."
 	icon_state = "mercwebvest"
 	item_state = "mercwebvest"
@@ -506,7 +498,7 @@
 	blood_overlay_type = "armor"
 	armor = list(
 		melee = 35,
-		bullet = 25,
+		bullet = 30,
 		energy = 40,
 		bomb = 20,
 		bio = 0,
@@ -585,7 +577,7 @@
 		melee = 50,
 		bullet = 50,
 		energy = 50,
-		bomb = 25,
+		bomb = 20,
 		bio = 0,
 		rad = 0
 	)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -577,7 +577,7 @@
 		melee = 50,
 		bullet = 50,
 		energy = 50,
-		bomb = 20,
+		bomb = 25,
 		bio = 0,
 		rad = 0
 	)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -335,7 +335,7 @@
 	armor = list(
 		melee = 30,
 		bullet = 30,
-		energy = 50,
+		energy = 40,
 		bomb = 20,
 		bio = 0,
 		rad = 0

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -40,7 +40,7 @@
 //Guild Technician
 /obj/item/clothing/suit/storage/cargo_jacket
 	name = "guild technician jacket"
-	desc = "Stylish jacket lined with pockets. It seems have a little protection from physical harm."
+	desc = "Stylish jacket lined with pockets. It seems to have a little protection from physical harm."
 	icon_state = "cargo_jacket"
 	item_state = "cargo_jacket"
 	blood_overlay_type = "coat"
@@ -64,7 +64,7 @@
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	armor = list(
-		melee = 30,
+		melee = 20,
 		bullet = 20,
 		energy = 20,
 		bomb = 0,
@@ -114,7 +114,7 @@
 	style_coverage = COVERS_TORSO|COVERS_UPPER_ARMS|COVERS_UPPER_LEGS
 	spawn_blacklisted = TRUE
 	armor = list(
-		melee = 25,
+		melee = 20,
 		bullet = 20,
 		energy = 20,
 		bomb = 0,
@@ -127,7 +127,7 @@
 //Chaplain
 /obj/item/clothing/suit/storage/neotheology_jacket
 	name = "acolyte jacket"
-	desc = "A long, lightly armoured jacket. Dark, stylish, and authoritarian."
+	desc = "A long jacket. Dark, stylish, and authoritarian."
 	icon_state = "chaplain_hoodie"
 	item_state = "chaplain_hoodie"
 	blood_overlay_type = "coat"
@@ -136,8 +136,8 @@
 	spawn_blacklisted = TRUE
 	armor = list(
 		melee = 20,
-		bullet = 15,
-		energy = 15,
+		bullet = 10,
+		energy = 10,
 		bomb = 0,
 		bio = 50,  //same as labcoats at LEAST
 		rad = 0
@@ -153,7 +153,7 @@
 	spawn_blacklisted = TRUE
 	matter = list(MATERIAL_BIOMATTER = 20, MATERIAL_GOLD = 5)
 	armor = list(
-		melee = 30,
+		melee = 20,
 		bullet = 20,
 		energy = 20,
 		bomb = 0,
@@ -170,9 +170,9 @@
 	style_coverage = COVERS_CHEST|COVERS_UPPER_ARMS
 	spawn_blacklisted = TRUE
 	armor = list(
-		melee = 25,
+		melee = 10,
 		bullet = 10,
-		energy = 20,
+		energy = 10,
 		bomb = 0,
 		bio = 0,
 		rad = 0
@@ -270,7 +270,7 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	spawn_blacklisted = TRUE
 	armor = list(
-		melee = 25,
+		melee = 30,
 		bullet = 20,
 		energy = 20,
 		bomb = 0,
@@ -290,8 +290,8 @@
 	price_tag = 50
 	armor = list(
 		melee = 10,
-		bullet = 0,
-		energy = 0,
+		bullet = 10,
+		energy = 10,
 		bomb = 0,
 		bio = 0,
 		rad = 0

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -8,9 +8,9 @@
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|ARMS
 	armor = list(
-		melee = 0,
-		bullet = 0,
-		bomb = 0,
+		melee = 10,
+		bullet = 10,
+		energy = 10,
 		bio = 50,
 		bomb = 0,
 		bio = 0,
@@ -39,8 +39,9 @@
 	icon_open = "labcoat_vir_open"
 	icon_closed = "labcoat_vir"
 	armor = list(
-		melee = 0,
-		bullet = 0,
+		melee = 10,
+		bullet = 10,
+		energy = 10,
 		bomb = 0,
 		bio = 75,
 		bomb = 0,

--- a/code/modules/clothing/suits/neotheology.dm
+++ b/code/modules/clothing/suits/neotheology.dm
@@ -8,7 +8,7 @@
 	light_overlay = "helmet_light"
 	brightness_on = 4
 	armor = list(
-		melee = 35,
+		melee = 30,
 		bullet = 30,
 		energy = 30,
 		bomb = 25,
@@ -25,7 +25,7 @@
 	matter = list(MATERIAL_PLASTIC = 30, MATERIAL_STEEL = 25, MATERIAL_BIOMATTER = 40)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	armor = list(
-		melee = 35,
+		melee = 30,
 		bullet = 30,
 		energy = 30,
 		bomb = 25,
@@ -45,10 +45,10 @@
 	light_overlay = "helmet_light"
 	brightness_on = 4
 	armor = list(
-		melee = 25,
-		bullet = 25,
-		energy = 25,
-		bomb = 25,
+		melee = 20,
+		bullet = 20,
+		energy = 20,
+		bomb = 10,
 		bio = 100,
 		rad = 75
 	)
@@ -63,10 +63,10 @@
 	matter = list(MATERIAL_PLASTIC = 30, MATERIAL_STEEL = 15, MATERIAL_BIOMATTER = 40)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	armor = list(
-		melee = 25,
-		bullet = 25,
-		energy = 25,
-		bomb = 25,
+		melee = 20,
+		bullet = 20,
+		energy = 20,
+		bomb = 10,
 		bio = 100,
 		rad = 75
 	)
@@ -82,10 +82,10 @@
 	light_overlay = "helmet_light"
 	brightness_on = 4
 	armor = list(
-		melee = 25,
-		bullet = 25,
-		energy = 25,
-		bomb = 25,
+		melee = 30,
+		bullet = 20,
+		energy = 20,
+		bomb = 10,
 		bio = 200,
 		rad = 90
 	)
@@ -100,10 +100,10 @@
 	matter = list(MATERIAL_PLASTIC = 40, MATERIAL_STEEL = 15, MATERIAL_BIOMATTER = 40)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	armor = list(
-		melee = 25,
-		bullet = 25,
-		energy = 25,
-		bomb = 25,
+		melee = 30,
+		bullet = 20,
+		energy = 20,
+		bomb = 20,
 		bio = 200,
 		rad = 90
 	)

--- a/code/modules/clothing/suits/neotheology.dm
+++ b/code/modules/clothing/suits/neotheology.dm
@@ -8,7 +8,7 @@
 	light_overlay = "helmet_light"
 	brightness_on = 4
 	armor = list(
-		melee = 30,
+		melee = 40,
 		bullet = 30,
 		energy = 30,
 		bomb = 25,
@@ -25,7 +25,7 @@
 	matter = list(MATERIAL_PLASTIC = 30, MATERIAL_STEEL = 25, MATERIAL_BIOMATTER = 40)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	armor = list(
-		melee = 30,
+		melee = 40,
 		bullet = 30,
 		energy = 30,
 		bomb = 25,

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -62,7 +62,7 @@
 	name = "heavy laser"
 	icon_state = "heavylaser"
 	damage_types = list(BURN = 50)
-	armor_penetration = 30
+	armor_penetration = 20
 
 	muzzle_type = /obj/effect/projectile/laser_heavy/muzzle
 	tracer_type = /obj/effect/projectile/laser_heavy/tracer

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -5,6 +5,7 @@
 	hitsound_wall = 'sound/weapons/guns/misc/laser_searwall.ogg'
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 	damage_types = list(BURN = 30)
+	armor_penetration = 10
 	check_armour = ARMOR_ENERGY
 	eyeblur = 4
 	var/frequency = 1
@@ -33,7 +34,7 @@
 	name = "cutting beam"
 	icon_state = "plasmablaster"
 	damage_types = list(BRUTE = 25)
-	armor_penetration = 10
+	armor_penetration = 20
 	pass_flags = PASSTABLE
 
 	muzzle_type = /obj/effect/projectile/laser/plasmacutter/muzzle
@@ -55,13 +56,13 @@
 	eyeblur = 2
 
 /obj/item/projectile/beam/midlaser
-	armor_penetration = 10
+	armor_penetration = 20
 
 /obj/item/projectile/beam/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"
 	damage_types = list(BURN = 50)
-	armor_penetration = 20
+	armor_penetration = 30
 
 	muzzle_type = /obj/effect/projectile/laser_heavy/muzzle
 	tracer_type = /obj/effect/projectile/laser_heavy/tracer


### PR DESCRIPTION
## About The Pull Request

Rebalances armor, primarily buffing low to mid tier armors, and buffs laser beam AP.

## Why It's Good For The Game

Hopefully makes armor a little more meaningful. I've personally found that anything less that 40% did very little to help me survive. I believe this will make armor tiers that aren't BP more effective. I also standardized the stats a bit because I suspect I have OCD and the numbers were triggering me, so helmets will line up with their vests.

In case anyone is worried, bulletproof armor did not get any stronger against ballistics, 60% is still the highest you'll see on ship. I strengthed some of the lesser specialist armors without making them completely useless against their weakness (looking at you flak armor), so with energy weapons hopefully becoming more prominent, we shouldn't see too many issues in that department.

Also I disabled ablative's deflection cause it was wack.

I have laser bias. That is all. Jokes aside, lasers would be hit too hard with these changes if I didn't give them AP. Plasma have enough to stand on their own so they weren't boosted.

## Changelog
:cl:
balance: Rebalance armor numbers. In general, lower tier armors should be more valuable now, and some things that didn't seem like they should be so armored were reduced.
balance: Gave lasers to compensate for armor change, plasma already has enough to be sustainable.
balance: Removed ablative's ability to deflect projectiles, to make it less of a hard counter to certain weapons.
tweak: Renamed heavy armor vest to mercenary armor vest.
/:cl: