### PR TITLE
Carrion menu with colors

### DIFF
--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -1,7 +1,10 @@
+var/const/WIRE_EXPLODE = 1
 /datum/wires/explosive
 	wire_count = 1
+	descriptions = list(
+		new /datum/wire_description(WIRE_EXPLODE, "Detonation"),
+	)
 
-var/const/WIRE_EXPLODE = 1
 
 /datum/wires/explosive/proc/explode()
 	return

--- a/nano/templates/carrion_spiders.tmpl
+++ b/nano/templates/carrion_spiders.tmpl
@@ -33,17 +33,17 @@ Used In File(s): code\modules\organs\internal\carrion.dm
 		{{if value.assigned_group_1}}
 			<td>{{:helper.link('', 'check', {'toggle_group_1' : value.spider})}}</td>
 		{{else}}
-			<td>{{:helper.link('', 'close', {'toggle_group_1' : value.spider})}}</td>
+			<td>{{:helper.link('', 'close', {'toggle_group_1' : value.spider}, null, 'redButton')}}</td>
 		{{/if}}
 		{{if value.assigned_group_2}}
 			<td>{{:helper.link('', 'check', {'toggle_group_2' : value.spider})}}</td>
 		{{else}}
-			<td>{{:helper.link('', 'close', {'toggle_group_2' : value.spider})}}</td>
+			<td>{{:helper.link('', 'close', {'toggle_group_2' : value.spider}, null, 'redButton')}}</td>
 		{{/if}}
 		{{if value.assigned_group_3}}
 			<td>{{:helper.link('', 'check', {'toggle_group_3' : value.spider})}}</td>
 		{{else}}
-			<td>{{:helper.link('', 'close' , {'toggle_group_3' : value.spider})}}</td>
+			<td>{{:helper.link('', 'close' , {'toggle_group_3' : value.spider}, null, 'redButton')}}</td>
 		{{/if}}
 		<td>
 		{{if value.implanted}}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The carrion spider group buttons will now be red when the spider is not in a group and blue when it is in a group.

## Why It's Good For The Game

easier to distinguish which spiders are in which group.
## Changelog
:cl:
add: colors for carrion group activation buttons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
