### PR TITLE
Warn player if they are trying to spawn without brain or eyes

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -99,6 +99,24 @@
 	if(href_list["ready"])
 		if(SSticker.current_state <= GAME_STATE_PREGAME) // Make sure we don't ready up after the round has started
 			ready = text2num(href_list["ready"])
+			if(ready)
+				// Warn the player if they are trying to spawn without a brain
+				var/datum/body_modification/mod = client.prefs.get_modification(BP_BRAIN)
+				if(istype(mod, /datum/body_modification/limb/amputation))
+					if(alert(src,"Are you sure you wish to spawn without a brain? This will likely cause you do die immediately. \
+								If not, go into the Augmentation section of Setup Character and check you do not have Removed for the brain category.", \
+								"Player Setup", "Yes", "No") == "No")
+						ready = 0
+						return
+
+				// Warn the player if they are trying to spawn without eyes
+				mod = client.prefs.get_modification(BP_EYES)
+				if(istype(mod, /datum/body_modification/limb/amputation))
+					if(alert(src,"Are you sure you wish to spawn without eyes? It will likely be difficult to see without them. \
+								If not, go into the Augmentation section of Setup Character and check you do not have Removed for the eyes category.", \
+								"Player Setup", "Yes", "No") == "No")
+						ready = 0
+						return
 		else
 			ready = 0
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -150,6 +150,22 @@
 			to_chat(usr, "\red The round is either not ready, or has already finished...")
 			return
 
+		// Warn the player if they are trying to spawn without a brain
+		var/datum/body_modification/mod = client.prefs.get_modification(BP_BRAIN)
+		if(istype(mod, /datum/body_modification/limb/amputation))
+			if(alert(src,"Are you sure you wish to spawn without a brain? This will likely cause you do die immediately. \
+			              If not, go into the Augmentation section of Setup Character and check you do not have Removed for the brain category.", \
+						  "Player Setup", "Yes", "No") == "No")
+				return 0
+
+		// Warn the player if they are trying to spawn without eyes
+		mod = client.prefs.get_modification(BP_EYES)
+		if(istype(mod, /datum/body_modification/limb/amputation))
+			if(alert(src,"Are you sure you wish to spawn without eyes? It will likely be difficult to see without them. \
+			              If not, go into the Augmentation section of Setup Character and check you do not have Removed for the eyes category.", \
+						  "Player Setup", "Yes", "No") == "No")
+				return 0
+
 		if(!check_rights(R_ADMIN, 0))
 			var/datum/species/S = all_species[client.prefs.species]
 			if((S.spawn_flags & IS_WHITELISTED) && !is_alien_whitelisted(src, client.prefs.species))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -103,8 +103,8 @@
 				// Warn the player if they are trying to spawn without a brain
 				var/datum/body_modification/mod = client.prefs.get_modification(BP_BRAIN)
 				if(istype(mod, /datum/body_modification/limb/amputation))
-					if(alert(src,"Are you sure you wish to spawn without a brain? This will likely cause you do die immediately. \
-								If not, go into the Augmentation section of Setup Character and check you do not have Removed for the brain category.", \
+					if(alert(src,"Are you sure you wish to spawn without a brain? This will likely cause you to do die immediately. \
+								If not, go to the Augmentation section of Setup Character and change the \"brain\" slot from Removed to the desired kind of brain.", \
 								"Player Setup", "Yes", "No") == "No")
 						ready = 0
 						return
@@ -113,7 +113,7 @@
 				mod = client.prefs.get_modification(BP_EYES)
 				if(istype(mod, /datum/body_modification/limb/amputation))
 					if(alert(src,"Are you sure you wish to spawn without eyes? It will likely be difficult to see without them. \
-								If not, go into the Augmentation section of Setup Character and check you do not have Removed for the eyes category.", \
+								If not, go to the Augmentation section of Setup Character and change the \"eyes\" slot from Removed to the desired kind of eyes.", \
 								"Player Setup", "Yes", "No") == "No")
 						ready = 0
 						return
@@ -171,8 +171,8 @@
 		// Warn the player if they are trying to spawn without a brain
 		var/datum/body_modification/mod = client.prefs.get_modification(BP_BRAIN)
 		if(istype(mod, /datum/body_modification/limb/amputation))
-			if(alert(src,"Are you sure you wish to spawn without a brain? This will likely cause you do die immediately. \
-			              If not, go into the Augmentation section of Setup Character and check you do not have Removed for the brain category.", \
+			if(alert(src,"Are you sure you wish to spawn without a brain? This will likely cause you to do die immediately. \
+			              If not, go to the Augmentation section of Setup Character and change the \"brain\" slot from Removed to the desired kind of brain.", \
 						  "Player Setup", "Yes", "No") == "No")
 				return 0
 
@@ -180,7 +180,7 @@
 		mod = client.prefs.get_modification(BP_EYES)
 		if(istype(mod, /datum/body_modification/limb/amputation))
 			if(alert(src,"Are you sure you wish to spawn without eyes? It will likely be difficult to see without them. \
-			              If not, go into the Augmentation section of Setup Character and check you do not have Removed for the eyes category.", \
+			              If not, go to the Augmentation section of Setup Character and change the \"eyes\" slot from Removed to the desired kind of eyes.", \
 						  "Player Setup", "Yes", "No") == "No")
 				return 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Warn player if they are trying to spawn without brain or eyes.
Avoid ahelps of players dying right when they spawn because they let brain to "Removed" in their player setup.

## Changelog
:cl: Hyperio
add: Added warning when trying to spawn without brain or eyes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
