### PR TITLE
Gives the voice changer mask chameleon capabilities

### DIFF
--- a/code/datums/uplink/stealth and camouflage items.dm
+++ b/code/datums/uplink/stealth and camouflage items.dm
@@ -33,9 +33,9 @@
 	path = /obj/item/storage/box/syndie_kit/cleanup_kit
 
 /datum/uplink_item/item/stealth_items/voice
-	name = "Voice Changer"
+	name = "Chameleon Voice Changer"
 	item_cost = 5
-	path = /obj/item/clothing/mask/gas/voice
+	path = /obj/item/clothing/mask/chameleon/voice
 
 /datum/uplink_item/item/stealth_items/chameleon_projector
 	name = "Chameleon-Projector"

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -5,7 +5,7 @@
 	switch (pickweight(list("bloodyspai" = 1, "stealth" = 1, "screwed" = 1, "guns" = 1, "murder" = 1, "freedom" = 1, "hacker" = 1, /*"lordsingulo" = 1,*/ "smoothoperator" = 1)))
 		if("bloodyspai")
 			new /obj/item/clothing/under/chameleon(src)
-			new /obj/item/clothing/mask/gas/voice(src)
+			new /obj/item/clothing/mask/chameleon/voice(src)
 			new /obj/item/card/id/syndicate(src)
 			new /obj/item/clothing/shoes/syndigaloshes(src)
 			return

--- a/code/modules/clothing/masks/voice.dm
+++ b/code/modules/clothing/masks/voice.dm
@@ -11,14 +11,14 @@
 	origin_tech = list(TECH_COVERT = 4)
 
 /obj/item/clothing/mask/chameleon/voice/verb/Toggle_Voice_Changer()
-	set category = "Object"
+	set category = "Chameleon Items"
 	set src in usr
 
 	changer.active = !changer.active
 	to_chat(usr, "<span class='notice'>You [changer.active ? "enable" : "disable"] the voice-changing module in \the [src].</span>")
 
 /obj/item/clothing/mask/chameleon/voice/verb/Set_Voice(name as text)
-	set category = "Object"
+	set category = "Chameleon Items"
 	set src in usr
 
 	var/voice = sanitize(name, MAX_NAME_LEN)

--- a/code/modules/clothing/masks/voice.dm
+++ b/code/modules/clothing/masks/voice.dm
@@ -4,20 +4,20 @@
 	var/voice //If set and item is present in mask/suit, this name will be used for the wearer's speech.
 	var/active
 
-/obj/item/clothing/mask/gas/voice
+/obj/item/clothing/mask/chameleon/voice
 	name = "gas mask"
 	desc = "A face-covering mask that can be connected to an air supply. It seems to house some odd electronics."
 	var/obj/item/voice_changer/changer
 	origin_tech = list(TECH_COVERT = 4)
 
-/obj/item/clothing/mask/gas/voice/verb/Toggle_Voice_Changer()
+/obj/item/clothing/mask/chameleon/voice/verb/Toggle_Voice_Changer()
 	set category = "Object"
 	set src in usr
 
 	changer.active = !changer.active
 	to_chat(usr, "<span class='notice'>You [changer.active ? "enable" : "disable"] the voice-changing module in \the [src].</span>")
 
-/obj/item/clothing/mask/gas/voice/verb/Set_Voice(name as text)
+/obj/item/clothing/mask/chameleon/voice/verb/Set_Voice(name as text)
 	set category = "Object"
 	set src in usr
 
@@ -26,6 +26,6 @@
 	changer.voice = voice
 	to_chat(usr, SPAN_NOTICE("You are now mimicking <B>[changer.voice]</B>."))
 
-/obj/item/clothing/mask/gas/voice/New()
+/obj/item/clothing/mask/chameleon/voice/New()
 	..()
 	changer = new(src)

--- a/code/modules/clothing/spawn_data/spawn_data.dm
+++ b/code/modules/clothing/spawn_data/spawn_data.dm
@@ -648,7 +648,7 @@
 /obj/item/clothing/mask/gas/german
 	rarity_value = 36
 
-/obj/item/clothing/mask/gas/voice
+/obj/item/clothing/mask/chameleon/voice
 	rarity_value = 100
 
 /obj/item/clothing/mask/gas

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -127,7 +127,7 @@
 	if(ishuman(speaker))
 		var/mob/living/carbon/human/H = speaker
 
-		if(H.wear_mask && istype(H.wear_mask, /obj/item/clothing/mask/gas/voice))
+		if(H.wear_mask && istype(H.wear_mask, /obj/item/clothing/mask/chameleon/voice))
 			changed_voice = TRUE
 			var/mob/living/carbon/human/I
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The voice changer mask now works exactly like a chameleon mask, meaning that you can change it's appearance at will.
Also moves the "toggle voice" and "change voice" verbs to the Chameleon items tab.

## Why It's Good For The Game

harder to spot someone obviously mimicking someone's voice

## Changelog
:cl:
tweak: The voice changer mask can now change appearances like a chameleon mask. 
tweak: The "change voice" and "toggle voice" verbs of the voice changer have been moved to the chameleon item tab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
