### PR TITLE
carrion spider group coloring

### DIFF
--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -127,7 +127,7 @@
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "carrion_spiders.tmpl", "Carrion Spiders", 400, 400)
+		ui = new(user, src, ui_key, "carrion_spiders.tmpl", "Carrion Spiders", 500, 400)
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)

--- a/nano/templates/carrion_spiders.tmpl
+++ b/nano/templates/carrion_spiders.tmpl
@@ -30,21 +30,10 @@ Used In File(s): code\modules\organs\internal\carrion.dm
 		<td>{{:value.name}}</td>
 		<td>{{:value.location}}</td>
 		<td>{{:helper.link('activate', 'circle-arrow-s', {'activate_spider' : value.spider})}}</td>
-		{{if value.assigned_group_1}}
-			<td>{{:helper.link('', 'check', {'toggle_group_1' : value.spider})}}</td>
-		{{else}}
-			<td>{{:helper.link('', 'close', {'toggle_group_1' : value.spider}, null, 'redButton')}}</td>
-		{{/if}}
-		{{if value.assigned_group_2}}
-			<td>{{:helper.link('', 'check', {'toggle_group_2' : value.spider})}}</td>
-		{{else}}
-			<td>{{:helper.link('', 'close', {'toggle_group_2' : value.spider}, null, 'redButton')}}</td>
-		{{/if}}
-		{{if value.assigned_group_3}}
-			<td>{{:helper.link('', 'check', {'toggle_group_3' : value.spider})}}</td>
-		{{else}}
-			<td>{{:helper.link('', 'close' , {'toggle_group_3' : value.spider}, null, 'redButton')}}</td>
-		{{/if}}
+		<td>{{:helper.link('', value.assigned_group_1 ? 'check' : 'close', {'toggle_group_1' : value.spider}, null, value.assigned_group_1 ? null : 'redButton')}}</td>
+		<td>{{:helper.link('', value.assigned_group_2 ? 'check' : 'close', {'toggle_group_2' : value.spider}, null, value.assigned_group_2 ? null : 'redButton')}}</td>
+		<td>{{:helper.link('', value.assigned_group_3 ? 'check' : 'close', {'toggle_group_3' : value.spider}, null, value.assigned_group_3 ? null : 'redButton')}}</td>
+
 		<td>
 		{{if value.implanted}}
 		{{:helper.link('pop out', 'circle-arrow-s', {'pop_out_spider' : value.spider})}}

--- a/nano/templates/carrion_spiders.tmpl
+++ b/nano/templates/carrion_spiders.tmpl
@@ -33,17 +33,17 @@ Used In File(s): code\modules\organs\internal\carrion.dm
 		{{if value.assigned_group_1}}
 			<td>{{:helper.link('', 'check', {'toggle_group_1' : value.spider})}}</td>
 		{{else}}
-			<td>{{:helper.link('', 'close', {'toggle_group_1' : value.spider})}}</td>
+			<td>{{:helper.link('', 'close', {'toggle_group_1' : value.spider}, null, 'redButton')}}</td>
 		{{/if}}
 		{{if value.assigned_group_2}}
 			<td>{{:helper.link('', 'check', {'toggle_group_2' : value.spider})}}</td>
 		{{else}}
-			<td>{{:helper.link('', 'close', {'toggle_group_2' : value.spider})}}</td>
+			<td>{{:helper.link('', 'close', {'toggle_group_2' : value.spider}, null, 'redButton')}}</td>
 		{{/if}}
 		{{if value.assigned_group_3}}
 			<td>{{:helper.link('', 'check', {'toggle_group_3' : value.spider})}}</td>
 		{{else}}
-			<td>{{:helper.link('', 'close' , {'toggle_group_3' : value.spider})}}</td>
+			<td>{{:helper.link('', 'close' , {'toggle_group_3' : value.spider}, null, 'redButton')}}</td>
 		{{/if}}
 		<td>
 		{{if value.implanted}}
@@ -54,3 +54,4 @@ Used In File(s): code\modules\organs\internal\carrion.dm
 	{{/for}}
 </table>
 </div>
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The carrion spider group buttons will now be red when the spider is not in a group and blue when it is in a group.
words are hard, so this is what it looks like now.
![grafik](https://user-images.githubusercontent.com/45079529/153728753-19d0e5e9-478e-4a4d-b529-9fb1efb22fff.png)

also replaces a few else ifs with something better.
and makes the spider window a bit wider by default to accommodate all the buttons properly.
## Why It's Good For The Game

easier to distinguish which spiders are in which group.

## Changelog
:cl:
add: adds colors to carrion group activation buttons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
