### PR TITLE
NT pilum throwing damage reduction

### DIFF
--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -163,7 +163,7 @@
 	price_tag = 150
 	allow_spin = FALSE
 	matter = list(MATERIAL_BIOMATTER = 10, MATERIAL_STEEL = 5) // easy to mass-produce and arm the faithful
-
+	style_damage = 50
 /obj/item/tool/sword/nt/spear/equipped(mob/living/W)
 	..()
 	if(is_held() && is_neotheology_disciple(W))

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -157,7 +157,7 @@
 	var/throwforce_broken = WEAPON_FORCE_HARMLESS
 	w_class = ITEM_SIZE_HUGE
 	slot_flags = SLOT_BACK | SLOT_BELT
-	throwforce = 75
+	throwforce = 45
 	armor_penetration = ARMOR_PEN_HALF
 	throw_speed = 3
 	price_tag = 150


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

reduced the damage the NT spear does when thrown from 75 to 45. the 75 value is a remnant of when all throwforces were multiplied by 0.6 for the purpose of applying damage. This changes it back to it's old damage.

also increases the style damage of the spear to 50 (requested by humon)

## Why It's Good For The Game

fix but also balance

## Changelog
:cl:
balance: The NT spear now deals the intended 45 damage when thrown instead of 75 damage, and deals 50 style damage instead of 20.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
