### PR TITLE
Carrion spider menu QOL

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
@@ -105,10 +105,11 @@
 	owner_mob = owner_core.owner
 
 /obj/item/implant/carrion_spider/proc/toggle_group(group)
-	if(group == 1)
-		assigned_group_1 = !assigned_group_1
-	if(group == 2)
-		assigned_group_2 = !assigned_group_2
-	if(group == 3)
-		assigned_group_3 = !assigned_group_3	
+	switch(group)
+		if(1)
+			assigned_group_1 = !assigned_group_1
+		if(2)
+			assigned_group_2 = !assigned_group_2
+		if(3)
+			assigned_group_3 = !assigned_group_3	
 

--- a/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
@@ -12,6 +12,10 @@
 	var/do_gibs = TRUE
 	var/last_stun_time = 0 //Used to avoid cheese
 
+	var/assigned_group_1 = FALSE
+	var/assigned_group_2 = FALSE	
+	var/assigned_group_3 = FALSE
+
 	var/obj/item/organ/internal/carrion/core/owner_core
 	var/mob/living/carbon/human/owner_mob
 
@@ -98,3 +102,21 @@
 
 /obj/item/implant/carrion_spider/proc/update_owner_mob()
 	owner_mob = owner_core.owner
+
+/obj/item/implant/carrion_spider/proc/toggle_group(group)
+	if(group == 1)
+		if(assigned_group_1 == FALSE)
+			assigned_group_1 = TRUE
+		else
+			assigned_group_1 = FALSE
+	if(group == 2)
+		if(assigned_group_2 == FALSE)
+			assigned_group_2 = TRUE
+		else
+			assigned_group_2 = FALSE
+	if(group == 3)
+		if(assigned_group_3 == FALSE)
+			assigned_group_3 = TRUE
+		else
+			assigned_group_3 = FALSE	
+

--- a/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
@@ -84,7 +84,7 @@
 /obj/item/implant/carrion_spider/proc/toggle_attack(mob/user)
 	if (ready_to_attack)
 		ready_to_attack = FALSE
-		to_chat(user, SPAN_NOTICE("\The [src] wont attack nearby creatures anymore."))
+		to_chat(user, SPAN_NOTICE("\The [src] won't attack nearby creatures anymore."))
 	else
 		ready_to_attack = TRUE
 		to_chat(user, SPAN_NOTICE("\The [src] is ready to attack nearby creatures."))

--- a/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
@@ -11,6 +11,7 @@
 	var/gene_price = 0
 	var/do_gibs = TRUE
 	var/last_stun_time = 0 //Used to avoid cheese
+	var/ignore_activate_all = FALSE
 
 	var/assigned_group_1 = FALSE
 	var/assigned_group_2 = FALSE	
@@ -105,18 +106,9 @@
 
 /obj/item/implant/carrion_spider/proc/toggle_group(group)
 	if(group == 1)
-		if(assigned_group_1 == FALSE)
-			assigned_group_1 = TRUE
-		else
-			assigned_group_1 = FALSE
+		assigned_group_1 = !assigned_group_1
 	if(group == 2)
-		if(assigned_group_2 == FALSE)
-			assigned_group_2 = TRUE
-		else
-			assigned_group_2 = FALSE
+		assigned_group_2 = !assigned_group_2
 	if(group == 3)
-		if(assigned_group_3 == FALSE)
-			assigned_group_3 = TRUE
-		else
-			assigned_group_3 = FALSE	
+		assigned_group_3 = !assigned_group_3	
 

--- a/code/game/objects/items/weapons/implant/implants/carrion/observer_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/observer_spider.dm
@@ -3,6 +3,7 @@
 	desc = "A small spider with a giant blue eye. \red It's looking right at you."
 	icon_state = "spiderling_observer"
 	spider_price = 10
+	ignore_activate_all = TRUE
 	var/owner_loc
 	var/active = FALSE
 

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -114,7 +114,10 @@
 				"name" = initial(S.name),
 				"location" = "[spider_location]",
 				"spider" = "\ref[item]",
-				"implanted" = S.wearer
+				"implanted" = S.wearer,
+				"assigned_group_1" = S.assigned_group_1,
+				"assigned_group_2" = S.assigned_group_2,
+				"assigned_group_3" = S.assigned_group_3
 			)
 		)
 
@@ -141,7 +144,7 @@
 	if(href_list["activate_all"])
 		for(var/spider in active_spiders)
 			var/obj/item/implant/carrion_spider/CS = spider
-			if(istype(CS))
+			if(istype(CS) && CS.ignore_activate_all == FALSE)
 				CS.activate()
 
 	if(href_list["activate_group_1"])

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -150,7 +150,7 @@
 	if(href_list["activate_group_1"])
 		for(var/spider in active_spiders)
 			var/obj/item/implant/carrion_spider/CS = spider
-			if(istype(CS) && CS.assigned_group_1 == TRUE)
+			if(istype(CS) && CS.assigned_group_1)
 				CS.activate()
 
 	if(href_list["activate_group_2"])

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -144,6 +144,39 @@
 			if(istype(CS))
 				CS.activate()
 
+	if(href_list["activate_group_1"])
+		for(var/spider in active_spiders)
+			var/obj/item/implant/carrion_spider/CS = spider
+			if(istype(CS) && CS.assigned_group_1 == TRUE)
+				CS.activate()
+
+	if(href_list["activate_group_2"])
+		for(var/spider in active_spiders)
+			var/obj/item/implant/carrion_spider/CS = spider
+			if(istype(CS) && CS.assigned_group_2 == TRUE)
+				CS.activate()
+
+	if(href_list["activate_group_3"])
+		for(var/spider in active_spiders)
+			var/obj/item/implant/carrion_spider/CS = spider
+			if(istype(CS) && CS.assigned_group_3 == TRUE)
+				CS.activate()
+
+	if(href_list["toggle_group_1"])
+		var/obj/item/implant/carrion_spider/activated_spider = locate(href_list["toggle_group_1"]) in active_spiders
+		if(activated_spider)
+			activated_spider.toggle_group(1)
+
+	if(href_list["toggle_group_2"])
+		var/obj/item/implant/carrion_spider/activated_spider = locate(href_list["toggle_group_2"]) in active_spiders
+		if(activated_spider)
+			activated_spider.toggle_group(2)
+
+	if(href_list["toggle_group_3"])
+		var/obj/item/implant/carrion_spider/activated_spider = locate(href_list["toggle_group_3"]) in active_spiders
+		if(activated_spider)
+			activated_spider.toggle_group(3)
+
 	if(href_list["P"])
 		purchasePower(href_list["P"])
 		EvolutionMenu()

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -162,7 +162,7 @@
 	if(href_list["activate_group_3"])
 		for(var/spider in active_spiders)
 			var/obj/item/implant/carrion_spider/CS = spider
-			if(istype(CS) && CS.assigned_group_3 == TRUE)
+			if(istype(CS) && CS.assigned_group_3)
 				CS.activate()
 
 	if(href_list["toggle_group_1"])

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -144,7 +144,7 @@
 	if(href_list["activate_all"])
 		for(var/spider in active_spiders)
 			var/obj/item/implant/carrion_spider/CS = spider
-			if(istype(CS) && CS.ignore_activate_all == FALSE)
+			if(istype(CS) && !CS.ignore_activate_all)
 				CS.activate()
 
 	if(href_list["activate_group_1"])

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -156,7 +156,7 @@
 	if(href_list["activate_group_2"])
 		for(var/spider in active_spiders)
 			var/obj/item/implant/carrion_spider/CS = spider
-			if(istype(CS) && CS.assigned_group_2 == TRUE)
+			if(istype(CS) && CS.assigned_group_2)
 				CS.activate()
 
 	if(href_list["activate_group_3"])

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -36,7 +36,7 @@
 	else if(W.is_refillable())
 		return FALSE //so we can refill them via their afterattack.
 
-	else if(QUALITY_BOLT_TURNING in W.tool_qualities && user.a_intent == I_HELP)
+	else if((QUALITY_BOLT_TURNING in W.tool_qualities) && (user.a_intent == I_HELP))
 		if(W.use_tool(user, src, WORKTIME_NEAR_INSTANT, QUALITY_BOLT_TURNING, FAILCHANCE_EASY,  required_stat = STAT_MEC))
 			src.add_fingerprint(user)
 			if(anchored)
@@ -161,7 +161,7 @@
 
 /obj/structure/reagent_dispensers/fueltank/attackby(obj/item/I, mob/user)
 	src.add_fingerprint(user)
-	if(QUALITY_SCREW_DRIVING in I.tool_qualities && user.a_intent == I_HURT)
+	if((QUALITY_SCREW_DRIVING in I.tool_qualities) && (user.a_intent == I_HURT))
 		if(I.use_tool(user, src, WORKTIME_FAST, QUALITY_SCREW_DRIVING, FAILCHANCE_EASY,  required_stat = STAT_MEC))
 			user.visible_message("[user] screws [src]'s faucet [modded ? "closed" : "open"].", \
 				"You screw [src]'s faucet [modded ? "closed" : "open"]")

--- a/nano/templates/carrion_spiders.tmpl
+++ b/nano/templates/carrion_spiders.tmpl
@@ -8,12 +8,13 @@ Used In File(s): code\modules\organs\internal\carrion.dm
 		{{:helper.link('Activate All', 'radiation', {'activate_all' : 1}, null, 'fixedLeft')}}
 	</div>
 </div>
-<div class="item">
-	<div class="itemContent">
-		<td>{{:helper.link('Activate Group 1', null, {'activate_group_1' : 1}, null)}}<td>
-		<td>{{:helper.link('Activate Group 2', null, {'activate_group_2' : 1}, null)}}<td>
-		<td>{{:helper.link('Activate Group 3', null, {'activate_group_3' : 1}, null)}}<td>
+<div class="item" style="width: 100%;">
+	<div table class="itemContent" style="width: 100%;">
+		{{:helper.link('Activate Group 1', null, {'activate_group_1' : 1}, null)}}
+		{{:helper.link('Activate Group 2', null, {'activate_group_2' : 1}, null)}}
+		{{:helper.link('Activate Group 3', null, {'activate_group_3' : 1}, null)}}
 	</div>
+</table>
 </div>
 <table class='itemContent' style="width: 100%;">
 	<tr>
@@ -30,19 +31,19 @@ Used In File(s): code\modules\organs\internal\carrion.dm
 		<td>{{:value.location}}</td>
 		<td>{{:helper.link('activate', 'circle-arrow-s', {'activate_spider' : value.spider})}}</td>
 		{{if value.assigned_group_1}}
-			<td style="font-weight: bold;">{{:helper.link('1', null, {'toggle_group_1' : value.spider})}}</td>
+			<td>{{:helper.link('', 'check', {'toggle_group_1' : value.spider})}}</td>
 		{{else}}
-			<td style="font-weight: bold;"">{{:helper.link('1', null, {'toggle_group_1' : value.spider})}}</td>
+			<td>{{:helper.link('', 'close', {'toggle_group_1' : value.spider})}}</td>
 		{{/if}}
 		{{if value.assigned_group_2}}
-			<td style="font-weight: bold;">{{:helper.link('2', null, {'toggle_group_2' : value.spider})}}</td>
+			<td>{{:helper.link('', 'check', {'toggle_group_2' : value.spider})}}</td>
 		{{else}}
-			<td style="font-weight: bold;">{{:helper.link('2', null, {'toggle_group_2' : value.spider})}}</td>
+			<td>{{:helper.link('', 'close', {'toggle_group_2' : value.spider})}}</td>
 		{{/if}}
 		{{if value.assigned_group_3}}
-			<td style="font-weight: bold;">{{:helper.link('3', null, {'toggle_group_3' : value.spider})}}</td>
+			<td>{{:helper.link('', 'check', {'toggle_group_3' : value.spider})}}</td>
 		{{else}}
-			<td style="font-weight: bold;">{{:helper.link('3', null, {'toggle_group_3' : value.spider})}}</td>
+			<td>{{:helper.link('', 'close' , {'toggle_group_3' : value.spider})}}</td>
 		{{/if}}
 		<td>
 		{{if value.implanted}}

--- a/nano/templates/carrion_spiders.tmpl
+++ b/nano/templates/carrion_spiders.tmpl
@@ -6,9 +6,13 @@ Used In File(s): code\modules\organs\internal\carrion.dm
 <div class="item">
 	<div class="itemContent">
 		{{:helper.link('Activate All', 'radiation', {'activate_all' : 1}, null, 'fixedLeft')}}
-		{{:helper.link('Activate Group 1', 'null', {'activate_group_1' : 1}, null)}}
-		{{:helper.link('Activate Group 2', 'null', {'activate_group_2' : 1}, null)}}
-		{{:helper.link('Activate Group 3', 'null', {'activate_group_3' : 1}, null)}}
+	</div>
+</div>
+<div class="item">
+	<div class="itemContent">
+		<td>{{:helper.link('Activate Group 1', null, {'activate_group_1' : 1}, null)}}<td>
+		<td>{{:helper.link('Activate Group 2', null, {'activate_group_2' : 1}, null)}}<td>
+		<td>{{:helper.link('Activate Group 3', null, {'activate_group_3' : 1}, null)}}<td>
 	</div>
 </div>
 <table class='itemContent' style="width: 100%;">
@@ -16,15 +20,30 @@ Used In File(s): code\modules\organs\internal\carrion.dm
 		<td><b>Name</b></td>
 		<td><b>Location</b></td>
 		<td><b>Activation</b></td>
+		<td><b>1</b></td>
+		<td><b>2</b></td>
+		<td><b>3</b></td>
 	</tr>
 	{{for data.list_of_spiders}}
 		<tr>
 		<td>{{:value.name}}</td>
 		<td>{{:value.location}}</td>
 		<td>{{:helper.link('activate', 'circle-arrow-s', {'activate_spider' : value.spider})}}</td>
-		<td>{{:helper.link('1', 'null', {'toggle_group_1' : value.spider})}}</td>
-		<td>{{:helper.link('2', 'null', {'toggle_group_2' : value.spider})}}</td>
-		<td>{{:helper.link('3', 'null', {'toggle_group_3' : value.spider})}}</td>
+		{{if value.assigned_group_1}}
+			<td style="font-weight: bold;">{{:helper.link('1', null, {'toggle_group_1' : value.spider})}}</td>
+		{{else}}
+			<td style="font-weight: bold;"">{{:helper.link('1', null, {'toggle_group_1' : value.spider})}}</td>
+		{{/if}}
+		{{if value.assigned_group_2}}
+			<td style="font-weight: bold;">{{:helper.link('2', null, {'toggle_group_2' : value.spider})}}</td>
+		{{else}}
+			<td style="font-weight: bold;">{{:helper.link('2', null, {'toggle_group_2' : value.spider})}}</td>
+		{{/if}}
+		{{if value.assigned_group_3}}
+			<td style="font-weight: bold;">{{:helper.link('3', null, {'toggle_group_3' : value.spider})}}</td>
+		{{else}}
+			<td style="font-weight: bold;">{{:helper.link('3', null, {'toggle_group_3' : value.spider})}}</td>
+		{{/if}}
 		<td>
 		{{if value.implanted}}
 		{{:helper.link('pop out', 'circle-arrow-s', {'pop_out_spider' : value.spider})}}

--- a/nano/templates/carrion_spiders.tmpl
+++ b/nano/templates/carrion_spiders.tmpl
@@ -6,6 +6,9 @@ Used In File(s): code\modules\organs\internal\carrion.dm
 <div class="item">
 	<div class="itemContent">
 		{{:helper.link('Activate All', 'radiation', {'activate_all' : 1}, null, 'fixedLeft')}}
+		{{:helper.link('Activate Group 1', 'null', {'activate_group_1' : 1}, null)}}
+		{{:helper.link('Activate Group 2', 'null', {'activate_group_2' : 1}, null)}}
+		{{:helper.link('Activate Group 3', 'null', {'activate_group_3' : 1}, null)}}
 	</div>
 </div>
 <table class='itemContent' style="width: 100%;">
@@ -19,6 +22,9 @@ Used In File(s): code\modules\organs\internal\carrion.dm
 		<td>{{:value.name}}</td>
 		<td>{{:value.location}}</td>
 		<td>{{:helper.link('activate', 'circle-arrow-s', {'activate_spider' : value.spider})}}</td>
+		<td>{{:helper.link('1', 'null', {'toggle_group_1' : value.spider})}}</td>
+		<td>{{:helper.link('2', 'null', {'toggle_group_2' : value.spider})}}</td>
+		<td>{{:helper.link('3', 'null', {'toggle_group_3' : value.spider})}}</td>
 		<td>
 		{{if value.implanted}}
 		{{:helper.link('pop out', 'circle-arrow-s', {'pop_out_spider' : value.spider})}}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can now assign carrion spiders to one or multiple groups, and activate all the spiders in a group at the same time.

The observer spider will also no longer be triggered when activating all spiders, since you don't really want that to happen if you hit "activate all".

Also fixes a bug with fuel tanks, you can now make them leak fuel and secure them to the floor again.

Hyperioo, Handyman and Shown were a great help as per usual.

## Why It's Good For The Game

makes it easier to pull off 9000 IQ schemes
![carrionmenu](https://user-images.githubusercontent.com/45079529/153068906-a8161c76-5460-4aaa-95d7-c86659cf1a49.png)

## Changelog
:cl:
add: Carrion spiders can now be assigned to groups to make them activateable at the same time.
tweak: the observer spider will no longer be triggered when activating all carrion spiders
fix: you can now secure water and fuel tanks to the ground and make fuel tanks leak fuel again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
