### PR TITLE
embedded SMG crafting improvements

### DIFF
--- a/code/datums/craft/recipes/guns.dm
+++ b/code/datums/craft/recipes/guns.dm
@@ -119,6 +119,19 @@
 		list(QUALITY_ADHESIVE, 15)
 	)
 
+/datum/craft_recipe/gun/armgun
+	name = "embedded SMG"
+	result = /obj/item/organ_module/active/simple/armsmg
+	steps = list(
+		list(/obj/item/part/gun, 5),
+		list(QUALITY_ADHESIVE, 15, 70),
+		list(CRAFT_MATERIAL, 20, MATERIAL_PLASTEEL, "time" = 10),
+		list(QUALITY_WELDING, 10, "time" = 40),
+		list(/obj/item/stack/cable_coil, 5, "time" = 20),
+		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTIC, "time" = 10),
+		list(QUALITY_ADHESIVE, 15, 70)
+	)
+
 /datum/craft_recipe/gun/flaregun
 	name = "Flare gun shotgun"
 	result = /obj/item/gun/projectile/flare_gun/shotgun

--- a/code/datums/craft/recipes/weapon.dm
+++ b/code/datums/craft/recipes/weapon.dm
@@ -282,21 +282,6 @@
 		list(QUALITY_ADHESIVE, 15, 70)
 	)
 
-/datum/craft_recipe/weapon/armgun
-	name = "embedded SMG"
-	result = /obj/item/organ_module/active/simple/armsmg
-	steps = list(
-		list(/obj/item/gun/projectile/automatic, 1),
-		list(/obj/item/trash/material/metal, "time" = 10),
-		list(CRAFT_MATERIAL, 20, MATERIAL_PLASTEEL, "time" = 10),
-		list(/obj/item/gun/projectile, 1, "time" = 20),
-		list(QUALITY_WELDING, 10, "time" = 40),
-		list(/obj/item/stack/cable_coil, 5, "time" = 20),
-		list(/obj/item/trash/material/circuit, 1),
-		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTIC, "time" = 10),
-		list(QUALITY_ADHESIVE, 15, 70)
-	)
-
 /datum/craft_recipe/weapon/landmine
 	name = "makeshift landmine"
 	result = /obj/item/mine/improv


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves the embedded SMG to the gun tab where it belongs.
Also makes it use gun parts for crafting and simplifies the recipe a bit.

## Why It's Good For The Game

more convenience

## Changelog
:cl:
tweak: moved the embedded smg to gun crafting window, made it easier to craft
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
