### PR TITLE
QoL Changes so hammers are viable alt melee

### DIFF
--- a/code/game/objects/items/weapons/tools/hammer.dm
+++ b/code/game/objects/items/weapons/tools/hammer.dm
@@ -21,8 +21,8 @@
 	item_state = "homewrecker"
 	wielded_icon = "homewrecker1"
 	structure_damage_factor = STRUCTURE_DAMAGE_HEAVY
-	armor_penetration = ARMOR_PEN_DEEP
-	force = WEAPON_FORCE_NORMAL
+	armor_penetration = ARMOR_PEN_MODERATE
+	force = WEAPON_FORCE_PAINFUL
 	force_wielded_multiplier = 2.6
 	slot_flags = SLOT_BELT|SLOT_BACK
 	w_class = ITEM_SIZE_HUGE
@@ -38,8 +38,8 @@
 	icon_state = "powered_hammer"
 	item_state = "powered_hammer"
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
-	armor_penetration = ARMOR_PEN_DEEP
-	force = WEAPON_FORCE_DANGEROUS
+	armor_penetration = ARMOR_PEN_EXTREME
+	force = WEAPON_FORCE_BRUTAL
 	w_class = ITEM_SIZE_HUGE
 	tool_qualities = list(QUALITY_HAMMERING = 30)
 	matter = list(MATERIAL_STEEL = 5, MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 1)
@@ -57,7 +57,7 @@
 	wielded_icon = "onehammer_on"
 	structure_damage_factor = STRUCTURE_DAMAGE_DESTRUCTIVE
 	armor_penetration = ARMOR_PEN_EXTREME
-	force= WEAPON_FORCE_DANGEROUS
+	force= WEAPON_FORCE_BRUTAL
 	force_wielded_multiplier = 1.65
 	w_class = ITEM_SIZE_HUGE
 	slot_flags = SLOT_BACK
@@ -78,8 +78,8 @@
 	icon_state = "mace"
 	item_state = "mace"
 	w_class = ITEM_SIZE_NORMAL
-	armor_penetration = ARMOR_PEN_DEEP
-	force = WEAPON_FORCE_DANGEROUS
+	armor_penetration = ARMOR_PEN_EXTREME
+	force = WEAPON_FORCE_ROBUST
 	tool_qualities = list(QUALITY_HAMMERING = 20)
 	spawn_tags = SPAWN_TAG_WEAPON
 	rarity_value = 15
@@ -90,7 +90,7 @@
 	desc = "Some metal attached to the end of a stick, for applying blunt force trauma to a roach."
 	icon_state = "ghetto_mace"
 	item_state = "ghetto_mace"
-	force = WEAPON_FORCE_PAINFUL
+	force = WEAPON_FORCE_DANGEROUS
 	tool_qualities = list(QUALITY_HAMMERING = 15)
 	degradation = 3 //This one breaks fast
 	max_upgrades = 5 //all makeshift tools get more mods to make them actually viable for mid-late game
@@ -127,6 +127,7 @@
 	item_state = "chargehammer"
 	w_class = ITEM_SIZE_HUGE
 	switched_on_force = WEAPON_FORCE_BRUTAL
+	armor_penetration = ARMOR_PEN_MASSIVE
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
 	switched_on_qualities = list(QUALITY_HAMMERING = 60)
 	switched_off_qualities = list(QUALITY_HAMMERING = 35)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The damage and armour piercing values of six hammers have been modified, said hammers are listed below

- Makeshift Mace
- Mace
- Home Wrecker
- Powered Hammer
- Charge Hammer
- One Star Powered Hammer

In all cases except for the Home Wrecker this was a buff, the Home Wreckers AP was nerfed slightly to bring it in line with the others.

I've attempted to divide their damage into tiers depending on their quality and size.

I've additionally attached a [worksheet](https://docs.google.com/spreadsheets/d/1YE5jRkzpAWpIUOUxmQ_8p7RxcJvaszR7gK6RsMOsQPM/edit?usp=sharing) which shows the maximum damage that can be achieved with each choice, raw and modded.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is an attempt to make hammer/blunt type weapons more pleasing to use for players, as well as presenting them as an alternative armour piercing when compared to the bladed weapons. 

My opinion is entirely biased, but I believe that variety in the choice of weapon (beyond the gun you choose) should present different but still viable styles of play. 

I catered this PR to the style of play I prefer and have noticed is lacking, but hope other players will find it enjoyable as well.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The following hammers have been buffed damage wise; Makeshift Mace, Mace, Home Wrecker, Powered Hammer, One Star Powered Hammer, Charge Hammer
balance: The following hammers have been buffed slightly AP wise; Makeshift Mace, Mace, Powered Hammer, One Star Powered Hammer
balance: The homewrecker has been slightly nerfed in AP
balance: The Charge Hammer has been tremendously buffed compared to its previous AP
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
