### PR TITLE
Spider menu QOL and new features

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
@@ -1,3 +1,8 @@
+ #define SPIDER_GROUP_1 1
+ #define SPIDER_GROUP_2 2
+ #define SPIDER_GROUP_3 4
+ #define SPIDER_GROUP_4 8
+
 /obj/item/implant/carrion_spider
 	name = "spooky spider"
 	desc = "Small spider filled with some sort of strange fluid."
@@ -14,9 +19,7 @@
 	var/last_stun_time = 0 //Used to avoid cheese
 	var/ignore_activate_all = FALSE
 
-	var/assigned_group_1 = FALSE
-	var/assigned_group_2 = FALSE	
-	var/assigned_group_3 = FALSE
+	var/assigned_groups
 
 	var/obj/item/organ/internal/carrion/core/owner_core
 	var/mob/living/carbon/human/owner_mob
@@ -103,14 +106,15 @@
 		layer = PROJECTILE_HIT_THRESHHOLD_LAYER //You are still able to shoot them while they apper below tables
 
 /obj/item/implant/carrion_spider/proc/update_owner_mob()
-	owner_mob = owner_core.owner
+	owner_mob = owner_core.owner	
 
 /obj/item/implant/carrion_spider/proc/toggle_group(group)
-	switch(group)
-		if(1)
-			assigned_group_1 = !assigned_group_1
-		if(2)
-			assigned_group_2 = !assigned_group_2
-		if(3)
-			assigned_group_3 = !assigned_group_3	
-
+	if(check_group(group))
+		assigned_groups = assigned_groups & ~group
+	else
+		assigned_groups = assigned_groups | group
+/obj/item/implant/carrion_spider/proc/check_group(group)
+	if(assigned_groups & group)
+		return TRUE
+	else
+		return FALSE

--- a/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
@@ -106,13 +106,14 @@
 		layer = PROJECTILE_HIT_THRESHHOLD_LAYER //You are still able to shoot them while they apper below tables
 
 /obj/item/implant/carrion_spider/proc/update_owner_mob()
-	owner_mob = owner_core.owner	
+	owner_mob = owner_core.owner
 
 /obj/item/implant/carrion_spider/proc/toggle_group(group)
 	if(check_group(group))
 		assigned_groups = assigned_groups & ~group
 	else
 		assigned_groups = assigned_groups | group
+
 /obj/item/implant/carrion_spider/proc/check_group(group)
 	if(assigned_groups & group)
 		return TRUE

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -53,6 +53,7 @@
 	var/list/spiderlist = list()
 	var/list/active_spiders = list()
 	var/geneticpoints = 10
+	var/autoassign_groups = FALSE
 
 	var/mob/living/simple_animal/spider_core/associated_spider = null
 
@@ -96,6 +97,13 @@
 		active_spiders += spider
 		spider.owner_core = src
 		spider.update_owner_mob()
+		if(autoassign_groups)
+			var/obj/item/implant/carrion_spider/A
+			for(var/obj/item/implant/carrion_spider/F in active_spiders)
+				if(istype(F, spider.type))
+					A = F
+					spider.assigned_groups = A.assigned_groups
+					break
 
 		owner.put_in_active_hand(spider)
 
@@ -117,17 +125,19 @@
 				"location" = "[spider_location]",
 				"spider" = "\ref[item]",
 				"implanted" = S.wearer,
-				"assigned_group_1" = S.assigned_group_1,
-				"assigned_group_2" = S.assigned_group_2,
-				"assigned_group_3" = S.assigned_group_3
+				"assigned_group_1" = S.check_group(SPIDER_GROUP_1),
+				"assigned_group_2" = S.check_group(SPIDER_GROUP_2),
+				"assigned_group_3" = S.check_group(SPIDER_GROUP_3),
+				"assigned_group_4" = S.check_group(SPIDER_GROUP_4)
 			)
 		)
 
 	data["list_of_spiders"] = spiders_in_list
+	data["autoassigning"] = autoassign_groups
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "carrion_spiders.tmpl", "Carrion Spiders", 500, 400)
+		ui = new(user, src, ui_key, "carrion_spiders.tmpl", "Carrion Spiders", 600, 400)
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)
@@ -152,35 +162,49 @@
 	if(href_list["activate_group_1"])
 		for(var/spider in active_spiders)
 			var/obj/item/implant/carrion_spider/CS = spider
-			if(istype(CS) && CS.assigned_group_1)
+			if(istype(CS) && CS.check_group(SPIDER_GROUP_1))
 				CS.activate()
 
 	if(href_list["activate_group_2"])
 		for(var/spider in active_spiders)
 			var/obj/item/implant/carrion_spider/CS = spider
-			if(istype(CS) && CS.assigned_group_2)
+			if(istype(CS) && CS.check_group(SPIDER_GROUP_2))
 				CS.activate()
 
 	if(href_list["activate_group_3"])
 		for(var/spider in active_spiders)
 			var/obj/item/implant/carrion_spider/CS = spider
-			if(istype(CS) && CS.assigned_group_3)
+			if(istype(CS) && CS.check_group(SPIDER_GROUP_3))
+				CS.activate()
+
+	if(href_list["activate_group_4"])
+		for(var/spider in active_spiders)
+			var/obj/item/implant/carrion_spider/CS = spider
+			if(istype(CS) && CS.check_group(SPIDER_GROUP_4))
 				CS.activate()
 
 	if(href_list["toggle_group_1"])
 		var/obj/item/implant/carrion_spider/activated_spider = locate(href_list["toggle_group_1"]) in active_spiders
 		if(activated_spider)
-			activated_spider.toggle_group(1)
+			activated_spider.toggle_group(SPIDER_GROUP_1)
 
 	if(href_list["toggle_group_2"])
 		var/obj/item/implant/carrion_spider/activated_spider = locate(href_list["toggle_group_2"]) in active_spiders
 		if(activated_spider)
-			activated_spider.toggle_group(2)
+			activated_spider.toggle_group(SPIDER_GROUP_2)
 
 	if(href_list["toggle_group_3"])
 		var/obj/item/implant/carrion_spider/activated_spider = locate(href_list["toggle_group_3"]) in active_spiders
 		if(activated_spider)
-			activated_spider.toggle_group(3)
+			activated_spider.toggle_group(SPIDER_GROUP_3)
+
+	if(href_list["toggle_group_4"])
+		var/obj/item/implant/carrion_spider/activated_spider = locate(href_list["toggle_group_4"]) in active_spiders
+		if(activated_spider)
+			activated_spider.toggle_group(SPIDER_GROUP_4)
+
+	if(href_list["toggle_autoassign"])
+		autoassign_groups = !autoassign_groups
 
 	if(href_list["P"])
 		purchasePower(href_list["P"])

--- a/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
@@ -21,9 +21,11 @@
 	recoil_buildup = 1.3
 	one_hand_penalty = 15 //automatic rifle level
 	silenced = TRUE
+	burst_delay = 1
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY,
-		BURST_2_ROUND
+		BURST_2_ROUND,
+		list(mode_name="6-round bursts", burst=6, fire_delay=5, move_delay=7, icon="burst")		
 		)
 	gun_parts = list(/obj/item/part/gun/frame/vintorez = 1, /obj/item/part/gun/grip/excel = 1, /obj/item/part/gun/mechanism/autorifle = 1, /obj/item/part/gun/barrel/srifle = 1)
 

--- a/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
@@ -21,11 +21,9 @@
 	recoil_buildup = 1.3
 	one_hand_penalty = 15 //automatic rifle level
 	silenced = TRUE
-	burst_delay = 1
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY,
-		BURST_2_ROUND,
-		list(mode_name="6-round bursts", burst=6, fire_delay=5, move_delay=7, icon="burst")		
+		BURST_2_ROUND	
 		)
 	gun_parts = list(/obj/item/part/gun/frame/vintorez = 1, /obj/item/part/gun/grip/excel = 1, /obj/item/part/gun/mechanism/autorifle = 1, /obj/item/part/gun/barrel/srifle = 1)
 

--- a/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
@@ -23,7 +23,7 @@
 	silenced = TRUE
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY,
-		BURST_2_ROUND	
+		BURST_2_ROUND
 		)
 	gun_parts = list(/obj/item/part/gun/frame/vintorez = 1, /obj/item/part/gun/grip/excel = 1, /obj/item/part/gun/mechanism/autorifle = 1, /obj/item/part/gun/barrel/srifle = 1)
 

--- a/nano/templates/carrion_spiders.tmpl
+++ b/nano/templates/carrion_spiders.tmpl
@@ -6,6 +6,7 @@ Used In File(s): code\modules\organs\internal\carrion.dm
 <div class="item">
 	<div class="itemContent">
 		{{:helper.link('Activate All', 'radiation', {'activate_all' : 1}, null, 'fixedLeft')}}
+		{{:helper.link(data.autoassigning ? 'Group auto-assigning: On' : 'Group auto-assigning: Off', null, {'toggle_autoassign' : 1}, null)}}
 	</div>
 </div>
 <div class="item" style="width: 100%;">
@@ -13,6 +14,7 @@ Used In File(s): code\modules\organs\internal\carrion.dm
 		{{:helper.link('Activate Group 1', null, {'activate_group_1' : 1}, null)}}
 		{{:helper.link('Activate Group 2', null, {'activate_group_2' : 1}, null)}}
 		{{:helper.link('Activate Group 3', null, {'activate_group_3' : 1}, null)}}
+		{{:helper.link('Activate Group 4', null, {'activate_group_4' : 1}, null)}}
 	</div>
 </table>
 </div>
@@ -24,6 +26,7 @@ Used In File(s): code\modules\organs\internal\carrion.dm
 		<td><b>1</b></td>
 		<td><b>2</b></td>
 		<td><b>3</b></td>
+		<td><b>4</b></td>
 	</tr>
 	{{for data.list_of_spiders}}
 		<tr>
@@ -33,7 +36,8 @@ Used In File(s): code\modules\organs\internal\carrion.dm
 		<td>{{:helper.link('', value.assigned_group_1 ? 'check' : 'close', {'toggle_group_1' : value.spider}, null, value.assigned_group_1 ? null : 'redButton')}}</td>
 		<td>{{:helper.link('', value.assigned_group_2 ? 'check' : 'close', {'toggle_group_2' : value.spider}, null, value.assigned_group_2 ? null : 'redButton')}}</td>
 		<td>{{:helper.link('', value.assigned_group_3 ? 'check' : 'close', {'toggle_group_3' : value.spider}, null, value.assigned_group_3 ? null : 'redButton')}}</td>
-
+		<td>{{:helper.link('', value.assigned_group_4 ? 'check' : 'close', {'toggle_group_4' : value.spider}, null, value.assigned_group_4 ? null : 'redButton')}}</td>
+		
 		<td>
 		{{if value.implanted}}
 		{{:helper.link('pop out', 'circle-arrow-s', {'pop_out_spider' : value.spider})}}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes carrion spider groups handled by bitflags.

Adds an extra group for carrion spiders (now 4 groups), 3 groups weren't enough.

Newly spawned spiders will now get assigned to all groups that another spider of the same type is in (if there is a spark spider that's in group 1 and 3, a newly spawned spark spider will also be assigned to group 1 and 3 automatically). Auto-assigning can an be turned on and off.

Makes the carrion spider activation window even wider!

Hyperio helped with the code for group auto-assigning.

## Why It's Good For The Game

more QOL

## Changelog
:cl:
tweak: Some QOL changes to the carrion spider activation menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
