### PR TITLE
Fixes radio runtime [Testing required]

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -524,10 +524,10 @@ var/global/list/default_medbay_channels = list(
 		if (!accept)
 			for (var/ch_name in channels)
 				var/datum/radio_frequency/RF = secure_radio_connections[ch_name]
-				if (RF.frequency==freq && (channels[ch_name]&FREQ_LISTENING))
-					accept = 1
-					break
-
+				if(RF)
+					if (RF.frequency==freq && (channels[ch_name]&FREQ_LISTENING))
+						accept = 1
+						break
 		if (!accept)
 			return -1
 	return canhear_range

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -524,10 +524,9 @@ var/global/list/default_medbay_channels = list(
 		if (!accept)
 			for (var/ch_name in channels)
 				var/datum/radio_frequency/RF = secure_radio_connections[ch_name]
-				if(RF)
-					if (RF.frequency==freq && (channels[ch_name]&FREQ_LISTENING))
-						accept = 1
-						break
+				if(RF?.frequency == freq && (channels[ch_name] & FREQ_LISTENING))
+					accept = 1
+					break
 		if (!accept)
 			return -1
 	return canhear_range


### PR DESCRIPTION
## About The Pull Request

This most likely fixes radios runtiming, as it checks for nulls in the line where it runtimes due to the existence of nulls. Potentially a bandaid fix to a different problem, or just fixes an oversight. We might never know.

## Why It's Good For The Game

It will reduce the amount of runtimes.

## Changelog
:cl:
fix: radios don't runtime constantly
/:cl: