### PR TITLE
Unrandomizes wires on most types of machinery

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -1,6 +1,7 @@
 // Wires for airlocks
 
 /datum/wires/airlock/secure
+	random = 1
 	wire_count = 14
 
 /datum/wires/airlock

--- a/code/datums/wires/camera.dm
+++ b/code/datums/wires/camera.dm
@@ -1,6 +1,7 @@
 // Wires for cameras.
 
 /datum/wires/camera
+	random = 1
 	holder_type = /obj/machinery/camera
 	wire_count = 6
 	descriptions = list(

--- a/code/datums/wires/nuclearbomb.dm
+++ b/code/datums/wires/nuclearbomb.dm
@@ -1,4 +1,5 @@
 /datum/wires/nuclearbomb
+	random = 1
 	holder_type = /obj/machinery/nuclearbomb
 	wire_count = 7
 	descriptions = list(

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -1,4 +1,5 @@
 /datum/wires/robot
+	random = 1
 	holder_type = /mob/living/silicon/robot
 	wire_count = 5
 	descriptions = list(

--- a/code/datums/wires/smartfridge.dm
+++ b/code/datums/wires/smartfridge.dm
@@ -8,6 +8,7 @@
 	)
 
 /datum/wires/smartfridge/secure
+	random = 1
 	wire_count = 4
 
 var/const/SMARTFRIDGE_WIRE_ELECTRIFY	= 1

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -11,7 +11,7 @@ var/list/wireColours = list("red", "blue", "green", "darkred", "orange", "brown"
 
 /datum/wires
 
-	var/random = 1 // Will the wires be different for every single instance.
+	var/random = 0 // Will the wires be different for every single instance.
 	var/atom/holder = null // The holder
 	var/holder_type = null // The holder type; used to make sure that the holder is the correct type.
 	var/wire_count = 0 // Max is 16

--- a/code/modules/clothing/spacesuits/rig/rig_wiring.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_wiring.dm
@@ -1,4 +1,5 @@
 /datum/wires/rig
+	random = 1
 	holder_type = /obj/item/rig
 	wire_count = 5
 	descriptions = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR undoes the randomization of wires for every instance of a type of machinery, such as airlocks. This means that the wires in one airlock are similar to those in all other airlocks, instead of assigning every airlock a random set of wires.

The only things that keep their randomized wires are robots, RIG wires, the nuke, the smartfridge, cameras and secure airlocks, because they did so before the randomisation, too.

Currently, seeing a series of locked doors I want to pass makes me not want to hack them open, but instead brute-force them open with a weapon or murder someone for access, because that feels like less effort than having to check the wires on every single door while possibly bolting and shocking the door in the process.
I could understand randomized wires if hacking was actually quick to pull off and people would use it constantly to effortlessly break into places, but that's not the case.

Randomized wires only serve the purpose of cucking people who didn't powergame for high MEC by making wiring pure pain to interact with. Wires are such a cool system, and it's sad that actually using them is discouraged through randomized wiring.

## Why It's Good For The Game

~~I just want to be able to pull off funny spark spider shenanigans~~

I would like to be able to interact with the systems of the game in a way that makes me not want to bash my head into a brick wall without having to result to powergaming.

## Changelog
:cl:
tweak: most types of machinery will no longer have randomized wiring for every instance.
/:cl:
