### PR TITLE
Chaos Level

### DIFF
--- a/code/__HELPERS/bluespace_entropy.dm
+++ b/code/__HELPERS/bluespace_entropy.dm
@@ -25,7 +25,7 @@ GLOBAL_VAR_INIT(bluespace_distotion_cooldown, 10 MINUTES)
 		GLOB.bluespace_entropy += entropy_value
 		var/entropy_cap = rand(GLOB.bluespace_hazard_threshold, GLOB.bluespace_hazard_threshold*2)
 		if(GLOB.bluespace_entropy >= entropy_cap && world.time > GLOB.bluespace_distotion_cooldown)
-			GLOB.bluespace_distotion_cooldown = world.time + (10 MINUTES * GLOB.chaos_level)
+			GLOB.bluespace_distotion_cooldown = world.time + (10 MINUTES / GLOB.chaos_level)
 			bluespace_distorsion(T, minor_distortion)
 			GLOB.bluespace_entropy -= rand(GLOB.bluespace_hazard_threshold, GLOB.bluespace_hazard_threshold*1.5)
 

--- a/code/__HELPERS/bluespace_entropy.dm
+++ b/code/__HELPERS/bluespace_entropy.dm
@@ -12,20 +12,20 @@ GLOBAL_VAR_INIT(bluespace_distotion_cooldown, 10 MINUTES)
 	do_teleport(ateleatom, adestination, aprecision, afteleport, aeffectin, aeffectout, asoundin, asoundout)
 
 /proc/bluespace_entropy(max_value=1, turf/T, minor_distortion=FALSE)
-	var/entropy_value = rand(0, max_value)
+	var/entropy_value = rand(0, max_value) * GLOB.chaos_level
 	var/area/A = get_area(T)
 	if(minor_distortion && A)
 		A.bluespace_entropy += entropy_value
 		var/area_entropy_cap = rand(A.bluespace_hazard_threshold, A.bluespace_hazard_threshold*2)
 		if(A.bluespace_entropy > area_entropy_cap && world.time > GLOB.bluespace_distotion_cooldown)
-			GLOB.bluespace_distotion_cooldown = world.time + 5 MINUTES
+			GLOB.bluespace_distotion_cooldown = world.time + (5 MINUTES / GLOB.chaos_level)
 			A.bluespace_entropy -= rand(A.bluespace_hazard_threshold, A.bluespace_hazard_threshold*1.5)
 			bluespace_distorsion(T, minor_distortion)
 	else
 		GLOB.bluespace_entropy += entropy_value
 		var/entropy_cap = rand(GLOB.bluespace_hazard_threshold, GLOB.bluespace_hazard_threshold*2)
 		if(GLOB.bluespace_entropy >= entropy_cap && world.time > GLOB.bluespace_distotion_cooldown)
-			GLOB.bluespace_distotion_cooldown = world.time + 10 MINUTES
+			GLOB.bluespace_distotion_cooldown = world.time + (10 MINUTES * GLOB.chaos_level)
 			bluespace_distorsion(T, minor_distortion)
 			GLOB.bluespace_entropy -= rand(GLOB.bluespace_hazard_threshold, GLOB.bluespace_hazard_threshold*1.5)
 

--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -233,10 +233,10 @@
 
 
 /datum/poll/chaos_level_increase
-	name = "Increse Chaos Level"
-	question = "Do you want to incease the chaos level?"
+	name = "Increase Chaos Level"
+	question = "Do you want to increase the chaos level?"
 	description = "Higher chaos level makes storyteller events much more likely."
-	time = 60
+	time = 120
 	minimum_win_percentage = 0.75 //High % needed for something that alters the whole round
 	cooldown = 30 MINUTES
 	next_vote = 90 MINUTES //Same lenght as bluspace jump
@@ -251,6 +251,8 @@
 
 /datum/vote_choice/yes_chaos_level/on_win()
 	GLOB.chaos_level += 1
+	for (var/mob/M as mob in SSmobs.mob_list)
+		to_chat(M, "<br><center><span class='danger'><b><font size=4>Chaos Level Increased</font></b><br></span></center><br>")
 
 /datum/vote_choice/no_chaos_level
 	text = "We have enough chaos already!"

--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -232,6 +232,29 @@
 	text = "No need to depart yet!"
 
 
+/datum/poll/chaos_level_increase
+	name = "Increse Chaos Level"
+	question = "Do you want to incease the chaos level?"
+	description = "Higher chaos level makes storyteller events much more likely."
+	time = 60
+	minimum_win_percentage = 0.75 //High % needed for something that alters the whole round
+	cooldown = 30 MINUTES
+	next_vote = 90 MINUTES //Same lenght as bluspace jump
+	choice_types = list(/datum/vote_choice/yes_chaos_level, /datum/vote_choice/no_chaos_level)
+	only_admin = FALSE
+	can_revote = TRUE
+	can_unvote = TRUE
+	
+
+/datum/vote_choice/yes_chaos_level
+	text = "Increase the chaos level!"
+
+/datum/vote_choice/yes_chaos_level/on_win()
+	GLOB.chaos_level += 1
+
+/datum/vote_choice/no_chaos_level
+	text = "We have enough chaos already!"
+
 
 
 

--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -239,7 +239,7 @@
 	time = 120
 	minimum_win_percentage = 0.75 //High % needed for something that alters the whole round
 	cooldown = 30 MINUTES
-	next_vote = 90 MINUTES //Same lenght as bluspace jump
+	next_vote = 90 MINUTES //Same lenght as bluespace jump
 	choice_types = list(/datum/vote_choice/yes_chaos_level, /datum/vote_choice/no_chaos_level)
 	only_admin = FALSE
 	can_revote = TRUE

--- a/code/game/gamemodes/storyteller.dm
+++ b/code/game/gamemodes/storyteller.dm
@@ -1,4 +1,5 @@
 GLOBAL_DATUM(storyteller, /datum/storyteller)
+GLOBAL_VAR_INIT(chaos_level, 1) //Works as global multiplier for all storyteller points, also used in bluespace entropy.
 
 /datum/storyteller
 	//Strings
@@ -222,10 +223,10 @@ GLOBAL_DATUM(storyteller, /datum/storyteller)
 			points[a] += delta
 
 /datum/storyteller/proc/handle_points()
-	points[EVENT_LEVEL_MUNDANE] += 1 * (gain_mult_mundane) * (RAND_DECIMAL(1-variance, 1+variance))
-	points[EVENT_LEVEL_MODERATE] += 1 * (gain_mult_moderate) * (RAND_DECIMAL(1-variance, 1+variance))
-	points[EVENT_LEVEL_MAJOR] += 1 * (gain_mult_major) * (RAND_DECIMAL(1-variance, 1+variance))
-	points[EVENT_LEVEL_ROLESET] += 1 * (gain_mult_roleset) * (RAND_DECIMAL(1-variance, 1+variance))
+	points[EVENT_LEVEL_MUNDANE] += GLOB.chaos_level * (gain_mult_mundane) * (RAND_DECIMAL(1-variance, 1+variance))
+	points[EVENT_LEVEL_MODERATE] += GLOB.chaos_level * (gain_mult_moderate) * (RAND_DECIMAL(1-variance, 1+variance))
+	points[EVENT_LEVEL_MAJOR] += GLOB.chaos_level * (gain_mult_major) * (RAND_DECIMAL(1-variance, 1+variance))
+	points[EVENT_LEVEL_ROLESET] += GLOB.chaos_level * (gain_mult_roleset) * (RAND_DECIMAL(1-variance, 1+variance))
 	check_thresholds()
 
 /datum/storyteller/proc/check_thresholds()

--- a/code/game/gamemodes/storyteller_print.dm
+++ b/code/game/gamemodes/storyteller_print.dm
@@ -59,6 +59,7 @@
 	data += "<br>Round duration: <b>[round(world.time / 36000)]:[add_zero(world.time / 600 % 60, 2)]:[world.time / 100 % 6][world.time / 100 % 10]</b>"
 	data += "<br>Debug mode: <b><a href='?src=\ref[src];toggle_debug=1'>\[[debug_mode?"ON":"OFF"]\]</a></b>"
 	data += "<br>One role per player: <b><a href='?src=\ref[src];toggle_orpp=1'>\[[one_role_per_player?"YES":"NO"]\]</a></b>"
+	data += "<br>Chaos Level: <a href='?src=\ref[src];edit_chaos=1'>\[[GLOB.chaos_level]\]</a>"
 	data += "</td><td style=\"padding-left: 40px\">"
 
 	data += "Heads: [heads] "
@@ -198,6 +199,9 @@
 
 	if(href_list["toggle_orpp"])	//one role per player
 		one_role_per_player = !one_role_per_player
+
+	if(href_list["edit_chaos"])
+		GLOB.chaos_level = input("Enter new chaos level, only use values >=1.","Chaos Level",GLOB.chaos_level) as num
 
 	if(href_list["call_shuttle"])
 		switch(href_list["call_shuttle"])

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -66,49 +66,49 @@ macro "borghotkeymode"
 		name = "NORTHWEST"
 		command = ".northwest"
 	elem 
-		name = "ALT+WEST"
+		name = "ALT+CTRL+WEST"
 		command = "westfaceperm"
 	elem 
 		name = "CTRL+WEST"
 		command = "westface"
 	elem 
-		name = "ALT+NORTH"
+		name = "ALT+CTRL+NORTH"
 		command = "northfaceperm"
 	elem 
 		name = "CTRL+NORTH"
 		command = "northface"
 	elem 
-		name = "ALT+EAST"
+		name = "ALT+CTRL+EAST"
 		command = "eastfaceperm"
 	elem 
 		name = "CTRL+EAST"
 		command = "eastface"
 	elem 
-		name = "ALT+SOUTH"
+		name = "ALT+CTRL+SOUTH"
 		command = "southfaceperm"
 	elem 
 		name = "CTRL+SOUTH"
 		command = "southface"
 	elem
-		name = "ALT+A"
+		name = "ALT+CTRL+A"
 		command = "westfaceperm"
 	elem 
 		name = "CTRL+A"
 		command = "westface"
 	elem 
-		name = "ALT+W"
+		name = "ALT+CTRL+W"
 		command = "northfaceperm"
 	elem 
 		name = "CTRL+W"
 		command = "northface"
 	elem 
-		name = "ALT+D"
+		name = "ALT+CTRL+D"
 		command = "eastfaceperm"
 	elem 
 		name = "CTRL+D"
 		command = "eastface"
 	elem 
-		name = "ALT+S"
+		name = "ALT+CTRL+S"
 		command = "southfaceperm"
 	elem 
 		name = "CTRL+S"
@@ -326,25 +326,25 @@ macro "macro"
 		name = "NORTHWEST"
 		command = ".northwest"
 	elem 
-		name = "ALT+WEST"
+		name = "ALT+CTRL+WEST"
 		command = "westfaceperm"
 	elem 
 		name = "CTRL+WEST"
 		command = "westface"
 	elem 
-		name = "ALT+NORTH"
+		name = "ALT+CTRL+NORTH"
 		command = "northfaceperm"
 	elem 
 		name = "CTRL+NORTH"
 		command = "northface"
 	elem 
-		name = "ALT+EAST"
+		name = "ALT+CTRL+EAST"
 		command = "eastfaceperm"
 	elem 
 		name = "CTRL+EAST"
 		command = "eastface"
 	elem 
-		name = "ALT+SOUTH"
+		name = "ALT+CTRL+SOUTH"
 		command = "southfaceperm"
 	elem 
 		name = "CTRL+SOUTH"
@@ -523,49 +523,49 @@ macro "hotkeymode"
 		name = "NORTHWEST"
 		command = ".northwest"
 	elem 
-		name = "ALT+WEST"
+		name = "ALT+CTRL+WEST"
 		command = "westfaceperm"
 	elem 
 		name = "CTRL+WEST"
 		command = "westface"
 	elem 
-		name = "ALT+NORTH"
+		name = "ALT+CTRL+NORTH"
 		command = "northfaceperm"
 	elem 
 		name = "CTRL+NORTH"
 		command = "northface"
 	elem 
-		name = "ALT+EAST"
+		name = "ALT+CTRL+EAST"
 		command = "eastfaceperm"
 	elem 
 		name = "CTRL+EAST"
 		command = "eastface"
 	elem 
-		name = "ALT+SOUTH"
+		name = "ALT+CTRL+SOUTH"
 		command = "southfaceperm"
 	elem 
 		name = "CTRL+SOUTH"
 		command = "southface"
 		elem
-		name = "ALT+A"
+		name = "ALT+CTRL+A"
 		command = "westfaceperm"
 	elem 
 		name = "CTRL+A"
 		command = "westface"
 	elem 
-		name = "ALT+W"
+		name = "ALT+CTRL+W"
 		command = "northfaceperm"
 	elem 
 		name = "CTRL+W"
 		command = "northface"
 	elem 
-		name = "ALT+D"
+		name = "ALT+CTRL+D"
 		command = "eastfaceperm"
 	elem 
 		name = "CTRL+D"
 		command = "eastface"
 	elem 
-		name = "ALT+S"
+		name = "ALT+CTRL+S"
 		command = "southfaceperm"
 	elem 
 		name = "CTRL+S"
@@ -672,6 +672,12 @@ macro "hotkeymode"
 	elem 
 		name = "CTRL+Y"
 		command = "Activate-Held-Object"
+	elem
+		name = "C"
+		command = "rest"
+	elem
+		name = "C+UP"
+		command = "stopSliding"
 	elem 
 		name = "Z"
 		command = "Activate-Held-Object"
@@ -810,25 +816,25 @@ macro "borgmacro"
 		name = "NORTHWEST"
 		command = ".northwest"
 	elem 
-		name = "ALT+WEST"
+		name = "ALT+CTRL+WEST"
 		command = "westfaceperm"
 	elem 
 		name = "CTRL+WEST"
 		command = "westface"
 	elem 
-		name = "ALT+NORTH"
+		name = "ALT+CTRL+NORTH"
 		command = "northfaceperm"
 	elem 
 		name = "CTRL+NORTH"
 		command = "northface"
 	elem 
-		name = "ALT+EAST"
+		name = "ALT+CTRL+EAST"
 		command = "eastfaceperm"
 	elem 
 		name = "CTRL+EAST"
 		command = "eastface"
 	elem 
-		name = "ALT+SOUTH"
+		name = "ALT+CTRL+SOUTH"
 		command = "southfaceperm"
 	elem 
 		name = "CTRL+SOUTH"
@@ -1494,4 +1500,3 @@ window "text_editor"
 		border = line
 		saved-params = ""
 		multi-line = true
-

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -66,49 +66,49 @@ macro "borghotkeymode"
 		name = "NORTHWEST"
 		command = ".northwest"
 	elem 
-		name = "ALT+CTRL+WEST"
+		name = "ALT+WEST"
 		command = "westfaceperm"
 	elem 
 		name = "CTRL+WEST"
 		command = "westface"
 	elem 
-		name = "ALT+CTRL+NORTH"
+		name = "ALT+NORTH"
 		command = "northfaceperm"
 	elem 
 		name = "CTRL+NORTH"
 		command = "northface"
 	elem 
-		name = "ALT+CTRL+EAST"
+		name = "ALT+EAST"
 		command = "eastfaceperm"
 	elem 
 		name = "CTRL+EAST"
 		command = "eastface"
 	elem 
-		name = "ALT+CTRL+SOUTH"
+		name = "ALT+SOUTH"
 		command = "southfaceperm"
 	elem 
 		name = "CTRL+SOUTH"
 		command = "southface"
 	elem
-		name = "ALT+CTRL+A"
+		name = "ALT+A"
 		command = "westfaceperm"
 	elem 
 		name = "CTRL+A"
 		command = "westface"
 	elem 
-		name = "ALT+CTRL+W"
+		name = "ALT+W"
 		command = "northfaceperm"
 	elem 
 		name = "CTRL+W"
 		command = "northface"
 	elem 
-		name = "ALT+CTRL+D"
+		name = "ALT+D"
 		command = "eastfaceperm"
 	elem 
 		name = "CTRL+D"
 		command = "eastface"
 	elem 
-		name = "ALT+CTRL+S"
+		name = "ALT+S"
 		command = "southfaceperm"
 	elem 
 		name = "CTRL+S"
@@ -326,25 +326,25 @@ macro "macro"
 		name = "NORTHWEST"
 		command = ".northwest"
 	elem 
-		name = "ALT+CTRL+WEST"
+		name = "ALT+WEST"
 		command = "westfaceperm"
 	elem 
 		name = "CTRL+WEST"
 		command = "westface"
 	elem 
-		name = "ALT+CTRL+NORTH"
+		name = "ALT+NORTH"
 		command = "northfaceperm"
 	elem 
 		name = "CTRL+NORTH"
 		command = "northface"
 	elem 
-		name = "ALT+CTRL+EAST"
+		name = "ALT+EAST"
 		command = "eastfaceperm"
 	elem 
 		name = "CTRL+EAST"
 		command = "eastface"
 	elem 
-		name = "ALT+CTRL+SOUTH"
+		name = "ALT+SOUTH"
 		command = "southfaceperm"
 	elem 
 		name = "CTRL+SOUTH"
@@ -523,49 +523,49 @@ macro "hotkeymode"
 		name = "NORTHWEST"
 		command = ".northwest"
 	elem 
-		name = "ALT+CTRL+WEST"
+		name = "ALT+WEST"
 		command = "westfaceperm"
 	elem 
 		name = "CTRL+WEST"
 		command = "westface"
 	elem 
-		name = "ALT+CTRL+NORTH"
+		name = "ALT+NORTH"
 		command = "northfaceperm"
 	elem 
 		name = "CTRL+NORTH"
 		command = "northface"
 	elem 
-		name = "ALT+CTRL+EAST"
+		name = "ALT+EAST"
 		command = "eastfaceperm"
 	elem 
 		name = "CTRL+EAST"
 		command = "eastface"
 	elem 
-		name = "ALT+CTRL+SOUTH"
+		name = "ALT+SOUTH"
 		command = "southfaceperm"
 	elem 
 		name = "CTRL+SOUTH"
 		command = "southface"
 		elem
-		name = "ALT+CTRL+A"
+		name = "ALT+A"
 		command = "westfaceperm"
 	elem 
 		name = "CTRL+A"
 		command = "westface"
 	elem 
-		name = "ALT+CTRL+W"
+		name = "ALT+W"
 		command = "northfaceperm"
 	elem 
 		name = "CTRL+W"
 		command = "northface"
 	elem 
-		name = "ALT+CTRL+D"
+		name = "ALT+D"
 		command = "eastfaceperm"
 	elem 
 		name = "CTRL+D"
 		command = "eastface"
 	elem 
-		name = "ALT+CTRL+S"
+		name = "ALT+S"
 		command = "southfaceperm"
 	elem 
 		name = "CTRL+S"
@@ -672,12 +672,6 @@ macro "hotkeymode"
 	elem 
 		name = "CTRL+Y"
 		command = "Activate-Held-Object"
-	elem
-		name = "C"
-		command = "rest"
-	elem
-		name = "C+UP"
-		command = "stopSliding"
 	elem 
 		name = "Z"
 		command = "Activate-Held-Object"
@@ -816,25 +810,25 @@ macro "borgmacro"
 		name = "NORTHWEST"
 		command = ".northwest"
 	elem 
-		name = "ALT+CTRL+WEST"
+		name = "ALT+WEST"
 		command = "westfaceperm"
 	elem 
 		name = "CTRL+WEST"
 		command = "westface"
 	elem 
-		name = "ALT+CTRL+NORTH"
+		name = "ALT+NORTH"
 		command = "northfaceperm"
 	elem 
 		name = "CTRL+NORTH"
 		command = "northface"
 	elem 
-		name = "ALT+CTRL+EAST"
+		name = "ALT+EAST"
 		command = "eastfaceperm"
 	elem 
 		name = "CTRL+EAST"
 		command = "eastface"
 	elem 
-		name = "ALT+CTRL+SOUTH"
+		name = "ALT+SOUTH"
 		command = "southfaceperm"
 	elem 
 		name = "CTRL+SOUTH"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1500,3 +1500,4 @@ window "text_editor"
 		border = line
 		saved-params = ""
 		multi-line = true
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the chaos level vote into the game. It can be called after an hour and a half from roundstart and after that every 30 minutes. Each vote increases storyteller point generation (first vote OG value * 2, second vote OG value * 3 and so on), bluespace entropy generation and lowers cooldowns on bluespace entropy events.
Player vote need 75% positive votes to pass as it increases point generation for the rest of the round.
Bandaid fix until storyteller rework (never)

## Why It's Good For The Game

Speeds up rounds after the 90 minute mark, and only if the players want so. Many a time have I found myself at this time of the game after a major threat has been defeated (excels, hive, serbs), with the choice to wait another hour so something interesting would happen or jump now and wait again, but in the next round. Now there is a third choice.

## Changelog
:cl:
add: Added chaos level that can be increased by player vote, that increases storyteller point generation.
/:cl:

