### PR TITLE
Chemsmoke fix (not really)

### DIFF
--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -162,6 +162,17 @@
 					continue
 				else if (ismob(A))
 					chemholder.reagents.touch_mob(A)
+					if(istype(A, /mob/living/carbon))
+						var/mob/living/carbon/H = A
+						var/internals = H.get_breath_from_internal()
+						var/gasmask = FALSE
+						if(H.wear_mask)
+							gasmask = (H.wear_mask.item_flags & BLOCK_GAS_SMOKE_EFFECT)
+						to_chat(world, "gasmaks: [gasmask]")	
+						to_chat(world, "internals: [internals]")					
+						if(!internals && !gasmask)
+							chemholder.reagents.trans_to_mob(H, 5, CHEM_INGEST, copy = 1)
+							chemholder.reagents.trans_to_mob(H, 5, CHEM_BLOOD, copy = 1)
 				else if(isobj(A) && !A.simulated)
 					chemholder.reagents.touch_obj(A)
 

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -167,12 +167,10 @@
 						var/internals = H.get_breath_from_internal()
 						var/gasmask = FALSE
 						if(H.wear_mask)
-							gasmask = (H.wear_mask.item_flags & BLOCK_GAS_SMOKE_EFFECT)
-						to_chat(world, "gasmaks: [gasmask]")	
-						to_chat(world, "internals: [internals]")					
+							gasmask = H.wear_mask.item_flags & BLOCK_GAS_SMOKE_EFFECT			
 						if(!internals && !gasmask)
-							chemholder.reagents.trans_to_mob(H, 5, CHEM_INGEST, copy = 1)
-							chemholder.reagents.trans_to_mob(H, 5, CHEM_BLOOD, copy = 1)
+							chemholder.reagents.trans_to_mob(H, 5, CHEM_INGEST, copy = FALSE)
+							chemholder.reagents.trans_to_mob(H, 5, CHEM_BLOOD, copy = FALSE)
 				else if(isobj(A) && !A.simulated)
 					chemholder.reagents.touch_obj(A)
 

--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -64,7 +64,7 @@
 /mob/living/carbon/proc/handle_chemical_smoke(datum/gas_mixture/environment)
 	if(species && environment.return_pressure() < species.breath_pressure/5)
 		return //pressure is too low to even breathe in.
-	if(wear_mask && (wear_mask.flags & BLOCK_GAS_SMOKE_EFFECT))
+	if(wear_mask && (wear_mask.item_flags & BLOCK_GAS_SMOKE_EFFECT))
 		return
 
 	for(var/obj/effect/effect/smoke/chem/smoke in view(1, src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR changes the way chemsmoke is handled. Previously, reagents would only get transferred to a mob if they touched one of the visible gas clouds created by a chem reaction. And This didn't work like 90% of the time. Now, if you are inside the area of the smoke reaction when it occurs and you're not wearing a gas mask/or active internals, 5 units of whatever was in the smoke will be transferred to your bloodstream, and 5 units will be ingested (These amounts are the same as the ones you could take in from one visible smoke cloud). 
Theoretically this means that you could take in twice the amount of chems from a single smoke reaction since you can still breathe in the smoke clouds, but that only happens extremely rarely, so I hope that's fine.

Also fixes a bug where the actually visible smoke cloud would ignore someone with a gasmask having protection from the cloud.
## Why It's Good For The Game

Fixes good
I will not be held responsible for any warcrimes committed.

## Changelog
:cl:
fix: chemical reagent smoke should be much more reliable now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
