### PR TITLE
Rapid burst mode for the Sol

### DIFF
--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -47,20 +47,21 @@
 #define STRUCTURE_DAMAGE_BORING 		3
 
 //Quick defines for fire modes
-#define FULL_AUTO_300		list(mode_name = "full auto",  mode_desc = "300 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 2  , icon="auto", damage_mult_add = -0.1, style_damage_mult = 0.5)
-#define FULL_AUTO_400		list(mode_name = "full auto",  mode_desc = "400 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 1.5, icon="auto", damage_mult_add = -0.1, style_damage_mult = 0.5)
-#define FULL_AUTO_600		list(mode_name = "full auto",  mode_desc = "600 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 1  , icon="auto", damage_mult_add = -0.1, style_damage_mult = 0.5)
-#define FULL_AUTO_800		list(mode_name = "fuller auto",  mode_desc = "800 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 0.8, icon="auto", damage_mult_add = -0.1, style_damage_mult = 0.5)
+#define FULL_AUTO_300		list(mode_name = "full auto",  mode_desc = "300 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 2  , icon="auto", damage_mult_add = -0.2, style_damage_mult = 0.5)
+#define FULL_AUTO_400		list(mode_name = "full auto",  mode_desc = "400 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 1.5, icon="auto", damage_mult_add = -0.2, style_damage_mult = 0.5)
+#define FULL_AUTO_600		list(mode_name = "full auto",  mode_desc = "600 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 1  , icon="auto", damage_mult_add = -0.2, style_damage_mult = 0.5)
+#define FULL_AUTO_800		list(mode_name = "fuller auto",  mode_desc = "800 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 0.8, icon="auto", damage_mult_add = -0.2, style_damage_mult = 0.5)
 
 #define SEMI_AUTO_NODELAY	list(mode_name = "semiauto",  mode_desc = "Fire as fast as you can pull the trigger", burst=1, fire_delay=0, move_delay=null, icon="semi")
 
 //Cog firemode
-#define BURST_2_BEAM		list(mode_name="2-beam bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, move_delay=2, icon="burst", damage_mult_add = -0.1)
+#define BURST_2_BEAM		list(mode_name="2-beam bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, move_delay=2, icon="burst", damage_mult_add = -0.2)
 
-#define BURST_2_ROUND		list(mode_name="2-round bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, move_delay=2, icon="burst", damage_mult_add = -0.1)
-#define BURST_3_ROUND		list(mode_name="3-round bursts", mode_desc = "Short, controlled bursts", burst=3, fire_delay=null, move_delay=4, icon="burst", damage_mult_add = -0.1)
-#define BURST_5_ROUND		list(mode_name="5-round bursts", mode_desc = "Short, controlled bursts", burst=5, fire_delay=null, move_delay=6, icon="burst", damage_mult_add = -0.1)
-#define BURST_8_ROUND		list(mode_name="8-round bursts", mode_desc = "Short, uncontrolled bursts", burst=8, fire_delay=null, move_delay=8, icon="burst", damage_mult_add = -0.1)
+#define BURST_2_ROUND		list(mode_name="2-round bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, move_delay=2, icon="burst", damage_mult_add = -0.2)
+#define BURST_3_ROUND		list(mode_name="3-round bursts", mode_desc = "Short, controlled bursts", burst=3, fire_delay=null, move_delay=4, icon="burst", damage_mult_add = -0.2)
+#define BURST_3_ROUND_RAPID		list(mode_name=" High-delay Rapid 3-round bursts", mode_desc = "Short, fast bursts with a higher delay between bursts", burst=3, fire_delay=15, move_delay=4, icon="auto", damage_mult_add = -0.2, burst_delay = 0.9)
+#define BURST_5_ROUND		list(mode_name="5-round bursts", mode_desc = "Short, controlled bursts", burst=5, fire_delay=null, move_delay=6, icon="burst", damage_mult_add = -0.2)
+#define BURST_8_ROUND		list(mode_name="8-round bursts", mode_desc = "Short, uncontrolled bursts", burst=8, fire_delay=null, move_delay=8, icon="burst", damage_mult_add = -0.2)
 
 #define WEAPON_NORMAL		list(mode_name="standard", burst =1, icon="semi")
 #define WEAPON_CHARGE		list(mode_name="charge mode", mode_desc="Hold down the trigger, and let loose a more powerful shot", mode_type = /datum/firemode/charge, icon="charge")

--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -47,21 +47,21 @@
 #define STRUCTURE_DAMAGE_BORING 		3
 
 //Quick defines for fire modes
-#define FULL_AUTO_300		list(mode_name = "full auto",  mode_desc = "300 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 2  , icon="auto", damage_mult_add = -0.2, style_damage_mult = 0.5)
-#define FULL_AUTO_400		list(mode_name = "full auto",  mode_desc = "400 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 1.5, icon="auto", damage_mult_add = -0.2, style_damage_mult = 0.5)
-#define FULL_AUTO_600		list(mode_name = "full auto",  mode_desc = "600 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 1  , icon="auto", damage_mult_add = -0.2, style_damage_mult = 0.5)
-#define FULL_AUTO_800		list(mode_name = "fuller auto",  mode_desc = "800 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 0.8, icon="auto", damage_mult_add = -0.2, style_damage_mult = 0.5)
+#define FULL_AUTO_300		list(mode_name = "full auto",  mode_desc = "300 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 2  , icon="auto", damage_mult_add = -0.1, style_damage_mult = 0.5)
+#define FULL_AUTO_400		list(mode_name = "full auto",  mode_desc = "400 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 1.5, icon="auto", damage_mult_add = -0.1, style_damage_mult = 0.5)
+#define FULL_AUTO_600		list(mode_name = "full auto",  mode_desc = "600 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 1  , icon="auto", damage_mult_add = -0.1, style_damage_mult = 0.5)
+#define FULL_AUTO_800		list(mode_name = "fuller auto",  mode_desc = "800 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 0.8, icon="auto", damage_mult_add = -0.1, style_damage_mult = 0.5)
 
 #define SEMI_AUTO_NODELAY	list(mode_name = "semiauto",  mode_desc = "Fire as fast as you can pull the trigger", burst=1, fire_delay=0, move_delay=null, icon="semi")
 
 //Cog firemode
-#define BURST_2_BEAM		list(mode_name="2-beam bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, move_delay=2, icon="burst", damage_mult_add = -0.2)
+#define BURST_2_BEAM		list(mode_name="2-beam bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, move_delay=2, icon="burst", damage_mult_add = -0.1)
 
-#define BURST_2_ROUND		list(mode_name="2-round bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, move_delay=2, icon="burst", damage_mult_add = -0.2)
-#define BURST_3_ROUND		list(mode_name="3-round bursts", mode_desc = "Short, controlled bursts", burst=3, fire_delay=null, move_delay=4, icon="burst", damage_mult_add = -0.2)
-#define BURST_3_ROUND_RAPID		list(mode_name=" High-delay Rapid 3-round bursts", mode_desc = "Short, fast bursts with a higher delay between bursts", burst=3, fire_delay=15, move_delay=4, icon="auto", damage_mult_add = -0.2, burst_delay = 0.9)
-#define BURST_5_ROUND		list(mode_name="5-round bursts", mode_desc = "Short, controlled bursts", burst=5, fire_delay=null, move_delay=6, icon="burst", damage_mult_add = -0.2)
-#define BURST_8_ROUND		list(mode_name="8-round bursts", mode_desc = "Short, uncontrolled bursts", burst=8, fire_delay=null, move_delay=8, icon="burst", damage_mult_add = -0.2)
+#define BURST_2_ROUND		list(mode_name="2-round bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, move_delay=2, icon="burst", damage_mult_add = -0.1)
+#define BURST_3_ROUND		list(mode_name="3-round bursts", mode_desc = "Short, controlled bursts", burst=3, fire_delay=null, move_delay=4, icon="burst", damage_mult_add = -0.1)
+#define BURST_3_ROUND_RAPID		list(mode_name=" High-delay Rapid 3-round bursts", mode_desc = "Short, fast bursts with a higher delay between bursts", burst=3, fire_delay=15, move_delay=4, icon="auto", damage_mult_add = -0.1, burst_delay = 0.9)
+#define BURST_5_ROUND		list(mode_name="5-round bursts", mode_desc = "Short, controlled bursts", burst=5, fire_delay=null, move_delay=6, icon="burst", damage_mult_add = -0.1)
+#define BURST_8_ROUND		list(mode_name="8-round bursts", mode_desc = "Short, uncontrolled bursts", burst=8, fire_delay=null, move_delay=8, icon="burst", damage_mult_add = -0.1)
 
 #define WEAPON_NORMAL		list(mode_name="standard", burst =1, icon="semi")
 #define WEAPON_CHARGE		list(mode_name="charge mode", mode_desc="Hold down the trigger, and let loose a more powerful shot", mode_type = /datum/firemode/charge, icon="charge")

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -662,7 +662,6 @@
 	if(index > firemodes.len)
 		index = 1
 	var/datum/firemode/new_mode = firemodes[sel_mode]
-	new_mode.apply_to(src)
 	new_mode.update()
 	update_hud_actions()
 	return new_mode
@@ -852,6 +851,7 @@
 	proj_step_multiplier = initial(proj_step_multiplier)
 	proj_agony_multiplier = initial(proj_agony_multiplier)
 	fire_delay = initial(fire_delay)
+	burst_delay = initial(burst_delay)
 	move_delay = initial(move_delay)
 	recoil_buildup = initial(recoil_buildup)
 	muzzle_flash = initial(muzzle_flash)
@@ -901,13 +901,8 @@
 
 /obj/item/gun/zoom(tileoffset, viewsize)
 	..()
-	if(!ishuman(usr))
-		return
-	var/mob/living/carbon/human/H = usr
 	if(zoom)
-		H.using_scope = src
 		init_offset -= scoped_offset_reduction
 	else
-		H.using_scope = null
 		refresh_upgrades()
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -662,6 +662,7 @@
 	if(index > firemodes.len)
 		index = 1
 	var/datum/firemode/new_mode = firemodes[sel_mode]
+	new_mode.apply_to(src)
 	new_mode.update()
 	update_hud_actions()
 	return new_mode

--- a/code/modules/projectiles/guns/projectile/automatic/sol.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sol.dm
@@ -25,7 +25,8 @@
 
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY,
-		BURST_3_ROUND
+		BURST_3_ROUND,
+		BURST_3_ROUND_RAPID
 		)
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
 	gun_parts = list(/obj/item/part/gun/frame/sol = 1, /obj/item/part/gun/grip/rubber = 1, /obj/item/part/gun/mechanism/smg = 1, /obj/item/part/gun/barrel/clrifle = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new fire mode to the Sol: Rapid 3-round bursts. Within the bursts, the rounds are fired more quickly, but the delay between the bursts is much larger than that of the regular 3-round burst mode, resulting in an overall worse RoF.

Also removes some redundant code related to zooming with guns.

WIGFTG

You can use this mode when you can't get LoS on a target for longer amounts of times, for example when you or your target are hiding behind cover and only peek around a corner for short amounts of time.
Gives IH ops a reason to choose the sol over the wintermute 

## Changelog
:cl:
add: Adds rapid 3-round-bursts to the Sol
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
