### PR TITLE
Make melee damage scale with limb efficiency

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -128,6 +128,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	var/power = force
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
+		power *= ((H.organs_by_name[(H.hand ? BP_L_ARM : BP_R_ARM)]:limb_efficiency) / 100) //Makes all weapon damage scale on limb efficiency of the hand holding it
 		power *= H.damage_multiplier
 	if(HULK in user.mutations)
 		power *= 2

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -128,7 +128,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	var/power = force
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		power *= ((H.organs_by_name[(H.hand ? BP_L_ARM : BP_R_ARM)]:limb_efficiency) / 100) //Makes all weapon damage scale on limb efficiency of the hand holding it
+		power *= max(((H.organs_by_name[(H.hand ? BP_L_ARM : BP_R_ARM)]:limb_efficiency) / 100), 0.6) //Makes all weapon damage scale on limb efficiency of the hand holding it
 		power *= H.damage_multiplier
 	if(HULK in user.mutations)
 		power *= 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Melee needs a nerf, and this allows it to hit as hard as it always has... Until someone's arms take damage.

## Changelog
:cl:
tweak: Causes the damage dealt by a melee attack to scale based on limb efficiency (And by extension, the amount of damage someone's arms has taken)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
