### PR TITLE
Molotov fix

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -16,6 +16,7 @@
 	var/rag_underlay = "rag"
 	var/icon_state_full
 	var/icon_state_empty
+	var/bottle_thrower
 
 /obj/item/reagent_containers/food/drinks/bottle/on_reagent_change()
 	update_icon()
@@ -34,12 +35,17 @@
 	rag = null
 	return ..()
 
+/obj/item/reagent_containers/food/drinks/bottle/throw_at(atom/target, range, speed, thrower)
+	bottle_thrower = thrower
+	..()
+	bottle_thrower = null
+
 //when thrown on impact, bottles smash and spill their contents
 /obj/item/reagent_containers/food/drinks/bottle/throw_impact(atom/hit_atom, speed)
 	..()
 
-	var/mob/M = thrower
-	if(isGlass && istype(M) && M.a_intent == I_HURT)
+	var/mob/M = bottle_thrower
+	if(istype(M) && M.a_intent == I_HURT)
 		var/throw_dist = get_dist(throw_source, loc)
 		if(speed >= throw_speed && smash_check(throw_dist)) //not as reliable as smashing directly
 			if(reagents)
@@ -50,12 +56,8 @@
 /obj/item/reagent_containers/food/drinks/bottle/proc/smash_check(distance)
 	if(!isGlass || !smash_duration)
 		return 0
-
-	var/list/chance_table = list(90, 90, 85, 85, 60, 35, 15) //starting from distance 0
-	var/idx = max(distance + 1, 1) //since list indices start at 1
-	if(idx > chance_table.len)
-		return 0
-	return prob(chance_table[idx])
+	else
+		return TRUE
 
 /obj/item/reagent_containers/food/drinks/bottle/proc/smash(newloc, atom/against)
 	if(ismob(loc))

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -16,7 +16,7 @@
 	var/rag_underlay = "rag"
 	var/icon_state_full
 	var/icon_state_empty
-	var/bottle_thrower
+	var/bottle_thrower_intent
 
 /obj/item/reagent_containers/food/drinks/bottle/on_reagent_change()
 	update_icon()
@@ -36,16 +36,17 @@
 	return ..()
 
 /obj/item/reagent_containers/food/drinks/bottle/throw_at(atom/target, range, speed, thrower)
-	bottle_thrower = thrower
+	var/mob/H = thrower
+	if(istype(H))
+		bottle_thrower_intent = H.a_intent
 	..()
-	bottle_thrower = null
+	bottle_thrower_intent = null
 
 //when thrown on impact, bottles smash and spill their contents
 /obj/item/reagent_containers/food/drinks/bottle/throw_impact(atom/hit_atom, speed)
 	..()
 
-	var/mob/M = bottle_thrower
-	if(istype(M) && M.a_intent == I_HURT)
+	if(bottle_thrower_intent == I_HURT)
 		var/throw_dist = get_dist(throw_source, loc)
 		if(speed >= throw_speed && smash_check(throw_dist)) //not as reliable as smashing directly
 			if(reagents)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bottles properly break when thrown with harm intent again.

https://github.com/discordia-space/CEV-Eris/pull/5211 
broke bottles breaking when thrown (I now realize how stupid this sounds, but I'm not going to change it), because bottles check if the thrower is in harm intent when the bottle smashes, but that PR made the thrower var on the item get set to null before the throw_impact. This is a workaround.

I also removed the random chance from bottles breaking when thrown, they now always break regardless of range traveled when thrown by someone with harm intent. Fire is weak enough already, no need to add a random chance for a molotov not to break on impact.

## Why It's Good For The Game

No good revolution without molotovs.

## Changelog
:cl:
balance: bottles now always break when thrown with harm intent active
fix: bottles can now break again when thrown with harm intent active
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
