### PR TITLE
Mining Overhaul Part 2.2

### DIFF
--- a/code/modules/mining/drilling/deep_drill.dm
+++ b/code/modules/mining/drilling/deep_drill.dm
@@ -8,8 +8,8 @@
 
 	circuit = /obj/item/electronics/circuitboard/miningdrill
 
-	var/max_health = 1000
-	var/health = 1000
+	var/max_health = 2000
+	var/health = 2000
 
 	var/active = FALSE
 	var/list/resource_field = list()

--- a/code/modules/mining/drilling/deep_drill.dm
+++ b/code/modules/mining/drilling/deep_drill.dm
@@ -181,7 +181,12 @@
 		if(I.use_tool(user, src, WORKTIME_LONG, QUALITY_WELDING, FAILCHANCE_EASY, required_stat = STAT_ROB))
 			playsound(src, 'sound/items/Welder.ogg', 100, 1)
 			to_chat(user, "<span class='notice'>You finish repairing the damage to [src].</span>")
-			take_damage(-damage)
+			if(damage < 0.33 * max_health)
+				take_damage(-damage)  // Completely repair the drill
+			else if(damage < 0.66 * max_health)
+				take_damage(-(0.66 * max_health - health))  // Repair the drill to 66 percents
+			else
+				take_damage(-(0.33 * max_health - health))  // Repair the drill to 33 percents
 		return
 
 	if(!panel_open || active)
@@ -341,12 +346,14 @@
 	. = ..()
 	if(health <= 0)
 		to_chat(user, "\The [src] is wrecked.")
-	else if(health < max_health * 0.25)
+	else if(health < max_health * 0.33)
 		to_chat(user, "<span class='danger'>\The [src] looks like it's about to break!</span>")
-	else if(health < max_health * 0.5)
+	else if(health < max_health * 0.66)
 		to_chat(user, "<span class='danger'>\The [src] looks seriously damaged!</span>")
-	else if(health < max_health * 0.75)
+	else if(health < max_health)
 		to_chat(user, "\The [src] shows signs of damage!")
+	else
+		to_chat(user, "\The [src] is in pristine condition.")
 
 /obj/machinery/mining/deep_drill/verb/unload()
 	set name = "Unload Drill"

--- a/code/modules/mining/drilling/golem_wave.dm
+++ b/code/modules/mining/drilling/golem_wave.dm
@@ -29,7 +29,7 @@ GLOBAL_LIST_INIT(golem_waves, list(/datum/golem_wave/dormant,
 	golem_spawn = 2
 	spawn_interval = 20 SECONDS
 	special_probability = 0
-	mineral_multiplier = 1.1
+	mineral_multiplier = 1.4
 
 /datum/golem_wave/typical
 	burrow_count = 3
@@ -37,7 +37,7 @@ GLOBAL_LIST_INIT(golem_waves, list(/datum/golem_wave/dormant,
 	golem_spawn = 3
 	spawn_interval = 18 SECONDS
 	special_probability = 10
-	mineral_multiplier = 1.2
+	mineral_multiplier = 1.7
 
 /datum/golem_wave/substantial
 	burrow_count = 3
@@ -45,7 +45,7 @@ GLOBAL_LIST_INIT(golem_waves, list(/datum/golem_wave/dormant,
 	golem_spawn = 3
 	spawn_interval = 18 SECONDS
 	special_probability = 20
-	mineral_multiplier = 1.35
+	mineral_multiplier = 2
 
 /datum/golem_wave/major
 	burrow_count = 4
@@ -53,7 +53,7 @@ GLOBAL_LIST_INIT(golem_waves, list(/datum/golem_wave/dormant,
 	golem_spawn = 4
 	spawn_interval = 14 SECONDS
 	special_probability = 30
-	mineral_multiplier = 1.5
+	mineral_multiplier = 2.3
 
 /datum/golem_wave/abnormal
 	burrow_count = 5
@@ -61,4 +61,4 @@ GLOBAL_LIST_INIT(golem_waves, list(/datum/golem_wave/dormant,
 	golem_spawn = 4
 	spawn_interval = 12 SECONDS
 	special_probability = 30
-	mineral_multiplier = 2.0
+	mineral_multiplier = 3.0

--- a/code/modules/mining/drilling/golem_wave.dm
+++ b/code/modules/mining/drilling/golem_wave.dm
@@ -17,48 +17,48 @@ GLOBAL_LIST_INIT(golem_waves, list(/datum/golem_wave/dormant,
 
 /datum/golem_wave/dormant
 	burrow_count = 2
-	burrow_interval = 15 SECONDS
+	burrow_interval = 30 SECONDS
 	golem_spawn = 2
-	spawn_interval = 12 SECONDS
+	spawn_interval = 24 SECONDS
 	special_probability = 0
 	mineral_multiplier = 1.0
 
 /datum/golem_wave/negligible
 	burrow_count = 2
-	burrow_interval = 12 SECONDS
+	burrow_interval = 24 SECONDS
 	golem_spawn = 2
-	spawn_interval = 10 SECONDS
+	spawn_interval = 20 SECONDS
 	special_probability = 0
 	mineral_multiplier = 1.1
 
 /datum/golem_wave/typical
 	burrow_count = 3
-	burrow_interval = 12 SECONDS
+	burrow_interval = 24 SECONDS
 	golem_spawn = 3
-	spawn_interval = 9 SECONDS
+	spawn_interval = 18 SECONDS
 	special_probability = 10
 	mineral_multiplier = 1.2
 
 /datum/golem_wave/substantial
 	burrow_count = 3
-	burrow_interval = 12 SECONDS
+	burrow_interval = 24 SECONDS
 	golem_spawn = 3
-	spawn_interval = 9 SECONDS
+	spawn_interval = 18 SECONDS
 	special_probability = 20
 	mineral_multiplier = 1.35
 
 /datum/golem_wave/major
 	burrow_count = 4
-	burrow_interval = 10 SECONDS
+	burrow_interval = 20 SECONDS
 	golem_spawn = 4
-	spawn_interval = 7 SECONDS
+	spawn_interval = 14 SECONDS
 	special_probability = 30
 	mineral_multiplier = 1.5
 
 /datum/golem_wave/abnormal
 	burrow_count = 5
-	burrow_interval = 9 SECONDS
+	burrow_interval = 18 SECONDS
 	golem_spawn = 4
-	spawn_interval = 6 SECONDS
+	spawn_interval = 12 SECONDS
 	special_probability = 30
 	mineral_multiplier = 2.0

--- a/code/modules/mob/living/carbon/superior_animal/golem/golem.dm
+++ b/code/modules/mob/living/carbon/superior_animal/golem/golem.dm
@@ -129,7 +129,8 @@ GLOBAL_LIST_INIT(golems_special, list(/mob/living/carbon/superior_animal/golem/s
 		T.attack_generic(src, rand(surrounds_mult * melee_damage_lower, surrounds_mult * melee_damage_upper), attacktext, TRUE)
 	else
 		var/obj/structure/obstacle = locate(/obj/structure) in T
-		obstacle?.attack_generic(src, rand(surrounds_mult * melee_damage_lower, surrounds_mult * melee_damage_upper), attacktext, TRUE)
+		if(obstacle && !istype(obstacle, /obj/structure/golem_burrow))
+			obstacle.attack_generic(src, rand(surrounds_mult * melee_damage_lower, surrounds_mult * melee_damage_upper), attacktext, TRUE)
 
 /mob/living/carbon/superior_animal/golem/handle_ai()
 	// Chance to re-aggro the drill if doing nothing


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Another balance pass:
* Double time interval between burrows for all waves
* Double time interval between golem spawn for all waves
* Double drill health
* Increased mineral multiplier
* Golems no longer try to destry golem burrows in their way
* Drill has three health stage. If its healths falls under 66%, you can only repair it up to 66%. If it falls under 33%, you can only repair it up to 33%.

Note: Destroying golem burrows by hitting them with weapons is a good way to avoid a snowball of the number of golems. Updated deep mining guide to include tips.

## Changelog
:cl: Hyperio
balance: Double time interval between burrows for all waves
balance: Double time interval between golem spawn for all waves
balance: Double drill health
balance: Increased mineral multiplier
fix: Golems no longer try to destry golem burrows in their way
add: Drill has three health stage. If its healths falls under 66%, you can only repair it up to 66%. If it falls under 33%, you can only repair it up to 33%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
