### PR TITLE
Fixes "Get-Server-Log" not working if server hits midnight during a round

### DIFF
--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -92,13 +92,7 @@ ADMIN_VERB_ADD(/datum/admins/proc/view_txt_log, R_ADMIN, FALSE)
 	set name = "Show Server Log"
 	set desc = "Shows today's server log."
 
-	var/path = "data/logs/[time2text(world.realtime,"YYYY/MM-Month/DD-Day")].log"
-	if( fexists(path) )
-		src << run( file(path) )
-	else
-		to_chat(src, "<font color='red'>Error: view_txt_log(): File not found/Invalid path([path]).</font>")
-		return
-
+	src << run(diary)
 	return
 
 ADMIN_VERB_ADD(/datum/admins/proc/view_atk_log, R_ADMIN, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently, if the server's time hits the next day, the server log for that round will no longer be accessible from in-game.
This makes it so that the "Get Server Log" verb uses the `diary` var, which is set to the server file for the round on world start, and doesn't change.

## Changelog
:cl:
admin: Get-Server-Log will no longer stop working if the server hits midnight during a round.
/:cl: