### PR TITLE
Make asteroid and exoplanet turfs indestructible

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -500,3 +500,7 @@
 
 /turf/simulated/floor/asteroid/proc/check_radial_dig()
 	return FALSE
+
+/turf/simulated/floor/asteroid/take_damage(var/damage, var/damage_type = BRUTE, var/ignore_resistance = FALSE)
+	// Asteroid turfs are indestructible, otherwise they can be destroyed at some point and expose metal plating
+	return

--- a/code/modules/overmap/exoplanets/turfs.dm
+++ b/code/modules/overmap/exoplanets/turfs.dm
@@ -215,3 +215,7 @@
 
 	else
 		..(C,user)
+
+/turf/simulated/floor/exoplanet/take_damage(var/damage, var/damage_type = BRUTE, var/ignore_resistance = FALSE)
+	// Exoplanet turfs are indestructible, otherwise they can be destroyed at some point and expose metal plating
+	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Make asteroid and exoplanet turfs indestructible by overwritting their take_damage proc so that it does nothing. That way those turfs won't expose metal plating after being hit by weapon or by explosion. Problem was that a whole planet could be vented by a hole (destroying the plating exposes space).

## Changelog
:cl: Hyperio
tweak: Asteroid and exoplanet turfs are now indestructible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
