### PR TITLE
Chameleon clothing update, this time without warnings

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -87,6 +87,7 @@
 	var/max_upgrades = 3
 
 	var/can_use_lying = 0
+	var/chameleon_slot //if this is a chameleon item, what kind of item is it?
 
 /obj/item/Initialize()
 	if(islist(armor))

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -129,7 +129,7 @@
 
 /obj/item/storage/box/syndie_kit/chameleon
 	name = "chameleon kit"
-	desc = "Comes with all the clothes you need to impersonate most people.  Acting lessons sold seperately."
+	desc = "Comes with all the clothes you need to impersonate most people. Acting lessons sold seperately. Wearing the uniform will allow fot quick switching between appearances."
 
 /obj/item/storage/box/syndie_kit/chameleon/populate_contents()
 	new /obj/item/clothing/under/chameleon(src)
@@ -137,6 +137,7 @@
 	new /obj/item/clothing/suit/chameleon(src)
 	new /obj/item/clothing/shoes/chameleon(src)
 	new /obj/item/storage/backpack/chameleon(src)
+	new /obj/item/storage/backpack/satchel/chameleon(src)
 	new /obj/item/clothing/gloves/chameleon(src)
 	new /obj/item/clothing/mask/chameleon(src)
 	new /obj/item/clothing/glasses/chameleon(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -129,7 +129,7 @@
 
 /obj/item/storage/box/syndie_kit/chameleon
 	name = "chameleon kit"
-	desc = "Comes with all the clothes you need to impersonate most people. Acting lessons sold seperately. Wearing the uniform will allow fot quick switching between appearances."
+	desc = "Comes with all the clothes you need to impersonate most people. Acting lessons sold separately. Wearing the uniform will allow for quick switching between appearances."
 
 /obj/item/storage/box/syndie_kit/chameleon/populate_contents()
 	new /obj/item/clothing/under/chameleon(src)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -174,15 +174,15 @@ obj/item/clothing/disguise(newtype, mob/user)
 
 /obj/item/clothing/under/chameleon/proc/disguise_as_loadout(mob/user, loadout)
 	var/obj/item/A
+	for(var/obj/item/clothing/suit/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[3], user)
 	for(var/obj/item/clothing/under/chameleon/F in user.get_contents())
 		A = F
 		A.disguise(loadout[1], user)
 	for(var/obj/item/clothing/head/chameleon/F in user.get_contents())
 		A = F
 		A.disguise(loadout[2], user)
-	for(var/obj/item/clothing/suit/chameleon/F in user.get_contents())
-		A = F
-		A.disguise(loadout[3], user)
 	for(var/obj/item/clothing/shoes/chameleon/F in user.get_contents())
 		A = F
 		A.disguise(loadout[4], user)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -14,6 +14,7 @@
 	icon_state = copy.icon_state
 	item_state = copy.item_state
 	body_parts_covered = copy.body_parts_covered
+	flags_inv = copy.flags_inv
 
 	item_icons = copy.item_icons.Copy()
 	item_state_slots = copy.item_state_slots.Copy()
@@ -53,6 +54,51 @@ obj/item/clothing/disguise(newtype, mob/user)
 	origin_tech = list(TECH_COVERT = 3)
 	var/global/list/clothing_choices
 
+	var/list/loadout_1 = list(/obj/item/clothing/under/rank/assistant,
+	/obj/item/clothing/head/hardhat,
+	/obj/item/clothing/suit/storage/ass_jacket,
+	/obj/item/clothing/shoes/reinforced,
+	/obj/item/storage/backpack/satchel,
+	/obj/item/clothing/gloves/thick,
+	/obj/item/clothing/mask/smokable/cigarette,
+	/obj/item/clothing/glasses/sunglasses,
+	/obj/item/gun/projectile/boltgun/serbian,
+	/obj/item/device/radio/headset)
+
+	var/list/loadout_2 = list(/obj/item/clothing/under/rank/security,
+	/obj/item/clothing/head/armor/helmet/ironhammer,
+	/obj/item/clothing/suit/armor/vest/full/ironhammer,
+	/obj/item/clothing/shoes/jackboots/ironhammer,
+	/obj/item/storage/backpack/satchel/security,
+	/obj/item/clothing/gloves/stungloves,
+	/obj/item/clothing/mask/balaclava/tactical,
+	/obj/item/clothing/glasses/sunglasses/sechud/tactical,
+	/obj/item/gun/projectile/automatic/sol,
+	/obj/item/device/radio/headset/headset_sec)
+
+	var/list/loadout_3 = list(/obj/item/clothing/under/rank/scientist,
+	/obj/item/clothing/head/bandana/orange,
+	/obj/item/clothing/suit/storage/toggle/labcoat/science,
+	/obj/item/clothing/shoes/jackboots,
+	/obj/item/storage/backpack/satchel/purple/scientist,
+	/obj/item/clothing/gloves/thick,
+	/obj/item/clothing/mask/gas,
+	/obj/item/clothing/glasses/powered/science,
+	/obj/item/gun/energy/lasercannon,
+	/obj/item/device/radio/headset/headset_sci)
+
+	var/list/loadout_4 = list(/obj/item/clothing/under/rank/acolyte,
+	/obj/item/clothing/head/armor/acolyte,
+	/obj/item/clothing/suit/armor/acolyte,
+	/obj/item/clothing/shoes/reinforced,
+	/obj/item/storage/backpack/satchel/neotheology,
+	/obj/item/clothing/gloves/thick,
+	/obj/item/clothing/mask/scarf/red,
+	/obj/item/clothing/glasses/sunglasses,
+	/obj/item/gun/energy/laser,
+	/obj/item/device/radio/headset/church)
+
+
 /obj/item/clothing/under/chameleon/New()
 	..()
 	if(!clothing_choices)
@@ -75,6 +121,175 @@ obj/item/clothing/disguise(newtype, mob/user)
 		return
 
 	disguise(clothing_choices[picked], usr)
+
+//********************************************
+//**Chameleon Jumpsuit loadout functionality**
+//********************************************
+
+/obj/item/clothing/under/chameleon/proc/set_single_loadout_slot(itemtype, loadout)
+	var/obj/item/currentitem = new itemtype(null)
+	var/obj/item/chameleonitem
+	var/obj/item/item_to_disguise
+	if(istype(currentitem, /obj/item/clothing/under))
+		var/obj/item/clothing/under/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[1] = G.clothing_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/clothing/head))
+		var/obj/item/clothing/head/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[2] = G.clothing_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/clothing/suit))
+		var/obj/item/clothing/suit/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[3] = G.clothing_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/clothing/shoes))
+		var/obj/item/clothing/shoes/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[4] = G.clothing_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/storage/backpack))
+		var/obj/item/storage/backpack/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[5] = G.clothing_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/clothing/gloves))
+		var/obj/item/clothing/gloves/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[6] = G.clothing_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/clothing/mask))
+		var/obj/item/clothing/mask/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[7] = G.clothing_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/clothing/glasses))
+		var/obj/item/clothing/glasses/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[8] = G.clothing_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/gun))
+		var/obj/item/gun/energy/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.gun_choices
+		loadout[9] = G.gun_choices[item_to_disguise]
+	if(istype(currentitem, /obj/item/device/radio/headset))
+		var/obj/item/device/radio/headset/chameleon/G = chameleonitem
+		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
+		loadout[10] = G.clothing_choices[item_to_disguise]
+
+
+/obj/item/clothing/under/chameleon/proc/disguise_as_loadout(mob/user, loadout)
+	var/obj/item/A
+	for(var/obj/item/clothing/under/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[1], user)
+	for(var/obj/item/clothing/head/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[2], user)
+	for(var/obj/item/clothing/suit/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[3], user)
+	for(var/obj/item/clothing/shoes/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[4], user)
+	for(var/obj/item/storage/backpack/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[5], user)
+	for(var/obj/item/storage/backpack/satchel/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[5], user)
+	for(var/obj/item/clothing/gloves/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[6], user)
+	for(var/obj/item/clothing/mask/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[7], user)
+	for(var/obj/item/clothing/glasses/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[8], user)
+	for(var/obj/item/gun/energy/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[9], user)
+	for(var/obj/item/device/radio/headset/chameleon/F in user.get_contents())
+		A = F
+		A.disguise(loadout[10], user)
+
+
+/obj/item/clothing/under/chameleon/ui_interact(mob/user, ui_key, datum/nanoui/ui, force_open, datum/nanoui/master_ui, datum/topic_state/state)
+	var/list/data = list()
+
+	var/list/loadouts = list()
+	loadouts += list(loadout_1, loadout_2, loadout_3, loadout_4)
+
+	var/list/clothes_in_loadout = list()
+	var/current_loadout = 1
+	for(var/I in loadouts)
+		var/list/S = I
+		for(var/G in S)
+			var/obj/item/copy = new G (null)
+			clothes_in_loadout += list(
+				list(
+					"name" = copy.name,
+					"type" = copy.type,
+					"loadout" = current_loadout
+				)
+			)
+		current_loadout++
+	data["clothes_in_loadout"] = clothes_in_loadout
+
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
+	if(!ui)
+		ui = new(user, src, ui_key, "chameleon.tmpl", "Chameleon clothing", 1000, 400)
+		ui.set_initial_data(data)
+		ui.open()
+
+/obj/item/clothing/under/chameleon/Topic(href, href_list)
+	var/list/loadouts = list()
+	loadouts += list(loadout_1, loadout_2, loadout_3, loadout_4)
+	if(href_list["set_clothing_1"])
+		var/chameleontype = href_list["set_clothing_1"]
+		set_single_loadout_slot(chameleontype, loadout_1)
+	if(href_list["set_clothing_2"])
+		var/chameleontype = href_list["set_clothing_2"]
+		set_single_loadout_slot(chameleontype, loadout_2)
+	if(href_list["set_clothing_3"])
+		var/chameleontype = href_list["set_clothing_3"]
+		set_single_loadout_slot(chameleontype, loadout_3)
+	if(href_list["set_clothing_4"])
+		var/chameleontype = href_list["set_clothing_4"]
+		set_single_loadout_slot(chameleontype, loadout_4)
+	SSnano.update_uis(src)
+	..()
+
+/obj/item/clothing/under/chameleon/verb/configure_loadouts()
+	set name = "Configure loadouts"
+	set category = "Chameleon Items"
+	set src in usr.contents
+
+	ui_interact(usr)
+
+/obj/item/clothing/under/chameleon/verb/disguise_as_loadout_1()
+	set name = "Disguise as loadout 1"
+	set category = "Chameleon Items"
+	set src in usr.contents
+
+	disguise_as_loadout(usr, loadout_1)
+
+/obj/item/clothing/under/chameleon/verb/disguise_as_loadout_2()
+	set name = "Disguise as loadout 2"
+	set category = "Chameleon Items"
+	set src in usr.contents
+
+	disguise_as_loadout(usr, loadout_2)
+
+/obj/item/clothing/under/chameleon/verb/disguise_as_loadout_3()
+	set name = "Disguise as loadout 3"
+	set category = "Chameleon Items"
+	set src in usr.contents
+
+	disguise_as_loadout(usr, loadout_3)
+
+/obj/item/clothing/under/chameleon/verb/disguise_as_loadout_4()
+	set name = "Disguise as loadout 4"
+	set category = "Chameleon Items"
+	set src in usr.contents
+
+	disguise_as_loadout(usr, loadout_4)
+
 
 //*****************
 //**Chameleon Hat**
@@ -216,6 +431,43 @@ obj/item/clothing/disguise(newtype, mob/user)
 
 /obj/item/storage/backpack/chameleon/verb/change(picked in clothing_choices)
 	set name = "Change Backpack Appearance"
+	set category = "Chameleon Items"
+	set src in usr
+
+	if(!ispath(clothing_choices[picked]))
+		return
+
+	disguise(clothing_choices[picked], usr)
+
+//**********************
+//**Chameleon Satchel**
+//**********************
+/obj/item/storage/backpack/satchel/chameleon
+	name = "grey satchel"
+	icon_state = "satchel"
+	desc = "A satchel outfitted with cloaking tech. It seems to have a small dial inside, kept away from the storage."
+	origin_tech = list(TECH_COVERT = 3)
+	spawn_blacklisted = TRUE
+	spawn_tags = SPAWN_TAG_BACKPACK_CHAMALEON
+	rarity_value = 50
+	var/global/list/clothing_choices
+
+/obj/item/storage/backpack/satchel/chameleon/Initialize()
+	. = ..()
+	if(!clothing_choices)
+		var/blocked = list(src.type, /obj/item/storage/backpack/satchel/leather/withwallet)
+		clothing_choices = generate_chameleon_choices(/obj/item/storage/backpack, blocked)
+
+/obj/item/storage/backpack/satchel/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
+	name = "grey satchel"
+	desc = "A satchel outfitted with cloaking tech. It seems to have a small dial inside, kept away from the storage."
+	icon_state = "backpack"
+	item_state = "backpack"
+	update_icon()
+	update_wear_icon()
+
+/obj/item/storage/backpack/satchel/chameleon/verb/change(picked in clothing_choices)
+	set name = "Change Satchel Appearance"
 	set category = "Chameleon Items"
 	set src in usr
 

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -104,6 +104,11 @@ obj/item/clothing/disguise(newtype, mob/user)
 	if(!clothing_choices)
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/under)
 
+/obj/item/clothing/under/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
+
 /obj/item/clothing/under/chameleon/emp_act(severity)
 	name = "psychedelic"
 	desc = "Groovy!"
@@ -311,6 +316,11 @@ obj/item/clothing/disguise(newtype, mob/user)
 		var/blocked = list(src.type, /obj/item/clothing/head/justice,)//Prevent infinite loops and bad hats.
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/head, blocked)
 
+/obj/item/clothing/head/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
+
 /obj/item/clothing/head/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
 	name = "grey cap"
 	desc = "A baseball hat in a tasteful grey colour."
@@ -346,6 +356,11 @@ obj/item/clothing/disguise(newtype, mob/user)
 	if(!clothing_choices)
 		var/blocked = list(src.type, null)
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/suit, blocked)
+
+/obj/item/clothing/suit/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
 
 /obj/item/clothing/suit/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
 	name = "armor"
@@ -383,6 +398,11 @@ obj/item/clothing/disguise(newtype, mob/user)
 		var/blocked = list(src.type, /obj/item/clothing/shoes/syndigaloshes, /obj/item/clothing/shoes/cyborg)//prevent infinite loops and bad shoes.
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/shoes, blocked)
 
+/obj/item/clothing/shoes/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
+
 /obj/item/clothing/shoes/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
 	name = "black shoes"
 	desc = "A pair of black shoes."
@@ -415,11 +435,16 @@ obj/item/clothing/disguise(newtype, mob/user)
 	rarity_value = 50
 	var/global/list/clothing_choices
 
-/obj/item/storage/backpack/chameleon/Initialize()
+/obj/item/storage/backpack/chameleon/New()
 	. = ..()
 	if(!clothing_choices)
 		var/blocked = list(src.type, /obj/item/storage/backpack/satchel/leather/withwallet)
 		clothing_choices = generate_chameleon_choices(/obj/item/storage/backpack, blocked)
+
+/obj/item/storage/backpack/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
 
 /obj/item/storage/backpack/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
 	name = "grey backpack"
@@ -452,11 +477,16 @@ obj/item/clothing/disguise(newtype, mob/user)
 	rarity_value = 50
 	var/global/list/clothing_choices
 
-/obj/item/storage/backpack/satchel/chameleon/Initialize()
+/obj/item/storage/backpack/satchel/chameleon/New()
 	. = ..()
 	if(!clothing_choices)
 		var/blocked = list(src.type, /obj/item/storage/backpack/satchel/leather/withwallet)
 		clothing_choices = generate_chameleon_choices(/obj/item/storage/backpack, blocked)
+
+/obj/item/storage/backpack/satchel/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
 
 /obj/item/storage/backpack/satchel/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
 	name = "grey satchel"
@@ -494,6 +524,11 @@ obj/item/clothing/disguise(newtype, mob/user)
 	..()
 	if(!clothing_choices)
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/gloves, list(src.type))
+
+/obj/item/clothing/gloves/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
 
 /obj/item/clothing/gloves/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
 	name = "black gloves"
@@ -533,6 +568,11 @@ obj/item/clothing/disguise(newtype, mob/user)
 	if(!clothing_choices)
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/mask, list(src.type))
 
+/obj/item/clothing/mask/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
+
 /obj/item/clothing/mask/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
 	name = "gas mask"
 	desc = "A gas mask."
@@ -568,6 +608,11 @@ obj/item/clothing/disguise(newtype, mob/user)
 	..()
 	if(!clothing_choices)
 		clothing_choices = generate_chameleon_choices(/obj/item/clothing/glasses, list(src.type))
+
+/obj/item/clothing/glasses/chameleon/Initialize(mapload, ...)
+	. = ..()
+	matter = list()
+	matter.Add(list(MATERIAL_PLASTIC = 2 * w_class))
 
 /obj/item/clothing/glasses/chameleon/emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
 	name = "Optical Meson Scanner"

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -133,48 +133,68 @@ obj/item/clothing/disguise(newtype, mob/user)
 
 /obj/item/clothing/under/chameleon/proc/set_single_loadout_slot(itemtype, loadout)
 	var/obj/item/currentitem = new itemtype(null)
-	var/obj/item/chameleonitem
+	var/chameleon_choice
 	var/obj/item/item_to_disguise
 	if(istype(currentitem, /obj/item/clothing/under))
-		var/obj/item/clothing/under/chameleon/G = chameleonitem
-		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
-		loadout[1] = G.clothing_choices[item_to_disguise]
+		var/obj/item/clothing/under/chameleon/G
+		chameleon_choice = G
+		chameleon_choice = G.clothing_choices
+		item_to_disguise = input("","Choose a disguise") in chameleon_choice
+		loadout[1] = chameleon_choice[item_to_disguise]
 	if(istype(currentitem, /obj/item/clothing/head))
-		var/obj/item/clothing/head/chameleon/G = chameleonitem
-		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
-		loadout[2] = G.clothing_choices[item_to_disguise]
+		var/obj/item/clothing/head/chameleon/G
+		chameleon_choice = G
+		chameleon_choice = G.clothing_choices
+		item_to_disguise = input("","Choose a disguise") in chameleon_choice
+		loadout[2] = chameleon_choice[item_to_disguise]
 	if(istype(currentitem, /obj/item/clothing/suit))
-		var/obj/item/clothing/suit/chameleon/G = chameleonitem
-		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
-		loadout[3] = G.clothing_choices[item_to_disguise]
+		var/obj/item/clothing/suit/chameleon/G = new /obj/item/clothing/suit/chameleon(null)
+		chameleon_choice = G
+		chameleon_choice = G.clothing_choices
+		item_to_disguise = input("","Choose a disguise") in chameleon_choice
+		loadout[3] = chameleon_choice[item_to_disguise]
 	if(istype(currentitem, /obj/item/clothing/shoes))
-		var/obj/item/clothing/shoes/chameleon/G = chameleonitem
-		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
-		loadout[4] = G.clothing_choices[item_to_disguise]
+		var/obj/item/clothing/shoes/chameleon/G = new /obj/item/clothing/shoes/chameleon(null)
+		chameleon_choice = G
+		chameleon_choice = G.clothing_choices
+		item_to_disguise = input("","Choose a disguise") in chameleon_choice
+		loadout[4] = chameleon_choice[item_to_disguise]
 	if(istype(currentitem, /obj/item/storage/backpack))
-		var/obj/item/storage/backpack/chameleon/G = chameleonitem
-		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
-		loadout[5] = G.clothing_choices[item_to_disguise]
+		var/obj/item/storage/backpack/chameleon/G = new /obj/item/storage/backpack/chameleon(null)
+		chameleon_choice = G
+		chameleon_choice = G.clothing_choices
+		item_to_disguise = input("","Choose a disguise") in chameleon_choice
+		loadout[5] = chameleon_choice[item_to_disguise]
 	if(istype(currentitem, /obj/item/clothing/gloves))
-		var/obj/item/clothing/gloves/chameleon/G = chameleonitem
-		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
-		loadout[6] = G.clothing_choices[item_to_disguise]
+		var/obj/item/clothing/gloves/chameleon/G = new /obj/item/clothing/gloves/chameleon(null)
+		chameleon_choice = G
+		chameleon_choice = G.clothing_choices
+		item_to_disguise = input("","Choose a disguise") in chameleon_choice
+		loadout[6] = chameleon_choice[item_to_disguise]
 	if(istype(currentitem, /obj/item/clothing/mask))
-		var/obj/item/clothing/mask/chameleon/G = chameleonitem
-		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
-		loadout[7] = G.clothing_choices[item_to_disguise]
+		var/obj/item/clothing/mask/chameleon/G = new /obj/item/clothing/mask/chameleon(null)
+		chameleon_choice = G
+		chameleon_choice = G.clothing_choices		
+		item_to_disguise = input("","Choose a disguise") in chameleon_choice
+		loadout[7] = chameleon_choice[item_to_disguise]
 	if(istype(currentitem, /obj/item/clothing/glasses))
-		var/obj/item/clothing/glasses/chameleon/G = chameleonitem
-		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
-		loadout[8] = G.clothing_choices[item_to_disguise]
+		var/obj/item/clothing/glasses/chameleon/G = new /obj/item/clothing/glasses/chameleon(null)
+		chameleon_choice = G
+		chameleon_choice = G.clothing_choices
+		item_to_disguise = input("","Choose a disguise") in chameleon_choice
+		loadout[8] = chameleon_choice[item_to_disguise]
 	if(istype(currentitem, /obj/item/gun))
-		var/obj/item/gun/energy/chameleon/G = chameleonitem
-		item_to_disguise = input("","Choose a disguise") in G.gun_choices
-		loadout[9] = G.gun_choices[item_to_disguise]
+		var/obj/item/gun/energy/chameleon/G = new /obj/item/gun/energy/chameleon(null)
+		chameleon_choice = G	
+		chameleon_choice = G.gun_choices
+		item_to_disguise = input("","Choose a disguise") in chameleon_choice
+		loadout[9] = chameleon_choice[item_to_disguise]
 	if(istype(currentitem, /obj/item/device/radio/headset))
-		var/obj/item/device/radio/headset/chameleon/G = chameleonitem
-		item_to_disguise = input("","Choose a disguise") in G.clothing_choices
-		loadout[10] = G.clothing_choices[item_to_disguise]
+		var/obj/item/device/radio/headset/chameleon/G = new /obj/item/device/radio/headset/chameleon(null)
+		chameleon_choice = G	
+		chameleon_choice = G.clothing_choices
+		item_to_disguise = input("","Choose a disguise") in chameleon_choice
+		loadout[10] = chameleon_choice[item_to_disguise]
 
 
 /obj/item/clothing/under/chameleon/proc/disguise_as_loadout(mob/user, loadout)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -137,7 +137,7 @@ obj/item/clothing/disguise(newtype, mob/user)
 //**Chameleon Jumpsuit loadout functionality**
 //********************************************
 
-/obj/item/clothing/under/chameleon/proc/set_single_loadout_slot(slot, loadout)
+/obj/item/clothing/under/chameleon/proc/set_loadout_slot(slot, loadout)
 	var/chameleon_choices
 	var/obj/item/item_to_disguise
 	switch(slot)
@@ -187,16 +187,8 @@ obj/item/clothing/disguise(newtype, mob/user)
 	for(var/obj/item/A in user.get_contents())
 		if(A.chameleon_slot)
 			user_chameleon_items += A
-	var/list/ordered_list = list() //sadly neccessary because the suit and glasses need to be disguised before all other items, otherwise shoes and glasses will appear invisible.
 	for(var/obj/item/I in user_chameleon_items)
-		if(istype(obj/item/clothing/suit/chameleon))
-			ordered_list += I
-		else if(istype(obj/item/clothing/glasses_chameleon))
-			ordered_list += I
-	user_chameleon_items -= ordered_list
-	ordered_list += user_chameleon_items
-	for(var/obj/item/U in ordered_list)
-		disguise(loadout[U.chameleon_slot], user)
+		I.disguise(loadout[I.chameleon_slot], user)
 
 /obj/item/clothing/under/chameleon/ui_interact(mob/user, ui_key, datum/nanoui/ui, force_open, datum/nanoui/master_ui, datum/topic_state/state)
 	var/list/data = list()
@@ -223,7 +215,7 @@ obj/item/clothing/disguise(newtype, mob/user)
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "chameleon.tmpl", "Chameleon clothing", 1000, 400)
+		ui = new(user, src, ui_key, "chameleon.tmpl", "Chameleon clothing", 1100, 400)
 		ui.set_initial_data(data)
 		ui.open()
 
@@ -233,16 +225,16 @@ obj/item/clothing/disguise(newtype, mob/user)
 	loadouts += list(loadout_1, loadout_2, loadout_3, loadout_4)
 	if(href_list["set_clothing_1"])
 		slot = href_list["set_clothing_1"]
-		set_single_loadout_slot(slot, loadout_1)
+		set_loadout_slot(slot, loadout_1)
 	if(href_list["set_clothing_2"])
 		slot = href_list["set_clothing_2"]
-		set_single_loadout_slot(slot, loadout_2)
+		set_loadout_slot(slot, loadout_2)
 	if(href_list["set_clothing_3"])
 		slot = href_list["set_clothing_3"]
-		set_single_loadout_slot(slot, loadout_3)
+		set_loadout_slot(slot, loadout_3)
 	if(href_list["set_clothing_4"])
 		slot = href_list["set_clothing_4"]
-		set_single_loadout_slot(slot, loadout_4)
+		set_loadout_slot(slot, loadout_4)
 	SSnano.update_uis(src)
 	..()
 
@@ -258,14 +250,15 @@ obj/item/clothing/disguise(newtype, mob/user)
 	set category = "Chameleon Items"
 	set src in usr.contents
 
+	disguise_as_loadout(usr, loadout_1)//need to do this twice, otherwise jumpsuits will appear invisible when switching from a voidsuit to a non-voidsuit disguise (known bug when taking off suits)
 	disguise_as_loadout(usr, loadout_1)
-
 
 /obj/item/clothing/under/chameleon/verb/disguise_as_loadout_2()
 	set name = "Disguise as loadout 2"
 	set category = "Chameleon Items"
 	set src in usr.contents
 
+	disguise_as_loadout(usr, loadout_2)
 	disguise_as_loadout(usr, loadout_2)
 
 /obj/item/clothing/under/chameleon/verb/disguise_as_loadout_3()
@@ -274,6 +267,7 @@ obj/item/clothing/disguise(newtype, mob/user)
 	set src in usr.contents
 
 	disguise_as_loadout(usr, loadout_3)
+	disguise_as_loadout(usr, loadout_3)
 
 /obj/item/clothing/under/chameleon/verb/disguise_as_loadout_4()
 	set name = "Disguise as loadout 4"
@@ -281,7 +275,7 @@ obj/item/clothing/disguise(newtype, mob/user)
 	set src in usr.contents
 
 	disguise_as_loadout(usr, loadout_4)
-
+	disguise_as_loadout(usr, loadout_4)
 
 //*****************
 //**Chameleon Hat**

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -53,51 +53,49 @@ obj/item/clothing/disguise(newtype, mob/user)
 
 	origin_tech = list(TECH_COVERT = 3)
 	var/global/list/clothing_choices
+	var/list/loadout_1 = list(uniform = /obj/item/clothing/under/rank/assistant,
+	hat = /obj/item/clothing/head/hardhat,
+	suit = /obj/item/clothing/suit/storage/ass_jacket,
+	shoes = /obj/item/clothing/shoes/reinforced,
+	back = /obj/item/storage/backpack/satchel,
+	gloves = /obj/item/clothing/gloves/thick,
+	mask = /obj/item/clothing/mask/smokable/cigarette,
+	glasses = /obj/item/clothing/glasses/sunglasses,
+	gun = /obj/item/gun/projectile/boltgun/serbian,
+	headset = /obj/item/device/radio/headset)
 
-	var/list/loadout_1 = list(/obj/item/clothing/under/rank/assistant,
-	/obj/item/clothing/head/hardhat,
-	/obj/item/clothing/suit/storage/ass_jacket,
-	/obj/item/clothing/shoes/reinforced,
-	/obj/item/storage/backpack/satchel,
-	/obj/item/clothing/gloves/thick,
-	/obj/item/clothing/mask/smokable/cigarette,
-	/obj/item/clothing/glasses/sunglasses,
-	/obj/item/gun/projectile/boltgun/serbian,
-	/obj/item/device/radio/headset)
+	var/list/loadout_2 = list(uniform = /obj/item/clothing/under/rank/security,
+	hat = /obj/item/clothing/head/armor/helmet/ironhammer,
+	suit = /obj/item/clothing/suit/armor/vest/full/ironhammer,
+	shoes = /obj/item/clothing/shoes/jackboots/ironhammer,
+	back = /obj/item/storage/backpack/satchel/security,
+	gloves = /obj/item/clothing/gloves/stungloves,
+	mask = /obj/item/clothing/mask/balaclava/tactical,
+	glasses = /obj/item/clothing/glasses/sunglasses/sechud/tactical,
+	gun = /obj/item/gun/projectile/automatic/sol,
+	headset = /obj/item/device/radio/headset/headset_sec)
 
-	var/list/loadout_2 = list(/obj/item/clothing/under/rank/security,
-	/obj/item/clothing/head/armor/helmet/ironhammer,
-	/obj/item/clothing/suit/armor/vest/full/ironhammer,
-	/obj/item/clothing/shoes/jackboots/ironhammer,
-	/obj/item/storage/backpack/satchel/security,
-	/obj/item/clothing/gloves/stungloves,
-	/obj/item/clothing/mask/balaclava/tactical,
-	/obj/item/clothing/glasses/sunglasses/sechud/tactical,
-	/obj/item/gun/projectile/automatic/sol,
-	/obj/item/device/radio/headset/headset_sec)
+	var/list/loadout_3 = list(uniform = /obj/item/clothing/under/rank/scientist,
+	hat = /obj/item/clothing/head/bandana/orange,
+	suit = /obj/item/clothing/suit/storage/toggle/labcoat/science,
+	shoes = /obj/item/clothing/shoes/jackboots,
+	back = /obj/item/storage/backpack/satchel/purple/scientist,
+	gloves = /obj/item/clothing/gloves/thick,
+	mask = /obj/item/clothing/mask/gas,
+	glasses = /obj/item/clothing/glasses/powered/science,
+	gun = /obj/item/gun/energy/lasercannon,
+	headset =/obj/item/device/radio/headset/headset_sci)
 
-	var/list/loadout_3 = list(/obj/item/clothing/under/rank/scientist,
-	/obj/item/clothing/head/bandana/orange,
-	/obj/item/clothing/suit/storage/toggle/labcoat/science,
-	/obj/item/clothing/shoes/jackboots,
-	/obj/item/storage/backpack/satchel/purple/scientist,
-	/obj/item/clothing/gloves/thick,
-	/obj/item/clothing/mask/gas,
-	/obj/item/clothing/glasses/powered/science,
-	/obj/item/gun/energy/lasercannon,
-	/obj/item/device/radio/headset/headset_sci)
-
-	var/list/loadout_4 = list(/obj/item/clothing/under/rank/acolyte,
-	/obj/item/clothing/head/armor/acolyte,
-	/obj/item/clothing/suit/armor/acolyte,
-	/obj/item/clothing/shoes/reinforced,
-	/obj/item/storage/backpack/satchel/neotheology,
-	/obj/item/clothing/gloves/thick,
-	/obj/item/clothing/mask/scarf/red,
-	/obj/item/clothing/glasses/sunglasses,
-	/obj/item/gun/energy/laser,
-	/obj/item/device/radio/headset/church)
-
+	var/list/loadout_4 = list(uniform = /obj/item/clothing/under/rank/acolyte,
+	hat = /obj/item/clothing/head/armor/acolyte,
+	suit = /obj/item/clothing/suit/armor/acolyte,
+	shoes = /obj/item/clothing/shoes/reinforced,
+	back = /obj/item/storage/backpack/satchel/neotheology,
+	gloves = /obj/item/clothing/gloves/thick,
+	mask = /obj/item/clothing/mask/scarf/red,
+	glasses = /obj/item/clothing/glasses/sunglasses,
+	gun = /obj/item/gun/energy/laser,
+	headset = /obj/item/device/radio/headset/church)
 
 /obj/item/clothing/under/chameleon/New()
 	..()
@@ -131,107 +129,107 @@ obj/item/clothing/disguise(newtype, mob/user)
 //**Chameleon Jumpsuit loadout functionality**
 //********************************************
 
-/obj/item/clothing/under/chameleon/proc/set_single_loadout_slot(itemtype, loadout)
-	var/obj/item/currentitem = new itemtype(null)
+/obj/item/clothing/under/chameleon/proc/set_single_loadout_slot(slot, loadout)
 	var/chameleon_choice
 	var/obj/item/item_to_disguise
-	if(istype(currentitem, /obj/item/clothing/under))
-		var/obj/item/clothing/under/chameleon/G
-		chameleon_choice = G
-		chameleon_choice = G.clothing_choices
-		item_to_disguise = input("","Choose a disguise") in chameleon_choice
-		loadout[1] = chameleon_choice[item_to_disguise]
-	if(istype(currentitem, /obj/item/clothing/head))
-		var/obj/item/clothing/head/chameleon/G
-		chameleon_choice = G
-		chameleon_choice = G.clothing_choices
-		item_to_disguise = input("","Choose a disguise") in chameleon_choice
-		loadout[2] = chameleon_choice[item_to_disguise]
-	if(istype(currentitem, /obj/item/clothing/suit))
-		var/obj/item/clothing/suit/chameleon/G = new /obj/item/clothing/suit/chameleon(null)
-		chameleon_choice = G
-		chameleon_choice = G.clothing_choices
-		item_to_disguise = input("","Choose a disguise") in chameleon_choice
-		loadout[3] = chameleon_choice[item_to_disguise]
-	if(istype(currentitem, /obj/item/clothing/shoes))
-		var/obj/item/clothing/shoes/chameleon/G = new /obj/item/clothing/shoes/chameleon(null)
-		chameleon_choice = G
-		chameleon_choice = G.clothing_choices
-		item_to_disguise = input("","Choose a disguise") in chameleon_choice
-		loadout[4] = chameleon_choice[item_to_disguise]
-	if(istype(currentitem, /obj/item/storage/backpack))
-		var/obj/item/storage/backpack/chameleon/G = new /obj/item/storage/backpack/chameleon(null)
-		chameleon_choice = G
-		chameleon_choice = G.clothing_choices
-		item_to_disguise = input("","Choose a disguise") in chameleon_choice
-		loadout[5] = chameleon_choice[item_to_disguise]
-	if(istype(currentitem, /obj/item/clothing/gloves))
-		var/obj/item/clothing/gloves/chameleon/G = new /obj/item/clothing/gloves/chameleon(null)
-		chameleon_choice = G
-		chameleon_choice = G.clothing_choices
-		item_to_disguise = input("","Choose a disguise") in chameleon_choice
-		loadout[6] = chameleon_choice[item_to_disguise]
-	if(istype(currentitem, /obj/item/clothing/mask))
-		var/obj/item/clothing/mask/chameleon/G = new /obj/item/clothing/mask/chameleon(null)
-		chameleon_choice = G
-		chameleon_choice = G.clothing_choices		
-		item_to_disguise = input("","Choose a disguise") in chameleon_choice
-		loadout[7] = chameleon_choice[item_to_disguise]
-	if(istype(currentitem, /obj/item/clothing/glasses))
-		var/obj/item/clothing/glasses/chameleon/G = new /obj/item/clothing/glasses/chameleon(null)
-		chameleon_choice = G
-		chameleon_choice = G.clothing_choices
-		item_to_disguise = input("","Choose a disguise") in chameleon_choice
-		loadout[8] = chameleon_choice[item_to_disguise]
-	if(istype(currentitem, /obj/item/gun))
-		var/obj/item/gun/energy/chameleon/G = new /obj/item/gun/energy/chameleon(null)
-		chameleon_choice = G	
-		chameleon_choice = G.gun_choices
-		item_to_disguise = input("","Choose a disguise") in chameleon_choice
-		loadout[9] = chameleon_choice[item_to_disguise]
-	if(istype(currentitem, /obj/item/device/radio/headset))
-		var/obj/item/device/radio/headset/chameleon/G = new /obj/item/device/radio/headset/chameleon(null)
-		chameleon_choice = G	
-		chameleon_choice = G.clothing_choices
-		item_to_disguise = input("","Choose a disguise") in chameleon_choice
-		loadout[10] = chameleon_choice[item_to_disguise]
+	switch(slot)
+		if("uniform")
+			var/obj/item/clothing/under/chameleon/G
+			chameleon_choice = G
+			chameleon_choice = G.clothing_choices
+			item_to_disguise = input("","Choose a disguise") in chameleon_choice
+			loadout["uniform"] = chameleon_choice[item_to_disguise]
+		if("hat")
+			var/obj/item/clothing/head/chameleon/G
+			chameleon_choice = G
+			chameleon_choice = G.clothing_choices
+			item_to_disguise = input("","Choose a disguise") in chameleon_choice
+			loadout["hat"] = chameleon_choice[item_to_disguise]
+		if("suit")
+			var/obj/item/clothing/suit/chameleon/G = new /obj/item/clothing/suit/chameleon(null)
+			chameleon_choice = G
+			chameleon_choice = G.clothing_choices
+			item_to_disguise = input("","Choose a disguise") in chameleon_choice
+			loadout["suit"] = chameleon_choice[item_to_disguise]
+		if("shoes")
+			var/obj/item/clothing/shoes/chameleon/G = new /obj/item/clothing/shoes/chameleon(null)
+			chameleon_choice = G
+			chameleon_choice = G.clothing_choices
+			item_to_disguise = input("","Choose a disguise") in chameleon_choice
+			loadout["shoes"] = chameleon_choice[item_to_disguise]
+		if("back")
+			var/obj/item/storage/backpack/chameleon/G = new /obj/item/storage/backpack/chameleon(null)
+			chameleon_choice = G
+			chameleon_choice = G.clothing_choices
+			item_to_disguise = input("","Choose a disguise") in chameleon_choice
+			loadout["back"] = chameleon_choice[item_to_disguise]
+		if("gloves")
+			var/obj/item/clothing/gloves/chameleon/G = new /obj/item/clothing/gloves/chameleon(null)
+			chameleon_choice = G
+			chameleon_choice = G.clothing_choices
+			item_to_disguise = input("","Choose a disguise") in chameleon_choice
+			loadout["gloves"] = chameleon_choice[item_to_disguise]
+		if("mask")
+			var/obj/item/clothing/mask/chameleon/G = new /obj/item/clothing/mask/chameleon(null)
+			chameleon_choice = G
+			chameleon_choice = G.clothing_choices		
+			item_to_disguise = input("","Choose a disguise") in chameleon_choice
+			loadout["mask"] = chameleon_choice[item_to_disguise]
+		if("glasses")
+			var/obj/item/clothing/glasses/chameleon/G = new /obj/item/clothing/glasses/chameleon(null)
+			chameleon_choice = G
+			chameleon_choice = G.clothing_choices
+			item_to_disguise = input("","Choose a disguise") in chameleon_choice
+			loadout["glasses"] = chameleon_choice[item_to_disguise]
+		if("gun")
+			var/obj/item/gun/energy/chameleon/G = new /obj/item/gun/energy/chameleon(null)
+			chameleon_choice = G	
+			chameleon_choice = G.gun_choices
+			item_to_disguise = input("","Choose a disguise") in chameleon_choice
+			loadout["gun"] = chameleon_choice[item_to_disguise]
+		if("headset")
+			var/obj/item/device/radio/headset/chameleon/G = new /obj/item/device/radio/headset/chameleon(null)
+			chameleon_choice = G	
+			chameleon_choice = G.clothing_choices
+			item_to_disguise = input("","Choose a disguise") in chameleon_choice
+			loadout["headset"] = chameleon_choice[item_to_disguise]
 
 
 /obj/item/clothing/under/chameleon/proc/disguise_as_loadout(mob/user, loadout)
 	var/obj/item/A
 	for(var/obj/item/clothing/suit/chameleon/F in user.get_contents())
 		A = F
-		A.disguise(loadout[3], user)
+		A.disguise(loadout["suit"], user)
 	for(var/obj/item/clothing/under/chameleon/F in user.get_contents())
 		A = F
-		A.disguise(loadout[1], user)
+		A.disguise(loadout["uniform"], user)
 	for(var/obj/item/clothing/head/chameleon/F in user.get_contents())
 		A = F
-		A.disguise(loadout[2], user)
+		A.disguise(loadout["hat"], user)
 	for(var/obj/item/clothing/shoes/chameleon/F in user.get_contents())
 		A = F
-		A.disguise(loadout[4], user)
+		A.disguise(loadout["shoes"], user)
 	for(var/obj/item/storage/backpack/chameleon/F in user.get_contents())
 		A = F
-		A.disguise(loadout[5], user)
+		A.disguise(loadout["back"], user)
 	for(var/obj/item/storage/backpack/satchel/chameleon/F in user.get_contents())
 		A = F
-		A.disguise(loadout[5], user)
+		A.disguise(loadout["back"], user)
 	for(var/obj/item/clothing/gloves/chameleon/F in user.get_contents())
 		A = F
-		A.disguise(loadout[6], user)
+		A.disguise(loadout["gloves"], user)
 	for(var/obj/item/clothing/mask/chameleon/F in user.get_contents())
 		A = F
-		A.disguise(loadout[7], user)
+		A.disguise(loadout["mask"], user)
 	for(var/obj/item/clothing/glasses/chameleon/F in user.get_contents())
 		A = F
-		A.disguise(loadout[8], user)
+		A.disguise(loadout["glasses"], user)
 	for(var/obj/item/gun/energy/chameleon/F in user.get_contents())
 		A = F
-		A.disguise(loadout[9], user)
+		A.disguise(loadout["gun"], user)
 	for(var/obj/item/device/radio/headset/chameleon/F in user.get_contents())
 		A = F
-		A.disguise(loadout[10], user)
+		A.disguise(loadout["headset"], user)
 
 
 /obj/item/clothing/under/chameleon/ui_interact(mob/user, ui_key, datum/nanoui/ui, force_open, datum/nanoui/master_ui, datum/topic_state/state)
@@ -245,11 +243,12 @@ obj/item/clothing/disguise(newtype, mob/user)
 	for(var/I in loadouts)
 		var/list/S = I
 		for(var/G in S)
-			var/obj/item/copy = new G (null)
+			var/K = S[G]
+			var/obj/item/copy = new K (null)
 			clothes_in_loadout += list(
 				list(
 					"name" = copy.name,
-					"type" = copy.type,
+					"slot" = G,
 					"loadout" = current_loadout
 				)
 			)
@@ -264,19 +263,20 @@ obj/item/clothing/disguise(newtype, mob/user)
 
 /obj/item/clothing/under/chameleon/Topic(href, href_list)
 	var/list/loadouts = list()
+	var/slot
 	loadouts += list(loadout_1, loadout_2, loadout_3, loadout_4)
 	if(href_list["set_clothing_1"])
-		var/chameleontype = href_list["set_clothing_1"]
-		set_single_loadout_slot(chameleontype, loadout_1)
+		slot = href_list["set_clothing_1"]
+		set_single_loadout_slot(slot, loadout_1)
 	if(href_list["set_clothing_2"])
-		var/chameleontype = href_list["set_clothing_2"]
-		set_single_loadout_slot(chameleontype, loadout_2)
+		slot = href_list["set_clothing_2"]
+		set_single_loadout_slot(slot, loadout_2)
 	if(href_list["set_clothing_3"])
-		var/chameleontype = href_list["set_clothing_3"]
-		set_single_loadout_slot(chameleontype, loadout_3)
+		slot = href_list["set_clothing_3"]
+		set_single_loadout_slot(slot, loadout_3)
 	if(href_list["set_clothing_4"])
-		var/chameleontype = href_list["set_clothing_4"]
-		set_single_loadout_slot(chameleontype, loadout_4)
+		slot = href_list["set_clothing_4"]
+		set_single_loadout_slot(slot, loadout_4)
 	SSnano.update_uis(src)
 	..()
 
@@ -293,6 +293,7 @@ obj/item/clothing/disguise(newtype, mob/user)
 	set src in usr.contents
 
 	disguise_as_loadout(usr, loadout_1)
+
 
 /obj/item/clothing/under/chameleon/verb/disguise_as_loadout_2()
 	set name = "Disguise as loadout 2"

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -28,11 +28,18 @@ obj/item/clothing/disguise(newtype, mob/user)
 	if (istype(copy))
 		style_coverage = copy.style_coverage
 
-/proc/generate_chameleon_choices(basetype, blacklist=list())
+/proc/generate_chameleon_choices(basetype)
 	. = list()
 
 	var/i = 1 //in case there is a collision with both name AND icon_state
-	for(var/typepath in typesof(basetype) - blacklist)
+	var/is_item = FALSE
+	if(istype(basetype, /obj/item))
+		is_item = TRUE
+	for(var/typepath in typesof(basetype))
+		if(is_item)
+			var/obj/item/K = typepath
+			if(K.chameleon_slot)
+				return
 		var/obj/O = typepath
 		if(initial(O.icon) && initial(O.icon_state))
 			var/name = initial(O.name)
@@ -50,6 +57,7 @@ obj/item/clothing/disguise(newtype, mob/user)
 	item_state = "bl_suit"
 	spawn_blacklisted = TRUE
 	spawn_tags = SPAWN_TAG_CLOTHING_UNDER_CHAMALEON
+	chameleon_slot = "uniform"
 
 	origin_tech = list(TECH_COVERT = 3)
 	var/global/list/clothing_choices
@@ -130,107 +138,65 @@ obj/item/clothing/disguise(newtype, mob/user)
 //********************************************
 
 /obj/item/clothing/under/chameleon/proc/set_single_loadout_slot(slot, loadout)
-	var/chameleon_choice
+	var/chameleon_choices
 	var/obj/item/item_to_disguise
 	switch(slot)
 		if("uniform")
-			var/obj/item/clothing/under/chameleon/G
-			chameleon_choice = G
-			chameleon_choice = G.clothing_choices
-			item_to_disguise = input("","Choose a disguise") in chameleon_choice
-			loadout["uniform"] = chameleon_choice[item_to_disguise]
+			chameleon_choices = generate_chameleon_choices(/obj/item/clothing/under)
+			item_to_disguise = input("","Choose a disguise") in chameleon_choices
+			loadout["uniform"] = chameleon_choices[item_to_disguise]
 		if("hat")
-			var/obj/item/clothing/head/chameleon/G
-			chameleon_choice = G
-			chameleon_choice = G.clothing_choices
-			item_to_disguise = input("","Choose a disguise") in chameleon_choice
-			loadout["hat"] = chameleon_choice[item_to_disguise]
+			chameleon_choices = generate_chameleon_choices(/obj/item/clothing/head)
+			item_to_disguise = input("","Choose a disguise") in chameleon_choices
+			loadout["hat"] = chameleon_choices[item_to_disguise]
 		if("suit")
-			var/obj/item/clothing/suit/chameleon/G = new /obj/item/clothing/suit/chameleon(null)
-			chameleon_choice = G
-			chameleon_choice = G.clothing_choices
-			item_to_disguise = input("","Choose a disguise") in chameleon_choice
-			loadout["suit"] = chameleon_choice[item_to_disguise]
+			chameleon_choices = generate_chameleon_choices(/obj/item/clothing/suit)
+			item_to_disguise = input("","Choose a disguise") in chameleon_choices
+			loadout["suit"] = chameleon_choices[item_to_disguise]
 		if("shoes")
-			var/obj/item/clothing/shoes/chameleon/G = new /obj/item/clothing/shoes/chameleon(null)
-			chameleon_choice = G
-			chameleon_choice = G.clothing_choices
-			item_to_disguise = input("","Choose a disguise") in chameleon_choice
-			loadout["shoes"] = chameleon_choice[item_to_disguise]
+			chameleon_choices = generate_chameleon_choices(/obj/item/clothing/shoes)
+			item_to_disguise = input("","Choose a disguise") in chameleon_choices
+			loadout["shoes"] = chameleon_choices[item_to_disguise]
 		if("back")
-			var/obj/item/storage/backpack/chameleon/G = new /obj/item/storage/backpack/chameleon(null)
-			chameleon_choice = G
-			chameleon_choice = G.clothing_choices
-			item_to_disguise = input("","Choose a disguise") in chameleon_choice
-			loadout["back"] = chameleon_choice[item_to_disguise]
+			chameleon_choices = generate_chameleon_choices(/obj/item/storage/backpack)
+			item_to_disguise = input("","Choose a disguise") in chameleon_choices
+			loadout["back"] = chameleon_choices[item_to_disguise]
 		if("gloves")
-			var/obj/item/clothing/gloves/chameleon/G = new /obj/item/clothing/gloves/chameleon(null)
-			chameleon_choice = G
-			chameleon_choice = G.clothing_choices
-			item_to_disguise = input("","Choose a disguise") in chameleon_choice
-			loadout["gloves"] = chameleon_choice[item_to_disguise]
-		if("mask")
-			var/obj/item/clothing/mask/chameleon/G = new /obj/item/clothing/mask/chameleon(null)
-			chameleon_choice = G
-			chameleon_choice = G.clothing_choices		
-			item_to_disguise = input("","Choose a disguise") in chameleon_choice
-			loadout["mask"] = chameleon_choice[item_to_disguise]
+			chameleon_choices = generate_chameleon_choices(/obj/item/clothing/gloves)
+			item_to_disguise = input("","Choose a disguise") in chameleon_choices
+			loadout["gloves"] = chameleon_choices[item_to_disguise]
+		if("mask")	
+			chameleon_choices = generate_chameleon_choices(/obj/item/clothing/mask)
+			item_to_disguise = input("","Choose a disguise") in chameleon_choices
+			loadout["mask"] = chameleon_choices[item_to_disguise]
 		if("glasses")
-			var/obj/item/clothing/glasses/chameleon/G = new /obj/item/clothing/glasses/chameleon(null)
-			chameleon_choice = G
-			chameleon_choice = G.clothing_choices
-			item_to_disguise = input("","Choose a disguise") in chameleon_choice
-			loadout["glasses"] = chameleon_choice[item_to_disguise]
+			chameleon_choices = generate_chameleon_choices(/obj/item/clothing/glasses)
+			item_to_disguise = input("","Choose a disguise") in chameleon_choices
+			loadout["glasses"] = chameleon_choices[item_to_disguise]
 		if("gun")
-			var/obj/item/gun/energy/chameleon/G = new /obj/item/gun/energy/chameleon(null)
-			chameleon_choice = G	
-			chameleon_choice = G.gun_choices
-			item_to_disguise = input("","Choose a disguise") in chameleon_choice
-			loadout["gun"] = chameleon_choice[item_to_disguise]
+			chameleon_choices = generate_chameleon_choices(/obj/item/gun)
+			item_to_disguise = input("","Choose a disguise") in chameleon_choices
+			loadout["gun"] = chameleon_choices[item_to_disguise]
 		if("headset")
-			var/obj/item/device/radio/headset/chameleon/G = new /obj/item/device/radio/headset/chameleon(null)
-			chameleon_choice = G	
-			chameleon_choice = G.clothing_choices
-			item_to_disguise = input("","Choose a disguise") in chameleon_choice
-			loadout["headset"] = chameleon_choice[item_to_disguise]
-
+			chameleon_choices = generate_chameleon_choices(/obj/item/device/radio/headset)
+			item_to_disguise = input("","Choose a disguise") in chameleon_choices
+			loadout["headset"] = chameleon_choices[item_to_disguise]
 
 /obj/item/clothing/under/chameleon/proc/disguise_as_loadout(mob/user, loadout)
-	var/obj/item/A
-	for(var/obj/item/clothing/suit/chameleon/F in user.get_contents())
-		A = F
-		A.disguise(loadout["suit"], user)
-	for(var/obj/item/clothing/under/chameleon/F in user.get_contents())
-		A = F
-		A.disguise(loadout["uniform"], user)
-	for(var/obj/item/clothing/head/chameleon/F in user.get_contents())
-		A = F
-		A.disguise(loadout["hat"], user)
-	for(var/obj/item/clothing/shoes/chameleon/F in user.get_contents())
-		A = F
-		A.disguise(loadout["shoes"], user)
-	for(var/obj/item/storage/backpack/chameleon/F in user.get_contents())
-		A = F
-		A.disguise(loadout["back"], user)
-	for(var/obj/item/storage/backpack/satchel/chameleon/F in user.get_contents())
-		A = F
-		A.disguise(loadout["back"], user)
-	for(var/obj/item/clothing/gloves/chameleon/F in user.get_contents())
-		A = F
-		A.disguise(loadout["gloves"], user)
-	for(var/obj/item/clothing/mask/chameleon/F in user.get_contents())
-		A = F
-		A.disguise(loadout["mask"], user)
-	for(var/obj/item/clothing/glasses/chameleon/F in user.get_contents())
-		A = F
-		A.disguise(loadout["glasses"], user)
-	for(var/obj/item/gun/energy/chameleon/F in user.get_contents())
-		A = F
-		A.disguise(loadout["gun"], user)
-	for(var/obj/item/device/radio/headset/chameleon/F in user.get_contents())
-		A = F
-		A.disguise(loadout["headset"], user)
-
+	var/list/user_chameleon_items = list()
+	for(var/obj/item/A in user.get_contents())
+		if(A.chameleon_slot)
+			user_chameleon_items += A
+	var/list/ordered_list = list() //sadly neccessary because the suit and glasses need to be disguised before all other items, otherwise shoes and glasses will appear invisible.
+	for(var/obj/item/I in user_chameleon_items)
+		if(istype(obj/item/clothing/suit/chameleon))
+			ordered_list += I
+		else if(istype(obj/item/clothing/glasses_chameleon))
+			ordered_list += I
+	user_chameleon_items -= ordered_list
+	ordered_list += user_chameleon_items
+	for(var/obj/item/U in ordered_list)
+		disguise(loadout[U.chameleon_slot], user)
 
 /obj/item/clothing/under/chameleon/ui_interact(mob/user, ui_key, datum/nanoui/ui, force_open, datum/nanoui/master_ui, datum/topic_state/state)
 	var/list/data = list()
@@ -329,13 +295,13 @@ obj/item/clothing/disguise(newtype, mob/user)
 	body_parts_covered = 0
 	spawn_blacklisted = TRUE
 	spawn_tags = SPAWN_TAG_CLOTHING_HEAD_CHAMALEON
+	chameleon_slot = "hat"
 	var/global/list/clothing_choices
 
 /obj/item/clothing/head/chameleon/New()
 	..()
 	if(!clothing_choices)
-		var/blocked = list(src.type, /obj/item/clothing/head/justice,)//Prevent infinite loops and bad hats.
-		clothing_choices = generate_chameleon_choices(/obj/item/clothing/head, blocked)
+		clothing_choices = generate_chameleon_choices(/obj/item/clothing/head)
 
 /obj/item/clothing/head/chameleon/Initialize(mapload, ...)
 	. = ..()
@@ -370,13 +336,13 @@ obj/item/clothing/disguise(newtype, mob/user)
 	desc = "It appears to be a vest of standard armor, except this is embedded with a hidden holographic cloaker, allowing it to change it's appearance, but offering no protection.. It seems to have a small dial inside."
 	origin_tech = list(TECH_COVERT = 3)
 	spawn_blacklisted = TRUE
+	chameleon_slot = "suit"
 	var/global/list/clothing_choices
 
 /obj/item/clothing/suit/chameleon/New()
 	..()
 	if(!clothing_choices)
-		var/blocked = list(src.type, null)
-		clothing_choices = generate_chameleon_choices(/obj/item/clothing/suit, blocked)
+		clothing_choices = generate_chameleon_choices(/obj/item/clothing/suit)
 
 /obj/item/clothing/suit/chameleon/Initialize(mapload, ...)
 	. = ..()
@@ -411,13 +377,13 @@ obj/item/clothing/disguise(newtype, mob/user)
 	origin_tech = list(TECH_COVERT = 3)
 	spawn_blacklisted = TRUE
 	spawn_tags = SPAWN_TAG_SHOES_CHAMALEON
+	chameleon_slot = "shoes"
 	var/global/list/clothing_choices
 
 /obj/item/clothing/shoes/chameleon/New()
 	..()
 	if(!clothing_choices)
-		var/blocked = list(src.type, /obj/item/clothing/shoes/syndigaloshes, /obj/item/clothing/shoes/cyborg)//prevent infinite loops and bad shoes.
-		clothing_choices = generate_chameleon_choices(/obj/item/clothing/shoes, blocked)
+		clothing_choices = generate_chameleon_choices(/obj/item/clothing/shoes)
 
 /obj/item/clothing/shoes/chameleon/Initialize(mapload, ...)
 	. = ..()
@@ -454,13 +420,13 @@ obj/item/clothing/disguise(newtype, mob/user)
 	spawn_blacklisted = TRUE
 	spawn_tags = SPAWN_TAG_BACKPACK_CHAMALEON
 	rarity_value = 50
+	chameleon_slot = "back"
 	var/global/list/clothing_choices
 
 /obj/item/storage/backpack/chameleon/New()
 	. = ..()
 	if(!clothing_choices)
-		var/blocked = list(src.type, /obj/item/storage/backpack/satchel/leather/withwallet)
-		clothing_choices = generate_chameleon_choices(/obj/item/storage/backpack, blocked)
+		clothing_choices = generate_chameleon_choices(/obj/item/storage/backpack)
 
 /obj/item/storage/backpack/chameleon/Initialize(mapload, ...)
 	. = ..()
@@ -496,13 +462,13 @@ obj/item/clothing/disguise(newtype, mob/user)
 	spawn_blacklisted = TRUE
 	spawn_tags = SPAWN_TAG_BACKPACK_CHAMALEON
 	rarity_value = 50
+	chameleon_slot = "back"
 	var/global/list/clothing_choices
 
 /obj/item/storage/backpack/satchel/chameleon/New()
 	. = ..()
 	if(!clothing_choices)
-		var/blocked = list(src.type, /obj/item/storage/backpack/satchel/leather/withwallet)
-		clothing_choices = generate_chameleon_choices(/obj/item/storage/backpack, blocked)
+		clothing_choices = generate_chameleon_choices(/obj/item/storage/backpack)
 
 /obj/item/storage/backpack/satchel/chameleon/Initialize(mapload, ...)
 	. = ..()
@@ -539,12 +505,13 @@ obj/item/clothing/disguise(newtype, mob/user)
 	origin_tech = list(TECH_COVERT = 3)
 	spawn_blacklisted = TRUE
 	spawn_tags = SPAWN_TAG_GLOVES_CHAMALEON
+	chameleon_slot = "gloves"
 	var/global/list/clothing_choices
 
 /obj/item/clothing/gloves/chameleon/New()
 	..()
 	if(!clothing_choices)
-		clothing_choices = generate_chameleon_choices(/obj/item/clothing/gloves, list(src.type))
+		clothing_choices = generate_chameleon_choices(/obj/item/clothing/gloves)
 
 /obj/item/clothing/gloves/chameleon/Initialize(mapload, ...)
 	. = ..()
@@ -581,13 +548,14 @@ obj/item/clothing/disguise(newtype, mob/user)
 	spawn_blacklisted = TRUE
 	spawn_tags = SPAWN_TAG_MASK_CONTRABAND
 	flags_inv = HIDEEYES|HIDEFACE
+	chameleon_slot = "mask"
 	var/global/list/clothing_choices
 	style_coverage = COVERS_WHOLE_FACE//default state
 
 /obj/item/clothing/mask/chameleon/New()
 	..()
 	if(!clothing_choices)
-		clothing_choices = generate_chameleon_choices(/obj/item/clothing/mask, list(src.type))
+		clothing_choices = generate_chameleon_choices(/obj/item/clothing/mask)
 
 /obj/item/clothing/mask/chameleon/Initialize(mapload, ...)
 	. = ..()
@@ -623,12 +591,13 @@ obj/item/clothing/disguise(newtype, mob/user)
 	origin_tech = list(TECH_COVERT = 3)
 	spawn_blacklisted = TRUE
 	spawn_tags = SPAWN_TAG_GLASSES_CHAMALEON
+	chameleon_slot = "glasses"
 	var/list/global/clothing_choices
 
 /obj/item/clothing/glasses/chameleon/New()
 	..()
 	if(!clothing_choices)
-		clothing_choices = generate_chameleon_choices(/obj/item/clothing/glasses, list(src.type))
+		clothing_choices = generate_chameleon_choices(/obj/item/clothing/glasses)
 
 /obj/item/clothing/glasses/chameleon/Initialize(mapload, ...)
 	. = ..()
@@ -666,6 +635,7 @@ obj/item/clothing/disguise(newtype, mob/user)
 	rarity_value = 25
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2, TECH_COVERT = 2)
 	matter = list()
+	chameleon_slot = "gun"
 
 	fire_sound = 'sound/weapons/Gunshot.ogg'
 	projectile_type = /obj/item/projectile/chameleon
@@ -742,12 +712,13 @@ obj/item/clothing/disguise(newtype, mob/user)
 	origin_tech = list(TECH_COVERT = 1)
 	spawn_blacklisted = TRUE
 	ks1type = null // No keys pre-installed
+	chameleon_slot = "headset"
 	var/list/global/clothing_choices
 
 /obj/item/device/radio/headset/chameleon/New()
 	..()
 	if(!clothing_choices)
-		clothing_choices = generate_chameleon_choices(/obj/item/device/radio/headset, list(src.type))
+		clothing_choices = generate_chameleon_choices(/obj/item/device/radio/headset)
 
 /obj/item/device/radio/headset/chameleon/emp_act(severity)
 	name = "radio headset"

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -187,6 +187,7 @@ obj/item/clothing/disguise(newtype, mob/user)
 	for(var/obj/item/A in user.get_contents())
 		if(A.chameleon_slot)
 			user_chameleon_items += A
+
 	for(var/obj/item/I in user_chameleon_items)
 		I.disguise(loadout[I.chameleon_slot], user)
 

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -193,20 +193,18 @@ obj/item/clothing/disguise(newtype, mob/user)
 /obj/item/clothing/under/chameleon/ui_interact(mob/user, ui_key, datum/nanoui/ui, force_open, datum/nanoui/master_ui, datum/topic_state/state)
 	var/list/data = list()
 
-	var/list/loadouts = list()
-	loadouts += list(loadout_1, loadout_2, loadout_3, loadout_4)
-
+	var/list/loadouts = list(loadout_1, loadout_2, loadout_3, loadout_4)
 	var/list/clothes_in_loadout = list()
+
 	var/current_loadout = 1
-	for(var/I in loadouts)
-		var/list/S = I
-		for(var/G in S)
-			var/K = S[G]
+	for(var/list/loadout in loadouts)
+		for(var/slot in loadout)
+			var/K = loadout[slot]
 			var/obj/item/copy = new K (null)
 			clothes_in_loadout += list(
 				list(
 					"name" = copy.name,
-					"slot" = G,
+					"slot" = slot,
 					"loadout" = current_loadout
 				)
 			)

--- a/nano/templates/chameleon.tmpl
+++ b/nano/templates/chameleon.tmpl
@@ -1,0 +1,52 @@
+<!-- 
+Used In File(s): code/modules/clothing/chameleon.dm
+ -->
+{{:helper.syndicateMode()}}
+<table class='itemContent' style="width: 25%;">
+	<tr>
+		<td><b>Loadout 1</b></td>
+	</tr>
+	{{for data.clothes_in_loadout}}
+		{{if value.loadout == 1}}
+			<tr>
+			<td>{{:helper.link(value.name, 'circle-arrow-s', {'set_clothing_1' : value.type})}}</td>
+			</tr>
+		{{/if}}	
+	{{/for}}
+</table>
+<table class='itemContent' style="width: 25%;">
+	<tr>
+		<td><b>Loadout 2</b></td>
+	</tr>
+	{{for data.clothes_in_loadout}}
+		{{if value.loadout == 2}}
+			<tr>
+			<td>{{:helper.link(value.name, 'circle-arrow-s', {'set_clothing_2' : value.type})}}</td>
+			</tr>
+		{{/if}}	
+	{{/for}}
+</table>
+<table class='itemContent' style="width: 25%;">
+	<tr>
+		<td><b>Loadout 3</b></td>
+	</tr>
+	{{for data.clothes_in_loadout}}
+		{{if value.loadout == 3}}
+			<tr>
+			<td>{{:helper.link(value.name, 'circle-arrow-s', {'set_clothing_3' : value.type})}}</td>
+			</tr>
+		{{/if}}	
+	{{/for}}
+</table>
+<table class='itemContent' style="width: 25%;">
+	<tr>
+		<td><b>Loadout 4</b></td>
+	</tr>
+	{{for data.clothes_in_loadout}}
+		{{if value.loadout == 4}}
+			<tr>
+			<td>{{:helper.link(value.name, 'circle-arrow-s', {'set_clothing_4' : value.type})}}</td>
+			</tr>
+		{{/if}}	
+	{{/for}}
+</table>

--- a/nano/templates/chameleon.tmpl
+++ b/nano/templates/chameleon.tmpl
@@ -9,7 +9,7 @@ Used In File(s): code/modules/clothing/chameleon.dm
 	{{for data.clothes_in_loadout}}
 		{{if value.loadout == 1}}
 			<tr>
-			<td>{{:helper.link(value.name, 'circle-arrow-s', {'set_clothing_1' : value.type})}}</td>
+			<td>{{:helper.link(value.name, 'circle-arrow-s', {'set_clothing_1' : value.slot})}}</td>
 			</tr>
 		{{/if}}	
 	{{/for}}
@@ -21,7 +21,7 @@ Used In File(s): code/modules/clothing/chameleon.dm
 	{{for data.clothes_in_loadout}}
 		{{if value.loadout == 2}}
 			<tr>
-			<td>{{:helper.link(value.name, 'circle-arrow-s', {'set_clothing_2' : value.type})}}</td>
+			<td>{{:helper.link(value.name, 'circle-arrow-s', {'set_clothing_2' : value.slot})}}</td>
 			</tr>
 		{{/if}}	
 	{{/for}}
@@ -33,7 +33,7 @@ Used In File(s): code/modules/clothing/chameleon.dm
 	{{for data.clothes_in_loadout}}
 		{{if value.loadout == 3}}
 			<tr>
-			<td>{{:helper.link(value.name, 'circle-arrow-s', {'set_clothing_3' : value.type})}}</td>
+			<td>{{:helper.link(value.name, 'circle-arrow-s', {'set_clothing_3' : value.slot})}}</td>
 			</tr>
 		{{/if}}	
 	{{/for}}
@@ -45,7 +45,7 @@ Used In File(s): code/modules/clothing/chameleon.dm
 	{{for data.clothes_in_loadout}}
 		{{if value.loadout == 4}}
 			<tr>
-			<td>{{:helper.link(value.name, 'circle-arrow-s', {'set_clothing_4' : value.type})}}</td>
+			<td>{{:helper.link(value.name, 'circle-arrow-s', {'set_clothing_4' : value.slot})}}</td>
 			</tr>
 		{{/if}}	
 	{{/for}}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://github.com/discordia-space/CEV-Eris/pull/7072
but doesn't cause warnings anymore (the horror!)

now ~~marginally~~ much less convoluted as well, thanks to Kirov.
Also cleans up some chameleon clothing items in general and removed some things you can't disguise chameleon items as.

## Why It's Good For The Game

ask nestor

## Changelog
:cl:
add: added the ability to quickly switch between different loadouts for chameleon clothes if the chameleon jumpsuit is worn.
add: Added the chameleon satchel
fix: chameleon items will no longer block other clothing sprites from appearing when they weren't supposed to
tweak: chameleon clothes are now made of plastic instead of bioatter
tweak: removed some things you can't disguise chameleon items as.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
