### PR TITLE
Fixes in-game Date

### DIFF
--- a/code/global.dm
+++ b/code/global.dm
@@ -35,7 +35,7 @@ var/const/company_name  = "CEV Eris"
 var/const/company_short = "Eris"
 var/game_version        = "Discordia"
 var/changelog_hash      = ""
-var/game_year           = (text2num(time2text(world.realtime, "YYYY")) + 320)
+var/game_year           = (text2num(time2text(world.realtime, "YYYY")) + 319)
 
 var/round_progressing = 1
 var/master_storyteller       = "shitgenerator"

--- a/code/global.dm
+++ b/code/global.dm
@@ -35,7 +35,7 @@ var/const/company_name  = "CEV Eris"
 var/const/company_short = "Eris"
 var/game_version        = "Discordia"
 var/changelog_hash      = ""
-var/game_year           = (text2num(time2text(world.realtime, "YYYY")) + 544)
+var/game_year           = (text2num(time2text(world.realtime, "YYYY")) + 320)
 
 var/round_progressing = 1
 var/master_storyteller       = "shitgenerator"

--- a/code/modules/economy/economy_misc.dm
+++ b/code/modules/economy/economy_misc.dm
@@ -122,7 +122,7 @@ var/global/datum/computer_file/data/email_account/service/payroll/payroll_mailer
 
 	//create an entry in the account transaction log for when it was created
 	var/datum/transaction/T = new(department.account_initial_balance, department_account.owner_name, "Account creation", "Asters Guild Terminal #277")
-	T.date = "2 April, 2555"
+	T.date = "2 April, 2339"
 	T.time = "11:24"
 
 	//add the account


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
its always annoyed me how in a few small places the date was set to be several hundred years after the game is set because bay leftover lore. so i changed it to the correct date (at least according to the wiki). the current date is now 2341 (Current date +319 in code) halfway through Eris's journey. bank account creation date is 2339, when the wiki says the Eris departed
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
correct information in game as to when eris takes place, """lore""" in game good, bay leftovers bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed bank account creation date to be lore accurate
config: changed game year to be lore accurate
:cl:
