### PR TITLE
Mandella buff

### DIFF
--- a/code/modules/projectiles/guns/projectile/pistol/mandella.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mandella.dm
@@ -18,8 +18,9 @@
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_PISTOL
 	magazine_type = /obj/item/ammo_magazine/cspistol
-	damage_multiplier = 1.2
-	penetration_multiplier = 1.7
+	proj_step_multiplier = 0.8
+	damage_multiplier = 1.6
+	penetration_multiplier = 3
 	recoil_buildup = 2
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Yoooooo balance changes???

The mandella got hit by the nerf to non-pistol bullets, as it uses caseless rifle ammunition. Even before the nerf it wasn't the best choice, since at it's damage of 27.6 and with an AP value of 25.5, The mandella is quite weak for a gun that costs only 1 TC less than the miller.
an example: vs 60 bullet resist, the mandella deals 14.5 damage, while the miller deals 24 damage, the paco deals 16.2 damage and even the humble giskard deals 14.3 damage.

This is why I'm increasing the mandella's damage from 27.6 to 36.8 and it's AP from 25.5 to 45. With these stats, it deals 26.2 damage vs 60 bullet resist (only 2.2 more damage than the miller versus the same bullet resist).

The bullet velocity of the mandella has also been increased (similar velocity to that of a regular bullet with the accelerator gunmod) to make it a bit more unique and worth using.


## Why It's Good For The Game

a difference of 1 tc between guns should imply similar performance levels.

## Changelog
:cl:
balance: greatly buffed the damage, AP and bullet velocity of the mandella
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
