### PR TITLE
Better efficiency for the seclite

### DIFF
--- a/code/game/objects/items/devices/lighting/toggleable/flashlight.dm
+++ b/code/game/objects/items/devices/lighting/toggleable/flashlight.dm
@@ -312,8 +312,8 @@
 	desc = "A hand-held security flashlight."
 	icon_state = "seclite"
 	item_state = "seclite"
-	light_spot_radius = 3
 	light_spot_power = 2.5
+	tick_cost = 0.2
 
 /obj/item/device/lighting/toggleable/flashlight/seclite/update_icon()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the seclite use half the amount of power per tick as it did before.
(the removed light_spot radius of the seclite doesn't matter, since it doesn't matter from the base flashlight one)

## Why It's Good For The Game

Gives operatives a reason not to ditch their seclite for a heavy duty flashlight.

## Changelog
:cl:
tweak: the seclite now uses half as much power per tick as it did before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
