### PR TITLE
Chameleon clothing update

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -129,7 +129,7 @@
 
 /obj/item/storage/box/syndie_kit/chameleon
 	name = "chameleon kit"
-	desc = "Comes with all the clothes you need to impersonate most people.  Acting lessons sold seperately."
+	desc = "Comes with all the clothes you need to impersonate most people. Acting lessons sold seperately. Wearing the uniform will allow fot quick switching between appearances."
 
 /obj/item/storage/box/syndie_kit/chameleon/populate_contents()
 	new /obj/item/clothing/under/chameleon(src)
@@ -137,6 +137,7 @@
 	new /obj/item/clothing/suit/chameleon(src)
 	new /obj/item/clothing/shoes/chameleon(src)
 	new /obj/item/storage/backpack/chameleon(src)
+	new /obj/item/storage/backpack/satchel/chameleon(src)
 	new /obj/item/clothing/gloves/chameleon(src)
 	new /obj/item/clothing/mask/chameleon(src)
 	new /obj/item/clothing/glasses/chameleon(src)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -174,15 +174,15 @@ obj/item/clothing/disguise(newtype, mob/user)
 
 /obj/item/clothing/under/chameleon/proc/disguise_as_loadout(mob/user, loadout)
 	var/obj/item/A
+	for(var/obj/item/clothing/suit/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[3], user)
 	for(var/obj/item/clothing/under/chameleon/F in user.get_contents())
 		A = F
 		A.disguise(loadout[1], user)
 	for(var/obj/item/clothing/head/chameleon/F in user.get_contents())
 		A = F
 		A.disguise(loadout[2], user)
-	for(var/obj/item/clothing/suit/chameleon/F in user.get_contents())
-		A = F
-		A.disguise(loadout[3], user)
 	for(var/obj/item/clothing/shoes/chameleon/F in user.get_contents())
 		A = F
 		A.disguise(loadout[4], user)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -14,6 +14,7 @@
 	icon_state = copy.icon_state
 	item_state = copy.item_state
 	body_parts_covered = copy.body_parts_covered
+	flags_inv = copy.flags_inv
 
 	item_icons = copy.item_icons.Copy()
 	item_state_slots = copy.item_state_slots.Copy()
@@ -53,6 +54,51 @@ obj/item/clothing/disguise(newtype, mob/user)
 	origin_tech = list(TECH_COVERT = 3)
 	var/global/list/clothing_choices
 
+	var/list/loadout_1 = list(/obj/item/clothing/under/rank/assistant,
+	/obj/item/clothing/head/hardhat,
+	/obj/item/clothing/suit/storage/ass_jacket,
+	/obj/item/clothing/shoes/reinforced,
+	/obj/item/storage/backpack/satchel,
+	/obj/item/clothing/gloves/thick,
+	/obj/item/clothing/mask/smokable/cigarette,
+	/obj/item/clothing/glasses/sunglasses,
+	/obj/item/gun/projectile/boltgun/serbian,
+	/obj/item/device/radio/headset)
+
+	var/list/loadout_2 = list(/obj/item/clothing/under/rank/security,
+	/obj/item/clothing/head/armor/helmet/ironhammer,
+	/obj/item/clothing/suit/armor/vest/full/ironhammer,
+	/obj/item/clothing/shoes/jackboots/ironhammer,
+	/obj/item/storage/backpack/satchel/security,
+	/obj/item/clothing/gloves/stungloves,
+	/obj/item/clothing/mask/balaclava/tactical,
+	/obj/item/clothing/glasses/sunglasses/sechud/tactical,
+	/obj/item/gun/projectile/automatic/sol,
+	/obj/item/device/radio/headset/headset_sec)
+
+	var/list/loadout_3 = list(/obj/item/clothing/under/rank/scientist,
+	/obj/item/clothing/head/bandana/orange,
+	/obj/item/clothing/suit/storage/toggle/labcoat/science,
+	/obj/item/clothing/shoes/jackboots,
+	/obj/item/storage/backpack/satchel/purple/scientist,
+	/obj/item/clothing/gloves/thick,
+	/obj/item/clothing/mask/gas,
+	/obj/item/clothing/glasses/powered/science,
+	/obj/item/gun/energy/lasercannon,
+	/obj/item/device/radio/headset/headset_sci)
+
+	var/list/loadout_4 = list(/obj/item/clothing/under/rank/acolyte,
+	/obj/item/clothing/head/armor/acolyte,
+	/obj/item/clothing/suit/armor/acolyte,
+	/obj/item/clothing/shoes/reinforced,
+	/obj/item/storage/backpack/satchel/neotheology,
+	/obj/item/clothing/gloves/thick,
+	/obj/item/clothing/mask/scarf/red,
+	/obj/item/clothing/glasses/sunglasses,
+	/obj/item/gun/energy/laser,
+	/obj/item/device/radio/headset/church)
+
+
 /obj/item/clothing/under/chameleon/New()
 	..()
 	if(!clothing_choices)
@@ -75,6 +121,175 @@ obj/item/clothing/disguise(newtype, mob/user)
 		return
 
 	disguise(clothing_choices[picked], usr)
+
+//********************************************
+//**Chameleon Jumpsuit loadout functionality**
+//********************************************
+
+/obj/item/clothing/under/chameleon/proc/set_single_loadout_slot(itemtype, loadout)
+	var/obj/item/currentitem = new itemtype(null)
+	var/obj/item/chameleonitem
+	var/obj/item/item_to_disguise
+	if(istype(currentitem, /obj/item/clothing/under))
+		var/obj/item/clothing/under/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[1] = G.clothing_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/clothing/head))
+		var/obj/item/clothing/head/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[2] = G.clothing_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/clothing/suit))
+		var/obj/item/clothing/suit/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[3] = G.clothing_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/clothing/shoes))
+		var/obj/item/clothing/shoes/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[4] = G.clothing_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/storage/backpack))
+		var/obj/item/storage/backpack/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[5] = G.clothing_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/clothing/gloves))
+		var/obj/item/clothing/gloves/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[6] = G.clothing_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/clothing/mask))
+		var/obj/item/clothing/mask/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[7] = G.clothing_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/clothing/glasses))
+		var/obj/item/clothing/glasses/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[8] = G.clothing_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/gun))
+		var/obj/item/gun/energy/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.gun_choices
+		loadout[9] = G.gun_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/device/radio/headset))
+		var/obj/item/device/radio/headset/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[10] = G.clothing_choices[item_to_disguise]
+
+
+/obj/item/clothing/under/chameleon/proc/disguise_as_loadout(mob/user, loadout)
+	var/obj/item/A
+	for(var/obj/item/clothing/under/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[1], user)
+	for(var/obj/item/clothing/head/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[2], user)
+	for(var/obj/item/clothing/suit/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[3], user)
+	for(var/obj/item/clothing/shoes/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[4], user)
+	for(var/obj/item/storage/backpack/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[5], user)
+	for(var/obj/item/storage/backpack/satchel/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[5], user)
+	for(var/obj/item/clothing/gloves/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[6], user)
+	for(var/obj/item/clothing/mask/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[7], user)
+	for(var/obj/item/clothing/glasses/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[8], user)
+	for(var/obj/item/gun/energy/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[9], user)
+	for(var/obj/item/device/radio/headset/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[10], user)
+
+
+/obj/item/clothing/under/chameleon/ui_interact(mob/user, ui_key, datum/nanoui/ui, force_open, datum/nanoui/master_ui, datum/topic_state/state)
+	var/list/data = list()
+
+	var/list/loadouts = list()
+	loadouts += list(loadout_1, loadout_2, loadout_3, loadout_4)
+
+	var/list/clothes_in_loadout = list()
+	var/current_loadout = 1
+	for(var/I in loadouts)
+		var/list/S = I
+		for(var/G in S)
+			var/obj/item/copy = new G (null)
+			clothes_in_loadout += list(
+				list(
+					"name" = copy.name,
+					"type" = copy.type,
+					"loadout" = current_loadout
+				)
+			)
+		current_loadout++
+	data["clothes_in_loadout"] = clothes_in_loadout
+
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
+	if(!ui)
+		ui = new(user, src, ui_key, "chameleon.tmpl", "Chameleon clothing", 1000, 400)
+		ui.set_initial_data(data)
+		ui.open()
+
+/obj/item/clothing/under/chameleon/Topic(href, href_list)
+	var/list/loadouts = list()
+	loadouts += list(loadout_1, loadout_2, loadout_3, loadout_4)
+	if(href_list["set_clothing_1"])
+		var/chameleontype = href_list["set_clothing_1"]
+		set_single_loadout_slot(chameleontype, loadout_1)
+	if(href_list["set_clothing_2"])
+		var/chameleontype = href_list["set_clothing_2"]
+		set_single_loadout_slot(chameleontype, loadout_2)
+	if(href_list["set_clothing_3"])
+		var/chameleontype = href_list["set_clothing_3"]
+		set_single_loadout_slot(chameleontype, loadout_3)
+	if(href_list["set_clothing_4"])
+		var/chameleontype = href_list["set_clothing_4"]
+		set_single_loadout_slot(chameleontype, loadout_4)
+	SSnano.update_uis(src)
+	..()
+
+/obj/item/clothing/under/chameleon/verb/configure_loadouts()
+	set name = "Configure loadouts"
+	set category = "Chameleon Items"
+	set src in usr.contents
+
+	ui_interact(usr)
+
+/obj/item/clothing/under/chameleon/verb/disguise_as_loadout_1()
+	set name = "Disguise as loadout 1"
+	set category = "Chameleon Items"
+	set src in usr.contents
+
+	disguise_as_loadout(usr, loadout_1)
+
+/obj/item/clothing/under/chameleon/verb/disguise_as_loadout_2()
+	set name = "Disguise as loadout 2"
+	set category = "Chameleon Items"
+	set src in usr.contents
+
+	disguise_as_loadout(usr, loadout_2)
+
+/obj/item/clothing/under/chameleon/verb/disguise_as_loadout_3()
+	set name = "Disguise as loadout 3"
+	set category = "Chameleon Items"
+	set src in usr.contents
+
+	disguise_as_loadout(usr, loadout_3)
+
+/obj/item/clothing/under/chameleon/verb/disguise_as_loadout_4()
+	set name = "Disguise as loadout 4"
+	set category = "Chameleon Items"
+	set src in usr.contents
+
+	disguise_as_loadout(usr, loadout_4)
+
 
 //*****************
 //**Chameleon Hat**
@@ -216,6 +431,43 @@ obj/item/clothing/disguise(newtype, mob/user)
 
 /obj/item/storage/backpack/chameleon/verb/change(picked in clothing_choices)
 	set name = "Change Backpack Appearance"
+	set category = "Chameleon Items"
+	set src in usr
+
+	if(!ispath(clothing_choices[picked]))
+		return
+
+	disguise(clothing_choices[picked], usr)
+
+//**********************
+//**Chameleon Satchel**
+//**********************
+/obj/item/storage/backpack/satchel/chameleon
+	name = "grey satchel"
+	icon_state = "satchel"
+	desc = "A satchel outfitted with cloaking tech. It seems to have a small dial inside, kept away from the storage."
+	origin_tech = list(TECH_COVERT = 3)
+	spawn_blacklisted = TRUE
+	spawn_tags = SPAWN_TAG_BACKPACK_CHAMALEON
+	rarity_value = 50
+	var/global/list/clothing_choices
+
+/obj/item/storage/backpack/satchel/chameleon/Initialize()
+	. = ..()
+	if(!clothing_choices)
+		var/blocked = list(src.type, /obj/item/storage/backpack/satchel/leather/withwallet)
+		clothing_choices = generate_chameleon_choices(/obj/item/storage/backpack, blocked)
+
+/obj/item/storage/backpack/satchel/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
+	name = "grey satchel"
+	desc = "A satchel outfitted with cloaking tech. It seems to have a small dial inside, kept away from the storage."
+	icon_state = "backpack"
+	item_state = "backpack"
+	update_icon()
+	update_wear_icon()
+
+/obj/item/storage/backpack/satchel/chameleon/verb/change(picked in clothing_choices)
+	set name = "Change Satchel Appearance"
 	set category = "Chameleon Items"
 	set src in usr
 

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -104,6 +104,11 @@ obj/item/clothing/disguise(newtype, mob/user)
 	if(!clothing_choices)
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/under)
 
+/obj/item/clothing/under/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
+
 /obj/item/clothing/under/chameleon/emp_act(severity)
 	name = "psychedelic"
 	desc = "Groovy!"
@@ -311,6 +316,11 @@ obj/item/clothing/disguise(newtype, mob/user)
 		var/blocked = list(src.type, /obj/item/clothing/head/justice,)//Prevent infinite loops and bad hats.
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/head, blocked)
 
+/obj/item/clothing/head/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
+
 /obj/item/clothing/head/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
 	name = "grey cap"
 	desc = "A baseball hat in a tasteful grey colour."
@@ -346,6 +356,11 @@ obj/item/clothing/disguise(newtype, mob/user)
 	if(!clothing_choices)
 		var/blocked = list(src.type, null)
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/suit, blocked)
+
+/obj/item/clothing/suit/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
 
 /obj/item/clothing/suit/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
 	name = "armor"
@@ -383,6 +398,11 @@ obj/item/clothing/disguise(newtype, mob/user)
 		var/blocked = list(src.type, /obj/item/clothing/shoes/syndigaloshes, /obj/item/clothing/shoes/cyborg)//prevent infinite loops and bad shoes.
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/shoes, blocked)
 
+/obj/item/clothing/shoes/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
+
 /obj/item/clothing/shoes/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
 	name = "black shoes"
 	desc = "A pair of black shoes."
@@ -415,11 +435,16 @@ obj/item/clothing/disguise(newtype, mob/user)
 	rarity_value = 50
 	var/global/list/clothing_choices
 
-/obj/item/storage/backpack/chameleon/Initialize()
+/obj/item/storage/backpack/chameleon/New()
 	. = ..()
 	if(!clothing_choices)
 		var/blocked = list(src.type, /obj/item/storage/backpack/satchel/leather/withwallet)
 		clothing_choices = generate_chameleon_choices(/obj/item/storage/backpack, blocked)
+
+/obj/item/storage/backpack/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
 
 /obj/item/storage/backpack/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
 	name = "grey backpack"
@@ -452,11 +477,16 @@ obj/item/clothing/disguise(newtype, mob/user)
 	rarity_value = 50
 	var/global/list/clothing_choices
 
-/obj/item/storage/backpack/satchel/chameleon/Initialize()
+/obj/item/storage/backpack/satchel/chameleon/New()
 	. = ..()
 	if(!clothing_choices)
 		var/blocked = list(src.type, /obj/item/storage/backpack/satchel/leather/withwallet)
 		clothing_choices = generate_chameleon_choices(/obj/item/storage/backpack, blocked)
+
+/obj/item/storage/backpack/satchel/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
 
 /obj/item/storage/backpack/satchel/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
 	name = "grey satchel"
@@ -494,6 +524,11 @@ obj/item/clothing/disguise(newtype, mob/user)
 	..()
 	if(!clothing_choices)
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/gloves, list(src.type))
+
+/obj/item/clothing/gloves/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
 
 /obj/item/clothing/gloves/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
 	name = "black gloves"
@@ -533,6 +568,11 @@ obj/item/clothing/disguise(newtype, mob/user)
 	if(!clothing_choices)
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/mask, list(src.type))
 
+/obj/item/clothing/mask/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
+
 /obj/item/clothing/mask/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
 	name = "gas mask"
 	desc = "A gas mask."
@@ -568,6 +608,11 @@ obj/item/clothing/disguise(newtype, mob/user)
 	..()
 	if(!clothing_choices)
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/glasses, list(src.type))
+
+/obj/item/clothing/glasses/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
 
 /obj/item/clothing/glasses/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
 	name = "Optical Meson Scanner"

--- a/nano/templates/chameleon.tmpl
+++ b/nano/templates/chameleon.tmpl
@@ -1,0 +1,52 @@
+<!-- 
+Used In File(s): code/modules/clothing/chameleon.dm
+ -->
+{{:helper.syndicateMode()}}
+<table class='itemContent' style="width: 25%;">
+	<tr>
+		<td><b>Loadout 1</b></td>
+	</tr>
+	{{for data.clothes_in_loadout}}
+		{{if value.loadout == 1}}
+			<tr>
+			<td>{{:helper.link(value.name, 'circle-arrow-s', {'set_clothing_1' : value.type})}}</td>
+			</tr>
+		{{/if}}	
+	{{/for}}
+</table>
+<table class='itemContent' style="width: 25%;">
+	<tr>
+		<td><b>Loadout 2</b></td>
+	</tr>
+	{{for data.clothes_in_loadout}}
+		{{if value.loadout == 2}}
+			<tr>
+			<td>{{:helper.link(value.name, 'circle-arrow-s', {'set_clothing_2' : value.type})}}</td>
+			</tr>
+		{{/if}}	
+	{{/for}}
+</table>
+<table class='itemContent' style="width: 25%;">
+	<tr>
+		<td><b>Loadout 3</b></td>
+	</tr>
+	{{for data.clothes_in_loadout}}
+		{{if value.loadout == 3}}
+			<tr>
+			<td>{{:helper.link(value.name, 'circle-arrow-s', {'set_clothing_3' : value.type})}}</td>
+			</tr>
+		{{/if}}	
+	{{/for}}
+</table>
+<table class='itemContent' style="width: 25%;">
+	<tr>
+		<td><b>Loadout 4</b></td>
+	</tr>
+	{{for data.clothes_in_loadout}}
+		{{if value.loadout == 4}}
+			<tr>
+			<td>{{:helper.link(value.name, 'circle-arrow-s', {'set_clothing_4' : value.type})}}</td>
+			</tr>
+		{{/if}}	
+	{{/for}}
+</table>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

~~I'm deeply sorry~~

Wearing the chameleon jumpsuit will now allow you to quickly switch between one of 4 loadouts, which you can customize yourself (the default loadouts are a vagabond, an IH op, a scientist and a NT acolyte)

Also adds a chameleon satchel, so you are no longer bound to using a backpack if you want to go full chameleon clothes.
Chameleon clothes will now properly respect what the item they are mimicking is supposed to block from view. (Previously, having a chameleon mask with the appearance of a cigarette would not display glasses)
Chameleon clothes no longer contain biomatter, but plastic instead, so moebius can now actually print the chameleon kit.

Hex helped with the nanoUI stuff. Others who I forgot about probably helped, too.

this is the result of a copy-paste coder writing original code. has mining gone too far?

![grafik](https://user-images.githubusercontent.com/45079529/157745503-586e9a47-1b89-40f4-a996-2c12c5692ec2.png)
## Why It's Good For The Game

Chameleon clothes OP, plz nerf!
(makes chameleon clothes actually usable)

## Changelog
:cl:
add: added the ability to quickly switch between different loadouts for chameleon clothes if the chameleon jumpsuit is worn.
add: Added the chameleon satchel
fix: chameleon items will no longer block other clothing sprites from appearing when they weren't supposed to
tweak: chameleon clothes are now made of plastic instead of bioatter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
