### PR TITLE
Adds a few additional Noble options

### DIFF
--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -135,10 +135,25 @@
 		holder.stats.removePerk(src.type)
 		return
 	var/turf/T = get_turf(holder)
-	var/obj/item/W = pickweight(list(
+	var/obj/item/W = null
+	if(holder.get_core_implant(/obj/item/implant/core_implant/cruciform))
+		W = pickweight(list(
+				/obj/item/tool/sword/nt/longsword = 0.5,
+				/obj/item/tool/sword/nt/shortsword = 0.5,
+				/obj/item/tool/sword/nt/scourge = 0.1,
+				/obj/item/tool/knife/dagger/nt = 0.8,
+				/obj/item/gun/energy/nt_svalinn = 0.4,
+				/obj/item/gun/energy/stunrevolver/real = 0.1))
+	else
+		W = pickweight(list(
 				/obj/item/tool/knife/ritual = 0.5,
+				/obj/item/tool/knife/switchblade = 0.5,
 				/obj/item/tool/sword = 0.2,
 				/obj/item/tool/sword/katana = 0.2,
+				/obj/item/tool/sword/saber/real = 0.1,
+				/obj/item/tool/knife/dagger = 0.8,
+				/obj/item/gun/projectile/colt/real = 0.1,
+				/obj/item/gun/projectile/revolver/havelock/real = 0.1,
 				/obj/item/tool/knife/dagger/ceremonial = 0.8,
 				/obj/item/gun/projectile/revolver = 0.4))
 	holder.sanity.valid_inspirations += W

--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -136,12 +136,12 @@
 		return
 	var/turf/T = get_turf(holder)
 	var/obj/item/W = null
-	if(is_neotheology_disciple(holder))
+	if(is_neotheology_disciple(holder) && prob(50))
 		W = pickweight(list(
 				/obj/item/tool/sword/nt/longsword = 0.5,
 				/obj/item/tool/sword/nt/shortsword = 0.5,
 				/obj/item/tool/sword/nt/scourge = 0.1,
-				/obj/item/tool/knife/dagger/nt = 0.8,
+				/obj/item/tool/knife/dagger/nt = 0.6,
 				/obj/item/gun/energy/nt_svalinn = 0.4,
 				/obj/item/gun/energy/stunrevolver/relic = 0.1))
 	else
@@ -151,14 +151,15 @@
 				/obj/item/tool/sword = 0.2,
 				/obj/item/tool/sword/katana = 0.2,
 				/obj/item/tool/sword/saber/relic = 0.1,
-				/obj/item/tool/knife/dagger = 0.8,
+				/obj/item/tool/knife/dagger = 0.6,
 				/obj/item/gun/projectile/colt/relic = 0.1,
 				/obj/item/gun/projectile/revolver/havelock/relic = 0.1,
-				/obj/item/tool/knife/dagger/ceremonial = 0.8,
+				/obj/item/tool/knife/dagger/ceremonial = 0.6,
 				/obj/item/gun/projectile/revolver = 0.4))
 	holder.sanity.valid_inspirations += W
 	W = new W(T)
 	W.desc += " It has been inscribed with the \"[holder.last_name]\" family name."
+	W.name = "[W] of [holder.last_name]"
 	var/oddities = rand(2,4)
 	var/list/stats = ALL_STATS
 	var/list/final_oddity = list()

--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -136,7 +136,7 @@
 		return
 	var/turf/T = get_turf(holder)
 	var/obj/item/W = null
-	if(holder.get_core_implant(/obj/item/implant/core_implant/cruciform))
+	if(is_neotheology_disciple(holder))
 		W = pickweight(list(
 				/obj/item/tool/sword/nt/longsword = 0.5,
 				/obj/item/tool/sword/nt/shortsword = 0.5,

--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -143,17 +143,17 @@
 				/obj/item/tool/sword/nt/scourge = 0.1,
 				/obj/item/tool/knife/dagger/nt = 0.8,
 				/obj/item/gun/energy/nt_svalinn = 0.4,
-				/obj/item/gun/energy/stunrevolver/real = 0.1))
+				/obj/item/gun/energy/stunrevolver/relic = 0.1))
 	else
 		W = pickweight(list(
 				/obj/item/tool/knife/ritual = 0.5,
 				/obj/item/tool/knife/switchblade = 0.5,
 				/obj/item/tool/sword = 0.2,
 				/obj/item/tool/sword/katana = 0.2,
-				/obj/item/tool/sword/saber/real = 0.1,
+				/obj/item/tool/sword/saber/relic = 0.1,
 				/obj/item/tool/knife/dagger = 0.8,
-				/obj/item/gun/projectile/colt/real = 0.1,
-				/obj/item/gun/projectile/revolver/havelock/real = 0.1,
+				/obj/item/gun/projectile/colt/relic = 0.1,
+				/obj/item/gun/projectile/revolver/havelock/relic = 0.1,
 				/obj/item/tool/knife/dagger/ceremonial = 0.8,
 				/obj/item/gun/projectile/revolver = 0.4))
 	holder.sanity.valid_inspirations += W

--- a/code/datums/setup_option/backgrounds/fate.dm
+++ b/code/datums/setup_option/backgrounds/fate.dm
@@ -67,7 +67,7 @@
 	desc = "You are a descendant of a long-lasting family, being part of a lineage of high status that can be traced back to the early civilization of your domain. \
 			What legacy will you build? \
 			Start with an heirloom weapon, higher chance to be on contractor contracts and removed sanity cap. Stay clear of filth and danger."
-			
+
 	perks = list(PERK_NOBLE)
 
 /datum/category_item/setup_option/background/fate/rat

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -151,6 +151,15 @@
 	spawn_blacklisted = TRUE
 	price_tag = 10000
 
+/obj/item/tool/sword/saber/real
+	name = "traditional officer's saber"
+	desc = "A well-decorated steel saber with golden grip, made with traditional techniques in some bygone age."
+	matter = list(MATERIAL_STEEL = 15, MATERIAL_WOOD = 10, MATERIAL_GOLD = 10)
+	spawn_blacklisted = TRUE
+	price_tag = 4500
+	force = WEAPON_FORCE_DANGEROUS
+	armor_penetration = ARMOR_PEN_SHALLOW * 1.5
+
 /obj/item/tool/sword/improvised
 	name = "junkblade"
 	desc = "Hack and slash!"
@@ -211,6 +220,21 @@
 		overlays += "[icon_state]_power_on"
 	else
 		overlays += "[icon_state]_power_off"
+
+/obj/item/tool/sword/katana/real
+	name = "traditional katana"
+	desc = "An ancient single-edged straight sword forged in fuedal japan. Or at a 21st century replica shop. Either way, it's been created with folding techniques now lost to time."
+	icon_state = "katana"
+	item_state = "katana"
+	matter = list(MATERIAL_STEEL = 10, MATERIAL_WOOD = 2, MATERIAL_IRON = 2)
+	force = WEAPON_FORCE_ROBUST
+	armor_penetration = NONE//true katanas struggle even to cut through thick clothing
+	rarity_value = 75
+	spawn_blacklisted = TRUE
+	price_tag = 4500
+	max_health = 250
+	health_threshold = NONE
+	style = STYLE_HIGH + 1//a weapon wielded only by the deeply deranged and yakuza(not mutally exclusive)
 
 //Flails
 /obj/item/tool/chainofcommand

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -151,7 +151,7 @@
 	spawn_blacklisted = TRUE
 	price_tag = 10000
 
-/obj/item/tool/sword/saber/real
+/obj/item/tool/sword/saber/relic
 	name = "traditional officer's saber"
 	desc = "A well-decorated steel saber with golden grip, made with traditional techniques in some bygone age."
 	matter = list(MATERIAL_STEEL = 15, MATERIAL_WOOD = 10, MATERIAL_GOLD = 10)
@@ -220,21 +220,6 @@
 		overlays += "[icon_state]_power_on"
 	else
 		overlays += "[icon_state]_power_off"
-
-/obj/item/tool/sword/katana/real
-	name = "traditional katana"
-	desc = "An ancient single-edged straight sword forged in fuedal japan. Or at a 21st century replica shop. Either way, it's been created with folding techniques now lost to time."
-	icon_state = "katana"
-	item_state = "katana"
-	matter = list(MATERIAL_STEEL = 10, MATERIAL_WOOD = 2, MATERIAL_IRON = 2)
-	force = WEAPON_FORCE_ROBUST
-	armor_penetration = NONE//true katanas struggle even to cut through thick clothing
-	rarity_value = 75
-	spawn_blacklisted = TRUE
-	price_tag = 4500
-	max_health = 250
-	health_threshold = NONE
-	style = STYLE_HIGH + 1//a weapon wielded only by the deeply deranged and yakuza(not mutally exclusive)
 
 //Flails
 /obj/item/tool/chainofcommand

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -155,10 +155,8 @@
 	name = "traditional officer's saber"
 	desc = "A well-decorated steel saber with golden grip, made with traditional techniques in some bygone age."
 	matter = list(MATERIAL_STEEL = 15, MATERIAL_WOOD = 10, MATERIAL_GOLD = 10)
-	spawn_blacklisted = TRUE
 	price_tag = 4500
 	force = WEAPON_FORCE_DANGEROUS
-	armor_penetration = ARMOR_PEN_SHALLOW * 1.5
 
 /obj/item/tool/sword/improvised
 	name = "junkblade"

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -46,7 +46,7 @@
 	icon = 'icons/obj/guns/energy/stunrevolver_moebius.dmi'
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_STEEL = 6, MATERIAL_SILVER = 2, MATERIAL_PLASTIC = 5)
 
-/obj/item/gun/energy/stunrevolver/real
+/obj/item/gun/energy/stunrevolver/relic
 	name = "Nanotrasen \"Zeus\" Prototype"
 	desc = "A \"stun-revolver\" design produced in Nanotrasen's early weapons program. This rare antique comes from the weapon's limited preproduction run, during which it contained a prototype self-charging system."
 	self_recharge = TRUE

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -41,7 +41,18 @@
 	projectile_type = /obj/item/projectile/energy/electrode
 
 /obj/item/gun/energy/stunrevolver/moebius
-	name = "Moebius SP \"Suez\""	//Ersatz name 
+	name = "Moebius SP \"Suez\""	//Ersatz name
 	desc = "Also know as stunrevolver. A Moebius copy of the older and less precise Nanotrasen solution for non-lethal takedowns. This gun has smaller capacity in exchange for S-cells use."
 	icon = 'icons/obj/guns/energy/stunrevolver_moebius.dmi'
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_STEEL = 6, MATERIAL_SILVER = 2, MATERIAL_PLASTIC = 5)
+
+/obj/item/gun/energy/stunrevolver/real
+	name = "Nanotrasen \"Zeus\" Prototype"
+	desc = "A \"stun-revolver\" design produced in Nanotrasen's early weapons program. This rare antique comes from the weapon's limited preproduction run, during which it contained a prototype self-charging system."
+	self_recharge = TRUE
+	charge_cost = 75
+	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_STEEL = 6, MATERIAL_SILVER = 3, MATERIAL_URANIUM = 2)
+	price_tag = 6500
+	spawn_blacklisted = TRUE
+	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 3, TECH_POWER = 7)
+

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -47,12 +47,11 @@
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_STEEL = 6, MATERIAL_SILVER = 2, MATERIAL_PLASTIC = 5)
 
 /obj/item/gun/energy/stunrevolver/relic
-	name = "Nanotrasen \"Zeus\" Prototype"
+	name = "NanoTrasen \"Zeus\" Prototype"
 	desc = "A \"stun-revolver\" design produced in Nanotrasen's early weapons program. This rare antique comes from the weapon's limited preproduction run, during which it contained a prototype self-charging system at the cost of some of the weapon's capacitors."
 	self_recharge = TRUE
-	charge_cost = 120
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_STEEL = 6, MATERIAL_SILVER = 3, MATERIAL_URANIUM = 2)
 	price_tag = 4500
 	spawn_blacklisted = TRUE
-	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 3, TECH_POWER = 5)
+	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 3, TECH_POWER = 5)	
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -48,11 +48,11 @@
 
 /obj/item/gun/energy/stunrevolver/relic
 	name = "Nanotrasen \"Zeus\" Prototype"
-	desc = "A \"stun-revolver\" design produced in Nanotrasen's early weapons program. This rare antique comes from the weapon's limited preproduction run, during which it contained a prototype self-charging system."
+	desc = "A \"stun-revolver\" design produced in Nanotrasen's early weapons program. This rare antique comes from the weapon's limited preproduction run, during which it contained a prototype self-charging system at the cost of some of the weapon's capacitors."
 	self_recharge = TRUE
-	charge_cost = 75
+	charge_cost = 120
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_STEEL = 6, MATERIAL_SILVER = 3, MATERIAL_URANIUM = 2)
-	price_tag = 6500
+	price_tag = 4500
 	spawn_blacklisted = TRUE
-	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 3, TECH_POWER = 7)
+	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 3, TECH_POWER = 5)
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -47,7 +47,7 @@
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_STEEL = 6, MATERIAL_SILVER = 2, MATERIAL_PLASTIC = 5)
 
 /obj/item/gun/energy/stunrevolver/relic
-	name = "NanoTrasen \"Zeus\" Prototype"
+	name = "NT SP \"Zeus\" Prototype"
 	desc = "A \"stun-revolver\" design produced in Nanotrasen's early weapons program. This rare antique comes from the weapon's limited preproduction run, during which it contained a prototype self-charging system at the cost of some of the weapon's capacitors."
 	self_recharge = TRUE
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_STEEL = 6, MATERIAL_SILVER = 3, MATERIAL_URANIUM = 2)

--- a/code/modules/projectiles/guns/projectile/pistol/colt.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/colt.dm
@@ -47,7 +47,7 @@
 	mechanism = /obj/item/part/gun/mechanism/pistol
 	barrel = /obj/item/part/gun/barrel/pistol
 
-/obj/item/gun/projectile/colt/real
+/obj/item/gun/projectile/colt/relic
 	name = "Colt \"M1911\" Pistol"
 	desc = "An authentic Colt M1911 army standard. Appears to have been lightly modified with Frozen Star components to take more accessible .35 rounds."
 	origin_tech = list(TECH_COMBAT = 3)

--- a/code/modules/projectiles/guns/projectile/pistol/colt.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/colt.dm
@@ -46,3 +46,11 @@
 	grip = /obj/item/part/gun/grip/wood
 	mechanism = /obj/item/part/gun/mechanism/pistol
 	barrel = /obj/item/part/gun/barrel/pistol
+
+/obj/item/gun/projectile/colt/real
+	name = "Colt \"M1911\" Pistol"
+	desc = "An authentic Colt M1911 army standard. Appears to have been lightly modified with Frozen Star components to take more accessible .35 rounds."
+	origin_tech = list(TECH_COMBAT = 3)
+	matter = list(MATERIAL_STEEL = 11, MATERIAL_PLASTEEL = 1, MATERIAL_WOOD = 6)
+	spawn_blacklisted = TRUE
+	recoil_buildup = 6

--- a/code/modules/projectiles/guns/projectile/revolver/havelock.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/havelock.dm
@@ -27,4 +27,16 @@
 	result = /obj/item/gun/projectile/revolver/havelock
 	grip = /obj/item/part/gun/grip/wood
 	mechanism = /obj/item/part/gun/mechanism/revolver
-	barrel = /obj/item/part/gun/barrel/pistol 
+	barrel = /obj/item/part/gun/barrel/pistol
+
+/obj/item/gun/projectile/revolver/havelock/real
+	name = "S&W .35 \"Model 10\""
+	desc = "An authentic Smith & Wesson six-shooter, clearly grandfathered in from a more civilized age. Feels considerably heavier then modern plasteel gunworks."
+	price_tag = 4500
+	damage_multiplier = 1.6
+	penetration_multiplier = 1.6
+	recoil_buildup = 6
+	matter = list(MATERIAL_IRON = 12, MATERIAL_WOOD = 6)//you barbarian
+	origin_tech = list()
+	force = WEAPON_FORCE_ROBUST//heavier makes better pistol whipping
+	spawn_blacklisted = TRUE

--- a/code/modules/projectiles/guns/projectile/revolver/havelock.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/havelock.dm
@@ -29,7 +29,7 @@
 	mechanism = /obj/item/part/gun/mechanism/revolver
 	barrel = /obj/item/part/gun/barrel/pistol
 
-/obj/item/gun/projectile/revolver/havelock/real
+/obj/item/gun/projectile/revolver/havelock/relic
 	name = "S&W .35 \"Model 10\""
 	desc = "An authentic Smith & Wesson six-shooter, clearly grandfathered in from a more civilized age. Feels considerably heavier then modern plasteel gunworks."
 	price_tag = 4500

--- a/code/modules/projectiles/guns/projectile/revolver/havelock.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/havelock.dm
@@ -33,10 +33,10 @@
 	name = "S&W .35 \"Model 10\""
 	desc = "An authentic Smith & Wesson six-shooter, clearly grandfathered in from a more civilized age. Feels considerably heavier then modern plasteel gunworks."
 	price_tag = 4500
-	damage_multiplier = 1.6
-	penetration_multiplier = 1.6
+	damage_multiplier = 1.5
+	penetration_multiplier = 1.2
 	recoil_buildup = 6
 	matter = list(MATERIAL_IRON = 12, MATERIAL_WOOD = 6)//you barbarian
 	origin_tech = list()
-	force = WEAPON_FORCE_ROBUST//heavier makes better pistol whipping
+	force = WEAPON_FORCE_PAINFUL//heavier makes better pistol whipping
 	spawn_blacklisted = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a "the (item) of (family)" name framework to noble oddities.
Adds more possible options to noble weapon spawns.
Adds a few "relic" item variants, which are expensive, authentic old-world objects. Nobles can rarely carry these.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Neotheologists who choose noble may get an NT weapon.

## Why It's Good For The Game

You WILL steal a noble's shitty ceremonial sword and sell it on the black market
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new options to the Noble oddity table. Neotheologists who choose noble have a chance at aquiring an NT-themed weapon
add: Added "relic" item variants, for the Noble oddities
add: noble oddity names now contain the family line of the owner
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
