### PR TITLE
Fixes construction ritual result

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/construction.dm
+++ b/code/modules/core_implant/cruciform/rituals/construction.dm
@@ -254,7 +254,7 @@ GLOBAL_LIST_INIT(nt_blueprints, init_nt_blueprints())
 	build_time = 8 SECONDS
 /datum/nt_blueprint/machinery/bioreactor_platform
 	name = "Biomatter Reactor: Platform"
-	build_path = /obj/machinery/multistructure/bioreactor_part/biotank_platform
+	build_path = /obj/machinery/multistructure/bioreactor_part/platform
 	materials = list(
 		/obj/item/stack/material/steel = 10,
 		/obj/item/stack/tile/floor = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes one line so the ritual to construct the platform parts for the bioreactor gives the correct result, instead of another tank platform. Closes #7077 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Actually being able to build the machines you're supposed to be able to is good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Attempting to construct a bioreactor platform now gives the correct result, instead of a tank platform.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
