### PR TITLE
Removes bad return in borer_powers.dm

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -110,7 +110,6 @@
 	if(sight & SEE_MOBS)
 		sight &= ~SEE_MOBS
 		to_chat(src, SPAN_NOTICE("You cannot see living being through walls for now."))
-		return
 
 	host = M
 	host.status_flags |= PASSEMOTES


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Presently, attempting to infest a host with biograde vision active will cause it to deactivate, and then return, blocking infestation when it shouldn't - it even happens after the message for wiggling into the host's ear, which can cause a lot of confusion for both borers who don't know why they're not in the host, and humans who think they're infested when they're not.
Closes #7115 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The proc shouldn't stop midway through after removing biograde vision's effects.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: having biograde vision active as a borer no longer prevents infesting a host.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
