### PR TITLE
RIG Chem Dispenser rework.

### DIFF
--- a/code/datums/uplink/hardsuit_modules.dm
+++ b/code/datums/uplink/hardsuit_modules.dm
@@ -26,8 +26,8 @@
 
 /datum/uplink_item/item/chem_injector
 	name = "Mounted chemical injector"
-	item_cost = 6
-	path = /obj/item/rig_module/chem_dispenser
+	item_cost = 3
+	path = /obj/item/rig_module/modular_injector
 
 /datum/uplink_item/item/hardsuit_modules/portable_autodoc
 	name = "Portable autodoc"

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -166,7 +166,7 @@
 		charges = processed_charges
 
 
-/obj/item/rig_module/modular_injector/accepts_item(obj/item/reagent_containers/item, mob/living/user,userless = FALSE)
+/obj/item/rig_module/modular_injector/accepts_item(obj/item/reagent_containers/item, mob/living/user, userless = FALSE)
 	if(!istype(item))
 		return FALSE
 	if(beakers.len == max_beakers)

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -170,7 +170,7 @@
 	if(!istype(item))
 		return FALSE
 	if(beakers.len == max_beakers)
-		to_chat(user, "\The [src] has all its beaker slots filled , remove one of them!")
+		to_chat(user, "\The [src] has all its beaker slots filled, remove one of them!")
 		return FALSE
 	if(userless)
 		beakers += item

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -113,8 +113,158 @@
 		device.afterattack(target,holder.wearer,1)
 	return 1
 
+/obj/item/rig_module/modular_injector
+	name = "mounted modular injector"
+	desc = "A specialized system for inserting chemicals"
+	icon_state = "injector"
+	usable = TRUE
+	selectable = FALSE
+	toggleable = FALSE
+	disruptive = FALSE
+
+	engage_string = "Inject"
+
+	interface_name = "integrated injector"
+	interface_desc = "A chemical injector"
+	var/list/beakers = list()
+	var/max_beakers = 5
+	var/injection_amount = 5
+	var/max_injection_amount = 20
+	var/empties = 0
+	var/initial_beakers = null
+	/// ^ Used for initializing with beakers , the format used is list(beaker_type, beaker_reagent_id, beaker_reagent_amount)
+
+	charges = list()
+
+/obj/item/rig_module/modular_injector/Initialize()
+	. = ..()
+	if(initial_beakers)
+		for(var/list/bdata in initial_beakers)
+			var/btype = bdata[1]
+			var/obj/item/reagent_containers/beaker = new btype(src)
+			beaker.reagents.add_reagent(bdata[2], bdata[3])
+			accepts_item(beaker, null , TRUE)
+
+// Rebuilds charges , sad but necesarry due to how rig UI's get its data
+/obj/item/rig_module/modular_injector/proc/rebuild_charges()
+	empties = 0
+	if(beakers && beakers.len)
+		var/list/processed_charges = list()
+		for(var/obj/item/reagent_containers/beaker in beakers)
+			var/datum/rig_charge/charge_dat = new
+			var/reag_name = beaker.reagents.get_master_reagent_name()
+			empties++;
+
+			charge_dat.short_name   = reag_name ? reag_name : "Empty[empties]"
+			charge_dat.display_name = reag_name ? reag_name : "Empty[empties]"
+			charge_dat.product_type = ref(beaker)
+			charge_dat.charges      = beaker.reagents.total_volume
+
+			if(!charge_selected) charge_selected = charge_dat.short_name
+			processed_charges[charge_dat.short_name] = charge_dat
+
+		charges = processed_charges
 
 
+/obj/item/rig_module/modular_injector/accepts_item(obj/item/reagent_containers/item, mob/living/user,userless = FALSE)
+	if(!istype(item))
+		return FALSE
+	if(beakers.len == max_beakers)
+		to_chat(user, "\The [src] has all its beaker slots filled , remove one of them!")
+		return FALSE
+	if(userless)
+		beakers += item
+		rebuild_charges()
+		item.forceMove(src)
+		return TRUE
+	if(user.unEquip(item))
+		// Gotta keep it for later when we remove the beaker.
+		beakers += item
+		rebuild_charges()
+		item.forceMove(src)
+
+
+/obj/item/rig_module/modular_injector/attackby(obj/item/W, mob/user)
+	if(..())
+		return FALSE
+	if(istype(W, /obj/item/reagent_containers))
+		accepts_item(W, user)
+		return FALSE
+	if(W.get_tool_quality(QUALITY_SCREW_DRIVING))
+		var/obj/item/reagent_containers/sel_ref = input(user, "Choose a beaker to remove", null) in beakers
+		if(sel_ref)
+			beakers -= sel_ref
+			charge_selected = null
+			rebuild_charges()
+			user.visible_message("[user] removes \the [sel_ref.name] from \the [src]")
+			if(!user.put_in_active_hand(sel_ref))
+				sel_ref.loc = get_turf(src)
+	if(W.get_tool_quality(QUALITY_BOLT_TURNING))
+		var/amount = input(user, "Choose reagent injection amount", null) in list(0, initial(injection_amount), max_injection_amount * 0.5, max_injection_amount)
+		if(amount != null)
+			injection_amount = amount
+			to_chat(user, "You set the injection amount to [amount] on \the [src]")
+			user.visible_message("[user] tweaks the injection amount on \the [src]")
+
+/obj/item/rig_module/modular_injector/engage(atom/target)
+
+	if(!..())
+		return FALSE
+
+	var/mob/living/carbon/human/H = holder.wearer
+
+	if(!charge_selected)
+		to_chat(H, SPAN_DANGER("You have not selected a beaker to inject from!"))
+		return FALSE
+
+	var/datum/rig_charge/charge = charges[charge_selected]
+	var/obj/item/reagent_containers/beaker = locate(charge.product_type)
+	if(beaker.reagents.total_volume < injection_amount)
+		to_chat(H, SPAN_DANGER("Insufficient chems!"))
+		return FALSE
+
+	var/mob/living/carbon/target_mob
+	if(target)
+		if(iscarbon(target))
+			target_mob = target
+		else
+			return FALSE
+	else
+		target_mob = H
+
+	if(target_mob != H)
+		to_chat(H, SPAN_DANGER("You inject [target_mob] with [injection_amount] unit\s of [beaker.name]."))
+	to_chat(target_mob, "<span class='danger'>You feel a rushing in your veins as [injection_amount] unit\s are injected in your bloodstream.</span>")
+	// Update display
+	beaker.reagents.trans_to_mob(target_mob, injection_amount, CHEM_BLOOD)
+	rebuild_charges()
+	return TRUE
+
+/obj/item/rig_module/modular_injector/combat
+	name = "mounted combat injector"
+	desc = "A specialized system for inserting chemicals meant for combat"
+	max_injection_amount = 30
+	max_beakers = 6
+	initial_beakers = list(
+		list(/obj/item/reagent_containers/glass/beaker/large, "hyperzine", 60),
+		list(/obj/item/reagent_containers/glass/beaker/large, "tramadol", 60),
+		list(/obj/item/reagent_containers/glass/beaker/large, "nutriment", 60),
+		list(/obj/item/reagent_containers/glass/beaker/large, "tricordrazine", 60)
+	)
+
+/obj/item/rig_module/modular_injector/medical
+	name = "mounted medical injector"
+	desc = "A specialized system for inserting chemicals to pacients"
+	max_injection_amount = 60
+	max_beakers = 6
+	initial_beakers = list(
+		list(/obj/item/reagent_containers/glass/beaker/large, "bicaridine", 60),
+		list(/obj/item/reagent_containers/glass/beaker/large, "inaprovaline",60),
+		list(/obj/item/reagent_containers/glass/beaker/large, "kelotane",60),
+		list(/obj/item/reagent_containers/glass/beaker/large, "anti_toxin", 60),
+		list(/obj/item/reagent_containers/glass/beaker/large, "spaceacillin", 60)
+	)
+/*
 /obj/item/rig_module/chem_dispenser
 	name = "mounted chemical dispenser"
 	desc = "A complex web of tubing and needles suitable for hardsuit use."
@@ -261,6 +411,7 @@
 	interface_name = "mounted chem injector"
 	interface_desc = "Dispenses loaded chemicals via an arm-mounted injector."
 	rarity_value = 20
+*/
 
 /obj/item/rig_module/voice
 	name = "hardsuit voice synthesiser"

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -31,7 +31,7 @@
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/power_sink,
 		/obj/item/rig_module/electrowarfare_suite,
-		/obj/item/rig_module/chem_dispenser/combat
+		/obj/item/rig_module/modular_injector/combat
 		)
 
 //Ironhammer rig suit

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -108,7 +108,7 @@
 		/obj/item/rig_module/vision,
 		/obj/item/rig_module/voice,
 		/obj/item/rig_module/fabricator/energy_net,
-		/obj/item/rig_module/chem_dispenser,
+		/obj/item/rig_module/modular_injector/combat,
 		/obj/item/rig_module/grenade_launcher,
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/power_sink,

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -29,7 +29,7 @@
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/power_sink,
 		/obj/item/rig_module/electrowarfare_suite,
-		/obj/item/rig_module/chem_dispenser/combat,
+		/obj/item/rig_module/modular_injector/combat,
 		/obj/item/rig_module/fabricator/energy_net
 		)
 	stiffness = 0

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -307,7 +307,7 @@ Technomancer RIG
 	req_one_access = list()
 	rarity_value = 20
 	initial_modules = list(
-		/obj/item/rig_module/chem_dispenser/injector,
+		/obj/item/rig_module/modular_injector/medical,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/healthscanner,
 		/obj/item/rig_module/vision/medhud

--- a/code/modules/research/designs/rigmodules.dm
+++ b/code/modules/research/designs/rigmodules.dm
@@ -17,7 +17,7 @@
 /datum/design/research/item/chem_dispenser
 	name = "mounted chemical dispenser"
 	desc = "A complex web of tubing and needles suitable for hardsuit use."
-	build_path = /obj/item/rig_module/chem_dispenser
+	build_path = /obj/item/rig_module/modular_injector
 	sort_string = "VDAAD"
 
 /datum/design/research/item/medhud

--- a/code/modules/trade/datums/trade_stations_presets/1-common/suit_up.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/suit_up.dm
@@ -162,7 +162,7 @@
 			/obj/item/rig_module/device/anomaly_scanner = good_data("Mounted Anomaly Scanner", list(1,10)),
 			/obj/item/rig_module/device/rcd = good_data("Mounted RCD", list(1, 10)),
 			/obj/item/rig_module/device/healthscanner = good_data("Mounted Health Scanner", list(1, 10)),
-			/obj/item/rig_module/chem_dispenser/ninja = good_data("Mounted Chemical Dispenser (small version)", list(-3, 2)),
+			/obj/item/rig_module/modular_injector/medical = good_data("Mounted Chemical Dispenser (medical version)", list(-3, 2)),
 			/obj/item/rig_module/ai_container,
 			/obj/item/rig_module/power_sink,
 			/obj/item/rig_module/vision/meson,

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/rigprovider.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/rigprovider.dm
@@ -23,14 +23,14 @@
 			/obj/item/rig_module/held/energy_blade,
 			/obj/item/rig_module/held/shield,
 			/obj/item/rig_module/datajack,
-			/obj/item/rig_module/chem_dispenser
+			/obj/item/rig_module/modular_injector
 		)
 	)
 	secret_inventory = list(
 		"RIG Specialized Modules III" = list(
 			/obj/item/rig_module/electrowarfare_suite,
-			/obj/item/rig_module/chem_dispenser/combat,
-			/obj/item/rig_module/chem_dispenser/injector,
+			/obj/item/rig_module/modular_injector/combat,
+			/obj/item/rig_module/modular_injector/medical,
 			/obj/item/rig_module/cape
 		)
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fully reworks the rig chemical injectors , most notable changes
1)You can now insert/remove beakers
2)You can adjust the injection amount (and saboutage if you set it to 0)
3)Combat injectors now have hyperzine , nutriment , tricordazine and tramadol
4)Medical injectors now have dylovene , bicardine , kelotane , spaceacilin and inaprovaline
5)Modular injectors no longer start full , only their subtypes (RND printing injectors won't start full now)
6)Normal injector can fit 5 beakers , subtypes can fit 6
7)Uplink modular injector price changed from 6 to 3 tc(no longer starts full)

## Why It's Good For The Game
They suck in general , and were hard to refill , and use in general , now this  makes them more flexible for players and to their needs , especially paramedics which can finnaly fill theirs with upgraded chems.
## Changelog
:cl:
balance: RIG Combat dispenser now has hyperzine , nutriment , tricord and tramadol
balance :RIG medical dispenser added , with dylovene , bicardine , kelotane spaceacilin and inaprovaline
balance: You can now add and remove beakers from modular injectors
balance: Printed modular injector(chem dispensers) no longer start filled
balance: Uplink injector price changed from 6 to 3 tc as it no longer starts full.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
