### PR TITLE
Diving patch Mk. 2.1

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -199,6 +199,14 @@
 
 
 
+/obj/machinery/door/proc/hit_by_living(var/mob/living/M)
+	var/body_part = pick(BP_HEAD, BP_CHEST, BP_GROIN)
+	visible_message(SPAN_DANGER("[M] slams against \the [src]!"))
+	if(prob(30))
+		M.Weaken(1)
+	M.damage_through_armor(8, BRUTE, body_part, ARMOR_MELEE)
+	take_damage(M.mob_size)
+
 /obj/machinery/door/hitby(AM as mob|obj, var/speed=5)
 
 	..()
@@ -208,7 +216,8 @@
 		damage = O.throwforce
 	else if (istype(AM, /mob/living))
 		var/mob/living/M = AM
-		damage = M.mob_size
+		hit_by_living(M)
+		return
 	take_damage(damage)
 	return
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -193,6 +193,9 @@
 
 /obj/structure/window/hitby(AM as mob|obj)
 	..()
+	if(isliving(AM))
+		hit_by_living(AM)
+		return
 	visible_message(SPAN_DANGER("[src] was hit by [AM]."))
 	var/tforce = 0
 	if(ismob(AM))
@@ -278,6 +281,13 @@
 	sleep(5) //Allow a littleanimating time
 	return TRUE
 
+/obj/structure/window/proc/hit_by_living(var/mob/living/M)
+	var/body_part = pick(BP_HEAD, BP_CHEST, BP_GROIN)
+	var/direction = get_dir(M, src)
+	visible_message(SPAN_DANGER("[M] slams against \the [src]!"))
+	if(prob(30))
+		M.Weaken(1)
+	M.damage_through_armor(rand(7,10), BRUTE, body_part, ARMOR_MELEE)
 
 /obj/structure/window/attackby(obj/item/I, mob/user)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -633,6 +633,9 @@ default behaviour is:
 		var/_dir = C.true_dir
 		if(ishuman(src) && !weakened && (dir))// If true_dir = 0(src isn't moving), doesn't proc.
 			var/mob/living/carbon/human/H = src
+			var/range = 1 //checks for move intent; dive one tile further if on run intent
+			if (move_intent.flags & MOVE_INTENT_EXERTIVE)
+				range += 1
 			livmomentum = 5 // Set momentum value as soon as possible for stopSliding to work better
 			to_chat(H, SPAN_NOTICE("You dive onwards!"))
 			pass_flags += PASSTABLE // Jump over them!
@@ -640,7 +643,7 @@ default behaviour is:
 			var/is_jump = FALSE
 			if(istype(get_step(H, _dir), /turf/simulated/open))
 				is_jump = TRUE
-			H.throw_at(get_edge_target_turf(H, _dir), 2 + is_jump, 1)// "Diving"; if you dive over a table, your momentum is set to 0. If you dive over space, you are thrown a tile further.
+			H.throw_at(get_edge_target_turf(H, _dir), range + is_jump), 1)// "Diving"; if you dive over a table, your momentum is set to 0. If you dive over space, you are thrown a tile further.
 			update_lying_buckled_and_verb_status()
 			pass_flags -= PASSTABLE // Jumpn't over them anymore!
 			H.allow_spin = TRUE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -618,6 +618,7 @@ default behaviour is:
 
 	if(resting && unstack)
 		unstack = FALSE
+
 		if((livmomentum <= 0) && do_after(src, (src.stats.getPerk(PERK_PARKOUR) ? 0.3 SECONDS : 0.7 SECONDS), null, 0, 1, INCAPACITATION_DEFAULT, immobile = 0))
 			resting = FALSE
 			unstack = TRUE
@@ -629,27 +630,27 @@ default behaviour is:
 		var/client/C = src.client
 		var/speed = movement_delay()
 		resting = TRUE
-		var/dir = C.true_dir
-		if(ishuman(src) && (dir))// If true_dir = 0(src isn't moving), doesn't proc
+		var/_dir = C.true_dir
+		if(ishuman(src) && !weakened && (dir))// If true_dir = 0(src isn't moving), doesn't proc.
 			var/mob/living/carbon/human/H = src
 			livmomentum = 5 // Set momentum value as soon as possible for stopSliding to work better
 			to_chat(H, SPAN_NOTICE("You dive onwards!"))
 			pass_flags += PASSTABLE // Jump over them!
 			H.allow_spin = FALSE
 			var/is_jump = FALSE
-			if(istype(get_step(H, dir), /turf/simulated/open))
+			if(istype(get_step(H, _dir), /turf/simulated/open))
 				is_jump = TRUE
-			H.throw_at(get_edge_target_turf(H, dir), 2 + is_jump, 1)// "Diving"; if you dive over a table, your momentum is set to 0. If you dive over space, you are thrown a tile further.
+			H.throw_at(get_edge_target_turf(H, _dir), 2 + is_jump, 1)// "Diving"; if you dive over a table, your momentum is set to 0. If you dive over space, you are thrown a tile further.
 			update_lying_buckled_and_verb_status()
 			pass_flags -= PASSTABLE // Jumpn't over them anymore!
 			H.allow_spin = TRUE
 			sleep(2)
 			C.mloop = 1
 			while(livmomentum > 0 && C.true_dir)
-				H.Move(get_step(H.loc, dir),dir)
+				H.Move(get_step(H.loc, _dir),dir)
 				livmomentum = (livmomentum - speed)
 				H.regen_slickness(0.25) // The longer you slide, the more stylish it is
-				sleep(world.tick_lag + 1)
+				sleep(world.tick_lag + 1.5)
 			C.mloop = 0
 		else
 			to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"].</span>")

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -601,7 +601,8 @@
 			for(var/mob/living/H in src)
 				if(isdrone(H)) //Drones use the mailing code to move through the disposal system,
 					continue
-
+				if(H.stats.getPerk(PERK_SPACE_ASSHOLE)) //Assholes gain disposal immunity
+					continue
 				// Hurt any living creature jumping down disposals
 				var/multiplier = 1
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -498,18 +498,27 @@
 		qdel(H)
 
 /obj/machinery/disposal/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if (istype(mover,/obj/item) && mover.throwing)
+	if(ishuman(mover) && mover.throwing)
+		var/mob/living/carbon/human/H = mover
+		if(H.stats.getPerk(PERK_SPACE_ASSHOLE))
+			H.forceMove(src)
+			for(var/mob/M in viewers(src))
+				M.show_message("[H] dives into \the [src]!", 3)
+			flush = TRUE
+		return
+	else if (istype(mover,/obj/item) && mover.throwing)
 		var/obj/item/I = mover
 		if(istype(I, /obj/item/projectile))
 			return
-		if(prob(75))
-			I.forceMove(src)
-			for(var/mob/M in viewers(src))
-				M.show_message("\The [I] lands in \the [src].", 3)
 		else
-			for(var/mob/M in viewers(src))
-				M.show_message("\The [I] bounces off of \the [src]'s rim!", 3)
-		return 0
+			if(prob(75))
+				I.forceMove(src)
+				for(var/mob/M in viewers(src))
+					M.show_message("\The [I] lands in \the [src].", 3)
+			else
+				for(var/mob/M in viewers(src))
+					M.show_message("\The [I] bounces off of \the [src]\'s rim!", 3)
+		return
 	else
 		return ..(mover, target, height, air_group)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Added stuff from #6976 and #6978
you can change the range of a dive by changing your move intent - walk is one tile less
ass of concrete perk deals more damage to windows
space asshole can dive into disposal chutes, they deal no damage to assholes
~~thatta lot of ass innit?~~
## Why It's Good For The Game
patches cool
abuse no
unique interactions cool
## Changelog
:cl:
add: ass of concrete deals more damage to windows
add: space asshole dumpster diving(literally)
balance: removed titanfall, diving into windows and doors takes longer to break them, damages the jumper
fix: fixed cripples diving 
tweak: dive range depends on move intent
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
