### PR TITLE
default hotkey retaining on mob change

### DIFF
--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -224,7 +224,7 @@ var/list/_client_preferences_by_type
 /datum/client_preference/stay_in_hotkey_mode
 	description = "Keep hotkeys on mob change"
 	key = "KEEP_HOTKEY_MODE"
-	default_value = GLOB.PREF_NO
+	default_value = GLOB.PREF_YES
 
 /********************
 * General Staff Preferences *


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The "Keep hotkeys on mob change" preference will now be toggled on by default. This way, switching mobs (such as detaching as carrion) will no longer turn your hotkey mode off by default.

## Why It's Good For The Game

I didn't know this existed and neither did you


## Changelog
:cl:
tweak: the "Keep hotkeys on mob change" preference will now be toggled on by default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
