### PR TITLE
Antag confirmation

### DIFF
--- a/code/game/gamemodes/roleset/faction/excelsior.dm
+++ b/code/game/gamemodes/roleset/faction/excelsior.dm
@@ -10,5 +10,5 @@
 	base_quantity = 2 //They're a group antag, we want a few of em
 	scaling_threshold = 8
 
-	req_crew = 6
+	req_crew = 3
 	leaders = -1 //Every excelsior spawned directly is a leader. Non leaders are those recruited during gameplay

--- a/code/game/gamemodes/roleset/faction/mercenary.dm
+++ b/code/game/gamemodes/roleset/faction/mercenary.dm
@@ -4,7 +4,7 @@
 	role_id = ROLE_MERCENARY
 	weight = 0.4
 	ocurrences_max = 1
-	req_crew = 5
+	req_crew = 3
 	tags = list(TAG_DESTRUCTIVE, TAG_NEGATIVE)
 	
 	//Until we code some way to reset the merc base, can't allow this to happen more than once per round

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -322,8 +322,9 @@
 
 
 /datum/admins/proc/storyteller_panel()
-	if(get_storyteller())
-		get_storyteller().storyteller_panel()
+	var/datum/storyteller/ST = get_storyteller()
+	if(ST)
+		ST.storyteller_panel()
 	else
 		to_chat(usr, SPAN_WARNING("There is no storyteller."))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Asks the player if they want to become the antag. Same as the ghost antag roles, but for everything else. Also, fixes a runtime caused by the storyteller panel and lowers excel/serb crew req to 3.

## Why It's Good For The Game

Gives the player a choice to enter antag pool if they have the role enabled.

## Changelog
:cl:
add: antag confirmation window
tweak: excel and serb minimum crew req lowered to 3
fix: storyteller panel button runtime
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
