### PR TITLE
No more on demand ship melting plants

### DIFF
--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -144,7 +144,7 @@
 	seed_name = "death nettle"
 	display_name = "death nettles"
 	mutants = null
-	chems = list("nutriment" = list(1,50), "zombiepowder" = list(0,1))
+	chems = list("nutriment" = list(1,50), "toxin" = list(0,1))
 	kitchen_tag = "deathnettle"
 
 /datum/seed/nettle/death/New()

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -123,7 +123,7 @@
 	seed_name = "nettle"
 	display_name = "nettles"
 	mutants = list("deathnettle")
-	chems = list("nutriment" = list(1,50), "sacid" = list(0,1))
+	chems = list("nutriment" = list(1,50), "tricordrazine" = list(1,5))
 	kitchen_tag = "nettle"
 	kitchen_tag = "nettle"
 
@@ -144,7 +144,7 @@
 	seed_name = "death nettle"
 	display_name = "death nettles"
 	mutants = null
-	chems = list("nutriment" = list(1,50), "pacid" = list(0,1))
+	chems = list("nutriment" = list(1,50), "zombiepowder" = list(0,1))
 	kitchen_tag = "deathnettle"
 
 /datum/seed/nettle/death/New()


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes ship melting plant combinations from being so easy to obtain. No you need to roll a ~3% chance for a maint shroom to have it if you want to be THAT guy.


## Why It's Good For The Game

Before you can walk into NT hydroponics and make a ship melter in 3 minutes tops. Now you need a large amount of luck and be actively searching for maint shrooms that have it. There is already a large chance for zombie powder in strange plants so this doesnt really buff anything. 

## Changelog
:cl:
tweak: Changed nettle and death nettle chems to prevent easy ship melting strategies
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
