### PR TITLE
Removes Cruciforms From Preacher's Locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
@@ -27,8 +27,6 @@
 	new /obj/item/storage/fancy/candle_box(src)
 	new /obj/item/deck/tarot(src)
 	new /obj/item/storage/box/headset/church
-	for (var/i in 1 to 10)
-		new /obj/item/implant/core_implant/cruciform(src)
 	new /obj/item/tool/knife/neotritual(src)
 	new /obj/item/gun/energy/nt_svalinn(src)
 	new /obj/item/cell/small/neotheology/plasma(src)


### PR DESCRIPTION
## About The Pull Request
All 10 Cruciforms Removed From Preacher's Locker. 

## Why It's Good For The Game
Before the addition of the Cruciform Forge, 10 roundstart Cruciforms was welcome. At of the addition of the Cruciform forge, the existence of 10 roundstart cruciforms became excessive. As of the Chapel Remapping, with four additional Cruciforms added to spawn adjacent to the Altar, their existence became redundant. With the addition of a cruciform sink of the NTV Faith's export of cruciforms, NT players are provided with an effort free means to acquire large capital, with minimal fear of using their entire supply of roundstart cruciforms (an average of 2 required every twenty minutes, if deals with the guild are done perfectly). Dropping NT's supply of roundstard cruciforms would allow the Cruciform Forge to take up a more active roll, serve as a material sink, and push interdepartmental trade/cooperation.

## Changelog
:cl:
del: Removed Cruciforms from Preacher's locker

/:cl: