### PR TITLE
carrion spider balance

### DIFF
--- a/code/game/gamemodes/changeling/modularchangling.dm
+++ b/code/game/gamemodes/changeling/modularchangling.dm
@@ -39,7 +39,7 @@ var/list/datum/power/carrion/powerinstances = list()
 /datum/power/carrion/blight_spider
 	name = "Blight spider"
 	desc = "Evolves a spider filled with a sickening venom."
-	genomecost = 7
+	genomecost = 5
 	spiderpath = /obj/item/implant/carrion_spider/blight
 
 /datum/power/carrion/breeding_spider
@@ -82,7 +82,7 @@ var/list/datum/power/carrion/powerinstances = list()
 /datum/power/carrion/talking_spider
 	name = "Talking spider"
 	desc = "Creates a spider that can hijack someones vocal cords, giving you the ability to talk through them."
-	genomecost = 5
+	genomecost = 1
 	spiderpath = /obj/item/implant/carrion_spider/talking
 
 /datum/power/carrion/observer_spider
@@ -95,13 +95,13 @@ var/list/datum/power/carrion/powerinstances = list()
 /datum/power/carrion/identity_spider
 	name = "Idenitity spider"
 	desc = "Creates a spider with the ability to extract and transmit human DNA to you."
-	genomecost = 3
+	genomecost = 1
 	spiderpath = /obj/item/implant/carrion_spider/identity
 
 /datum/power/carrion/holographic_spider
 	name = "Holographic spider"
 	desc = "Creates a spider with the ability to mimic appearances. Not always able to create a perfect copy. Use in hand to toggle modes."
-	genomecost = 3
+	genomecost = 1
 	spiderpath = /obj/item/implant/carrion_spider/holographic
 
 /datum/power/carrion/smooth_spider

--- a/code/game/objects/items/weapons/implant/implants/carrion/blight_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/blight_spider.dm
@@ -1,12 +1,13 @@
 /obj/item/implant/carrion_spider/blight
 	name = "blight spider"
 	icon_state = "spiderling_blight"
-	spider_price = 30
+	spider_price = 15
 
 /obj/item/implant/carrion_spider/blight/activate()
 	..()
 	if(wearer)
-		wearer.reagents.add_reagent("amatoxin", 5)
+		wearer.reagents.add_reagent("amatoxin", 10)
+		wearer.reagents.add_reagent("pararein", 5)
 		to_chat(wearer, SPAN_WARNING("You feel sick and nauseous"))
 		die()
 	else

--- a/code/game/objects/items/weapons/implant/implants/carrion/identity_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/identity_spider.dm
@@ -1,7 +1,7 @@
 /obj/item/implant/carrion_spider/identity
 	name = "identity spider"
 	icon_state = "spiderling_identity"
-	spider_price = 25
+	spider_price = 15
 
 /obj/item/implant/carrion_spider/identity/activate()
 	..()

--- a/code/game/objects/items/weapons/implant/implants/carrion/talking_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/talking_spider.dm
@@ -1,7 +1,7 @@
 /obj/item/implant/carrion_spider/talking
 	name = "talking spider"
 	icon_state = "spiderling_talking"
-	spider_price = 30
+	spider_price = 15
 	var/on_cooldown = FALSE
 
 /obj/item/implant/carrion_spider/talking/activate()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Don't worry, this is the last balance PR in a while, content PR coming soon.

Lowers the gene point cost of the talking, identity and holographic spiders from 3 to 1, and also lowered the chem point cost of the talking and identity spider- All of these spiders aren't too powerful, but actually using them can make for fun rounds, so they should be cheaper to acquire and produce.

Reduces the gene point cost of the blight spider from 7 to 5, doubles the amount of amatoxin it injects from 5 to 10 and makes it inject 5 units of pararein as well. Previously, the toxins from a single blight spider would just get outhealed by passive toxin regeneration, and even if multiple were stacked, the toxins buildup was still extremely slow and could be easily healed.

Now, a single spider is at least able to deal a bit of toxin damage to someone and debuff their toughness, while stacking many still doesn't have a huge amount of toxins buildup, but at least enough so it can't just be ignored in the long run.

## Why It's Good For The Game

hopefully more use of interesting funny spiders

## Changelog
:cl:
balance: buffed the blight spider
balance: lowered the prices of some carrion spiders
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
