### PR TITLE
Withdrawal deals sanity damage, tweak perks focused on addiction

### DIFF
--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -67,49 +67,51 @@
 	name = "Drug Addict"
 	icon_state = "medicine" //https://game-icons.net/1x1/delapouite/medicines.html
 	desc = "For reasons you cannot remember, you decided to resort to major drug use. You have lost the battle, and now you suffer the consequences. \
-			You start with an addiction to a random drug, as well as a bottle of pills containing the drug."
+			You start with a permanent addiction to a random stimulator, as well as a bottle of pills containing the drug. \
+			Beware, if you get addicted to another stimulant, you will not get rid of the addiction."
 
 /datum/perk/fate/drug_addict/assign(mob/living/carbon/human/H)
 	..()
 	spawn(1)
 		var/turf/T = get_turf(holder)
-		var/drugtype = pick(subtypesof(/datum/reagent/drug))
+		var/drugtype = pick(subtypesof(/datum/reagent/stim))
 		if(!(drugtype in holder.metabolism_effects.addiction_list))
 			var/datum/reagent/drug = new drugtype
 			holder.metabolism_effects.addiction_list.Add(drug)
-			for(var/j= 1 to 2)
-				var/obj/item/storage/pill_bottle/PB = new /obj/item/storage/pill_bottle(T)
-				PB.name = "bottle of happiness"
-				for(var/i=1 to 7)
-					var/obj/item/reagent_containers/pill/pill = new /obj/item/reagent_containers/pill(T)
-					pill.reagents.add_reagent(drug.id, pill.volume)
-					pill.name = "happy pill"
-					PB.handle_item_insertion(pill)
-				holder.equip_to_storage_or_drop(PB)
+			var/obj/item/storage/pill_bottle/PB = new /obj/item/storage/pill_bottle(T)
+			PB.name = "[drug] (15 units)"
+			for(var/i=1 to 12)
+				var/obj/item/reagent_containers/pill/pill = new /obj/item/reagent_containers/pill(T)
+				pill.reagents.add_reagent(drug.id, 15)
+				pill.name = "[drug]"
+				PB.handle_item_insertion(pill)
+			holder.equip_to_storage_or_drop(PB)
 
 /datum/perk/fate/alcoholic
 	name = "Alcoholic"
 	icon_state = "beer" //https://game-icons.net/1x1/delapouite/beer-bottle.html
 	desc = "You imagined the egress from all your trouble and pain at the bottom of the bottle, but the way only led to a labyrinth. \
-			You have an alcohol addiction, which gives you a boost to robustness while under the influence and lowers your cognition permanently."
+			You never stopped from coming back to it, trying again and again, poisoning your mind until you lost control. Now your face bears witness to your self-destruction. \
+			There is only one key to survival, and it is the liquid that has shown you the way down. \
+			You have a permanent alcohol addiction, which gives you a boost to combat stats while under the influence and lowers your cognition permanently."
 
 /datum/perk/fate/alcoholic/assign(mob/living/carbon/human/H)
 	..()
-	var/ethanoltype = pick(subtypesof(/datum/reagent/alcohol))
-	if(!(ethanoltype in holder.metabolism_effects.addiction_list))
-		var/datum/reagent/alcohol = new ethanoltype
-		holder.metabolism_effects.addiction_list.Add(alcohol)
+	if(!(/datum/reagent/ethanol in holder.metabolism_effects.addiction_list))
+		var/datum/reagent/R = new /datum/reagent/ethanol
+		holder.metabolism_effects.addiction_list.Add(R)
 
 /datum/perk/fate/alcoholic_active
-	name = "Alcoholic (active)"
-	icon_state = "drinking" //https://game-icons.net/1x1/delapouite/drinking.html
+	name = "Alcoholic - active"
+	icon_state = "drinking" //https://game-icons.net
+	desc = "Combat stats increased."
 
 /datum/perk/fate/alcoholic_active/assign(mob/living/carbon/human/H)
 	..()
 	if(holder)
-		holder.stats.addTempStat(STAT_ROB, 10, INFINITY, "Fate Alcoholic")
-		holder.stats.addTempStat(STAT_TGH, 10, INFINITY, "Fate Alcoholic")
-		holder.stats.addTempStat(STAT_VIG, 10, INFINITY, "Fate Alcoholic")
+		holder.stats.addTempStat(STAT_ROB, 15, INFINITY, "Fate Alcoholic")
+		holder.stats.addTempStat(STAT_TGH, 15, INFINITY, "Fate Alcoholic")
+		holder.stats.addTempStat(STAT_VIG, 15, INFINITY, "Fate Alcoholic")
 
 /datum/perk/fate/alcoholic_active/remove()
 	if(holder)

--- a/code/modules/reagents/metabolism.dm
+++ b/code/modules/reagents/metabolism.dm
@@ -218,11 +218,12 @@
 					R.addiction_act_stage3(parent)
 				if(40 to 50)
 					R.addiction_act_stage4(parent)
-				if(50 to INFINITY && ((parent.stats.getPerk(PERK_ALCOHOLIC) && istype(R, /datum/reagent/ethanol)) || (parent.stats.getPerk(PERK_DRUG_ADDICT) && istype(R, /datum/reagent/stim))))
-					R.addiction_act_stage4(parent)
-				if(50 to INFINITY && !((parent.stats.getPerk(PERK_ALCOHOLIC) && istype(R, /datum/reagent/ethanol)) || (parent.stats.getPerk(PERK_DRUG_ADDICT) && istype(R, /datum/reagent/stim))))
-					R.addiction_end(parent)
-					addiction_list.Remove(R)
+				if(50 to INFINITY)
+					if((parent.stats.getPerk(PERK_ALCOHOLIC) && istype(R, /datum/reagent/ethanol)) || (parent.stats.getPerk(PERK_DRUG_ADDICT) && istype(R, /datum/reagent/stim)))
+						R.addiction_act_stage4(parent)
+					else
+						R.addiction_end(parent)
+						addiction_list.Remove(R)
 
 /datum/metabolism_effects/proc/clear_effects()
 	for(var/withdrawal in active_withdrawals)

--- a/code/modules/reagents/metabolism.dm
+++ b/code/modules/reagents/metabolism.dm
@@ -207,19 +207,20 @@
 			addiction_list.Remove(R)
 			continue
 
-		addiction_list[R] += 1
-		if(!parent.chem_effects[CE_PURGER])
-
+		if(!parent.chem_effects[CE_PURGER] && ishuman(parent))
+			addiction_list[R] += 1
 			switch(addiction_list[R])
-				if(1 to 10)
+				if(1 to 20)
 					R.addiction_act_stage1(parent)
-				if(10 to 20)
-					R.addiction_act_stage2(parent)
 				if(20 to 30)
-					R.addiction_act_stage3(parent)
+					R.addiction_act_stage2(parent)
 				if(30 to 40)
+					R.addiction_act_stage3(parent)
+				if(40 to 50)
 					R.addiction_act_stage4(parent)
-				if(40 to INFINITY)
+				if(50 to INFINITY && ((parent.stats.getPerk(PERK_ALCOHOLIC) && istype(R, /datum/reagent/ethanol)) || (parent.stats.getPerk(PERK_DRUG_ADDICT) && istype(R, /datum/reagent/stim))))
+					R.addiction_act_stage4(parent)
+				if(50 to INFINITY && !((parent.stats.getPerk(PERK_ALCOHOLIC) && istype(R, /datum/reagent/ethanol)) || (parent.stats.getPerk(PERK_DRUG_ADDICT) && istype(R, /datum/reagent/stim))))
 					R.addiction_end(parent)
 					addiction_list.Remove(R)
 

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -217,7 +217,7 @@
 // Addiction
 // Addiction
 /datum/reagent/proc/addiction_act_stage1(mob/living/carbon/human/M)
-	if(prob(30) && ishuman(M))
+	if(prob(30))
 		to_chat(M, SPAN_NOTICE("You feel like having some [name] right about now."))
 
 /datum/reagent/proc/addiction_act_stage2(mob/living/carbon/human/M)

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -215,24 +215,28 @@
 	return null
 
 // Addiction
-/datum/reagent/proc/addiction_act_stage1(mob/living/carbon/M)
-	if(prob(30))
+// Addiction
+/datum/reagent/proc/addiction_act_stage1(mob/living/carbon/human/M)
+	if(prob(30) && ishuman(M))
 		to_chat(M, SPAN_NOTICE("You feel like having some [name] right about now."))
 
-/datum/reagent/proc/addiction_act_stage2(mob/living/carbon/M)
+/datum/reagent/proc/addiction_act_stage2(mob/living/carbon/human/M)
 	if(prob(30))
 		to_chat(M, SPAN_NOTICE("You feel like you need [name]. You just can't get enough."))
 
-/datum/reagent/proc/addiction_act_stage3(mob/living/carbon/M)
+/datum/reagent/proc/addiction_act_stage3(mob/living/carbon/human/M)
 	if(prob(30))
 		to_chat(M, SPAN_DANGER("You have an intense craving for [name]."))
+		M.sanity.changeLevel(-5)
 
-/datum/reagent/proc/addiction_act_stage4(mob/living/carbon/M)
+/datum/reagent/proc/addiction_act_stage4(mob/living/carbon/human/M)
 	if(prob(30))
 		to_chat(M, SPAN_DANGER("You're not feeling good at all! You really need some [name]."))
+		M.sanity.changeLevel(-10)
 
-/datum/reagent/proc/addiction_end(mob/living/carbon/M)
+/datum/reagent/proc/addiction_end(mob/living/carbon/human/M)
 	to_chat(M, SPAN_NOTICE("You feel like you've gotten over your need for [name]."))
+	M.sanity.changeLevel(15)
 
 // Withdrawal
 /datum/reagent/proc/withdrawal_start(mob/living/carbon/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
alcoholic fate perk gets permanent addiction, alcoholic gets bonus of 15 stats, and yes this is a fair and balanced tradeoff
drug addict now gets a bottle of 12 pills full of 15 units of a random stim they are addicted to; before, they got FUCKING __60__(!!!) units of a drug in one pill, AND TWO BOTTLES of said pills(~25). also permanent addiction yea
withdrawal deals gradually more sanity damage when you get the... announcement? english hard
anyways: 
stage1 - 0 (sanity dmg)
stage2 - 0
stage3 - 5
stage4 - 10
end - +10 sanity restoration
## Why It's Good For The Game
trillionardos of people complained that withdrawal does nothing(except for stat debuffs for certain chems)
now, in REAL WORLD(sic!) withdrawals are pain!! time to add realism
also fates focused on addiction are actually addicted and good now, with an interesting tradeoff
## Changelog
:cl:
add: sanity damage on withdrawal
tweak: drug addict does not get two bottles of 60u pills now
tweak: addiction fate perks have permanent addiction
tweak: increased alcoholic bonus
/:cl:
