### PR TITLE
Shield of holding no more

### DIFF
--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -278,7 +278,6 @@
 	var/max_w_class = ITEM_SIZE_HUGE
 	var/list/can_hold = list(
 		/obj/item/tool/sword/nt/shortsword,
-		/obj/item/tool/sword/nt/spear,
 		/obj/item/tool/knife/dagger/nt,
 		/obj/item/tool/knife/neotritual,
 		/obj/item/book/ritual/cruciform,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can no longer store the NT spear in the NT buckler.

## Why It's Good For The Game

The NT spear does not fit into backpacks, but the NT buckler does. Thus, you shouldn't be able to put the NT spear into the buckler and store the buckler inside of a backpack. Also change for the sake of change (I was asked to do this)

## Changelog
:cl:
tweak: you cannot store the NT spear inside the NT buckler anymore (not balance, I swear!)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
