### PR TITLE
Uranium Solidification Changes

### DIFF
--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -611,7 +611,7 @@
 
 /datum/chemical_reaction/uraniumsolidification
 	result = null
-	required_reagents = list("iron" = 5, "frostoil" = 5, "uranium" = 20)
+	required_reagents = list("aluminum" = 5, "frostoil" = 10, "uranium" = 20)
 	result_amount = 1
 
 /datum/chemical_reaction/uraniumsolidification/on_reaction(var/datum/reagents/holder, var/created_volume)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You were right I was wrong. The Iron recipe wiped out the extra uranium, by putting it inside you. You couldnt help but get irradiated while doing that recipe. Even when wearing a hazard void I was still getting radiation. No idea how or what was happening but it was painful.

## Why It's Good For The Game

No need for constant rad chems to do this, and its less tedious as well

## Changelog
:cl:
fix: made a better uranium solidification recipe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
