### PR TITLE
EOTP adjustment

### DIFF
--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -28,10 +28,10 @@ var/global/obj/machinery/power/eotp/eotp
 
 
 	var/list/mob/living/carbon/human/scanned = list()
-	var/max_power = 100
+	var/max_power = 120
 	var/power = 0
 	var/power_gaine = 2
-	var/max_observation = 800
+	var/max_observation = 1800
 	var/observation = 0
 	var/min_observation = -100
 
@@ -54,8 +54,6 @@ var/global/obj/machinery/power/eotp/eotp
 	for(var/arm in arm_paths)
 		armaments += new arm
 
-
-
 /obj/machinery/power/eotp/examine(user)
 	..()
 
@@ -72,8 +70,6 @@ var/global/obj/machinery/power/eotp/eotp
 	..()
 	if(stat)
 		return
-
-	updateObservation()
 
 	if(world.time >= (last_rescan + rescan_cooldown) && length(scanned))
 		var/mob/living/carbon/human/H = pick(scanned)
@@ -104,15 +100,8 @@ var/global/obj/machinery/power/eotp/eotp
 	observation -= number
 	return observation
 
-/obj/machinery/power/eotp/proc/updateObservation()
-	if(observation > max_observation)
-		observation = max_observation
-
-	if(observation < min_observation)
-		observation = min_observation
-
 /obj/machinery/power/eotp/proc/updatePower()
-	power_gaine = initial(power_gaine) + (observation / 100)
+	power_gaine = initial(power_gaine) + (CLAMP(observation, min_observation, max_observation) / 100)
 
 	if(world.time >= (last_power_update + power_cooldown))
 		power += power_gaine

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -522,10 +522,10 @@
 		if(target.wearer && target.wearer.stat != DEAD)
 			return target
 
-/datum/ritual/cruciform/priest/buy_item
+/datum/ritual/cruciform/priest/acolyte/buy_item
 	name = "Order armaments"
 	phrase = "Et qui non habet, vendat tunicam suam et emat gladium."
-	desc = "Allows you to spend a point to unlock a NT disk."
+	desc = "Allows you to spend armament points to unlock a NT disk."
 	success_message = "Your prayers have been heard."
 	fail_message = "Your prayers have not been answered."
 	power = 20

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -530,7 +530,7 @@
 	fail_message = "Your prayers have not been answered."
 	power = 20
 
-/datum/ritual/cruciform/priest/buy_item/perform(mob/living/carbon/human/H, obj/item/implant/core_implant/C, targets)
+/datum/ritual/cruciform/priest/acolyte/buy_item/perform(mob/living/carbon/human/H, obj/item/implant/core_implant/C, targets)
 	var/list/OBJS = get_front(H)
 
 	var/obj/machinery/power/eotp/EOTP = locate(/obj/machinery/power/eotp) in OBJS


### PR DESCRIPTION
## About The Pull Request

The EOTP's observation limit was raised by 125% (from 800 to 1800)
As a result, maximum power gain rate has been doubled.

To offset this, now it requires 20% more power to release a miracle:
This means a maximum of 66% increase to miracles.
This however also means a slower roundstart power gain rate.

The logic for calculating observation was changed, up until now a bug prevented observation to ever reach maximum, as periodically it would lose 20 observation from updating.

Observation can now increase without limit, but its effects are capped at the maximum instead, allowing lategame church to secure observation gain more reliably.

The armament litany can now be casted by acolytes.

## Why It's Good For The Game

EOTP logic improvement, buffs miracle rate, increases incentive to build obelisks and cruciform the crew.

## Changelog
:cl:
tweak: acolytes can now call armaments from the EOTP
balance: observation maximum raised, but more power is required for a miracle
fix: observation update bug preventing reaching maximum observation
/:cl: