### PR TITLE
Adds special overdose effects for tricordazine , bicardine and dylovene

### DIFF
--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -41,6 +41,25 @@
 	M.heal_organ_damage(0.6 * effect_multiplier, 0, 5 * effect_multiplier)
 	M.add_chemical_effect(CE_BLOODCLOT, 0.15)
 
+/datum/reagent/medicine/bicaridine/overdose(mob/living/carbon/human/user, alien)
+	var/obj/item/organ/internal/muscle/pain = user.random_organ_by_process(OP_MUSCLE)
+	var/obj/item/organ/internal/nerve/pain2 = user.random_organ_by_process(OP_NERVE)
+	if(!pain)
+		return FALSE
+	pain.take_damage(round(volume/6))
+	if(!pain2)
+		return FALSE
+	pain2.take_damage(round(volume/6))
+	if(prob(3))
+		to_chat(user, span_danger("Your muscles ache with agonizing pain!"))
+		user.Weaken(2)
+	if(volume > 100 && prob(1))
+		var/obj/item/organ/internal/heart/powergamer_curbstomp = user.random_organ_by_process(OP_HEART)
+		if(!powergamer_curbstomp || BP_IS_ROBOTIC(powergamer_curbstomp))
+			return FALSE
+		to_chat(user, span_danger("You feel like your heart just exploded!"))
+		powergamer_curbstomp.take_damage(powergamer_curbstomp.health)
+
 /datum/reagent/medicine/meralyne
 	name = "Meralyne"
 	id = "meralyne"
@@ -99,6 +118,15 @@
 	holder.remove_reagent("pararein", 0.2 )
 	holder.remove_reagent("blattedin", 0.2 )
 
+/datum/reagent/medicine/dylovene/overdose(mob/living/carbon/human/user, alien)
+	var/obj/item/organ/internal/blood_vessel/pain = user.random_organ_by_process(OP_BLOOD_VESSEL)
+	if(!pain)
+		return FALSE
+	pain.take_damage(round(volume/10)) // 5 out of 100 at 60 units
+	if(prob(1))
+		to_chat(user, "You feel a sharp pain in your chest")
+
+
 /datum/reagent/medicine/dexalin
 	name = "Dexalin"
 	id = "dexalin"
@@ -147,6 +175,20 @@
 	M.heal_organ_damage(0.3 * effect_multiplier, 0.3 * effect_multiplier)
 	M.adjustToxLoss(-0.3 * effect_multiplier)
 	M.add_chemical_effect(CE_BLOODCLOT, 0.1)
+
+/datum/reagent/medicine/tricordrazine/overdose(mob/living/carbon/human/user, alien)
+	var/obj/item/organ/internal/liver/pain = user.random_organ_by_process(OP_LIVER)
+	if(!pain)
+		return FALSE
+	pain.take_damage(round(volume/12)) // 5 out of 100 at 60 units
+	// For those special people
+	if(volume > 300 && prob(10))
+		var/obj/item/organ/internal/blood_vessel/suffer = user.random_organ_by_process(OP_BLOOD_VESSEL)
+		if(!suffer)
+			return FALSE
+		to_chat(user, "You feel intense swelling in your [suffer.loc?.name] , and you notice it going numb and red!")
+		user.AdjustParalysis(5)
+		suffer.take_damage(suffer.health)
 
 /datum/reagent/medicine/cryoxadone
 	name = "Cryoxadone"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds special overdose effects for tricord,  bicardine and dylo
tricord > take  scaling liver damage with amount , if units > 300, have a chance to get paralysed and for blood vessels to burst
bicardine > take scaling muscle and nerve damage , if units > 100 , have a very small chance to have your heart explode
dylovene > scaling  blood vessel damage
## Why It's Good For The Game
People commonly tend to pump themselves copious amounts of these reagents before long engagements . They should pay attention to dossages.
## Changelog
:cl:
balance:Tricordazine , bicardine and dylovene now have far stronger overdose effects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
