### PR TITLE
Adds the Syndie Space Suit to the uplink

### DIFF
--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -90,7 +90,7 @@
 
 /datum/uplink_item/item/tools/softsuit
 	name = "Armoured Softsuit"
-	item_cost = 4
+	item_cost = 3
 	path = /obj/item/storage/box/syndie_kit/softsuit
 
 /datum/uplink_item/item/tools/thermal

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -88,6 +88,11 @@
 	item_cost = 6
 	path = /obj/item/storage/box/syndie_kit/space
 
+/datum/uplink_item/item/tools/softsuit
+	name = "Armoured Softsuit"
+	item_cost = 4
+	path = /obj/item/storage/box/syndie_kit/softsuit
+
 /datum/uplink_item/item/tools/thermal
 	name = "Thermal Imaging Glasses"
 	item_cost = 8

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -131,8 +131,8 @@
 	name = "boxed soft suit"
 
 /obj/item/storage/box/syndie_kit/softsuit/populate_contents()
-	new /obj/item/clothing/suit/space/syndicate
-	new /obj/item/clothing/head/space/syndicate
+	new /obj/item/clothing/suit/space/syndicate(src)
+	new /obj/item/clothing/head/space/syndicate(src)
 
 /obj/item/storage/box/syndie_kit/chameleon
 	name = "chameleon kit"

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -131,8 +131,8 @@
 	name = "boxed soft suit"
 
 /obj/item/storage/box/syndie_kit/softsuit/populate_contents()
-	new /obj/item/clothing/suit/space/syndicate(src)
-	new /obj/item/clothing/head/space/syndicate(src)
+	new /obj/item/clothing/suit/space/syndicate/uplink(src)
+	new /obj/item/clothing/head/space/syndicate/uplink(src)
 
 /obj/item/storage/box/syndie_kit/chameleon
 	name = "chameleon kit"

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -127,6 +127,13 @@
 	new /obj/item/clothing/suit/space/void/merc/boxed(src)
 	new /obj/item/clothing/mask/gas/syndicate(src)
 
+/obj/item/storage/box/syndie_kit/softsuit
+	name = "boxed soft suit"
+
+/obj/item/storage/box/syndie_kit/softsuit/populate_contents()
+	new /obj/item/clothing/suit/space/syndicate
+	new /obj/item/clothing/head/space/syndicate
+
 /obj/item/storage/box/syndie_kit/chameleon
 	name = "chameleon kit"
 	desc = "Comes with all the clothes you need to impersonate most people. Acting lessons sold seperately. Wearing the uniform will allow fot quick switching between appearances."

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -35,7 +35,7 @@
 	supporting_limbs = list()
 	spawn_blacklisted = TRUE
 	accompanying_object = /obj/item/clothing/head/space/syndicate
-	slowdown = MEDIUM_SLOWDOWN
+	slowdown = LIGHT_SLOWDOWN
 	stiffness = HEAVY_STIFFNESS
 
 ///////////////////////Black Market//////////////////////////////


### PR DESCRIPTION
## About The Pull Request

Simply adds the basic syndicate space suit to the traitor uplink. Sprites aren't mine, credit to whoever the original artist is.

## Why It's Good For The Game

![syndiespacesuit2](https://user-images.githubusercontent.com/61243846/158888159-727376bd-fefe-45e9-bf8b-798afb0dadd0.png)



It's a less armoured but more maneuverable and aesthetically pleasing alternative to the more commonly seen  Merc Voidsuit. It's also not used anywhere else, so why not?

## Changelog
:cl:

tweak: Adds the syndicate space suit to the uplink for the price of 3 TC.

/:cl:

