### PR TITLE
Fix Atom Initialization

### DIFF
--- a/code/controllers/subsystems/atoms.dm
+++ b/code/controllers/subsystems/atoms.dm
@@ -29,8 +29,10 @@ SUBSYSTEM_DEF(atoms)
 	if(initialized == INITIALIZATION_INSSATOMS)
 		return
 
-	old_initialized = initialized
-	initialized = INITIALIZATION_INNEW_MAPLOAD
+	var/previous_state = null
+	if(initialized != INITIALIZATION_INNEW_MAPLOAD)
+		previous_state = initialized
+		initialized = INITIALIZATION_INNEW_MAPLOAD
 
 	if (atoms_to_return)
 		LAZYINITLIST(created_atoms)
@@ -56,7 +58,8 @@ SUBSYSTEM_DEF(atoms)
 	testing("Initialized [count] atoms")
 	pass(count)
 
-	initialized = old_initialized
+	if(previous_state != initialized)
+		initialized = previous_state
 
 	if(late_loaders.len)
 		for(var/I in 1 to late_loaders.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This bug had the potential to make the atoms subsystem lock up and fail to call LateInitialize for any newly atoms for the rest of a round. The system throws virtually no errors when lockup happens, making it hard to tell exactly how many bugs this was making overall.

## Changelog
:cl:
fix: fixes a niche issue in TGUI when ssatoms.old_initialized is set by another process at the same time InitializeAtoms is sleeping due to lag compensation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
