### PR TITLE
rework how EOTP armaments work+ only 1 High Inquisitor's Seal spawn

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -1603,6 +1603,7 @@
 #include "code\modules\core_implant\cruciform\modules.dm"
 #include "code\modules\core_implant\cruciform\upgrades.dm"
 #include "code\modules\core_implant\cruciform\machinery\altar.dm"
+#include "code\modules\core_implant\cruciform\machinery\armaments.dm"
 #include "code\modules\core_implant\cruciform\machinery\cloning.dm"
 #include "code\modules\core_implant\cruciform\machinery\cruciformforge.dm"
 #include "code\modules\core_implant\cruciform\machinery\eotp.dm"

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -10,7 +10,7 @@
 	var/max_discount = 0 //max amount of discounts
 	var/rate_increase = 0 //rate increase per purchase
 	var/max_rate_increase = 0 //max rate increase from buying this
-	var/max_increase = 50 //incease of eotp max armement points per purchase
+	var/max_increase = 25 //incease of eotp max armement points per purchase
 
 //modifiers in the future? maby some rituals to reduce cost for certain subtype
 /datum/armament/proc/get_cost()
@@ -36,7 +36,7 @@
 	purchase_count++
 
 
-	if (purchase_count >= 0)
+	if (purchase_count <= 0)
 		eotp.max_armaments_points += max_increase
 		//eotp.armaments_rate += rate_increase
 

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -7,7 +7,7 @@
 	var/purchase_count = 0 //how many times its bought
 	var/discount_increase = 25 //discount increase per purchase
 	var/discount = 0 //total discount to apply to the cost
-	var/max_discount = 25 //max amount of discounts
+	var/max_discount = 0 //max amount of discounts
 	var/rate_increase = 0 //rate increase per purchase
 	var/max_rate_increase = 0 //max rate increase from buying this
 	var/max_increase = 50 //incease of eotp max armement points per purchase
@@ -37,12 +37,14 @@
 
 	purchase_count++
 
-	discount = max(max_discount,discount + discount_increase)
+	if (!max_discount)
+		discount = discount + discount_increase
+	else
+		discount = min(max_discount,discount + discount_increase)
 
-	if (eotp.armaments_rate + rate_increase > max_rate_increase)
-		eotp.armaments_rate += rate_increase
-
-	eotp.max_armaments_points += max_increase
+	if (purchase_count >= 0)
+		eotp.max_armaments_points += max_increase
+		//eotp.armaments_rate += rate_increase
 
 	on_purchase(H)
 	SSnano.update_uis(eotp)
@@ -96,11 +98,10 @@
 	if (path)
 		var/obj/_item = new path(get_turf(eotp))
 		eotp.visible_message(SPAN_NOTICE("The [_item.name] appers out of bluespace near the [eotp]!"))
-
 /datum/armament/item/disk
 	name = "disk"
-	cost = 100
-	discount_increase = 25
+	cost = 75
+	discount_increase = 100
 	min_cost = 25
 
 /datum/armament/item/disk/crusader
@@ -117,13 +118,96 @@
 
 /datum/armament/item/disk/cells
 	name = "Power Cells disk"
+	cost = 75
+	min_cost = 50
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/cells
+/datum/armament/item/disk/pouches
+	name = 'Pouches disk'
+	cost = 75
+	min_cost = 25
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/pouches
+
+/datum/armament/item/disk/svalinn
+	name = 'Svalinn disk'
+	cost = 125
+	min_cost = 75
+ 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/nt_svalinn
+
+/datum/armament/item/disk/velite
+	name = 'Velite disk'
+	cost = 125
+	min_cost = 75
+ 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/velite
+
+/datum/armament/item/disk/nt_protector
+	name = 'Protector disk'
+	cost = 175
+	min_cost = 125
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/nt_protector
+
+/datum/armament/item/disk/principes
+	name = 'Principes disk'
+	cost = 175
+	min_cost = 125
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/principes
+
+/datum/armament/item/disk/medicii
+	name = "Medicii disk"
+	cost = 175
+	min_cost = 125
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/medicii
+
+/datum/armament/item/disk/nt_dominion
+	name = "Dominion disk"
+	cost = 225
+	min_cost = 125
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/nt_dominion
+
+/datum/armament/item/disk/grenades
+	name = "Grenades disk"
+	cost = 225
+	min_cost = 175
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/grenades
+
+/datum/armament/item/disk/triarii
+	name = "Triarri disk"
+	cost = 225
+	min_cost = 175
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/triarii
+
+/datum/armament/item/disk/nt_lightfall
+	name = "Lightfall disk"
+	cost = 275
+	min_cost = 200
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/nt_lightfall
+
+/datum/armament/item/disk/excruciator
+	name = "Excruciator disk"
+	cost = 275
+	min_cost = 200
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/excruciator
+
 
 /datum/armament/item/grenade
 	name = "Grenade"
 	desc = "Summoning of boom booms"
 	path = /obj/item/grenade/explosive/nt
-	cost = 50
-	min_cost = 5
-	discount_increase = 5
+	cost = 275
+	min_cost = 200
+	discount_increase = 100
 
+/datum/armement/item/gun
+	name = 'gun'
+	discount_increase = 100
+
+/datum/armement/item/gun/largecrossobw
+	name = 'Large crossbow'
+	path = /obj/item/gun/energy/crossbow/largecrossbow
+	cost = 125
+	min_cost = 50
+
+/datum/armement/item/gun/destroyer
+	name = 'Destroyer'
+	path = /obj/item/gun/energy/plasma/destroyer
+	cost = 325
+	min_cost = 200

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -2,19 +2,19 @@
 	var/name = "Virtue of coding"
 	var/desc = "The gods made it quite clear this should not exist, Perhaps inform those above."
 	var/cost = 100
-	var/min_cost = 10
-	var/path = /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter_public
-	var/purchase_count = 0
-	var/discount_increase = 25
-	var/discount = 0
-	var/max_discount = 25
-	var/rate_increase = 0
-	var/max_rate_increase = 0
-	var/max_increase = 50
+	var/min_cost = 10 //aboslute minimum it should cost
+	var/path = /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter_public //path to spawn
+	var/purchase_count = 0 //how many times its bought
+	var/discount_increase = 25 //discount increase per purchase
+	var/discount = 0 //total discount to apply to the cost
+	var/max_discount = 25 //max amount of discounts
+	var/rate_increase = 0 //rate increase per purchase
+	var/max_rate_increase = 0 //max rate increase from buying this
+	var/max_increase = 50 //incease of eotp max armement points per purchase
 
 //modifiers in the future? maby some rituals to reduce cost for certain subtype
 /datum/armament/proc/get_cost()
-	return (cost - discount) > min_cost ? cost - discount : min_cost
+	return max(min_cost,cost - discount)
 
 /datum/armament/proc/purchase(var/mob/living/carbon/H)
 	if (!eotp)
@@ -37,13 +37,12 @@
 
 	purchase_count++
 
-	discount += discount_increase
-	if (max_discount > discount)
-		discount = max_discount
+	discount = max(max_discount,discount + discount_increase)
 
-	if (eotp.armaments_rate > max_rate_increase)
+	if (eotp.armaments_rate + rate_increase > max_rate_increase)
 		eotp.armaments_rate += rate_increase
 
+	eotp.max_armaments_points += max_increase
 
 	on_purchase(H)
 	SSnano.update_uis(eotp)

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -100,7 +100,9 @@
 /datum/armament/item/New()
 	if (desc == "item")
 		var/obj/item/I = path
-		desc = initial(I.desc)
+		var/text = initial(I.desc)
+		if (text)
+			desc = text
 
 /datum/armament/item/on_purchase(mob/living/carbon/H)
 	if (path)
@@ -116,25 +118,18 @@
 /datum/armament/item/disk/New()
 	if (desc == "item")
 		var/obj/item/computer_hardware/hard_drive/portable/design/D
-		desc = initial(D.disk_name)
+		var/text = initial(D.disk_name)
+		if (text)
+			desc = text
+		desc = text
 
-/datum/armament/item/disk/crusader
-	name = "Crusader disk"
-	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/crusader
-
-/datum/armament/item/disk/advancedmelee
-	name = "Advanced melee disk"
-	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/advancedmelee
-
-/datum/armament/item/disk/cruciform_upgrade
-	name = "Cruciform upgrade disk"
-	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/cruciform_upgrade
 
 /datum/armament/item/disk/cells
 	name = "Power Cells disk"
 	cost = 75
 	min_cost = 50
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/cells
+
 /datum/armament/item/disk/pouches
 	name = "Pouches disk"
 	cost = 75
@@ -145,13 +140,13 @@
 	name = "Svalinn disk"
 	cost = 125
 	min_cost = 75
- 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/nt_svalinn
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/nt_svalinn
 
 /datum/armament/item/disk/velite
 	name = "Velite disk"
 	cost = 125
 	min_cost = 75
- 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/velite
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/velite
 
 /datum/armament/item/disk/nt_protector
 	name = "Protector disk"
@@ -210,17 +205,17 @@
 	min_cost = 200
 	discount_increase = 100
 
-/datum/armement/item/gun
+/datum/armament/item/gun
 	name = "gun"
 	discount_increase = 100
 
-/datum/armement/item/gun/largecrossobw
+/datum/armament/item/gun/largecrossobw
 	name = "Large crossbow"
 	path = /obj/item/gun/energy/crossbow/largecrossbow
 	cost = 125
 	min_cost = 50
 
-/datum/armement/item/gun/destroyer
+/datum/armament/item/gun/destroyer
 	name = "Destroyer"
 	path = /obj/item/gun/energy/plasma/destroyer
 	cost = 325

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -32,13 +32,18 @@
 		to_chat(H, SPAN_DANGER("You lack required armament points."))
 		return FALSE
 
+	eotp.armaments_points -= get_cost()
 
 	purchase_count++
 
+	if (!max_discount)
+		discount = discount + discount_increase
+	else
+		discount = min(max_discount,discount + discount_increase)
 
-	if (purchase_count <= 0)
+
+	if (purchase_count < 2)
 		eotp.max_armaments_points += max_increase
-		//eotp.armaments_rate += rate_increase
 
 	on_purchase(H)
 	SSnano.update_uis(eotp)

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -20,6 +20,9 @@
 	if (!eotp)
 		error("no eotp found to purchase from")
 		return FALSE
+	if (get_dist(eotp.loc,H.loc) > 3)
+		log_and_message_admins("[key_name(H)] tryed to make a topic call out of range for the [eotp]")
+		return FALSE
 
 	if (!is_neotheology_disciple(H))
 		to_chat(H, SPAN_DANGER("You do not understand how to use this."))
@@ -43,6 +46,7 @@
 
 
 	on_purchase(H)
+	SSnano.update_uis(eotp)
 	ui_interact(H)
 	log_and_message_admins("[key_name(H)] has invoked [src.name]")
 	return TRUE
@@ -61,7 +65,7 @@
 		listed_armaments.Add(list(list(
 			"key" = i,
 			"name" = strip_improper(A.name),
-			"cost" = A.cost,
+			"cost" = A.get_cost(),
 			"desc" = A.desc)))
 	data["armaments"] = listed_armaments
 	return data
@@ -95,6 +99,27 @@
 		var/obj/_item = new path(get_turf(eotp))
 		eotp.visible_message(SPAN_NOTICE("The [_item.name] appers out of bluespace near the [eotp]!"))
 
+/datum/armament/item/disk
+	name = "disk"
+	cost = 100
+	discount_increase = 25
+	min_cost = 25
+
+/datum/armament/item/disk/crusader
+	name = "Crusader disk"
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/crusader
+
+/datum/armament/item/disk/advancedmelee
+	name = "Advanced melee disk"
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/advancedmelee
+
+/datum/armament/item/disk/cruciform_upgrade
+	name = "Cruciform upgrade disk"
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/cruciform_upgrade
+
+/datum/armament/item/disk/cells
+	name = "Power Cells disk"
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/cells
 
 
 

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -28,19 +28,13 @@
 		to_chat(H, SPAN_DANGER("You do not understand how to use this."))
 		return FALSE
 
-	if (!eotp.armaments_points >= cost)
+	if (!eotp.armaments_points >= get_cost())
 		to_chat(H, SPAN_DANGER("You lack required armament points."))
 		return FALSE
 
 
-	eotp.armaments_points -= get_cost()
-
 	purchase_count++
 
-	if (!max_discount)
-		discount = discount + discount_increase
-	else
-		discount = min(max_discount,discount + discount_increase)
 
 	if (purchase_count >= 0)
 		eotp.max_armaments_points += max_increase

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -2,7 +2,7 @@
 	var/name = "Virtue of coding"
 	var/desc = "The gods made it quite clear this should not exist, Perhaps inform those above."
 	var/cost = 100
-	var/min_cost = 10 //aboslute minimum it should cost
+	var/min_cost = 10 //absolute minimum it should cost
 	var/path = /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter_public //path to spawn
 	var/purchase_count = 0 //how many times its bought
 	var/discount_increase = 25 //discount increase per purchase
@@ -10,18 +10,18 @@
 	var/max_discount = 0 //max amount of discounts
 	var/rate_increase = 0 //rate increase per purchase
 	var/max_rate_increase = 0 //max rate increase from buying this
-	var/max_increase = 25 //incease of eotp max armement points per purchase
+	var/max_increase = 25 //increase of eotp max armament points per purchase
 
-//modifiers in the future? maby some rituals to reduce cost for certain subtype
+//modifiers in the future? maybe some rituals to reduce cost for certain subtype
 /datum/armament/proc/get_cost()
-	return max(min_cost,cost - discount)
+	return max(min_cost, cost - discount)
 
 /datum/armament/proc/purchase(var/mob/living/carbon/H)
 	if (!eotp)
-		error("no eotp found to purchase from")
+		error("No EOTP found to purchase from.")
 		return FALSE
-	if (get_dist(eotp.loc,H.loc) > 3)
-		log_and_message_admins("[key_name(H)] tryed to make a topic call out of range for the [eotp]")
+	if (get_dist(eotp.loc, H.loc) > 3)
+		log_and_message_admins("[key_name(H)] tried to make a topic call out of range of the [eotp]")
 		return FALSE
 
 	if (!is_neotheology_disciple(H))
@@ -29,7 +29,7 @@
 		return FALSE
 
 	if (eotp.armaments_points < get_cost())
-		to_chat(H, SPAN_DANGER("You lack required armament points."))
+		to_chat(H, SPAN_DANGER("You lack the required amount of armament points."))
 		return FALSE
 
 	eotp.armaments_points -= get_cost()
@@ -39,7 +39,7 @@
 	if (!max_discount)
 		discount = discount + discount_increase
 	else
-		discount = min(max_discount,discount + discount_increase)
+		discount = min(max_discount, discount + discount_increase)
 
 
 	if (purchase_count < 2)
@@ -51,7 +51,7 @@
 	return TRUE
 
 
-//maby buying buffs,blessings, miracles,etc instead of just items
+//maybe buying buffs, blessings, miracles, etc instead of just items
 /datum/armament/proc/on_purchase(var/mob/living/carbon/H)
 	return
 
@@ -107,7 +107,7 @@
 /datum/armament/item/on_purchase(mob/living/carbon/H)
 	if (path)
 		var/obj/_item = new path(get_turf(eotp))
-		eotp.visible_message(SPAN_NOTICE("The [_item.name] appers out of bluespace near the [eotp]!"))
+		eotp.visible_message(SPAN_NOTICE("The [_item.name] appears out of bluespace near the [eotp]!"))
 
 /datum/armament/item/disk
 	name = "disk"

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -43,7 +43,7 @@
 
 
 	on_purchase(H)
-
+	ui_interact(H)
 	log_and_message_admins("[key_name(H)] has invoked [src.name]")
 	return TRUE
 
@@ -51,7 +51,6 @@
 //maby buying buffs,blessings, miracles,etc instead of just items
 /datum/armament/proc/on_purchase(var/mob/living/carbon/H)
 	return
-
 
 
 /datum/armament/ui_data(mob/user)
@@ -64,26 +63,26 @@
 			"name" = strip_improper(A.name),
 			"cost" = A.cost,
 			"desc" = A.desc)))
-	data["armements"] = listed_armaments
+	data["armaments"] = listed_armaments
 	return data
 
 
 /datum/armament/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = NANOUI_FOCUS)
 	var/list/data = ui_data(user, ui_key)
 
-	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
+	ui = SSnano.try_update_ui(user, eotp, ui_key, ui, data, force_open)
 	if (!ui)
 		// the ui does not exist, so we'll create a new() one
 		// for a list of parameters and their descriptions see the code docs in \code\modules\nano\nanoui.dm
-		ui = new(user, src, ui_key, "eopt.tmpl", "Eye of the protector", 550, 655)
+		ui = new(user, eotp, ui_key, "eopt.tmpl", "Eye of the protector", 550, 655)
 		// when the ui is first opened this is the data it will use
 		ui.set_initial_data(data)
 		// open the new ui window
 		ui.open()
 
-/datum/armament/Topic(href, href_list)
-	if (href_list["Buy"])
-		var/i = text2num(href_list["vend"])
+/obj/machinery/power/eotp/Topic(href, href_list)
+	if (href_list["chosen"])
+		var/i = text2num(href_list["chosen"])
 		var/datum/armament/A = eotp.armaments[i]
 		A.purchase(usr)
 

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -47,7 +47,6 @@
 
 	on_purchase(H)
 	SSnano.update_uis(eotp)
-	ui_interact(H)
 	log_and_message_admins("[key_name(H)] has invoked [src.name]")
 	return TRUE
 
@@ -57,11 +56,11 @@
 	return
 
 
-/datum/armament/ui_data(mob/user)
+/obj/machinery/power/eotp/ui_data(mob/user)
 	var/list/data = list()
 	var/list/listed_armaments = list()
-	for(var/i=1 to eotp.armaments.len)
-		var/datum/armament/A = eotp.armaments[i]
+	for(var/i=1 to armaments.len)
+		var/datum/armament/A = armaments[i]
 		listed_armaments.Add(list(list(
 			"key" = i,
 			"name" = strip_improper(A.name),
@@ -71,14 +70,14 @@
 	return data
 
 
-/datum/armament/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = NANOUI_FOCUS)
+/obj/machinery/power/eotp/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = NANOUI_FOCUS)
 	var/list/data = ui_data(user, ui_key)
 
 	ui = SSnano.try_update_ui(user, eotp, ui_key, ui, data, force_open)
 	if (!ui)
 		// the ui does not exist, so we'll create a new() one
 		// for a list of parameters and their descriptions see the code docs in \code\modules\nano\nanoui.dm
-		ui = new(user, eotp, ui_key, "eopt.tmpl", "Eye of the protector", 550, 655)
+		ui = new(user, src, ui_key, "eopt.tmpl", "Eye of the protector", 550, 655)
 		// when the ui is first opened this is the data it will use
 		ui.set_initial_data(data)
 		// open the new ui window

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -120,5 +120,11 @@
 	name = "Power Cells disk"
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/cells
 
-
+/datum/armament/item/grenade
+	name = "Grenade"
+	desc = "Summoning of boom booms"
+	path = /obj/item/grenade/explosive/nt
+	cost = 50
+	min_cost = 5
+	discount_increase = 5
 

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -98,7 +98,7 @@
 
 //Im really lazy, some one else can make fitting descriptions
 /datum/armament/item/New()
-	if (desc == "item")
+	if (desc == initial(desc))
 		var/obj/item/I = path
 		var/text = initial(I.desc)
 		if (text)
@@ -116,8 +116,8 @@
 	min_cost = 25
 
 /datum/armament/item/disk/New()
-	if (desc == "item")
-		var/obj/item/computer_hardware/hard_drive/portable/design/D
+	if (desc == initial(desc))
+		var/obj/item/computer_hardware/hard_drive/portable/design/D = path
 		var/text = initial(D.disk_name)
 		if (text)
 			desc = text

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -1,0 +1,101 @@
+/datum/armament
+	var/name = "Virtue of coding"
+	var/desc = "The gods made it quite clear this should not exist, Perhaps inform those above."
+	var/cost = 100
+	var/min_cost = 10
+	var/path = /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter_public
+	var/purchase_count = 0
+	var/discount_increase = 25
+	var/discount = 0
+	var/max_discount = 25
+	var/rate_increase = 0
+	var/max_rate_increase = 0
+	var/max_increase = 50
+
+//modifiers in the future? maby some rituals to reduce cost for certain subtype
+/datum/armament/proc/get_cost()
+	return (cost - discount) > min_cost ? cost - discount : min_cost
+
+/datum/armament/proc/purchase(var/mob/living/carbon/H)
+	if (!eotp)
+		error("no eotp found to purchase from")
+		return FALSE
+
+	if (!is_neotheology_disciple(H))
+		to_chat(H, SPAN_DANGER("You do not understand how to use this."))
+		return FALSE
+
+	if (!eotp.armaments_points >= cost)
+		to_chat(H, SPAN_DANGER("You lack required armament points."))
+		return FALSE
+
+
+	eotp.armaments_points -= get_cost()
+
+	purchase_count++
+
+	discount += discount_increase
+	if (max_discount > discount)
+		discount = max_discount
+
+	if (eotp.armaments_rate > max_rate_increase)
+		eotp.armaments_rate += rate_increase
+
+
+	on_purchase(H)
+
+	log_and_message_admins("[key_name(H)] has invoked [src.name]")
+	return TRUE
+
+
+//maby buying buffs,blessings, miracles,etc instead of just items
+/datum/armament/proc/on_purchase(var/mob/living/carbon/H)
+	return
+
+
+
+/datum/armament/ui_data(mob/user)
+	var/list/data = list()
+	var/list/listed_armaments = list()
+	for(var/i=1 to eotp.armaments.len)
+		var/datum/armament/A = eotp.armaments[i]
+		listed_armaments.Add(list(list(
+			"key" = i,
+			"name" = strip_improper(A.name),
+			"cost" = A.cost,
+			"desc" = A.desc)))
+	data["armements"] = listed_armaments
+	return data
+
+
+/datum/armament/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = NANOUI_FOCUS)
+	var/list/data = ui_data(user, ui_key)
+
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
+	if (!ui)
+		// the ui does not exist, so we'll create a new() one
+		// for a list of parameters and their descriptions see the code docs in \code\modules\nano\nanoui.dm
+		ui = new(user, src, ui_key, "eopt.tmpl", "Eye of the protector", 550, 655)
+		// when the ui is first opened this is the data it will use
+		ui.set_initial_data(data)
+		// open the new ui window
+		ui.open()
+
+/datum/armament/Topic(href, href_list)
+	if (href_list["Buy"])
+		var/i = text2num(href_list["vend"])
+		var/datum/armament/A = eotp.armaments[i]
+		A.purchase(usr)
+
+//////////////////////Item summonings
+/datum/armament/item
+	name = "item summoning"
+
+/datum/armament/item/on_purchase(mob/living/carbon/H)
+	if (path)
+		var/obj/_item = new path(get_turf(eotp))
+		eotp.visible_message(SPAN_NOTICE("The [_item.name] appers out of bluespace near the [eotp]!"))
+
+
+
+

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -46,7 +46,7 @@
 		eotp.max_armaments_points += max_increase
 
 	on_purchase(H)
-	SSnano.update_uis(eotp)
+
 	log_and_message_admins("[key_name(H)] has invoked [src.name]")
 	return TRUE
 
@@ -88,6 +88,7 @@
 		var/i = text2num(href_list["chosen"])
 		var/datum/armament/A = eotp.armaments[i]
 		A.purchase(usr)
+		SSnano.update_uis(src)
 
 //////////////////////Item summonings
 /datum/armament/item

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -121,7 +121,6 @@
 		var/text = initial(D.disk_name)
 		if (text)
 			desc = text
-		desc = text
 
 
 /datum/armament/item/disk/cells

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -93,16 +93,30 @@
 //////////////////////Item summonings
 /datum/armament/item
 	name = "item summoning"
+	desc = "item"
+	path = /obj/item/book/ritual/cruciform
+
+//Im really lazy, some one else can make fitting descriptions
+/datum/armament/item/New()
+	if (desc == "item")
+		var/obj/item/I = path
+		desc = initial(I.desc)
 
 /datum/armament/item/on_purchase(mob/living/carbon/H)
 	if (path)
 		var/obj/_item = new path(get_turf(eotp))
 		eotp.visible_message(SPAN_NOTICE("The [_item.name] appers out of bluespace near the [eotp]!"))
+
 /datum/armament/item/disk
 	name = "disk"
 	cost = 75
 	discount_increase = 100
 	min_cost = 25
+
+/datum/armament/item/disk/New()
+	if (desc == "item")
+		var/obj/item/computer_hardware/hard_drive/portable/design/D
+		desc = initial(D.disk_name)
 
 /datum/armament/item/disk/crusader
 	name = "Crusader disk"
@@ -122,31 +136,31 @@
 	min_cost = 50
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/cells
 /datum/armament/item/disk/pouches
-	name = 'Pouches disk'
+	name = "Pouches disk"
 	cost = 75
 	min_cost = 25
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/pouches
 
 /datum/armament/item/disk/svalinn
-	name = 'Svalinn disk'
+	name = "Svalinn disk"
 	cost = 125
 	min_cost = 75
  	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/nt_svalinn
 
 /datum/armament/item/disk/velite
-	name = 'Velite disk'
+	name = "Velite disk"
 	cost = 125
 	min_cost = 75
  	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/velite
 
 /datum/armament/item/disk/nt_protector
-	name = 'Protector disk'
+	name = "Protector disk"
 	cost = 175
 	min_cost = 125
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/nt_protector
 
 /datum/armament/item/disk/principes
-	name = 'Principes disk'
+	name = "Principes disk"
 	cost = 175
 	min_cost = 125
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt/principes
@@ -197,17 +211,17 @@
 	discount_increase = 100
 
 /datum/armement/item/gun
-	name = 'gun'
+	name = "gun"
 	discount_increase = 100
 
 /datum/armement/item/gun/largecrossobw
-	name = 'Large crossbow'
+	name = "Large crossbow"
 	path = /obj/item/gun/energy/crossbow/largecrossbow
 	cost = 125
 	min_cost = 50
 
 /datum/armement/item/gun/destroyer
-	name = 'Destroyer'
+	name = "Destroyer"
 	path = /obj/item/gun/energy/plasma/destroyer
 	cost = 325
 	min_cost = 200

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -28,7 +28,7 @@
 		to_chat(H, SPAN_DANGER("You do not understand how to use this."))
 		return FALSE
 
-	if (!eotp.armaments_points >= get_cost())
+	if (eotp.armaments_points < get_cost())
 		to_chat(H, SPAN_DANGER("You lack required armament points."))
 		return FALSE
 

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -44,13 +44,15 @@ var/global/obj/machinery/power/eotp/eotp
 	var/armaments_points = 800
 	var/max_armaments_points = 800
 	var/armaments_rate = 100
+	var/static/list/unneeded_armaments = list(/datum/armament/item/gun,/datum/armament/item,/datum/armament/item/disk)
 
 /obj/machinery/power/eotp/New()
 	..()
 	eotp = src
-	var/list/arm_paths = subtypesof(/datum/armament)
+	var/list/arm_paths = subtypesof(/datum/armament) - unneeded_armaments
 	for(var/arm in arm_paths)
 		armaments += new arm
+
 
 
 /obj/machinery/power/eotp/examine(user)

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -1,5 +1,5 @@
 GLOBAL_VAR_INIT(miracle_points, 0)
-GLOBAL_VAR_INIT(armaments_points,0) //could be either global var or var of eotp, dunu
+GLOBAL_VAR_INIT(armaments_points,0)
 
 var/global/obj/machinery/power/eotp/eotp
 
@@ -26,8 +26,6 @@ var/global/obj/machinery/power/eotp/eotp
 							/obj/item/stack/material/diamond = 30,
 							/obj/item/stack/material/plasteel = 120,
 							/obj/item/stack/material/silver = 60)
-	var/list/disk_types = list()
-	var/list/unneeded_disk_types = list(/obj/item/computer_hardware/hard_drive/portable/design/nt/melee)
 
 	var/list/mob/living/carbon/human/scanned = list()
 	var/max_power = 100
@@ -43,6 +41,12 @@ var/global/obj/machinery/power/eotp/eotp
 	var/last_power_update = 0
 	var/rescan_cooldown = 10 MINUTES
 	var/last_rescan = 0
+	var/static/list/armaments = list(/obj/item/computer_hardware/hard_drive/portable/design/nt/advancedmelee = 50,
+									/obj/item/computer_hardware/hard_drive/portable/design/nt/cells = 25,
+									/obj/item/computer_hardware/hard_drive/portable/design/nt/cruciform_upgrade = 100,
+									/obj/item/computer_hardware/hard_drive/portable/design/nt/grenades = 200,
+									/obj/item/grenade/heatwave/nt = 10,
+									/obj/item/computer_hardware/hard_drive/portable/design/nt/crusader = 100)
 
 /obj/machinery/power/eotp/New()
 	..()
@@ -113,9 +117,6 @@ var/global/obj/machinery/power/eotp/eotp
 		power -= max_power
 		power_release()
 
-/obj/machinery/power/eotp/proc/disk_reward_update()
-	disk_types =  subtypesof(/obj/item/computer_hardware/hard_drive/portable/design/nt) - unneeded_disk_types
-
 /obj/machinery/power/eotp/proc/power_release()
 	var/type_release
 	if(current_rewards)
@@ -124,10 +125,9 @@ var/global/obj/machinery/power/eotp/eotp
 	else
 		type_release = pick(rewards)
 
-	if(type_release == ARMAMENTS)
-		GLOB.armaments_points++
+	GLOB.armaments_points += 100
 
-	else if(type_release == ALERT)
+	if(type_release == ALERT)
 
 		var/area/antagonist_area
 		var/preacher

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -1,5 +1,5 @@
 GLOBAL_VAR_INIT(miracle_points, 0)
-GLOBAL_VAR_INIT(armaments_points,0)
+GLOBAL_VAR_INIT(armaments_points,1000000)
 
 var/global/obj/machinery/power/eotp/eotp
 
@@ -41,7 +41,7 @@ var/global/obj/machinery/power/eotp/eotp
 	var/last_power_update = 0
 	var/rescan_cooldown = 10 MINUTES
 	var/last_rescan = 0
-	var/static/list/armaments = list(/obj/item/computer_hardware/hard_drive/portable/design/nt/advancedmelee = 50,
+	var/list/armaments = list(/obj/item/computer_hardware/hard_drive/portable/design/nt/advancedmelee = 50,
 									/obj/item/computer_hardware/hard_drive/portable/design/nt/cells = 25,
 									/obj/item/computer_hardware/hard_drive/portable/design/nt/cruciform_upgrade = 100,
 									/obj/item/computer_hardware/hard_drive/portable/design/nt/grenades = 200,

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -44,7 +44,7 @@ var/global/obj/machinery/power/eotp/eotp
 	var/armaments_points = 0
 	var/max_armaments_points = 100
 	var/armaments_rate = 100
-	var/static/list/unneeded_armaments = list(/datum/armament/item/gun,/datum/armament/item,/datum/armament/item/disk)
+	var/static/list/unneeded_armaments = list(/datum/armament/item/gun, /datum/armament/item, /datum/armament/item/disk)
 
 /obj/machinery/power/eotp/New()
 	..()
@@ -130,7 +130,7 @@ var/global/obj/machinery/power/eotp/eotp
 		type_release = pick(rewards)
 
 
-	armaments_points = min(armaments + armaments_rate,max_armaments_points)
+	armaments_points = min(armaments + armaments_rate, max_armaments_points)
 
 
 	if(type_release == ALERT)

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -1,5 +1,4 @@
 GLOBAL_VAR_INIT(miracle_points, 0)
-GLOBAL_VAR_INIT(armaments_points,1000000)
 
 var/global/obj/machinery/power/eotp/eotp
 
@@ -45,8 +44,14 @@ var/global/obj/machinery/power/eotp/eotp
 									/obj/item/computer_hardware/hard_drive/portable/design/nt/cells = 25,
 									/obj/item/computer_hardware/hard_drive/portable/design/nt/cruciform_upgrade = 100,
 									/obj/item/computer_hardware/hard_drive/portable/design/nt/grenades = 200,
+									/obj/item/computer_hardware/hard_drive/portable/design/nt/crusader = 100,
+									/obj/item/computer_hardware/hard_drive/portable/design/nt/excruciator = 200,
+									/obj/item/computer_hardware/hard_drive/portable/design/nt/guns/nt_dominion = 200,
+									/obj/item/computer_hardware/hard_drive/portable/design/nt/grenades = 200,
 									/obj/item/grenade/heatwave/nt = 10,
 									/obj/item/computer_hardware/hard_drive/portable/design/nt/crusader = 100)
+	var/armaments_points = 800
+	var/max_armaments_points = 800
 
 /obj/machinery/power/eotp/New()
 	..()
@@ -61,6 +66,7 @@ var/global/obj/machinery/power/eotp/eotp
 		if(I && I.active && I.wearer)
 			var/comment = "Power level: [power]/[max_power]."
 			comment += "\nObservation level: [observation]/[max_observation]."
+			comment += "\nArmement level: [armaments_points]/[max_armaments_points]"
 			to_chat(user, SPAN_NOTICE(comment))
 
 /obj/machinery/power/eotp/Process()
@@ -125,7 +131,10 @@ var/global/obj/machinery/power/eotp/eotp
 	else
 		type_release = pick(rewards)
 
-	GLOB.armaments_points += 100
+	if
+	armaments_points += 100
+	if armaments_points > max_armaments_points
+		armaments = max_armaments_points
 
 	if(type_release == ALERT)
 

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -127,10 +127,9 @@ var/global/obj/machinery/power/eotp/eotp
 	else
 		type_release = pick(rewards)
 
-	armaments_points += armaments_rate
 
-	if (armaments_points > max_armaments_points)
-		armaments = max_armaments_points
+	armaments_points = min(armaments + armaments_rate,max_armaments_points)
+
 
 	if(type_release == ALERT)
 

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -52,6 +52,7 @@ var/global/obj/machinery/power/eotp/eotp
 									/obj/item/computer_hardware/hard_drive/portable/design/nt/crusader = 100)
 	var/armaments_points = 800
 	var/max_armaments_points = 800
+	var/armaments_rate = 100
 
 /obj/machinery/power/eotp/New()
 	..()
@@ -131,7 +132,7 @@ var/global/obj/machinery/power/eotp/eotp
 	else
 		type_release = pick(rewards)
 
-	armaments_points += 100
+	armaments_points += armaments_rate
 
 	if (armaments_points > max_armaments_points)
 		armaments = max_armaments_points

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -1,4 +1,5 @@
 GLOBAL_VAR_INIT(miracle_points, 0)
+GLOBAL_VAR_INIT(armaments_points,0) //could be either global var or var of eotp, dunu
 
 var/global/obj/machinery/power/eotp/eotp
 
@@ -124,12 +125,7 @@ var/global/obj/machinery/power/eotp/eotp
 		type_release = pick(rewards)
 
 	if(type_release == ARMAMENTS)
-		if(!length(disk_types))
-			disk_reward_update()
-		var/reward_disk = pick(disk_types)
-		disk_types -= reward_disk
-		var/obj/item/_item = new reward_disk(get_turf(src))
-		visible_message(SPAN_NOTICE("The [_item.name] appers out of bluespace near the [src]!"))
+		GLOB.armaments_points++
 
 	else if(type_release == ALERT)
 
@@ -169,6 +165,7 @@ var/global/obj/machinery/power/eotp/eotp
 		var/oddity_reward = pick(subtypesof(/obj/item/oddity/nt))
 		var/obj/item/_item = new oddity_reward(get_turf(src))
 		visible_message(SPAN_NOTICE("The [_item.name] appers out of bluespace near the [src]!"))
+		rewards -= ODDITY
 
 	else if(type_release == STAT_BUFF)
 		var/random_stat = pick(ALL_STATS)

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -131,9 +131,9 @@ var/global/obj/machinery/power/eotp/eotp
 	else
 		type_release = pick(rewards)
 
-	if
 	armaments_points += 100
-	if armaments_points > max_armaments_points
+
+	if (armaments_points > max_armaments_points)
 		armaments = max_armaments_points
 
 	if(type_release == ALERT)

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -41,8 +41,8 @@ var/global/obj/machinery/power/eotp/eotp
 	var/rescan_cooldown = 10 MINUTES
 	var/last_rescan = 0
 	var/list/armaments = list()
-	var/armaments_points = 800
-	var/max_armaments_points = 800
+	var/armaments_points = 0
+	var/max_armaments_points = 100
 	var/armaments_rate = 100
 	var/static/list/unneeded_armaments = list(/datum/armament/item/gun,/datum/armament/item,/datum/armament/item/disk)
 

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -40,16 +40,7 @@ var/global/obj/machinery/power/eotp/eotp
 	var/last_power_update = 0
 	var/rescan_cooldown = 10 MINUTES
 	var/last_rescan = 0
-	var/list/armaments = list(/obj/item/computer_hardware/hard_drive/portable/design/nt/advancedmelee = 50,
-									/obj/item/computer_hardware/hard_drive/portable/design/nt/cells = 25,
-									/obj/item/computer_hardware/hard_drive/portable/design/nt/cruciform_upgrade = 100,
-									/obj/item/computer_hardware/hard_drive/portable/design/nt/grenades = 200,
-									/obj/item/computer_hardware/hard_drive/portable/design/nt/crusader = 100,
-									/obj/item/computer_hardware/hard_drive/portable/design/nt/excruciator = 200,
-									/obj/item/computer_hardware/hard_drive/portable/design/nt/guns/nt_dominion = 200,
-									/obj/item/computer_hardware/hard_drive/portable/design/nt/grenades = 200,
-									/obj/item/grenade/heatwave/nt = 10,
-									/obj/item/computer_hardware/hard_drive/portable/design/nt/crusader = 100)
+	var/list/armaments = list()
 	var/armaments_points = 800
 	var/max_armaments_points = 800
 	var/armaments_rate = 100
@@ -57,6 +48,10 @@ var/global/obj/machinery/power/eotp/eotp
 /obj/machinery/power/eotp/New()
 	..()
 	eotp = src
+	var/list/arm_paths = subtypesof(/datum/armament)
+	for(var/arm in arm_paths)
+		armaments += new arm
+
 
 /obj/machinery/power/eotp/examine(user)
 	..()

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -538,9 +538,6 @@
 		fail("You must be in front of the Eye of the Protector.", H, C)
 		return FALSE
 
-	var/datum/armament/arm = new /datum/armament
-	arm.ui_interact(H)
-	//if (!reward_armament[1].purchase(H))
-	//	return FALSE
+	eotp.ui_interact(H)
 	return TRUE
 

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -525,7 +525,7 @@
 /datum/ritual/cruciform/priest/buy_item
 	name = "Order armaments"
 	phrase = "Et qui non habet, vendat tunicam suam et emat gladium."
-	desc = "Allows you to spend a point to unlock an NT disk."
+	desc = "Allows you to spend a point to unlock a NT disk."
 	success_message = "Your prayers have been heard."
 	fail_message = "Your prayers have not been answered."
 	power = 20

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -531,8 +531,6 @@
 	power = 20
 
 /datum/ritual/cruciform/priest/buy_item/perform(mob/living/carbon/human/H, obj/item/implant/core_implant/C, targets)
-
-
 	var/list/OBJS = get_front(H)
 
 	var/obj/machinery/power/eotp/EOTP = locate(/obj/machinery/power/eotp) in OBJS
@@ -540,25 +538,18 @@
 		fail("You must be in front of the Eye of the Protector.", H, C)
 		return FALSE
 
-	if (!EOTP.armaments_points > 0)
-		fail("You have no miracle of this type to spend.",H,C)
-		return FALSE
+	var/list/armament_choice = list()
 
-	var/list/item_choice = list()
-	var/reward_Item
-
-	for(var/i=1; i<=length(EOTP.armaments);i++)
-		var/cost = EOTP.armaments[EOTP.armaments[i]]
-		item_choice["[cost] - [ispath(EOTP.armaments[i],/obj/item/computer_hardware/hard_drive/portable/design) ? initial(EOTP.armaments[i].disk_name) : initial(EOTP.armaments[i].name)]"] = EOTP.armaments[i]
-	var/item_chosen = input(H,"What does youre church require?","Armenents") as null | anything in item_choice
-	if (!item_chosen)
+	for(var/datum/armament/A in EOTP.armaments)
+		armament_choice["[A.get_cost()] - [A.name]"] = EOTP.armaments
+	var/armament_chosen = input(H,"What does youre church require?","Armenents") as null | anything in armament_choice
+	if (!armament_chosen)
 		fail("Pick a reward.",H,C)
 		return FALSE
-	reward_Item = item_choice[item_chosen]
-	var/obj/item/_item = new reward_Item(get_turf(EOTP))
-	EOTP.visible_message(SPAN_NOTICE("The [_item.name] appers out of bluespace near the [EOTP]!"))
-	EOTP.armaments_points -= EOTP.armaments[reward_Item]
-	log_and_message_admins("[key_name(H)] has orderd a [_item.name]")
+	var/datum/armament/reward_armament
+	reward_armament = armament_choice[armament_chosen]
 
+	if (!reward_armament[1].purchase(H))
+		return FALSE
 	return TRUE
 

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -531,15 +531,17 @@
 	power = 20
 
 /datum/ritual/cruciform/priest/buy_item/perform(mob/living/carbon/human/H, obj/item/implant/core_implant/C, targets)
-	if (!GLOB.armaments_points > 0)
-		fail("You have no miracle of this type to spend.",H,C)
-		return FALSE
+
 
 	var/list/OBJS = get_front(H)
 
 	var/obj/machinery/power/eotp/EOTP = locate(/obj/machinery/power/eotp) in OBJS
 	if(!EOTP)
 		fail("You must be in front of the Eye of the Protector.", H, C)
+		return FALSE
+
+	if (!EOTP.armaments_points > 0)
+		fail("You have no miracle of this type to spend.",H,C)
 		return FALSE
 
 	var/list/item_choice = list()
@@ -555,7 +557,7 @@
 	reward_Item = item_choice[item_chosen]
 	var/obj/item/_item = new reward_Item(get_turf(EOTP))
 	EOTP.visible_message(SPAN_NOTICE("The [_item.name] appers out of bluespace near the [EOTP]!"))
-	GLOB.armaments_points -= EOTP.armaments[reward_Item]
+	EOTP.armaments_points -= EOTP.armaments[reward_Item]
 	log_and_message_admins("[key_name(H)] has orderd a [_item.name]")
 
 	return TRUE

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -524,7 +524,7 @@
 
 /datum/ritual/cruciform/priest/buy_item
 	name = "Order armaments"
-	phrase = "I need suggestions for a phrase"
+	phrase = "Et qui non habet, vendat tunicam suam et emat gladium."
 	desc = "Allows you to spend a point to unlock an NT disk."
 	success_message = "Your prayers have been heard."
 	fail_message = "Your prayers have not been answered."

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -522,7 +522,7 @@
 		if(target.wearer && target.wearer.stat != DEAD)
 			return target
 
-/datum/ritual/cruciform/priest/buy_disk
+/datum/ritual/cruciform/priest/buy_item
 	name = "Order armaments"
 	phrase = "I need suggestions for a phrase"
 	desc = "Allows you to spend a point to unlock an NT disk."
@@ -530,7 +530,7 @@
 	fail_message = "Your prayers have not been answered."
 	power = 20
 
-/datum/ritual/cruciform/priest/buy_disk/perform(mob/living/carbon/human/H, obj/item/implant/core_implant/C, targets)
+/datum/ritual/cruciform/priest/buy_item/perform(mob/living/carbon/human/H, obj/item/implant/core_implant/C, targets)
 	if (!GLOB.armaments_points > 0)
 		fail("You have no miracle of this type to spend.",H,C)
 		return FALSE
@@ -542,23 +542,20 @@
 		fail("You must be in front of the Eye of the Protector.", H, C)
 		return FALSE
 
-	if(!length(EOTP.disk_types))
-		EOTP.disk_reward_update()
-	var/list/disk_choices = list()
-	var/reward_disk
+	var/list/item_choice = list()
+	var/reward_Item
 
-	for(var/i=1; i<=length(EOTP.disk_types);i++)
-		var/str = initial(EOTP.disk_types[i].disk_name)
-		disk_choices["[str]"] = EOTP.disk_types[i]
-	var/disk_chosen = input(H,"What does youre church require?","Armenents") as null | anything in disk_choices
-	if (!disk_chosen)
+	for(var/i=1; i<=length(EOTP.armaments);i++)
+		var/cost = EOTP.armaments[EOTP.armaments[i]]
+		item_choice["[cost] - [ispath(EOTP.armaments[i],/obj/item/computer_hardware/hard_drive/portable/design) ? initial(EOTP.armaments[i].disk_name) : initial(EOTP.armaments[i].name)]"] = EOTP.armaments[i]
+	var/item_chosen = input(H,"What does youre church require?","Armenents") as null | anything in item_choice
+	if (!item_chosen)
 		fail("Pick a reward.",H,C)
 		return FALSE
-	reward_disk = disk_choices[disk_chosen]
-	EOTP.disk_types -= reward_disk
-	var/obj/item/_item = new reward_disk(get_turf(EOTP))
+	reward_Item = item_choice[item_chosen]
+	var/obj/item/_item = new reward_Item(get_turf(EOTP))
 	EOTP.visible_message(SPAN_NOTICE("The [_item.name] appers out of bluespace near the [EOTP]!"))
-	GLOB.armaments_points--
+	GLOB.armaments_points -= EOTP.armaments[reward_Item]
 	log_and_message_admins("[key_name(H)] has orderd a [_item.name]")
 
 	return TRUE

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -538,18 +538,9 @@
 		fail("You must be in front of the Eye of the Protector.", H, C)
 		return FALSE
 
-	var/list/armament_choice = list()
-
-	for(var/datum/armament/A in EOTP.armaments)
-		armament_choice["[A.get_cost()] - [A.name]"] = EOTP.armaments
-	var/armament_chosen = input(H,"What does youre church require?","Armenents") as null | anything in armament_choice
-	if (!armament_chosen)
-		fail("Pick a reward.",H,C)
-		return FALSE
-	var/datum/armament/reward_armament
-	reward_armament = armament_choice[armament_chosen]
-
-	if (!reward_armament[1].purchase(H))
-		return FALSE
+	var/datum/armament/arm = new /datum/armament
+	arm.ui_interact(H)
+	//if (!reward_armament[1].purchase(H))
+	//	return FALSE
 	return TRUE
 

--- a/nano/templates/eopt.tmpl
+++ b/nano/templates/eopt.tmpl
@@ -3,7 +3,7 @@
 	<div class="block">
 		<div class='item'>
 			<div class='itemContent'>
-				{{:value.name}}  {{:value.cost}} {{:helper.link('Summon','power',{'chosen' : value.key})}}<br>
+				{{:value.name}} {{:helper.link('' + value.cost + '','power',{'chosen' : value.key})}}<br>
 				<div class="itemLabelWidest">{{:value.desc}}</div></b>
 			</div>
 		</div>

--- a/nano/templates/eopt.tmpl
+++ b/nano/templates/eopt.tmpl
@@ -1,0 +1,12 @@
+<div class='item'>
+	{{for data.armaments}}
+	<div class="block">
+		<div class='item'>
+			<div class='itemContent'>
+				{{:value.name}}  {{:value.cost}} {{:helper.link('Summon','power',{'chosen' : value.key})}}<br>
+				<div class="itemLabelWidest">{{:value.desc}}</div></b>
+			</div>
+		</div>
+	</div>
+	{{/for}}
+</div>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

refactors the code so the priest can pick any disk when an armenent miracle has occured and makes it so only 1 oddity miracle may occure

EDIT: smh got bamboozeld and rewrote the whole thing.

Priests gain a new litany that can be used near the EOPT to summon armenents. This new system simply spawns a type path so its relativly flexible exacly what you spawn, from items to mobs. and with the on_purchase proc you could implement some other effects(epic buffs or smth)


- [x] Basic for armament datum implemented
- [x] Nano UI 1: functional
- [x] Nano UI 2: pretty
- [x] Add subtypes so you can summon disks


lazy nano UI included
![image](https://user-images.githubusercontent.com/36102060/158078639-d65bc2fe-4054-4c1b-bece-8848748f6b30.png)


## Why It's Good For The Game

being able to pick the disk makes it much more interesting, also getting 7 "rare badges" is dumb

## Changelog
:cl:
add: priests may use new litany to summon items from the EOTP
tweak: Only 1 High Inquisitor's Seal may be recieved from the EOTP
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
