### PR TITLE
Remove cables and pipes from planetary ruins to reduce server load.

### DIFF
--- a/maps/submaps/planetary_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/submaps/planetary_ruins/crashed_pod/crashed_pod.dmm
@@ -12,30 +12,11 @@
 /area/map_template/crashed_pod)
 "ad" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
-	dir = 1
+	dir = 1;
+	icon_state = "heater"
 	},
 /obj/structure/girder,
 /obj/effect/window_lwall_spawn/plasma/reinforced,
-/turf/simulated/floor/plating,
-/area/map_template/crashed_pod)
-"af" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
-	dir = 6
-	},
-/turf/simulated/wall/r_wall,
-/area/map_template/crashed_pod)
-"ag" = (
-/obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
-	dir = 1
-	},
-/obj/structure/girder,
-/obj/effect/window_lwall_spawn/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 10
-	},
 /turf/simulated/floor/plating,
 /area/map_template/crashed_pod)
 "ah" = (
@@ -45,7 +26,6 @@
 	pixel_x = -25;
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/map_template/crashed_pod)
@@ -61,13 +41,8 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/map_template/crashed_pod)
 "ak" = (
-/obj/machinery/power/terminal,
 /obj/machinery/light/small{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -79,33 +54,10 @@
 	name = "\improper Lifepod Plaque";
 	pixel_y = 30
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/map_template/crashed_pod)
-"am" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/map_template/crashed_pod)
-"an" = (
-/obj/machinery/atmospherics/omni/filter,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/map_template/crashed_pod)
 "ao" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	icon_state = "map";
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/tastybread,
 /obj/spawner/booze,
@@ -127,8 +79,6 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/map_template/crashed_pod)
 "aq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = -27
@@ -137,11 +87,6 @@
 /area/map_template/crashed_pod)
 "ar" = (
 /obj/effect/floor_decal/industrial/outline/blue,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -155,20 +100,12 @@
 	operating = 1;
 	pixel_y = -28
 	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
 "at" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/smes/buildable{
 	charge = 50000;
@@ -178,24 +115,11 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
 "au" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	icon_state = "map";
-	dir = 8
-	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
-"av" = (
-/obj/machinery/atmospherics/omni/filter,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/map_template/crashed_pod)
 "aw" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	icon_state = "map";
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/map_template/crashed_pod)
@@ -205,18 +129,6 @@
 /area/map_template/crashed_pod)
 "ay" = (
 /turf/simulated/wall,
-/area/map_template/crashed_pod)
-"az" = (
-/obj/machinery/atmospherics/binary/pump,
-/turf/simulated/wall,
-/area/map_template/crashed_pod)
-"aA" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/map_template/crashed_pod)
 "aB" = (
 /obj/machinery/sleeper{
@@ -228,19 +140,8 @@
 "aC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering,
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	icon_state = "map";
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/map_template/crashed_pod)
-"aD" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
-	dir = 5
-	},
-/turf/simulated/wall,
 /area/map_template/crashed_pod)
 "aE" = (
 /obj/machinery/sleeper{
@@ -254,12 +155,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/map_template/crashed_pod)
@@ -270,7 +165,6 @@
 /obj/item/electronics/circuitboard/unary_atmos/cooler,
 /obj/item/electronics/circuitboard/unary_atmos/heater,
 /obj/item/tank/oxygen/red,
-/obj/structure/cable,
 /obj/item/stack/material/uranium{
 	amount = 10
 	},
@@ -313,13 +207,10 @@
 /obj/item/stack/material/sandstone{
 	amount = 50
 	},
-/mob/living/simple_animal/hostile/roomba/boomba,
+/mob/living/simple_animal/hostile/roomba/gun_ba,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
 "aH" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -341,12 +232,6 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/map_template/crashed_pod)
 "aK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -359,10 +244,6 @@
 /area/map_template/crashed_pod)
 "aL" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	icon_state = "map";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -379,34 +260,16 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/map_template/crashed_pod)
-"aO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	icon_state = "map_universal";
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
 "aP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/solar_assembly,
 /obj/item/solar_assembly,
 /obj/item/solar_assembly,
 /obj/item/solar_assembly,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/map_template/crashed_pod)
-"aQ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
 "aR" = (
@@ -417,24 +280,14 @@
 "aS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
 "aT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9;
-	icon_state = "intact"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/tastybread,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
 "aU" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
-	dir = 6
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -442,18 +295,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
-"aV" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/map_template/crashed_pod)
 "aW" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -462,14 +304,12 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
 "aY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
@@ -479,18 +319,11 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/map_template/crashed_pod)
-"ba" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
 "bc" = (
 /obj/landmark/corpse/engineer,
@@ -532,13 +365,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/map_template/crashed_pod)
-"bg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/map_template/crashed_pod)
 "bh" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -560,15 +386,8 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/map_template/crashed_pod)
 "bk" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
-"bl" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
@@ -587,11 +406,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
-"bo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/map_template/crashed_pod)
 "bq" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small{
@@ -606,16 +420,6 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
-"bt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/map_template/crashed_pod)
 "bu" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/reagent_containers/food/condiment/saltshaker,
@@ -625,20 +429,6 @@
 /obj/machinery/reagentgrinder,
 /obj/item/reagent_containers/food/condiment/sugar,
 /turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
-"bv" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/map_template/crashed_pod)
-"bw" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
 "bx" = (
 /obj/machinery/alarm{
@@ -653,43 +443,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
-"by" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/map_template/crashed_pod)
-"bz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/map_template/crashed_pod)
 "bA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
 "bB" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/engineering,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
 "bC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -699,31 +462,10 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
-"bE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/map_template/crashed_pod)
 "bF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
 "bG" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -739,10 +481,6 @@
 /obj/item/storage/briefcase/inflatable,
 /obj/item/storage/briefcase/inflatable,
 /obj/item/storage/briefcase/inflatable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
 "bJ" = (
@@ -766,12 +504,6 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
 "bM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/closet,
 /obj/spawner/cloth,
 /obj/spawner/cloth,
@@ -815,12 +547,6 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/map_template/crashed_pod)
 "bQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/closet,
 /obj/spawner/cloth,
 /obj/spawner/cloth,
@@ -872,12 +598,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/closet,
 /obj/spawner/cloth,
 /obj/spawner/cloth,
@@ -995,9 +715,6 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/map_template/crashed_pod)
 "bZ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/machinery/power/port_gen/pacman/super,
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -1020,9 +737,6 @@
 /obj/spawner/techpart/low_chance,
 /obj/spawner/techpart/low_chance,
 /obj/structure/closet/crate,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
@@ -1072,7 +786,7 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/map_template/crashed_pod)
 "zb" = (
-/mob/living/simple_animal/hostile/roomba/boomba,
+/mob/living/simple_animal/hostile/roomba/gun_ba,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/crashed_pod)
 
@@ -1107,7 +821,7 @@ be
 ca
 bx
 bK
-ax
+ay
 bV
 bS
 ab
@@ -1117,12 +831,12 @@ ac
 ad
 ah
 aq
-aA
+aC
 aF
 aN
 aS
-bg
-bg
+bG
+bG
 bC
 bL
 bJ
@@ -1137,11 +851,11 @@ ai
 as
 ay
 aK
-aO
+bA
 ay
 aZ
 bh
-bE
+bG
 bO
 ab
 ab
@@ -1155,11 +869,11 @@ aj
 ar
 ay
 aH
-aV
+bG
 ay
 bc
 bi
-bt
+bA
 bR
 ay
 bY
@@ -1173,12 +887,12 @@ ak
 at
 ax
 aI
-ba
+bG
 ax
 bd
 bk
 bG
-bv
+bF
 bB
 bF
 bZ
@@ -1191,11 +905,11 @@ al
 aG
 ax
 aI
-aQ
+bA
 ax
 bj
-bl
-bw
+bi
+bA
 bM
 ay
 bW
@@ -1205,15 +919,15 @@ ab
 (8,1,1) = {"
 ac
 ad
-am
+aj
 au
-az
+ay
 aP
 aT
 ay
 bc
 bm
-by
+bA
 bQ
 ay
 ay
@@ -1222,16 +936,16 @@ ab
 "}
 (9,1,1) = {"
 ab
-af
-an
-av
-aD
+ab
+aw
+bA
+ay
 aU
 aW
 ay
 bf
 bn
-by
+bA
 bU
 ay
 bH
@@ -1240,17 +954,17 @@ ab
 "}
 (10,1,1) = {"
 ac
-ag
+ad
 ao
 aw
 aC
 aL
 aX
 aY
-bo
-bo
 bA
-bz
+bA
+bA
+bF
 bB
 bI
 cb

--- a/maps/submaps/planetary_ruins/ec_old_crash/ec_old_crash.dmm
+++ b/maps/submaps/planetary_ruins/ec_old_crash/ec_old_crash.dmm
@@ -33,10 +33,6 @@
 /obj/structure/girder,
 /turf/template_noop,
 /area/template_noop)
-"ah" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
 "ai" = (
 /obj/effect/damagedfloor,
 /obj/structure/lattice,
@@ -57,35 +53,13 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	dir = 1;
-	pixel_y = 0;
-	d1 = 16;
-	d2 = 0
-	},
 /turf/simulated/floor/airless,
 /area/map_template/ecship/cockpit)
 "am" = (
-/obj/machinery/atmospherics/unary/vent_pump/low{
-	dir = 4;
-	layer = 2.4;
-	level = 2
-	},
 /obj/machinery/alarm/low{
 	dir = 4;
 	icon_state = "alarm0";
 	pixel_x = -24
-	},
-/turf/simulated/floor/airless,
-/area/map_template/ecship/cockpit)
-"an" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless,
 /area/map_template/ecship/cockpit)
@@ -102,11 +76,6 @@
 /area/map_template/ecship/crew)
 "ar" = (
 /obj/machinery/door/airlock,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/lowpressure,
 /area/map_template/ecship/cockpit)
 "as" = (
@@ -126,14 +95,6 @@
 /obj/item/disk/astrodata,
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/science)
-"av" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/airless,
-/area/map_template/ecship/crew)
 "aw" = (
 /obj/structure/sign/atmosplaque{
 	pixel_y = 32
@@ -147,8 +108,8 @@
 /area/map_template/ecship/crew)
 "ay" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_x = -32
@@ -157,8 +118,8 @@
 /area/map_template/ecship/crew)
 "az" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
-	dir = 8
+	dir = 8;
+	icon_state = "propulsion"
 	},
 /turf/simulated/floor/plating,
 /area/map_template/ecship/cryo)
@@ -169,25 +130,7 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/map_template/ecship/science)
-"aC" = (
-/obj/machinery/atmospherics/unary/vent_pump/low{
-	dir = 4;
-	layer = 2.4;
-	level = 2
-	},
-/obj/item/stool/padded,
-/turf/simulated/floor/tiled/airless,
-/area/map_template/ecship/crew)
 "aD" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/item/reagent_containers/food/drinks/coffee{
 	desc = "Old cup of coffee. Very cold.  ";
 	name = "Old Robust Coffee"
@@ -197,20 +140,14 @@
 "aE" = (
 /obj/machinery/cryopod/broken,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/cryo)
-"aF" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/airless,
-/area/map_template/ecship/crew)
 "aG" = (
 /obj/machinery/light{
 	dir = 4;
@@ -253,15 +190,7 @@
 	},
 /turf/simulated/floor/tiled/airless,
 /area/map_template/ecship/crew)
-"aN" = (
-/turf/simulated/floor/tiled/airless,
-/area/map_template/ecship/crew)
 "aO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/item/deck/cards,
 /turf/simulated/floor/tiled/airless,
 /area/map_template/ecship/crew)
@@ -291,8 +220,8 @@
 /obj/structure/curtain/open/shower,
 /obj/structure/toilet,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /obj/structure/closet/wall_mounted/emcloset,
 /turf/simulated/floor/tiled/airless,
@@ -301,18 +230,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light/small{
 	brightness_color = "#aa2733"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
 	},
 /turf/simulated/floor/airless,
 /area/map_template/ecship/cryo)
@@ -323,25 +240,18 @@
 /obj/spawner/closet/wardrobe,
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/cryo)
-"aU" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white/lowpressure,
-/area/map_template/ecship/cryo)
-"aV" = (
-/turf/simulated/floor/tiled/white/lowpressure,
-/area/map_template/ecship/cryo)
 "aW" = (
 /obj/machinery/cryopod/broken,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/cryo)
 "aX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/white/lowpressure,
@@ -357,18 +267,6 @@
 /area/map_template/ecship/science)
 "ba" = (
 /obj/machinery/door/airlock/external,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /turf/simulated/floor,
 /area/map_template/ecship/cryo)
 "bb" = (
@@ -381,17 +279,6 @@
 /area/map_template/ecship/science)
 "bc" = (
 /obj/item/soap,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/tiled/airless,
 /area/map_template/ecship/cryo)
 "bd" = (
@@ -399,30 +286,17 @@
 /turf/simulated/floor/tiled/airless,
 /area/map_template/ecship/crew)
 "be" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/airless,
 /area/map_template/ecship/cryo)
-"bf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/airless,
-/area/map_template/ecship/crew)
 "bg" = (
 /obj/structure/sink{
 	pixel_y = -14
 	},
 /obj/structure/curtain/open/shower,
 /obj/structure/curtain/open/shower{
-	icon_state = "shower";
-	dir = 1
+	dir = 1;
+	icon_state = "shower"
 	},
-/obj/structure/cable,
 /obj/machinery/alarm/low{
 	dir = 4;
 	icon_state = "alarm0";
@@ -439,19 +313,11 @@
 	},
 /obj/structure/curtain/open/shower,
 /obj/structure/curtain/open/shower{
-	icon_state = "shower";
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/low{
-	dir = 1
+	dir = 1;
+	icon_state = "shower"
 	},
 /turf/simulated/floor/tiled/airless,
 /area/map_template/ecship/cryo)
-"bi" = (
-/obj/structure/catwalk,
-/obj/effect/damagedfloor,
-/turf/template_noop,
-/area/map_template/ecship/engine)
 "bj" = (
 /obj/structure/railing{
 	dir = 8
@@ -459,56 +325,11 @@
 /obj/item/stool/padded,
 /turf/simulated/floor/tiled/airless,
 /area/map_template/ecship/crew)
-"bk" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	icon_state = "1-4";
-	dir = 8
-	},
-/obj/effect/damagedfloor,
-/turf/template_noop,
-/area/map_template/ecship/engine)
 "bl" = (
 /obj/machinery/door/airlock,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/lowpressure,
-/area/map_template/ecship/cryo)
-"bm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/lowpressure,
-/area/map_template/ecship/cryo)
-"bn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/cryo)
 "bo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /turf/simulated/floor/airless,
 /area/map_template/ecship/crew)
 "bp" = (
@@ -532,17 +353,7 @@
 	},
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/cryo)
-"br" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white/lowpressure,
-/area/map_template/ecship/science)
 "bs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/optable,
 /mob/living/carbon/superior_animal/giant_spider/hunter,
 /turf/simulated/floor/tiled/white/lowpressure,
@@ -559,50 +370,8 @@
 /obj/structure/closet/secure_closet/personal/agrolyte,
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/science)
-"bw" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/damagedfloor,
-/turf/template_noop,
-/area/map_template/ecship/engine)
-"bx" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/airless,
-/area/map_template/ecship/crew)
 "by" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/item/board,
-/turf/simulated/floor/tiled/airless,
-/area/map_template/ecship/crew)
-"bz" = (
-/obj/machinery/atmospherics/unary/vent_pump/low{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /turf/simulated/floor/tiled/airless,
 /area/map_template/ecship/crew)
 "bA" = (
@@ -610,51 +379,16 @@
 	dir = 8
 	},
 /obj/machinery/power/apc{
-	icon_state = "apc0";
 	dir = 4;
+	icon_state = "apc0";
 	pixel_x = 28
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	dir = 1;
-	pixel_y = 0;
-	d1 = 16;
-	d2 = 0
 	},
 /turf/simulated/floor/tiled/airless,
 /area/map_template/ecship/crew)
 "bB" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/item/stool/padded,
 /turf/simulated/floor/tiled/airless,
 /area/map_template/ecship/crew)
-"bC" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 4
-	},
-/obj/effect/damagedfloor,
-/turf/template_noop,
-/area/map_template/ecship/engine)
 "bD" = (
 /obj/spawner/closet/wardrobe,
 /obj/machinery/alarm/low{
@@ -665,9 +399,6 @@
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/cryo)
 "bE" = (
-/obj/machinery/atmospherics/unary/vent_pump/low{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/cryo)
 "bF" = (
@@ -691,13 +422,6 @@
 /mob/living/carbon/superior_animal/giant_spider,
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/science)
-"bH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white/lowpressure,
-/area/map_template/ecship/science)
-"bI" = (
-/turf/simulated/floor/tiled/white/lowpressure,
-/area/map_template/ecship/science)
 "bK" = (
 /obj/structure/railing{
 	dir = 8
@@ -709,8 +433,8 @@
 /area/map_template/ecship/science)
 "bL" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /obj/structure/curtain/open/shower{
 	pixel_y = 16
@@ -726,14 +450,13 @@
 	dir = 1
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /obj/structure/curtain/open/shower{
 	pixel_y = 16
 	},
 /obj/structure/curtain/open/shower,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/science)
 "bN" = (
@@ -752,51 +475,15 @@
 /area/map_template/ecship/science)
 "bP" = (
 /obj/machinery/door/airlock/external,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /turf/simulated/floor,
 /area/map_template/ecship/crew)
 "bQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /turf/simulated/floor/tiled/airless,
 /area/map_template/ecship/crew)
 "bR" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/airless,
 /area/map_template/ecship/crew)
@@ -811,119 +498,38 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/airless,
 /area/map_template/ecship/crew)
-"bV" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 4
-	},
-/turf/template_noop,
-/area/map_template/ecship/engine)
 "bW" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/science)
-"bX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white/lowpressure,
-/area/map_template/ecship/science)
-"bY" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/template_noop,
-/area/map_template/ecship/engine)
-"bZ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/lowpressure,
-/area/map_template/ecship/science)
 "ca" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/item/tool/scalpel{
 	pixel_y = 12
 	},
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/science)
-"cb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/lowpressure,
-/area/map_template/ecship/science)
 "cc" = (
 /obj/machinery/door/airlock,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/science)
 "cd" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/science)
 "cf" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/science)
 "cg" = (
 /obj/machinery/door/airlock/external,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /turf/simulated/floor,
 /area/map_template/ecship/science)
 "ch" = (
@@ -931,48 +537,12 @@
 /obj/machinery/light/small{
 	brightness_color = "#aa2733"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /turf/simulated/floor,
 /area/map_template/ecship/science)
-"ci" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/damagedfloor,
-/turf/template_noop,
-/area/map_template/ecship/engine)
-"cj" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/damagedfloor,
-/turf/template_noop,
-/area/map_template/ecship/engine)
 "ck" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
-	dir = 8
+	dir = 8;
+	icon_state = "propulsion"
 	},
 /turf/simulated/wall/r_wall,
 /area/map_template/ecship/cryo)
@@ -996,23 +566,11 @@
 	},
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/science)
-"cn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/portable_atmospherics/hydroponics{
-	closed_system = 1;
-	name = "isolation tray"
-	},
-/turf/simulated/floor/tiled/white/lowpressure,
-/area/map_template/ecship/science)
 "co" = (
 /obj/machinery/portable_atmospherics/hydroponics{
 	closed_system = 1;
 	name = "isolation tray"
 	},
-/turf/simulated/floor/tiled/white/lowpressure,
-/area/map_template/ecship/science)
-"cp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/science)
 "cq" = (
@@ -1044,21 +602,17 @@
 	pixel_y = -32
 	},
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/unary/vent_pump/low{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/science)
 "ct" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 6
+	dir = 6;
+	icon_state = "warning"
 	},
 /obj/structure/closet/l3closet,
-/obj/structure/cable,
 /obj/machinery/power/apc{
-	icon_state = "apc0";
 	dir = 4;
+	icon_state = "apc0";
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/white/lowpressure,
@@ -1085,18 +639,7 @@
 /obj/item/remains/xeno,
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/science)
-"cx" = (
-/obj/machinery/atmospherics/unary/vent_pump/low{
-	dir = 1;
-	layer = 2.4;
-	level = 2
-	},
-/turf/simulated/floor/tiled/white/lowpressure,
-/area/map_template/ecship/science)
 "cy" = (
-/obj/machinery/atmospherics/unary/vent_pump/low{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/science)
 "cz" = (
@@ -1143,11 +686,6 @@
 /area/map_template/ecship/engineering)
 "cI" = (
 /obj/machinery/door/airlock,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/lowpressure,
 /area/map_template/ecship/engineering)
 "cJ" = (
@@ -1161,30 +699,10 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor,
 /area/map_template/ecship/engineering)
-"cL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/map_template/ecship/engineering)
 "cM" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	dir = 1;
-	pixel_y = 0;
-	d1 = 16;
-	d2 = 0
-	},
 /obj/machinery/power/apc{
-	icon_state = "apc0";
 	dir = 1;
+	icon_state = "apc0";
 	pixel_y = 28
 	},
 /turf/simulated/floor,
@@ -1197,36 +715,12 @@
 /turf/simulated/floor,
 /area/map_template/ecship/engineering)
 "cO" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
-	dir = 6
-	},
 /obj/machinery/alarm/low{
 	dir = 4;
 	icon_state = "alarm0";
 	pixel_x = -24
 	},
 /obj/machinery/meter,
-/turf/simulated/floor,
-/area/map_template/ecship/engineering)
-"cP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/map_template/ecship/engineering)
-"cQ" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/map_template/ecship/engineering)
-"cR" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /turf/simulated/floor,
 /area/map_template/ecship/engineering)
 "cS" = (
@@ -1237,63 +731,15 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor,
 /area/map_template/ecship/engineering)
-"cU" = (
-/turf/simulated/floor,
-/area/map_template/ecship/engineering)
-"cV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/map_template/ecship/engineering)
-"cW" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/simulated/floor,
-/area/map_template/ecship/engineering)
-"cX" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/map_template/ecship/engineering)
 "cY" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 4
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_x = -32
 	},
 /obj/machinery/meter,
-/turf/simulated/floor,
-/area/map_template/ecship/engineering)
-"cZ" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/map_template/ecship/engineering)
-"da" = (
-/obj/machinery/atmospherics/unary/vent_pump/low{
-	dir = 8
-	},
 /turf/simulated/floor,
 /area/map_template/ecship/engineering)
 "db" = (
@@ -1302,43 +748,18 @@
 	icon_state = "tube1"
 	},
 /obj/machinery/power/smes/buildable,
-/obj/structure/cable,
 /turf/simulated/floor,
 /area/map_template/ecship/engineering)
 "dc" = (
 /obj/structure/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/template_noop,
 /area/map_template/ecship/engine)
-"dd" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
-/area/map_template/ecship/engineering)
 "de" = (
 /obj/machinery/suit_storage_unit/engineering,
 /obj/machinery/light/small{
 	brightness_color = "#aa2733";
-	icon_state = "bulb1";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor,
 /area/map_template/ecship/engineering)
@@ -1352,269 +773,57 @@
 	},
 /turf/simulated/wall/titanium,
 /area/map_template/ecship/engineering)
-"dh" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 1;
-	target_pressure = 200
-	},
-/turf/simulated/floor,
-/area/map_template/ecship/engineering)
-"di" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/map_template/ecship/engineering)
-"dj" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor,
-/area/map_template/ecship/engineering)
 "dk" = (
 /obj/machinery/suit_storage_unit/engineering,
 /obj/machinery/light/small{
 	brightness_color = "#aa2733";
-	icon_state = "bulb1";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/map_template/ecship/engineering)
-"dl" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
-/obj/effect/damagedfloor,
-/turf/template_noop,
-/area/map_template/ecship/engine)
-"dm" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 6
-	},
-/obj/effect/damagedfloor,
-/turf/template_noop,
-/area/map_template/ecship/engine)
-"dn" = (
-/obj/machinery/door/airlock/external,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/simulated/floor,
-/area/map_template/ecship/engineering)
-"do" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor,
 /area/map_template/ecship/engineering)
 "dp" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 5
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/simulated/floor,
-/area/map_template/ecship/engineering)
-"dq" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor,
 /area/map_template/ecship/engineering)
 "dr" = (
 /obj/structure/bed/chair,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor,
 /area/map_template/ecship/engineering)
 "ds" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/atmospherics/valve/open{
-	icon_state = "map_valve1";
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor,
 /area/map_template/ecship/engineering)
 "dt" = (
 /obj/machinery/door/airlock/external,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/map_template/ecship/engineering)
 "du" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/map_template/ecship/engineering)
-"dv" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/effect/damagedfloor,
-/turf/template_noop,
-/area/map_template/ecship/engine)
-"dw" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 9
-	},
-/obj/effect/damagedfloor,
-/turf/template_noop,
-/area/map_template/ecship/engine)
 "dx" = (
 /obj/structure/catwalk,
 /obj/effect/damagedfloor,
 /obj/effect/damagedfloor,
 /turf/template_noop,
 /area/map_template/ecship/engine)
-"dy" = (
-/obj/machinery/power/solar,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	dir = 4;
-	pixel_y = 0;
-	d1 = 16;
-	d2 = 0
-	},
-/turf/simulated/floor/airless,
-/area/map_template/ecship/engine)
 "dz" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
-/obj/structure/cable{
-	icon_state = "0-2";
-	dir = 4;
-	pixel_y = 0;
-	d1 = 16;
-	d2 = 0
-	},
 /obj/effect/damagedfloor,
 /turf/template_noop,
-/area/map_template/ecship/engine)
-"dA" = (
-/obj/machinery/power/solar,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 4
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/airless,
-/area/map_template/ecship/engine)
-"dB" = (
-/obj/machinery/power/solar,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/airless,
 /area/map_template/ecship/engine)
 "dE" = (
 /obj/structure/table/standard,
 /obj/machinery/button/ignition{
 	id = "sev_engine";
 	pixel_x = -5
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/map_template/ecship/engineering)
@@ -1624,33 +833,13 @@
 	},
 /turf/simulated/floor,
 /area/map_template/ecship/engineering)
-"dG" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 4
-	},
-/obj/effect/damagedfloor,
-/turf/template_noop,
-/area/map_template/ecship/engine)
 "dH" = (
 /obj/machinery/power/solar,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable{
-	icon_state = "0-2";
-	dir = 4;
-	pixel_y = 0;
-	d1 = 16;
-	d2 = 0
-	},
 /turf/simulated/floor/airless,
 /area/map_template/ecship/engine)
 "dI" = (
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
 /obj/effect/damagedfloor,
 /turf/template_noop,
 /area/map_template/ecship/engine)
@@ -1663,53 +852,12 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor,
 /area/map_template/ecship/engineering)
 "dL" = (
 /obj/structure/catwalk,
 /obj/machinery/power/tracker,
-/obj/structure/cable,
 /turf/template_noop,
-/area/map_template/ecship/engine)
-"dO" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "1-4";
-	dir = 4
-	},
-/obj/effect/damagedfloor,
-/turf/simulated/floor/airless,
-/area/map_template/ecship/engine)
-"dR" = (
-/turf/simulated/wall/r_wall,
-/area/map_template/ecship/engine)
-"dS" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/damagedfloor,
-/turf/simulated/floor/airless,
-/area/map_template/ecship/engine)
-"dT" = (
-/obj/machinery/air_sensor{
-	id_tag = "sev_hydrogen"
-	},
-/turf/simulated/floor/reinforced,
-/area/map_template/ecship/engine)
-"dU" = (
-/obj/machinery/air_sensor{
-	id_tag = "sev_oxygen"
-	},
-/turf/simulated/floor/reinforced,
-/area/map_template/ecship/engine)
-"dV" = (
-/turf/simulated/floor/reinforced,
 /area/map_template/ecship/engine)
 "dW" = (
 /obj/structure/sign/signnew/flammables{
@@ -1717,24 +865,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/map_template/ecship/engine)
-"dX" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 5
-	},
-/obj/effect/damagedfloor,
-/turf/simulated/floor/airless,
-/area/map_template/ecship/engine)
-"dY" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/effect/damagedfloor,
-/turf/template_noop,
-/area/template_noop)
 "dZ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/binary/passive_gate{
@@ -1746,46 +876,12 @@
 /obj/structure/sign/atmos_o2{
 	name = "\improper OXYGEN"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 4
-	},
 /turf/simulated/wall/r_wall,
-/area/map_template/ecship/engine)
-"eb" = (
-/obj/machinery/atmospherics/unary/vent_pump/engine{
-	icon_state = "map_vent";
-	dir = 8;
-	use_power = 1;
-	pump_direction = 0;
-	external_pressure_bound = 4000;
-	external_pressure_bound_default = 4000
-	},
-/turf/simulated/floor/reinforced,
 /area/map_template/ecship/engine)
 "ed" = (
-/obj/machinery/atmospherics/unary/vent_pump/engine{
-	dir = 4;
-	external_pressure_bound = 4000;
-	external_pressure_bound_default = 4000;
-	icon_state = "map_vent";
-	pump_direction = 0;
-	use_power = 1
-	},
 /turf/simulated/floor/reinforced,
 /area/map_template/ecship/engine)
-"ee" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	icon_state = "intact";
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/map_template/ecship/engine)
 "ef" = (
-/obj/machinery/atmospherics/valve{
-	icon_state = "map_valve0";
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/map_template/ecship/engine)
 "eg" = (
@@ -1795,24 +891,12 @@
 	},
 /turf/template_noop,
 /area/map_template/ecship/engine)
-"eh" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10
-	},
-/obj/effect/damagedfloor,
-/turf/template_noop,
-/area/map_template/ecship/engine)
 "ei" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/airless,
 /area/map_template/ecship/engine)
 "ej" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 6
-	},
 /obj/effect/damagedfloor,
 /turf/template_noop,
 /area/map_template/ecship/engine)
@@ -1825,16 +909,12 @@
 /area/map_template/ecship/engine)
 "el" = (
 /obj/machinery/atmospherics/valve/open{
-	icon_state = "map_valve1";
-	dir = 4
+	dir = 4;
+	icon_state = "map_valve1"
 	},
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "em" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
-	},
 /turf/simulated/wall/r_wall,
 /area/map_template/ecship/engine)
 "en" = (
@@ -1843,14 +923,8 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/map_template/ecship/engine)
-"eo" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/turf/template_noop,
-/area/template_noop)
 "ep" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/template_noop,
 /area/template_noop)
 "kP" = (
@@ -1876,7 +950,6 @@
 /turf/template_noop,
 /area/template_noop)
 "SX" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/item/device/scanner/xenobio,
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/science)
@@ -1887,7 +960,6 @@
 /turf/template_noop,
 /area/template_noop)
 "Vy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/tool/saw/circular,
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/science)
@@ -2018,7 +1090,7 @@ aA
 aX
 cm
 bG
-bI
+cy
 cm
 cw
 aX
@@ -2052,11 +1124,11 @@ aa
 aA
 aA
 aY
-br
+cy
 Vy
-bX
-cn
-cx
+cy
+co
+cy
 co
 aA
 aA
@@ -2089,10 +1161,10 @@ aB
 ao
 aZ
 aJ
-bI
+cy
 bs
 co
-bI
+cy
 co
 ao
 aB
@@ -2125,9 +1197,9 @@ aA
 aA
 aZ
 SX
-bH
-bZ
-cp
+cy
+cy
+cy
 cy
 cF
 aA
@@ -2161,9 +1233,9 @@ aA
 aA
 au
 bt
-bI
+cy
 ca
-bI
+cy
 cz
 cG
 aA
@@ -2172,17 +1244,17 @@ NM
 NM
 NM
 NM
-dy
-dy
-dy
-dy
-dy
-dy
-dy
-dy
-dy
-dy
-dy
+dH
+dH
+dH
+dH
+dH
+dH
+dH
+dH
+dH
+dH
+dH
 aa
 "}
 (9,1,1) = {"
@@ -2198,7 +1270,7 @@ aA
 aA
 bu
 bK
-cb
+cy
 cq
 cA
 aA
@@ -2207,8 +1279,8 @@ aA
 NM
 NM
 NM
-bk
-ci
+dI
+dI
 dc
 dc
 dc
@@ -2243,18 +1315,18 @@ NM
 NM
 NM
 NM
-bw
-dA
-dA
-dA
-dA
-dA
+dI
+dH
+dH
+dH
+dH
+dH
 aa
 aa
-ah
+ep
 aa
-dA
-dA
+dH
+dH
 aa
 "}
 (11,1,1) = {"
@@ -2279,17 +1351,17 @@ NM
 NM
 NM
 NM
-bw
-dB
-dB
+dI
+dH
+dH
 aa
 aa
-dB
+dH
 aa
-ah
+ep
 aa
 aa
-dB
+dH
 aa
 aa
 "}
@@ -2306,7 +1378,7 @@ NM
 NM
 aA
 bM
-bZ
+cy
 cs
 cB
 NM
@@ -2315,7 +1387,7 @@ NM
 NM
 NM
 NM
-bw
+dI
 NM
 aa
 aa
@@ -2351,14 +1423,14 @@ NM
 NM
 NM
 NM
-bw
+dI
 NM
 aa
 aa
 aa
 aa
 aa
-ah
+ep
 aa
 aa
 aa
@@ -2387,17 +1459,17 @@ NM
 NM
 NM
 NM
-bw
+dI
 NM
 NM
 aa
 aa
-dR
-dR
-dR
-dR
-dR
-dR
+em
+em
+em
+em
+em
+em
 aa
 aa
 "}
@@ -2422,19 +1494,19 @@ NM
 NM
 NM
 NM
-bi
-bw
-bi
-bi
+dI
+dI
+dI
+dI
 NM
-dR
-dR
-dV
-dV
-dV
-dV
-dR
-dR
+em
+em
+ed
+ed
+ed
+ed
+em
+em
 aa
 "}
 (16,1,1) = {"
@@ -2458,19 +1530,19 @@ NM
 NM
 NM
 cH
-dd
-dn
+dJ
+dt
 cH
-dl
+dz
 NM
-dR
-dT
-dV
-dV
-dV
-dV
-dV
-dR
+em
+ed
+ed
+ed
+ed
+ed
+ed
+em
 aa
 "}
 (17,1,1) = {"
@@ -2495,18 +1567,18 @@ NM
 cH
 cH
 de
-do
+du
 cH
-dl
+dz
 NM
-dR
-dR
-dV
+em
+em
 ed
-dV
-dV
-dR
-dR
+ed
+ed
+ed
+em
+em
 aa
 "}
 (18,1,1) = {"
@@ -2531,17 +1603,17 @@ cH
 cH
 cH
 df
-do
+du
 cH
-dl
+dz
 NM
 aa
-dR
+em
 dW
-ee
+em
 en
-dR
-dR
+em
+em
 aa
 aa
 "}
@@ -2567,15 +1639,15 @@ cH
 cH
 cH
 dg
-dn
+dt
 cH
-dl
+dz
 dx
 NM
 aa
-ah
+ep
 ef
-ah
+ep
 aa
 aa
 aa
@@ -2602,7 +1674,7 @@ cJ
 cO
 cT
 cY
-dh
+du
 dp
 cH
 cH
@@ -2611,7 +1683,7 @@ NM
 NM
 mD
 eg
-ah
+ep
 aa
 aa
 aa
@@ -2625,29 +1697,29 @@ ak
 am
 ac
 ax
-aC
-aN
+bB
+bQ
 bd
-bx
+bQ
 bo
 bS
 aq
 aq
 cH
 cK
-cP
-cU
-cP
+du
+du
+du
 sf
-dq
-cU
-dd
-dG
+du
+du
+dJ
+dI
 mD
 mD
 mD
-eh
-eo
+ej
+ep
 UQ
 aa
 aa
@@ -2658,34 +1730,34 @@ ad
 ad
 ad
 ad
-an
+ap
 ar
-av
+bQ
 aD
 aO
-bf
+bQ
 by
 bB
-bf
+bQ
 cu
 cC
 cI
-cL
-cQ
-cV
-cZ
-di
+du
+du
+du
+du
+du
 dr
 dE
 dJ
-dO
-dS
-dS
-dX
+YW
+YW
+YW
+YW
 YW
 ei
-ah
-ah
+ep
+ep
 aa
 aa
 "}
@@ -2697,27 +1769,27 @@ al
 ap
 ac
 aw
-aF
-aN
+bQ
+bQ
 bd
-bz
+bQ
 bQ
 bS
 aq
 aq
 cH
 cM
-cR
-cW
-da
-cU
-dq
+du
+du
+du
+du
+du
 dF
-dd
+dJ
 dI
 mD
 mD
-dY
+mD
 ej
 ep
 aa
@@ -2744,22 +1816,22 @@ NM
 cH
 cN
 cS
-cX
+du
 db
-dj
+du
 ds
 cH
 cH
-dv
+dz
 NM
 NM
-dY
+mD
 ek
-ah
+ep
 aa
 aa
 aa
-ah
+ep
 "}
 (25,1,1) = {"
 ac
@@ -2785,13 +1857,13 @@ cH
 dg
 dt
 cH
-dm
-dw
+dz
+dI
 NM
 aa
 dZ
 el
-ah
+ep
 aa
 aa
 aa
@@ -2821,13 +1893,13 @@ cH
 df
 du
 cH
-dv
+dz
 aa
 aa
-dR
+em
 ea
 em
-dR
+em
 aa
 aa
 aa
@@ -2857,13 +1929,13 @@ cH
 dk
 du
 cH
-dv
+dz
 aa
-dR
-dR
-eb
-eb
-dV
+em
+em
+ed
+ed
+ed
 aa
 aa
 aa
@@ -2890,18 +1962,18 @@ NM
 NM
 NM
 cH
-dd
+dJ
 dt
 cH
-dv
+dz
 aa
-dR
-dU
-dV
-dV
-dV
-dV
-dV
+em
+ed
+ed
+ed
+ed
+ed
+ed
 aa
 aa
 "}
@@ -2926,19 +1998,19 @@ NM
 NM
 NM
 NM
-bi
-bC
-cj
-dw
+dI
+dI
+dI
+dI
 aa
-dR
-dR
-dV
-dV
-dV
-dV
-dR
-dR
+em
+em
+ed
+ed
+ed
+ed
+em
+em
 aa
 "}
 (30,1,1) = {"
@@ -2963,17 +2035,17 @@ NM
 NM
 NM
 NM
-bV
+dc
 aa
 aa
 aa
 aa
-dR
-dR
-dR
-dR
-dR
-dR
+em
+em
+em
+em
+em
+em
 aa
 aa
 "}
@@ -2999,14 +2071,14 @@ NM
 NM
 NM
 NM
-bV
+dc
 aa
 aa
 aa
 aa
 aa
 aa
-ah
+ep
 aa
 aa
 aa
@@ -3035,14 +2107,14 @@ NM
 NM
 NM
 aa
-bV
+dc
 aa
 aa
 aa
 aa
 aa
 aa
-ah
+ep
 aa
 aa
 aa
@@ -3071,7 +2143,7 @@ NM
 NM
 NM
 aa
-bV
+dc
 aa
 aa
 aa
@@ -3107,18 +2179,18 @@ NM
 NM
 aa
 aa
-bV
+dc
 aa
 aa
 aa
-dy
-dy
-dy
-dy
-dy
-ah
+dH
+dH
+dH
+dH
+dH
+ep
 aa
-dy
+dH
 aa
 "}
 (35,1,1) = {"
@@ -3131,7 +2203,7 @@ ab
 as
 as
 aT
-bm
+bE
 bD
 as
 as
@@ -3143,7 +2215,7 @@ NM
 aa
 aa
 aa
-bY
+dc
 dc
 dc
 dc
@@ -3166,8 +2238,8 @@ aa
 at
 as
 aE
-aU
-bn
+bE
+bE
 bE
 bq
 as
@@ -3180,17 +2252,17 @@ aa
 aa
 aa
 aa
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
+dH
+dH
+dH
+dH
+dH
+dH
+dH
+dH
+dH
+dH
+dH
 aa
 "}
 (37,1,1) = {"
@@ -3202,9 +2274,9 @@ aa
 ab
 as
 aH
-aV
+bE
 kP
-aV
+bE
 aH
 as
 ab
@@ -3217,16 +2289,16 @@ aa
 aa
 aa
 aa
-dB
-dB
-dB
+dH
+dH
+dH
 aa
-ah
+ep
 aa
-dB
-dB
-dB
-dB
+dH
+dH
+dH
+dH
 aa
 "}
 (38,1,1) = {"

--- a/maps/submaps/planetary_ruins/marooned/marooned.dmm
+++ b/maps/submaps/planetary_ruins/marooned/marooned.dmm
@@ -56,8 +56,8 @@
 /area/map_template/marooned)
 "l" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -78,8 +78,8 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/item/paper/marooned/note09,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -100,8 +100,8 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/marooned)
@@ -117,8 +117,8 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/marooned)
@@ -129,8 +129,8 @@
 "t" = (
 /obj/structure/closet/crate/freezer,
 /obj/structure/railing{
-	icon_state = "handrail";
-	dir = 4
+	dir = 4;
+	icon_state = "handrail"
 	},
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -164,8 +164,8 @@
 	pixel_y = 1
 	},
 /obj/structure/railing{
-	icon_state = "handrail";
-	dir = 4
+	dir = 4;
+	icon_state = "handrail"
 	},
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -196,12 +196,12 @@
 /area/template_noop)
 "D" = (
 /obj/structure/railing{
-	icon_state = "handrail";
-	dir = 4
+	dir = 4;
+	icon_state = "handrail"
 	},
 /obj/structure/bed/chair{
-	icon_state = "chair_preview";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_preview"
 	},
 /obj/item/trash/liquidfood,
 /obj/item/trash/liquidfood,
@@ -222,12 +222,12 @@
 /area/map_template/marooned)
 "H" = (
 /obj/structure/railing{
-	icon_state = "handrail";
-	dir = 4
+	dir = 4;
+	icon_state = "handrail"
 	},
 /obj/structure/bed/chair{
-	icon_state = "chair_preview";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_preview"
 	},
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -236,10 +236,6 @@
 /obj/item/tool/wirecutters,
 /obj/item/stack/cable_coil,
 /obj/machinery/power/port_gen/pacman/super,
-/obj/structure/cable{
-	icon_state = "0-5";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/map_template/marooned)
 "J" = (
@@ -249,36 +245,28 @@
 "L" = (
 /obj/structure/inflatable/wall,
 /obj/structure/railing{
-	icon_state = "handrail";
-	dir = 4
+	dir = 4;
+	icon_state = "handrail"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/marooned)
 "M" = (
 /obj/structure/inflatable/door,
-/obj/structure/cable{
-	icon_state = "1-6";
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/map_template/marooned)
 "N" = (
 /obj/structure/inflatable/wall,
 /obj/structure/railing{
-	icon_state = "handrail";
-	dir = 8
+	dir = 8;
+	icon_state = "handrail"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/map_template/marooned)
 "O" = (
 /obj/structure/inflatable/door,
-/obj/structure/cable{
-	icon_state = "2-5";
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -288,15 +276,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
 /area/map_template/marooned)
-"Q" = (
-/obj/structure/inflatable/wall,
-/obj/structure/cable{
-	icon_state = "2-5";
-	dir = 2
-	},
-/obj/effect/damagedfloor,
-/turf/template_noop,
-/area/template_noop)
 "R" = (
 /obj/structure/inflatable/door,
 /obj/effect/damagedfloor,
@@ -304,14 +283,6 @@
 /area/template_noop)
 "S" = (
 /obj/structure/inflatable/wall,
-/obj/effect/damagedfloor,
-/turf/template_noop,
-/area/template_noop)
-"T" = (
-/obj/structure/cable{
-	icon_state = "2-5";
-	dir = 1
-	},
 /obj/effect/damagedfloor,
 /turf/template_noop,
 /area/template_noop)
@@ -332,24 +303,6 @@
 	},
 /obj/item/device/radio,
 /obj/item/stack/cable_coil,
-/obj/structure/cable{
-	icon_state = "0-6";
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/effect/damagedfloor,
-/turf/template_noop,
-/area/template_noop)
-"X" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
 /obj/effect/damagedfloor,
 /turf/template_noop,
 /area/template_noop)
@@ -359,10 +312,6 @@
 	name = "Jurry-rigged antenna";
 	pixel_x = 5;
 	pixel_y = 3
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /obj/effect/damagedfloor,
 /turf/template_noop,
@@ -581,9 +530,9 @@ E
 I
 L
 h
-Q
-T
-X
+S
+i
+i
 i
 i
 i
@@ -615,7 +564,7 @@ M
 O
 R
 i
-X
+i
 i
 i
 i
@@ -647,7 +596,7 @@ N
 h
 S
 i
-X
+i
 i
 i
 i
@@ -679,7 +628,7 @@ h
 P
 i
 i
-X
+i
 i
 i
 i
@@ -711,7 +660,7 @@ h
 i
 i
 i
-X
+i
 Z
 i
 a

--- a/maps/submaps/planetary_ruins/oldpod/oldpod.dmm
+++ b/maps/submaps/planetary_ruins/oldpod/oldpod.dmm
@@ -19,17 +19,14 @@
 /area/map_template/oldpod)
 "ag" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
-	dir = 1
+	dir = 1;
+	icon_state = "heater"
 	},
 /turf/simulated/floor/plating,
 /area/map_template/oldpod)
 "ah" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -46,9 +43,6 @@
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/map_template/oldpod)
@@ -79,8 +73,8 @@
 /area/map_template/oldpod)
 "ao" = (
 /obj/structure/bed/chair/shuttle{
-	icon_state = "shuttle_chair_preview";
-	dir = 8
+	dir = 8;
+	icon_state = "shuttle_chair_preview"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -90,8 +84,8 @@
 /area/map_template/oldpod)
 "ap" = (
 /obj/structure/bed/chair/shuttle{
-	icon_state = "shuttle_chair_preview";
-	dir = 4
+	dir = 4;
+	icon_state = "shuttle_chair_preview"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -121,23 +115,6 @@
 "at" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/map_template/oldpod)
-"au" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/map_template/oldpod)
-"av" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -225,25 +202,10 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/oldpod)
 "aH" = (
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/item/frame/apc,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cell/small,
 /obj/item/gun_upgrade/mechanism/battery_shunt,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/map_template/oldpod)
-"aI" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/map_template/oldpod)
 "aJ" = (
@@ -296,13 +258,12 @@
 /area/map_template/oldpod)
 "aP" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/cyan,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 5
+	dir = 5;
+	icon_state = "warning"
 	},
 /obj/machinery/power/smes/buildable,
 /turf/simulated/floor/plating,
@@ -313,8 +274,8 @@
 /area/map_template/oldpod)
 "aR" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -340,8 +301,8 @@
 /area/map_template/oldpod)
 "aT" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 5
+	dir = 5;
+	icon_state = "warning"
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -370,14 +331,6 @@
 /turf/simulated/floor/plating,
 /area/map_template/oldpod)
 "aW" = (
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -433,7 +386,6 @@
 /area/map_template/oldpod)
 "bc" = (
 /obj/machinery/power/port_gen/pacman,
-/obj/structure/cable/cyan,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -446,8 +398,8 @@
 /area/map_template/oldpod)
 "be" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 10
+	dir = 10;
+	icon_state = "warning"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -472,17 +424,13 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 6
+	dir = 6;
+	icon_state = "warning"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/map_template/oldpod)
-"bq" = (
-/mob/living/simple_animal/hostile/roomba/boomba,
-/turf/simulated/floor/plating,
 /area/map_template/oldpod)
 "jX" = (
 /mob/living/simple_animal/hostile/roomba/slayer,
@@ -538,12 +486,12 @@ aa
 aa
 "}
 (5,1,1) = {"
-bq
+jX
 ai
 am
-au
+am
 aB
-aI
+am
 aP
 aW
 bc
@@ -553,7 +501,7 @@ ad
 ae
 ai
 an
-av
+ai
 aC
 aJ
 aQ


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Remove cables and pipes from planetary ruins to reduce server load.
Also replace boombas by other roombas to avoid undesired roundstart explosions (boombas rush the corpses that have no factions).

## Changelog
:cl: Hyperio
tweak: Remove cables and pipes from planetary ruins to reduce server load.
tweak: Replace boombas by other roombas to avoid undesired roundstart explosions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
