### PR TITLE
Severity 4

### DIFF
--- a/code/game/gamemodes/events/blob.dm
+++ b/code/game/gamemodes/events/blob.dm
@@ -264,6 +264,8 @@
 			take_damage(rand(60, 100) / brute_resist)
 		if(3)
 			take_damage(rand(20, 60) / brute_resist)
+		if(4)
+			take_damage(rand(10, 30) / brute_resist)
 
 
 /obj/effect/blob/fire_act()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -411,6 +411,14 @@
 				s.start()
 			else
 				take_damage(150)
+		if(4)
+			if(prob(80))
+				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+				s.set_up(2, 1, src)
+				s.start()
+			else
+				take_damage(60)
+
 	return
 
 

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -16,7 +16,7 @@ var/list/doppler_arrays = list()
 	doppler_arrays -= src
 	. = ..()
 
-/obj/machinery/doppler_array/proc/sense_explosion(var/x0,var/y0,var/z0,var/devastation_range,var/heavy_impact_range,var/light_impact_range,var/took)
+/obj/machinery/doppler_array/proc/sense_explosion(var/x0,var/y0,var/z0,var/devastation_range,var/heavy_impact_range,var/light_impact_range,var/singe_impact_range,var/took)
 	if(stat & NOPOWER)	return
 	if(z != z0)			return
 
@@ -37,7 +37,7 @@ var/list/doppler_arrays = list()
 	if(distance > 100)		return
 	if(!(direct & dir))	return
 
-	var/message = "Explosive disturbance detected - Epicenter at: grid ([x0],[y0]). Epicenter radius: [devastation_range]. Outer radius: [heavy_impact_range]. Shockwave radius: [light_impact_range]. Temporal displacement of tachyons: [took] seconds."
+	var/message = "Explosive disturbance detected - Epicenter at: grid ([x0],[y0]). Epicenter radius: [devastation_range]. Outer radius: [heavy_impact_range] to [light_impact_range]. Shockwave radius: [singe_impact_range]. Temporal displacement of tachyons: [took] seconds."
 
 	for(var/mob/O in hearers(src, null))
 		O.show_message("<span class='game say'><span class='name'>[src]</span> states coldly, \"[message]\"</span>",2)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -517,6 +517,8 @@ var/list/turret_icons
 			take_damage(rand(80,170))
 		if (3)
 			take_damage(rand(50,120))
+		if (4)
+			take_damage(rand(25,60))
 
 /obj/machinery/porta_turret/proc/die()	//called when the turret dies, ie, health <= 0
 	health = 0

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -295,6 +295,10 @@
 			if(prob(50))
 				qdel(src)
 				return
+			if(prob(50))
+				spawn(0)
+					malfunction()
+					return
 		if(3)
 			if(prob(25))
 				spawn(0)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -1,6 +1,6 @@
 //TODO: Flash range does nothing currently
 
-proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = 1, z_transfer = UP|DOWN)
+proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = 1, z_transfer = UP|DOWN, singe_impact_range)
 	spawn(0)
 		if(config.use_recursive_explosions)
 			var/power = devastation_range * 2 + heavy_impact_range + light_impact_range //The ranges add up, ie light 14 includes both heavy 7 and devestation 3. So this calculation means devestation counts for 4, heavy for 2 and light for 1 power, giving us a cap of 27 power.
@@ -14,11 +14,11 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 		// Handles recursive propagation of explosions.
 		if(devastation_range > 2 || heavy_impact_range > 2)
 			if(HasAbove(epicenter.z) && z_transfer & UP)
-				explosion(GetAbove(epicenter), max(0, devastation_range - 2), max(0, heavy_impact_range - 2), max(0, light_impact_range - 2), max(0, flash_range - 2), 0, UP)
+				explosion(GetAbove(epicenter), max(0, devastation_range - 2), max(0, heavy_impact_range - 2), max(0, light_impact_range - 2), max(0, flash_range - 2), 0, UP, max(0, singe_impact_range - 2))
 			if(HasBelow(epicenter.z) && z_transfer & DOWN)
-				explosion(GetBelow(epicenter), max(0, devastation_range - 2), max(0, heavy_impact_range - 2), max(0, light_impact_range - 2), max(0, flash_range - 2), 0, DOWN)
+				explosion(GetBelow(epicenter), max(0, devastation_range - 2), max(0, heavy_impact_range - 2), max(0, light_impact_range - 2), max(0, flash_range - 2), 0, DOWN, max(0, singe_impact_range - 2))
 
-		var/max_range = max(devastation_range, heavy_impact_range, light_impact_range, flash_range)
+		var/max_range = max(devastation_range, heavy_impact_range, light_impact_range, flash_range, singe_impact_range)
 
 		// Play sounds; we want sounds to be different depending on distance so we will manually do it ourselves.
 		// Stereo users will also hear the direction of the explosion!
@@ -52,10 +52,10 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 			if(M.ear_deaf <= 0 || !M.ear_deaf) if(!istype(M.loc,/turf/space))
 				M << 'sound/effects/explosionfar.ogg'
 		if(adminlog)
-			message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[epicenter.x];Y=[epicenter.y];Z=[epicenter.z]'>JMP</a>)")
-			log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ")
+			message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [singe_impact_range]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[epicenter.x];Y=[epicenter.y];Z=[epicenter.z]'>JMP</a>)")
+			log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [singe_impact_range]) in area [epicenter.loc.name] ")
 
-		var/approximate_intensity = (devastation_range * 3) + (heavy_impact_range * 2) + light_impact_range
+		var/approximate_intensity = (devastation_range * 3) + (heavy_impact_range * 2) + light_impact_range + round(singe_impact_range / 2)
 		var/powernet_rebuild_was_deferred_already = defer_powernet_rebuild
 		// Large enough explosion. For performance reasons, powernets will be rebuilt manually
 		if(!defer_powernet_rebuild && (approximate_intensity > 25))
@@ -77,6 +77,7 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 			if(dist < devastation_range)		dist = 1
 			else if(dist < heavy_impact_range)	dist = 2
 			else if(dist < light_impact_range)	dist = 3
+			else if(dist < singe_impact_range)	dist = 4
 			else								continue
 
 			T.ex_act(dist)
@@ -93,7 +94,7 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 		for(var/i,i<=doppler_arrays.len,i++)
 			var/obj/machinery/doppler_array/Array = doppler_arrays[i]
 			if(Array)
-				Array.sense_explosion(x0,y0,z0,devastation_range,heavy_impact_range,light_impact_range,took)
+				Array.sense_explosion(x0,y0,z0,devastation_range,heavy_impact_range,light_impact_range,singe_impact_range,took)
 
 		sleep(8)
 

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -6,6 +6,10 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 			var/power = devastation_range * 2 + heavy_impact_range + light_impact_range //The ranges add up, ie light 14 includes both heavy 7 and devestation 3. So this calculation means devestation counts for 4, heavy for 2 and light for 1 power, giving us a cap of 27 power.
 			explosion_rec(epicenter, power)
 			return
+		
+		if(light_impact_range > 2 && isnull(singe_impact_range))
+			singe_impact_range = light_impact_range + 1
+			light_impact_range--
 
 		var/start = world.timeofday
 		epicenter = get_turf(epicenter)

--- a/code/game/objects/items/weapons/grenades/explosive.dm
+++ b/code/game/objects/items/weapons/grenades/explosive.dm
@@ -5,7 +5,8 @@
 
     var/devastation_range = -1
     var/heavy_range = 1
-    var/weak_range = 4
+    var/weak_range = 3
+    var/weakest_range = 5
     var/flash_range = 10
 
 
@@ -20,13 +21,13 @@
     qdel(src)
 
 /obj/item/grenade/explosive/proc/on_explosion(var/turf/O)
-	explosion(O, devastation_range, heavy_range, weak_range, flash_range)
+	explosion(O, devastation_range, heavy_range, weak_range, flash_range, singe_impact_range = weakest_range)
 
 /obj/item/grenade/explosive/nt
 	name = "NT OBG \"Holy Grail\""
 	desc = "There's an inscription along the bands. \'And the Lord spake, saying: First shalt thou take out the Holy Pin. Then, shalt thou count to three, no more, no less. Three shall be the number thou shalt count, and the number of the counting shall be three. Four shalt thou not count, nor either count thou two, excepting that thou then proceed to three. Five is right out! Once the number three, being the third number, be reached, then lobbest thou thy Holy Hand Grenade of Antioch towards thou foe, who being naughty in my sight, shall snuff it.\'"
 	icon_state = "explosive_nt"
 	item_state = "explosive_nt"
-	heavy_range = 1
-	weak_range = 5
+	weak_range = 4
+    weakest_range = 6
 	matter = list(MATERIAL_BIOMATTER = 100)

--- a/code/game/objects/items/weapons/grenades/explosive.dm
+++ b/code/game/objects/items/weapons/grenades/explosive.dm
@@ -29,5 +29,5 @@
 	icon_state = "explosive_nt"
 	item_state = "explosive_nt"
 	weak_range = 4
-    weakest_range = 6
+	weakest_range = 6
 	matter = list(MATERIAL_BIOMATTER = 100)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -314,9 +314,10 @@
 			take_damage(rand(500))
 		if(2)
 			take_damage(rand(120,300))
-
 		if(3)
 			take_damage(rand(60,180))
+		if(4)
+			take_damage(rand(20,80))
 
 
 /obj/structure/girder/get_fall_damage(var/turf/from, var/turf/dest)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -13,7 +13,8 @@
 
 
 /obj/structure/grille/ex_act(severity)
-	qdel(src)
+	if(severity < 4)
+		qdel(src)
 
 /obj/structure/grille/update_icon()
 	if(destroyed)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -157,14 +157,13 @@
 	switch(severity)
 		if(1)
 			qdel(src)
-			return
 		if(2)
 			shatter(0,TRUE)
-			return
 		if(3)
+			shatter(0,TRUE)
+		if(4)
 			if(prob(50))
 				shatter(0,TRUE)
-				return
 
 //TODO: Make full windows a separate type of window.
 //Once a full window, it will always be a full window, so there's no point

--- a/code/game/turfs/simulated/floor_acts.dm
+++ b/code/game/turfs/simulated/floor_acts.dm
@@ -21,6 +21,8 @@
 			take_damage(rand(115, 430), BLAST) //Breaks through 2 - 3 layers
 		if(3)
 			take_damage(rand(20, 120), BLAST) //Breaks 1-2 layers
+		if(4)
+			take_damage(rand(10, 50), BLAST)
 
 
 /turf/simulated/floor/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -386,6 +386,8 @@
 			take_damage(rand(200, 500))
 		if(3)
 			take_damage(rand(90, 250))
+		if(4)
+			take_damage(rand(40, 100))
 		else
 	return
 

--- a/code/modules/hivemind/machines.dm
+++ b/code/modules/hivemind/machines.dm
@@ -292,6 +292,8 @@
 			take_damage(30)
 		if(3)
 			take_damage(10)
+		if(4)
+			take_damage(5)
 
 
 /obj/machinery/hivemind_machine/emp_act(severity)
@@ -302,6 +304,9 @@
 		if(2)
 			take_damage(30)
 			stun(8)
+		if(3)
+			take_damage(15)
+			stun(3)
 	..()
 
 

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -148,7 +148,10 @@
 			if (prob(75))
 				die_off()
 				return
-		else
+		if(4)
+			if(prob(40))
+				die_off()
+				return
 	return
 
 //Fire is instakill. Deploy flamethrowers

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -136,7 +136,7 @@
 
 		if (2)
 			if (not_slick)
-				b_loss = 150
+				b_loss = 120
 				if (!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
 					adjustEarDamage(30,120)
 			else
@@ -146,9 +146,18 @@
 
 		if(3)
 			if (not_slick)
-				b_loss += 100
+				b_loss += 80
 				if (!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
 					adjustEarDamage(15,60)
+			else
+				visible_message(SPAN_WARNING("[src] rides the shockwave!"))
+				dodge_time = get_game_time()
+				confidence = FALSE
+		if(4)
+			if (not_slick)
+				b_loss += 50
+				if (!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
+					adjustEarDamage(10,30)
 			else
 				visible_message(SPAN_WARNING("[src] rides the shockwave!"))
 				dodge_time = get_game_time()
@@ -166,7 +175,7 @@
 		b_loss -= exp_damage
 		exp_damage = rand(0, b_loss)
 		src.apply_damage(exp_damage, BRUTE, organ_hit)
-		organ_hit = pickweight(list(BP_HEAD = 0.2, BP_GROIN = 0.2, BP_R_ARM = 0.1, BP_L_ARM = 0.1, BP_R_LEG = 0.1, BP_L_LEG = 0.1))  //We determine some other body parts that should be hit
+		organ_hit = pickweight(list(BP_HEAD = 0.1, BP_GROIN = 0.2, BP_R_ARM = 0.1, BP_L_ARM = 0.1, BP_R_LEG = 0.1, BP_L_LEG = 0.1))  //We determine some other body parts that should be hit
 
 /mob/living/carbon/human/restrained()
 	if (handcuffed)

--- a/code/modules/mob/living/carbon/superior_animal/defense.dm
+++ b/code/modules/mob/living/carbon/superior_animal/defense.dm
@@ -109,8 +109,8 @@
 		if (HUDtech.Find("flash"))
 			flick("flash", HUDtech["flash"])
 
+	var/bomb_defense = getarmor(null, ARMOR_BOMB)
 	var/b_loss = null
-	var/f_loss = null
 	switch (severity)
 		if (1)
 			gib()
@@ -118,7 +118,6 @@
 
 		if (2)
 			b_loss += 60
-			f_loss += 60
 			adjustEarDamage(30,120)
 
 		if (3)
@@ -126,9 +125,16 @@
 			if (prob(50))
 				Paralyse(1)
 			adjustEarDamage(15,60)
+		
+		if (4)
+			b_loss += 15
+			if (prob(25))
+				Paralyse(1)
+			adjustEarDamage(15,60)
+
+	b_loss = max(0, b_loss - bomb_defense)
 
 	adjustBruteLoss(b_loss)
-	adjustFireLoss(f_loss)
 
 	updatehealth()
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -268,6 +268,9 @@
 		if(3)
 			if (stat != 2)
 				adjustBruteLoss(30)
+		if(4)
+			if (stat != 2)
+				adjustBruteLoss(15)
 
 	updatehealth()
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -77,6 +77,8 @@
 
 		if(3)
 			adjustBruteLoss(50)
+		if(4)
+			adjustBruteLoss(25)
 
 /mob/living/simple_animal/hostile/megafauna/proc/SetRecoveryTime(buffer_time)
 	recovery_time = world.time + buffer_time

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -450,6 +450,8 @@
 
 		if(3)
 			adjustBruteLoss(30)
+		if(4)
+			adjustBruteLoss(15)
 
 
 

--- a/code/modules/power/antimatter/containment_jar.dm
+++ b/code/modules/power/antimatter/containment_jar.dm
@@ -31,6 +31,8 @@
 			stability -= 40
 		if(3)
 			stability -= 20
+		if(4)
+			stability -= 10
 	//check_stability()
 	return
 

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -109,6 +109,8 @@
 			stability -= 40
 		if(3)
 			stability -= 20
+		if(4)
+			stability -= 10
 	check_stability()
 	return
 

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -97,6 +97,8 @@
 			stability -= 40
 		if(3)
 			stability -= 20
+		if(4)
+			stability -= 10
 	check_stability()
 	return
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -236,6 +236,9 @@
 				return
 			if (prob(25))
 				corrupt()
+		if(4)
+			if (prob(25))
+				corrupt()
 	return
 
 // Calculation of cell shock damage

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -106,6 +106,8 @@
 			damage += 500
 		if(3)
 			damage += 200
+		if(4)
+			damage += 50
 
 /obj/machinery/power/supermatter/proc/explode()
 	log_and_message_admins("Supermatter exploded at [x] [y] [z]")

--- a/code/modules/projectiles/projectile/projectilegrenades.dm
+++ b/code/modules/projectiles/projectile/projectilegrenades.dm
@@ -26,11 +26,12 @@
 	name = "blast shell"
 	var/devastation_range = 0
 	var/heavy_impact_range = 0
-	var/light_impact_range = 3
+	var/light_impact_range = 1
+	var/lightest_impact_range = 3
 	var/flash_range = 10
 
 /obj/item/projectile/bullet/grenade/blast/grenade_effect(target)
-	explosion(target, devastation_range, heavy_impact_range, light_impact_range, flash_range)
+	explosion(target, devastation_range, heavy_impact_range, light_impact_range, flash_range, singe_impact_range = lightest_impact_range)
 
 /obj/item/projectile/bullet/grenade/frag
 	name = "frag shell"

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -35,7 +35,7 @@
 	..(target, target_zone, x_offset, y_offset, angle_offset)
 
 /obj/item/projectile/bullet/rocket/on_hit(atom/target)
-	explosion(target, 0, 1, 2, 4)
+	explosion(target, 0, 1, 2, 5)
 	set_light(0)
 	return TRUE
 
@@ -43,7 +43,7 @@
 	damage_types = list(BRUTE = 30)
 
 /obj/item/projectile/bullet/rocket/scrap/on_hit(atom/target)
-	explosion(target, -1, -1, 0, 3)
+	explosion(target, 0, 0, 1, 4, singe_impact_range = 3)
 	set_light(0)
 	return TRUE
 
@@ -55,7 +55,7 @@
 
 /obj/item/projectile/bullet/rocket/hesh/on_hit(atom/target)
 	fragment_explosion_angled(target, starting, /obj/item/projectile/bullet/pellet/fragment/strong, 20)
-	explosion(target, -1, 0, 2, 3) // Much weaker explosion, but offset by shrapnel released
+	explosion(target, 0, 0, 1, 3) // Much weaker explosion, but offset by shrapnel released
 	set_light(0)
 	return TRUE
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -908,6 +908,10 @@
 			health -= rand(0,15)
 			healthcheck()
 			return
+		if(4)
+			health -= rand(0,5)
+			healthcheck()
+			return
 
 
 	// test health for brokenness

--- a/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
@@ -314,6 +314,12 @@
 				my_effect.ToggleActivate()
 			if(secondary_effect && (secondary_effect.trigger == TRIGGER_FORCE || secondary_effect.trigger == TRIGGER_HEAT) && prob(25))
 				secondary_effect.ToggleActivate(0)
+		if(4)
+			if(prob(25))
+				if (my_effect.trigger == TRIGGER_FORCE || my_effect.trigger == TRIGGER_HEAT)
+					my_effect.ToggleActivate()
+				if(secondary_effect && (secondary_effect.trigger == TRIGGER_FORCE || secondary_effect.trigger == TRIGGER_HEAT) && prob(25))
+					secondary_effect.ToggleActivate(0)				
 	return
 
 /obj/machinery/artifact/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, var/glide_size_override = 0)

--- a/code/modules/research/xenoarchaeology/machinery/coolant.dm
+++ b/code/modules/research/xenoarchaeology/machinery/coolant.dm
@@ -13,8 +13,9 @@
 	if(Proj.get_structure_damage())
 		explode()
 
-/obj/structure/reagent_dispensers/coolanttank/ex_act()
-	explode()
+/obj/structure/reagent_dispensers/coolanttank/ex_act(severity)
+	if(severity < 4)
+		explode()
 
 /obj/structure/reagent_dispensers/coolanttank/explode()
 	var/datum/effect/effect/system/smoke_spread/S = new /datum/effect/effect/system/smoke_spread

--- a/code/modules/shieldgen/sheldwallgen.dm
+++ b/code/modules/shieldgen/sheldwallgen.dm
@@ -350,6 +350,12 @@
 				else
 					G = gen_secondary
 				G.storedpower -= 12000
+			if(3) //minuscule amount of boom
+				if(prob(50))
+					G = gen_primary
+				else
+					G = gen_secondary
+				G.storedpower -= 6000
 	return
 
 


### PR DESCRIPTION
## About The Pull Request

### Triple Kill; Grenadier; Killing Spree

Adds another layer of severity.

Reduces the damage of Severity 2 and 3 in accordance with the bullet damage nerf.

All explosions with the new severity not defined will reduce the severity 3 range by 1, and add severity 4 with the range of severity 3, but increased by two.
(Eg. if the severity 3 impact range is 4, then it is reduced to 3, and the severity 4 impact range is set to 5)

Severity 4 deals little to no damage to most structures, but can still cause significant damage to mobs, or unarmoured humans.

Even light armor gives a significant advantage, heavy armor will outright halve damage taken from severity 4, encouraging heavy armor to counter light explosives.

## Why It's Good For The Game

Salt PR (it isn't)
Balance good

## Changelog
:cl:
add: Severity 4 explosions implemented
balance: blast and explosive grenades now less deadly
/:cl: