### PR TITLE
fixes .60 ammo boxes

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -252,7 +252,8 @@
 	spawn_tags = SPAWN_TAG_AMMO
 
 /obj/item/storage/box/sniperammo/populate_contents()
-	new spawn_type(src)
+	for(var/i in 1 to initial_amount)
+		new spawn_type(src)
 	for(var/obj/item/ammo_casing/temp_casing in src)
 		temp_casing.update_icon()
 
@@ -265,11 +266,6 @@
 	spawn_type = /obj/item/ammo_casing/antim/emp/prespawned
 	spawn_tags = SPAWN_TAG_AMMO
 
-/obj/item/storage/box/sniperammo/emp/populate_contents()
-	new spawn_type(src)
-	for(var/obj/item/ammo_casing/temp_casing in src)
-		temp_casing.update_icon()
-
 /obj/item/storage/box/sniperammo/uranium
 	name = "box of .60 \"Meltdown\" Anti Material shells"
 	desc = "It has a picture of a gun and several warning symbols on the front, including a radiation hazard sign.<br>WARNING: Live depleted uranium ammunition. Misuse may result in serious injury or death."
@@ -279,11 +275,6 @@
 	spawn_type = /obj/item/ammo_casing/antim/uranium/prespawned
 	spawn_tags = SPAWN_TAG_AMMO
 
-/obj/item/storage/box/sniperammo/uranium/populate_contents()
-	new spawn_type(src)
-	for(var/obj/item/ammo_casing/temp_casing in src)
-		temp_casing.update_icon()
-
 /obj/item/storage/box/sniperammo/breach
 	name = "box of .60 \"Breacher\" Anti Material shells"
 	desc = "It has a picture of a gun and several warning symbols on the front, including an explosive hazard sign.<br>WARNING: Live breaching ammunition. Misuse may result in serious injury or death."
@@ -292,11 +283,6 @@
 	initial_amount = 3
 	spawn_type = /obj/item/ammo_casing/antim/breach/prespawned
 	spawn_tags = SPAWN_TAG_AMMO
-
-/obj/item/storage/box/sniperammo/breach/populate_contents()
-	new spawn_type(src)
-	for(var/obj/item/ammo_casing/temp_casing in src)
-		temp_casing.update_icon()
 
 /obj/item/storage/box/flashbangs
 	name = "box of flashbangs"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

.60 ammo boxes will now actually contain 15 shells instead of 5 

## Why It's Good For The Game


## Changelog
:cl:
fix: fixed .60 ammo boxes not containing as many shells as they should
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
