### PR TITLE
throwing knife damage fix

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -276,7 +276,7 @@
 	if(istype(item, /obj/item/stack/throwing_knife))
 		var/obj/item/stack/throwing_knife/V = item
 		var/ROB_throwing_damage = max(stats.getStat(STAT_ROB), 1)
-		V.throwforce = 35 / (1 + 100 / ROB_throwing_damage + 10) //soft cap; This would result in knives doing 10 damage at 0 rob, 20 at 50 ROB, 25 at 100 etc.
+		V.throwforce = 35 / (1 + 100 / ROB_throwing_damage) + 10 //soft cap; This would result in knives doing 10 damage at 0 rob, 20 at 50 ROB, 25 at 100 etc.
 		if(V.amount == 1)
 			drop_from_inventory(V)
 			V.throw_at(target, item.throw_range, item.throw_speed, src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

the calculation formula somehow managed to fuck up, so the damage numbers were always extremely low(I'm talking about 4 damage at 500 rob and 2 damage at 0)

## Why It's Good For The Game
bug fix
## Changelog
:cl:
fix: throwing knife damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
