### PR TITLE
Makes weaken() drop items carried in hands again.

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -396,8 +396,6 @@
 		to_chat(src, SPAN_WARNING("You slipped on [slipped_on]!"))
 		playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
 	Weaken(stun_duration)
-	if(l_hand) unEquip(l_hand)
-	if(r_hand) unEquip(r_hand)
 
 	return TRUE
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -273,7 +273,7 @@
 			if(prob(5) && prob(100 * RADIATION_SPEED_COEFFICIENT))
 				radiation -= 5 * RADIATION_SPEED_COEFFICIENT
 				to_chat(src, SPAN_WARNING("You feel weak."))
-				Weaken(3)
+				Weaken(3, FALSE)
 				if(!lying)
 					emote("collapse")
 			if(prob(5) && prob(100 * RADIATION_SPEED_COEFFICIENT) && species.get_bodytype() == SPECIES_HUMAN) //apes go bald

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -718,7 +718,7 @@ Note from Nanako: 2019-02-01
 TODO: Bay Movement:
 All Canmove setting in this proc is temporary. This var should not be set from here, but from movement controllers
 */
-/mob/proc/update_lying_buckled_and_verb_status()
+/mob/proc/update_lying_buckled_and_verb_status(dropitems = FALSE)
 
 	if(!resting && cannot_stand() && can_stand_overridden())
 		lying = 0
@@ -739,7 +739,7 @@ All Canmove setting in this proc is temporary. This var should not be set from h
 
 	if(lying)
 		set_density(0)
-		if(stat == UNCONSCIOUS)
+		if(stat == UNCONSCIOUS || dropitems)
 			if(l_hand) unEquip(l_hand) //we want to be able to keep items, for tactical resting and ducking behind cover
 			if(r_hand) unEquip(r_hand)
 	else
@@ -824,7 +824,7 @@ All Canmove setting in this proc is temporary. This var should not be set from h
 	if(status_flags & CANWEAKEN)
 		facing_dir = null
 		weakened = max(max(weakened,amount),0)
-		update_lying_buckled_and_verb_status()	//updates lying, canmove and icons
+		update_lying_buckled_and_verb_status(TRUE)	//updates lying, canmove and icons
 	return
 
 /mob/proc/SetWeakened(amount)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -820,11 +820,11 @@ All Canmove setting in this proc is temporary. This var should not be set from h
 		update_lying_buckled_and_verb_status()
 	return
 
-/mob/proc/Weaken(amount)
+/mob/proc/Weaken(amount, dropitems = TRUE)
 	if(status_flags & CANWEAKEN)
 		facing_dir = null
 		weakened = max(max(weakened,amount),0)
-		update_lying_buckled_and_verb_status(TRUE)	//updates lying, canmove and icons
+		update_lying_buckled_and_verb_status(dropitems)	//updates lying, canmove and icons
 	return
 
 /mob/proc/SetWeakened(amount)

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -166,7 +166,7 @@ see multiz/movement.dm for some info.
 			var/fall_damage = mover.get_fall_damage()
 			if(M == mover)
 				continue
-			if(M.getarmor(BP_HEAD, ARMOR_MELEE) < fall_damage || ismob(Mover))
+			if(M.getarmor(BP_HEAD, ARMOR_MELEE) < fall_damage || ismob(mover))
 				M.Weaken(10)
 			if(fall_damage >= FALL_GIB_DAMAGE)
 				M.gib()

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -166,7 +166,7 @@ see multiz/movement.dm for some info.
 			var/fall_damage = mover.get_fall_damage()
 			if(M == mover)
 				continue
-			if(M.getarmor(BP_HEAD, ARMOR_MELEE) < fall_damage)
+			if(M.getarmor(BP_HEAD, ARMOR_MELEE) < fall_damage || ismob(Mover))
 				M.Weaken(10)
 			if(fall_damage >= FALL_GIB_DAMAGE)
 				M.gib()

--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -2267,7 +2267,7 @@
 
 /datum/reagent/alcohol/neurotoxin/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
 	..()
-	M.Weaken(3 * effect_multiplier, FALSE)
+	M.Weaken(3 * effect_multiplier)
 	M.add_chemical_effect(CE_PULSE, -1)
 
 /datum/reagent/alcohol/patron

--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -2267,7 +2267,7 @@
 
 /datum/reagent/alcohol/neurotoxin/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
 	..()
-	M.Weaken(3 * effect_multiplier)
+	M.Weaken(3 * effect_multiplier, FALSE)
 	M.add_chemical_effect(CE_PULSE, -1)
 
 /datum/reagent/alcohol/patron

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -177,7 +177,7 @@
 							shake_camera(M, 10, 1)
 				if(istype(M, /mob/living/carbon))
 					if(!M.buckled)
-						M.Weaken(3)
+						M.Weaken(3, FALSE)
 
 		for(var/obj/structure/cable/C in A)
 			powernets |= C.powernet

--- a/oldcode/shuttles_old/old_shuttle.dm
+++ b/oldcode/shuttles_old/old_shuttle.dm
@@ -124,7 +124,7 @@
 					shake_camera(M, 10, 1)
 		if(iscarbon(M))
 			if(!M.buckled)
-				M.Weaken(3)
+				M.Weaken(3, FALSE)
 	// Power-related checks. If shuttle contains power related machinery, update powernets.
 	var/update_power = 0
 	for(var/obj/machinery/power/P in destination)
@@ -136,7 +136,7 @@
 		break
 
 	for(var/obj/structure/plasticflaps/mining/F in destination)
-		F.update_turf_underneath(1)	//костыли вы мои костылики
+		F.update_turf_underneath(1)	//пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 
 	if(update_power)
 		makepowernets()

--- a/oldcode/shuttles_old/old_shuttle.dm
+++ b/oldcode/shuttles_old/old_shuttle.dm
@@ -136,7 +136,7 @@
 		break
 
 	for(var/obj/structure/plasticflaps/mining/F in destination)
-		F.update_turf_underneath(1)	//������� �� ��� ���������
+		F.update_turf_underneath(1)	
 
 	if(update_power)
 		makepowernets()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Sources of getting weakened include falling down a zlevel, being electrocuted, tripping on underplating and many more. All of these now make you drop the items you are holding in your hands again, with the exceptions of being weakened by shuttle acceleration and by radiation effects. Resting and diving will NOT make you drop items in your hands.
Jumping on top of someone from above will now also weaken the person who is being jumped on regardless of whether or not they are wearing a helmet.

## Why It's Good For The Game

If I manage to push someone over a railing, I want him to drop whatever the fuck he is holding. This primal need of man is adressed by this PR.

## Changelog
:cl:
tweak: weaken() makes you drop items again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
