### PR TITLE
HV damage buff removed, uplink cost reduced

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -7,40 +7,19 @@
 
 /////.35 .40 pistols and smgs/////
 
-/datum/uplink_item/item/ammo/pistol
-	name = "Standard .35 Auto magazine"
-	desc = "Standard .35 magazine, loaded with lethal ammunition. Can fit 10 bullets."
-	item_cost = 1
-	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/ammo_magazine/pistol
-
 /datum/uplink_item/item/ammo/pistol/highvelocity
 	name = "Holdout .35 Auto HV magazine"
 	desc = "Holdout .35 magazine, loaded with high velocity ammunition.  Can fit 10 bullets."
-	item_cost = 2
+	item_cost = 1
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/ammo_magazine/pistol/highvelocity
-
-/datum/uplink_item/item/ammo/hpistol
-	name = "Highcap .35 Auto magazine"
-	desc = "Highcap .35 magazine, loaded with lethal ammunition.  Can fit 16 bullets."
-	item_cost = 2
-	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/ammo_magazine/hpistol
 
 /datum/uplink_item/item/ammo/hpistol/highvelocity
 	name = "Highcap .35 Auto HV magazine"
 	desc = "Highcap .35 magazine, loaded with high velocity ammunition.  Can fit 16 bullets."
-	item_cost = 3
+	item_cost = 2
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/ammo_magazine/hpistol/highvelocity
-
-/datum/uplink_item/item/ammo/smg
-	name = "SMG .35 Auto magazine"
-	desc = "SMG .35 magazine, loaded with lethal ammunition. Can fit 35 bullets."
-	item_cost = 3
-	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/ammo_magazine/smg
 
 /datum/uplink_item/item/ammo/smg/highvelocity
 	name = "SMG .35 Auto HV magazine"
@@ -49,61 +28,35 @@
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/ammo_magazine/smg/hv
 
-/datum/uplink_item/item/ammo/magnum
-	name = "Standard .40 magazine"
-	desc = "Standard .40 magazine, loaded with lethal ammunition. Can fit 10 bullets."
-	item_cost = 2
-	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/ammo_magazine/magnum
-
 /datum/uplink_item/item/ammo/magnum/hv
 	name = "Standard .40 HV magazine"
 	desc = "Standard .40 magazine, loaded with high velocity ammunition. Can fit 10 bullets."
-	item_cost = 3
+	item_cost = 2
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/ammo_magazine/magnum/hv
-
-/datum/uplink_item/item/ammo/magnum/msmg
-	name = "SMG .40 magazine"
-	desc = "SMG .40 magazine, loaded with lethal ammunition. Can fit 25 bullets."
-	item_cost = 3
-	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/ammo_magazine/msmg
 
 /datum/uplink_item/item/ammo/magnum/msmg/hv
 	name = "SMG .40 HV magazine"
 	desc = "SMG .40 magazine, loaded with high velocity ammunition. Can fit 25 bullets."
-	item_cost = 5
+	item_cost = 4
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/ammo_magazine/msmg/hv
 
 ///// .35 and .40 revolvers////
 
 /datum/uplink_item/item/ammo/slpistol
-	name = ".35 Auto SL box"
-	desc = "Contains 2 standard .35 Auto speed loaders, loaded with lethal ammunition. Can fit 6 bullets."
-	item_cost = 1
-	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/storage/box/syndie_kit/slpistol
 
 /datum/uplink_item/item/ammo/slpistol/highvelocity
 	name = ".35 Auto HV SL"
-	desc = "Contains 2 standard .35 Auto speed loaders, loaded with high-velocity ammunition. Can fit 6 bullets."
+	desc = "Contains 3 standard .35 Auto speed loaders, loaded with high-velocity ammunition. Can fit 6 bullets."
 	item_cost = 2
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/storage/box/syndie_kit/slpistol/hv
 
 
-/datum/uplink_item/item/ammo/slmagnum
-	name = ".40 magnum SL box"
-	desc = "Contains 2 .40 magnum speed loaders, loaded with lethal ammunition. Can fit 6 bullets."
-	item_cost = 1
-	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/storage/box/syndie_kit/slmagnum
-
 /datum/uplink_item/item/ammo/slmagnum/highvelocity
 	name = ".40 magnum HV SL box"
-	desc = "Contains 2 .40 magnum HV speed loaders, loaded with high velocity ammunition. Can fit 6 bullets."
+	desc = "Contains 3 .40 magnum HV speed loaders, loaded with high velocity ammunition. Can fit 6 bullets."
 	item_cost = 4
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/storage/box/syndie_kit/slmagnum/highvelocity
@@ -112,141 +65,106 @@
 /////.20 . 25 .30 Rifles/////
 
 /datum/uplink_item/item/ammo/srifle
-	name = ".20 Rifle magazine"
-	desc = "Standard .20 magazine with lethal ammunition. Well known for it's armor penetrating capabilities. Can fit 20 bullets."
-	item_cost = 2
-	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/ammo_magazine/srifle
 
 /datum/uplink_item/item/ammo/srifle/highvelocity
 	name = ".20 Rifle HV magazine"
-	desc = "Standard .20 magazine with high velocity ammunition. Well known for it's armor penetrating capabilities. Can fit 20 bullets."
+	desc = "Standard .20 magazine with high velocity ammunition. Well known for it's armor penetrating capabilities. Can fit 25 bullets."
 	item_cost = 3
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/ammo_magazine/srifle/hv
 
-/datum/uplink_item/item/ammo/ihclrifle
-	name = ".25 caseless magazine"
-	desc = "Standard .25 magazine with lethal ammunition. Used mostly in IHS carabines. Can fit 30 bullets."
-	item_cost = 3
-	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/ammo_magazine/ihclrifle
-
-/datum/uplink_item/item/ammo/ihclrifle/highvelocity
-	name = ".25 caseless HV magazine"
-	desc = "Standard .25 magazine with high velocity ammunition. Used mostly in IHS carabines. Can fit 30 bullets."
-	item_cost = 4
-	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/ammo_magazine/ihclrifle/hv
-
-/datum/uplink_item/item/ammo/cspistol
-	name = ".25 caseless pistol magazine"
-	desc = "Pistol .25 magazine with lethal ammunition. Used solely in Mandella. Can fit 10 bullets."
+/datum/uplink_item/item/ammo/sl_lrifle/highvelocity
+	name = ".20 Rifle HV ammo strip"
+	desc = "Contains 2 standard .20 ammo strips, loaded with high velocity ammunition. Can fit 5 bullets."
 	item_cost = 1
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/ammo_magazine/cspistol
+	path = /obj/item/storage/box/syndie_kit/sllrifle/hv
+	
+/datum/uplink_item/item/ammo/ihclrifle/highvelocity
+	name = ".25 caseless HV magazine"
+	desc = "Standard .25 magazine with high velocity ammunition. Used mostly in IHS carbines. Can fit 30 bullets."
+	item_cost = 3
+	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
+	path = /obj/item/ammo_magazine/ihclrifle/hv
 
 /datum/uplink_item/item/ammo/cspistol/highvelocity
 	name = ".25 caseless HV pistol magazine"
 	desc = "Pistol .25 magazine with high-velocity ammunition. Used solely in Mandella. Can fit 10 bullets."
-	item_cost = 2
+	item_cost = 1
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/ammo_magazine/cspistol/hv
-
-/datum/uplink_item/item/ammo/lrifle
-	name = ".30 Rifle magazine"
-	desc = "Long .30 magazine with lethal ammunition. Can fit 30 bullets."
-	item_cost = 3
-	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/ammo_magazine/lrifle
 
 /datum/uplink_item/item/ammo/lrifle/highvelocity
 	name = ".30 Rifle HV magazine"
 	desc = "Long .30 magazine with high velocity ammunition. Can fit 30 bullets."
-	item_cost = 4
+	item_cost = 3
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/ammo_magazine/lrifle/highvelocity
 
-/datum/uplink_item/item/ammo/sl_lrifle
-	name = ".30 Rifle ammo strip"
-	desc = "An ammo strip designed for bolt action rifles. Contains 5 rounds."
-	item_cost = 1
-	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/ammo_magazine/sllrifle
-
 /datum/uplink_item/item/ammo/sl_lrifle/highvelocity
 	name = ".30 Rifle HV ammo strip"
-	desc = "An High Velocity ammo strip designed for bolt action rifles. Contains 5 rounds."
-	item_cost = 2
+	desc = "Contains 2 standard .30 ammo strips, loaded with high velocity ammunition. Can fit 5 bullets."
+	item_cost = 1
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/ammo_magazine/sllrifle/hv
+	path = /obj/item/storage/box/syndie_kit/sllrifle/hv
 	
 //// HV ammo packets ////
 
 /datum/uplink_item/item/ammo/pistol_hv
 	name = ".35 Auto HV ammo packet"
-	desc = ".35 ammo packet with high velocity ammunition. Contain 30 bullets."
-	item_cost = 4
+	desc = ".35 ammo packet with high velocity ammunition. Contains 70 bullets. Cheaper than buying in magazines."
+	item_cost = 6
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/ammo_magazine/ammobox/pistol/hv
 
 /datum/uplink_item/item/ammo/magnum_hv
 	name = ".40 Magnum HV ammo packet"
-	desc = ".40 ammo packet with high velocity ammunition. Contain 30 bullets."
-
-	item_cost = 6
+	desc = ".40 ammo packet with high velocity ammunition. Contains 30 bullets. Cheaper than buying in magazines."
+	item_cost = 4
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-
 	path = /obj/item/ammo_magazine/ammobox/magnum/hv
 
 /datum/uplink_item/item/ammo/srifle_hv
 	name = ".20 Rifle HV ammo packet"
-	desc = ".20 ammo packet with high velocity ammunition. Contain 60 bullets."
-	item_cost = 6
+	desc = ".20 ammo packet with high velocity ammunition. Contains 50 bullets. Cheaper than buying in magazines."
+	item_cost = 4
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/ammo_magazine/ammobox/srifle_small/hv
 
 /datum/uplink_item/item/ammo/clrifle_hv
 	name = ".25 Rifle HV ammo packet"
-	desc = ".25 ammo packet with high velocity ammunition. Contain 60 bullets."
-	item_cost = 6
+	desc = ".25 ammo packet with high velocity ammunition. Contains 60 bullets. Cheaper than buying in magazines."
+	item_cost = 5
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/ammo_magazine/ammobox/clrifle_small/hv
 
 /datum/uplink_item/item/ammo/lrifle_hv
 	name = ".30 Rifle HV ammo packet"
-	desc = ".30 ammo packet with high velocity ammunition. Contain 60 bullets."
-	item_cost = 6
+	desc = ".30 ammo packet with high velocity ammunition. Contains 60 bullets. Cheaper than buying in magazines."
+	item_cost = 5
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/ammo_magazine/ammobox/lrifle_small/hv
 
 ////.50 Shotguns////
 
-/datum/uplink_item/item/ammo/m12/empty
-	name = "Empty M12 shotgun mag"
-	desc = "M12 shotgun magazine without any ammunition. Can fit 8 shells."
-	item_cost = 1
-	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
-	path = /obj/item/ammo_magazine/m12/empty
-
 /datum/uplink_item/item/ammo/m12
 	name = "M12 shotgun mag with slugs"
 	desc = "M12 shotgun magazine with slug shells loaded. Can fit 8 shells."
-	item_cost = 2
+	item_cost = 1
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/ammo_magazine/m12
 
 /datum/uplink_item/item/ammo/m12/beanbag
 	name = "M12 shotgun mag with beanbags"
 	desc = "M12 shotgun magazine with beanbag shells loaded. Can fit 8 shells."
-	item_cost = 2
+	item_cost = 1
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/ammo_magazine/m12/beanbag
 
 /datum/uplink_item/item/ammo/m12/pellet
 	name = "M12 shotgun mag with buckshot"
 	desc = "M12 shotgun magazine with buckshot shells loaded. Can fit 8 shells."
-	item_cost = 2
+	item_cost = 1
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/ammo_magazine/m12/pellet
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -360,25 +360,18 @@
 	new /obj/item/grenade/chem_grenade/cleaner(src)
 	new /obj/item/reagent_containers/spray/cleaner(src)
 
-/obj/item/storage/box/syndie_kit/slmagnum
-	name = ".40 lethal speedloader box"
-	desc = "Contains 2 .40 lethal speedloaders."
-
 /obj/item/storage/box/syndie_kit/slmagnum/populate_contents()
 	new /obj/item/ammo_magazine/slmagnum(src)
 	new /obj/item/ammo_magazine/slmagnum(src)
 
 /obj/item/storage/box/syndie_kit/slmagnum/highvelocity
 	name = ".40 HV speedloader box"
-	desc = "Contains 2 .40 HV speedloaders."
+	desc = "Contains 3 .40 HV speedloaders."
 
 /obj/item/storage/box/syndie_kit/slmagnum/highvelocity/populate_contents()
 	new /obj/item/ammo_magazine/slmagnum/highvelocity(src)
 	new /obj/item/ammo_magazine/slmagnum/highvelocity(src)
-
-/obj/item/storage/box/syndie_kit/slpistol
-	name = ".35 lethal speedloader box"
-	desc = "Contains 2 .35 lethal speedloaders."
+	new /obj/item/ammo_magazine/slmagnum/highvelocity(src)
 
 /obj/item/storage/box/syndie_kit/slpistol/populate_contents()
 	new /obj/item/ammo_magazine/slpistol(src)
@@ -386,9 +379,25 @@
 
 /obj/item/storage/box/syndie_kit/slpistol/hv
 	name = ".35 HV speedloaders box"
-	desc = "Contains 2 .35 HV speedloaders."
+	desc = "Contains 3 .35 HV speedloaders."
 
 /obj/item/storage/box/syndie_kit/slpistol/hv/populate_contents()
 	new /obj/item/ammo_magazine/slpistol/hv(src)
 	new /obj/item/ammo_magazine/slpistol/hv(src)
+	new /obj/item/ammo_magazine/slpistol/hv(src)
 
+/obj/item/storage/box/syndie_kit/slsrifle/hv
+	name = ".20 HV strip box"
+	desc = "Contains 2 .20 HV strips."
+
+/obj/item/storage/box/syndie_kit/slsrifle/hv/populate_contents()
+	new /obj/item/ammo_magazine/slsrifle/hv(src)
+	new /obj/item/ammo_magazine/slsrifle/hv(src)
+
+/obj/item/storage/box/syndie_kit/sllrifle/hv
+	name = ".30 HV strip box"
+	desc = "Contains 2 .30 HV strips."
+
+/obj/item/storage/box/syndie_kit/sllrifle/hv/populate_contents()
+	new /obj/item/ammo_magazine/sllrifle/hv(src)
+	new /obj/item/ammo_magazine/sllrifle/hv(src)

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -109,8 +109,8 @@
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_CARDBOARD = 1)
 	caliber = CAL_SRIFLE
 	ammo_type = /obj/item/ammo_casing/srifle
-	max_ammo = 60
-	ammo_states = list(60)
+	max_ammo = 50
+	ammo_states = list(50)
 
 /obj/item/ammo_magazine/ammobox/srifle_small/practice
 	ammo_type = /obj/item/ammo_casing/srifle/practice

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -18,7 +18,6 @@ There are important things regarding this file:
 	penetrating = 1
 
 /obj/item/projectile/bullet/pistol/hv
-	damage_types = list(BRUTE = 32)
 	armor_penetration = 20
 	step_delay = 0.75
 
@@ -67,8 +66,7 @@ There are important things regarding this file:
 	can_ricochet = FALSE
 
 /obj/item/projectile/bullet/srifle/hv
-	damage_types = list(BRUTE = 30)
-	armor_penetration = 30
+	armor_penetration = 35
 	step_delay = 0.75
 
 /obj/item/projectile/bullet/srifle/rubber
@@ -103,8 +101,7 @@ There are important things regarding this file:
 	can_ricochet = FALSE
 
 /obj/item/projectile/bullet/clrifle/hv
-	damage_types = list(BRUTE = 32)
-	armor_penetration = 20
+	armor_penetration = 25
 	step_delay = 0.75
 	can_ricochet = TRUE
 
@@ -140,7 +137,6 @@ There are important things regarding this file:
 	can_ricochet = FALSE
 
 /obj/item/projectile/bullet/lrifle/hv
-	damage_types = list(BRUTE = 30)
 	armor_penetration = 30
 	step_delay = 0.75
 
@@ -175,8 +171,7 @@ There are important things regarding this file:
 	can_ricochet = FALSE
 
 /obj/item/projectile/bullet/magnum/hv
-	damage_types = list(BRUTE = 39)
-	armor_penetration = 20
+	armor_penetration = 25
 	step_delay = 0.75
 
 /obj/item/projectile/bullet/magnum/rubber


### PR DESCRIPTION
## About The Pull Request

Removes the damage buffs to HV ammunition, removes lethal ammo from uplink, reduces the cost of HV ammo through uplink.

The penetration of HV ammo was increased where it was deemed too low for damage removal (.40 only receives 5 extra penetration from HV)

## Why It's Good For The Game

HV ammunition replacing lethals even more in an average contractor's armanents rewards observant inspectors, the reduction to damage makes HV less overpowered compared to other calibers, instead rewarding good use thanks to them being harder to dodge (high speed), and block (high AP)

## Changelog
:cl:
balance: HV ammo no longer has damage buff, penetration buffed where needed
balance: HV ammo is cheaper in uplink, uplink has no lethals anymore
spellcheck: fixed typos
/:cl: