### PR TITLE
Fix issue with JTB portals when releasing too soon

### DIFF
--- a/code/modules/dungeons/junk_tractor_beam.dm
+++ b/code/modules/dungeons/junk_tractor_beam.dm
@@ -1,7 +1,8 @@
 #define BEAM_IDLE        0
 #define BEAM_CAPTURING   1
-#define BEAM_STABILIZED  2
-#define BEAM_COOLDOWN    3
+#define BEAM_STABILIZING 2
+#define BEAM_STABILIZED  3
+#define BEAM_COOLDOWN    4
 
 #define JTB_EDGE     3
 #define JTB_MAXX   100
@@ -134,7 +135,7 @@
 	beam_state = BEAM_CAPTURING
 	spawn(beam_capture_time)
 		if(src && beam_state == BEAM_CAPTURING)  // Check if jtb_generator has not been destroyed during spawn time and if capture has not been cancelled
-			beam_state = BEAM_STABILIZED
+			beam_state = BEAM_STABILIZING  // Junk field is being created
 
 			generate_junk_field()  // Generate the junk field
 
@@ -144,6 +145,7 @@
 				jf_counter++
 
 			create_link_portal(T)
+			beam_state = BEAM_STABILIZED  // Junk field has been created and portals linked
 	return
 
 /obj/jtb_generator/proc/create_link_portal(var/turf/T)
@@ -923,6 +925,7 @@
 
 #undef BEAM_IDLE
 #undef BEAM_CAPTURING
+#undef BEAM_STABILIZING
 #undef BEAM_STABILIZED
 #undef JTB_EDGE
 #undef JTB_MAXX

--- a/nano/templates/jtb_console.tmpl
+++ b/nano/templates/jtb_console.tmpl
@@ -10,15 +10,17 @@
 			{{else data.beam_state == 1}}
 				<span style="font-weight: bold;color: #336699">CAPTURING JUNK FIELD</span>
 			{{else data.beam_state == 2}}
-				<span style="font-weight: bold;color: #336699">STABILIZED</span>
+				<span style="font-weight: bold;color: #336699">STABILIZING</span>
 			{{else data.beam_state == 3}}
+				<span style="font-weight: bold;color: #336699">STABILIZED</span>
+			{{else data.beam_state == 4}}
 				<span class="bad">COOLING DOWN</span>
 			{{else}}
 				<span class="bad">ERROR</span>
 			{{/if}}
 		</div>
 		<div class="itemContent">
-		{{if data.beam_state == 3}}
+		{{if data.beam_state == 4}}
 			{{:helper.displayBar(data.bar_current, 0, data.bar_max, 'good')}}
 		{{else}}
 			{{:helper.displayBar(0, 0, data.bar_max, 'good')}}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix issue with JTB portals when releasing too soon. You could release the junk field while it was being created, which glitched the generation and made a portal on the ship that led you to nullspace. There is now a new "STABILIZING" state during JTB creation and you can only release when it is finished, in STABILIZED state.

## Changelog
:cl: Hyperio
fix: Fix issue with JTB portals when releasing too soon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
