### PR TITLE
Carrion bug fix

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -5,7 +5,7 @@
 	. = FALSE
 	..()
 	if(config.enable_mob_sleep)
-		if(stat != DEAD)
+		if(stat != DEAD && !mind)	// Check for mind so player-driven, nonhuman mobs don't sleep
 			if(life_cycles_before_scan > 0)
 				life_cycles_before_scan--
 			else

--- a/code/modules/mob/living/simple_animal/spider_core.dm
+++ b/code/modules/mob/living/simple_animal/spider_core.dm
@@ -9,7 +9,7 @@
 
 	health = 60
 	maxHealth = 60 //Same as post nerf blitz hp
-	var/time_to_generate_body = 69 SECONDS		// Should be longer than the time it takes for the core to die in a vacuum. See New() for longer explanation.
+	var/time_to_generate_body = 66 SECONDS		// Should be longer than the time it takes for the core to die in a vacuum. Adjust accordingly when maxHealth changes (as of March 27 2022, it's 1 damage per second).
 
 	speed = -1
 	see_in_dark = 8
@@ -32,12 +32,6 @@
 	verbs |= /mob/living/proc/ventcrawl
 	verbs |= /mob/living/proc/hide
 	verbs |= /mob/living/simple_animal/spider_core/proc/generate_body
-
-	// If the spider core can generate a new body before the weakest environmental effect can kill it, a player can generate an indefinite number of bodies and grief the server.
-	// This approximates the time it would take for the core to die and adds 10%. Assuming everything works as intended, the core should die before a new body can be made.
-	var/seconds_per_tick = SSmobs.wait / (1 SECONDS)
-	var/time_extension_mult = 1.1
-	time_to_generate_body = ( maxHealth * (min(unsuitable_atoms_damage, heat_damage_per_tick, cold_damage_per_tick) / seconds_per_tick) ) * time_extension_mult SECONDS
 
 /mob/living/simple_animal/spider_core/death()
 	gibs(loc, null, /obj/effect/gibspawner/generic, "#666600", "#666600")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes some unintended behavior in the living Life() proc where player-controlled nonhuman mobs would sleep, preventing environmental effects among others from being applied. So, carrion spider cores will no longer be able to survive indefinitely in space. Also, the spider core would die in roughly 60 seconds in a vacuum if it was at 100%., which is about the time it takes to create a new body. The timer was changed to 66 seconds.

## Why It's Good For The Game

Removes abusable behavior.

## Changelog
:cl:
tweak: added mind check to living Life() sleep check logic
balance: slightly extends the generate_body() timer to 66 seconds from 60
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
