### PR TITLE
Makes an oddity more odd

### DIFF
--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -112,7 +112,7 @@
 
 /obj/item/oddity/common/old_newspaper
 	name = "old newspaper"
-	desc = "It contains a report on some old and strange phenomenon. Maybe it's lies, maybe it's corporate experiments gone wrong. Wait, there's two comically obvious holes for peering through!"
+	desc = "It contains a report on some old and strange phenomenon. Maybe it's lies, maybe it's corporate experiments gone wrong. Wait, there are two comically obvious holes for peering through!"
 	icon_state = "old_newspaper"
 	oddity_stats = list(
 		STAT_MEC = 4,

--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -112,13 +112,17 @@
 
 /obj/item/oddity/common/old_newspaper
 	name = "old newspaper"
-	desc = "It contains a report on some old and strange phenomenon. Maybe it's lies, maybe it's corporate experiments gone wrong."
+	desc = "It contains a report on some old and strange phenomenon. Maybe it's lies, maybe it's corporate experiments gone wrong. Wait, there's two comically obvious holes for peering through!"
 	icon_state = "old_newspaper"
 	oddity_stats = list(
 		STAT_MEC = 4,
 		STAT_COG = 4,
 		STAT_BIO = 4,
 	)
+
+/obj/item/oddity/common/old_newspaper/attack_self(mob/user)
+	zoom(8, 8)
+	..()
 
 /obj/item/oddity/common/paper_crumpled
 	name = "turn-out page"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The "Old newspaper" oddity can now be used to zoom out a couple tiles, similar to a binocular or scope, because there's comically obvious holes for spying through inside.
![grafik](https://user-images.githubusercontent.com/45079529/158464828-d2b95cf5-6eed-43dd-affb-eae5d245c4ba.png)

## Why It's Good For The Game

Oddities make even less sense now.

## Changelog
:cl:
add: The "Old newspaper" oddity can now be used to zoom out a couple tiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
