### PR TITLE
Adds a storage bag to every RIG, minor RIG buffs, minor exosuit buffs

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -734,6 +734,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 /datum/supply_pack/mech_ripley
 	name = "exosuit assembly crate"
 	contains = list(
+		/obj/structure/heavy_vehicle_frame,
 		/obj/item/mech_equipment/drill,
 		/obj/item/mech_equipment/clamp,
 		/obj/item/mech_equipment/light,
@@ -741,8 +742,15 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 		/obj/item/mech_component/chassis/cheap,
 		/obj/item/mech_component/manipulators/cheap,
 		/obj/item/mech_component/propulsion/cheap,
+		/obj/item/electronics/circuitboard/exosystem/utility,
+		/obj/item/robot_parts/robot_component/actuator,
+		/obj/item/robot_parts/robot_component/actuator,
+		/obj/item/robot_parts/robot_component/camera,
+		/obj/item/robot_parts/robot_component/radio,
 		/obj/item/robot_parts/robot_component/exosuit_control,
-		/obj/item/robot_parts/robot_component/armour/exosuit/plain
+		/obj/item/robot_parts/robot_component/armour/exosuit/plain,
+		/obj/item/robot_parts/robot_component/diagnosis_unit,
+		/obj/item/cell/large
 	)
 	cost = 2000
 	containertype = /obj/structure/closet/crate/secure/scisecurecrate

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -54,7 +54,9 @@
 
 	// Keeps track of what this rig should spawn with.
 	var/suit_type = "hardsuit"
-	var/list/initial_modules = list(/obj/item/rig_module/storage) //Probably isn't the best way of doing this
+	var/list/initial_modules = list(
+		/obj/item/rig_module/storage //Probably isn't the best way of doing this
+		)
 	var/chest_type = /obj/item/clothing/suit/space/rig
 	var/helm_type =  /obj/item/clothing/head/space/rig
 	var/boot_type =  /obj/item/clothing/shoes/magboots/rig

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -54,7 +54,7 @@
 
 	// Keeps track of what this rig should spawn with.
 	var/suit_type = "hardsuit"
-	var/list/initial_modules = list()
+	var/list/initial_modules = list(/obj/item/rig_module/storage) //Probably isn't the best way of doing this
 	var/chest_type = /obj/item/clothing/suit/space/rig
 	var/helm_type =  /obj/item/clothing/head/space/rig
 	var/boot_type =  /obj/item/clothing/shoes/magboots/rig

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -31,7 +31,8 @@
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/power_sink,
 		/obj/item/rig_module/electrowarfare_suite,
-		/obj/item/rig_module/modular_injector/combat
+		/obj/item/rig_module/modular_injector/combat,
+		/obj/item/rig_module/storage
 		)
 
 //Ironhammer rig suit
@@ -86,5 +87,6 @@
 		/obj/item/rig_module/vision/sechud,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/grenade_launcher,
-		/obj/item/rig_module/mounted/taser
+		/obj/item/rig_module/mounted/taser,
+		/obj/item/rig_module/storage
 		)

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -62,6 +62,7 @@
 		/obj/item/rig_module/electrowarfare_suite,
 		/obj/item/rig_module/voice,
 		/obj/item/rig_module/vision,
+		/obj/item/rig_module/storage
 		)
 
 //The cybersuit is not space-proof. It does however, have good siemens_coefficient values
@@ -113,7 +114,8 @@
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/power_sink,
 		/obj/item/rig_module/datajack,
-		/obj/item/rig_module/self_destruct
+		/obj/item/rig_module/self_destruct,
+		/obj/item/rig_module/storage
 		)
 
 /obj/item/clothing/gloves/rig/light/ninja
@@ -133,5 +135,6 @@
 
 	initial_modules = list(
 		/obj/item/rig_module/stealth_field,
-		/obj/item/rig_module/vision
+		/obj/item/rig_module/vision,
+		/obj/item/rig_module/storage
 		)

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -30,7 +30,8 @@
 		/obj/item/rig_module/power_sink,
 		/obj/item/rig_module/electrowarfare_suite,
 		/obj/item/rig_module/modular_injector/combat,
-		/obj/item/rig_module/fabricator/energy_net
+		/obj/item/rig_module/fabricator/energy_net,
+		/obj/item/rig_module/storage
 		)
 	stiffness = 0
 	obscuration = 0
@@ -39,5 +40,6 @@
 /obj/item/rig/merc/empty
 	initial_modules = list(
 		/obj/item/rig_module/ai_container,
-		/obj/item/rig_module/electrowarfare_suite, //might as well
+		/obj/item/rig_module/electrowarfare_suite, // might as well
+		/obj/item/rig_module/storage
 		)

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -49,7 +49,8 @@
 		/obj/item/device/t_scanner,
 		/obj/item/storage/bag/ore,
 		/obj/item/tool/pickaxe,
-		/obj/item/rcd
+		/obj/item/rcd,
+		/obj/item/rig_module/storage
 	)
 
 	req_access = list()
@@ -61,7 +62,8 @@
 		/obj/item/rig_module/device/drill,
 		/obj/item/rig_module/device/orescanner,
 		/obj/item/rig_module/device/rcd,
-		/obj/item/rig_module/vision/meson
+		/obj/item/rig_module/vision/meson,
+		/obj/item/rig_module/storage
 		)
 
 
@@ -74,9 +76,9 @@
 	desc = "A light rig for repairs and maintenance to the outside of habitats and vessels."
 	icon_state = "eva_rig"
 	armor = list(
-		melee = 20,
-		bullet = 10,
-		energy = 10,
+		melee = 30,
+		bullet = 20,
+		energy = 20,
 		bomb = 10,
 		bio = 100,
 		rad = 100
@@ -102,7 +104,8 @@
 	initial_modules = list(
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/rcd,
-		/obj/item/rig_module/vision/meson
+		/obj/item/rig_module/vision/meson,
+		/obj/item/rig_module/storage
 		)
 
 
@@ -137,7 +140,7 @@ Advanced Voidsuit: Technomancer Exultant
 		/obj/item/storage/toolbox,
 		/obj/item/storage/briefcase/inflatable,
 		/obj/item/device/t_scanner,
-		/obj/item/rcd
+		/obj/item/rcd,
 	)
 
 	req_access = list(access_ce)
@@ -204,8 +207,8 @@ Technomancer RIG
 
 /obj/item/rig/techno/equipped
 	initial_modules = list(
-		/obj/item/rig_module/storage,
 		/obj/item/rig_module/maneuvering_jets,
+		/obj/item/rig_module/storage
 		)
 
 /obj/item/clothing/gloves/rig/techno
@@ -232,7 +235,7 @@ Technomancer RIG
 	rarity_value = 25
 	armor = list(
 		melee = 30,
-		bullet = 20,
+		bullet = 30,
 		energy = 50,
 		bomb = 90,
 		bio = 100,
@@ -268,7 +271,8 @@ Technomancer RIG
 	initial_modules = list(
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/maneuvering_jets,
-		/obj/item/rig_module/device/anomaly_scanner
+		/obj/item/rig_module/device/anomaly_scanner,
+		/obj/item/rig_module/storage
 		)
 
 
@@ -282,9 +286,9 @@ Technomancer RIG
 	desc = "A relatively lightweight and durable RIG suit designed for medical rescue in hazardous locations."
 	icon_state = "medical_rig"
 	armor = list(
-		melee = 20,
-		bullet = 10,
-		energy = 10,
+		melee = 30,
+		bullet = 20,
+		energy = 20,
 		bomb = 50,
 		bio = 100,
 		rad = 100
@@ -310,5 +314,6 @@ Technomancer RIG
 		/obj/item/rig_module/modular_injector/medical,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/healthscanner,
-		/obj/item/rig_module/vision/medhud
+		/obj/item/rig_module/vision/medhud,
+		/obj/item/rig_module/storage
 		)

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -76,8 +76,8 @@
 	icon_state = "eva_rig"
 	armor = list(
 		melee = 30,
-		bullet = 20,
-		energy = 20,
+		bullet = 10,
+		energy = 10,
 		bomb = 10,
 		bio = 100,
 		rad = 100
@@ -261,7 +261,7 @@ Technomancer RIG
 
 	req_access = list()
 	req_one_access = list()
-	slowdown = HEAVY_SLOWDOWN * 0.7
+	slowdown = MEDIUM_SLOWDOWN
 
 /obj/item/rig/hazmat/equipped
 	req_access = list(access_rd)

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -49,8 +49,7 @@
 		/obj/item/device/t_scanner,
 		/obj/item/storage/bag/ore,
 		/obj/item/tool/pickaxe,
-		/obj/item/rcd,
-		/obj/item/rig_module/storage
+		/obj/item/rcd
 	)
 
 	req_access = list()
@@ -140,7 +139,7 @@ Advanced Voidsuit: Technomancer Exultant
 		/obj/item/storage/toolbox,
 		/obj/item/storage/briefcase/inflatable,
 		/obj/item/device/t_scanner,
-		/obj/item/rcd,
+		/obj/item/rcd
 	)
 
 	req_access = list(access_ce)

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -153,9 +153,9 @@
 	mech_layer = MECH_INTERMEDIATE_LAYER
 
 	var/on = FALSE
-	var/l_max_bright = 0.9
+	var/l_max_bright = 1.2
 	var/l_inner_range = 1
-	var/l_outer_range = 6
+	var/l_outer_range = 9
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 
 /obj/item/mech_equipment/light/attack_self(var/mob/user)

--- a/code/modules/research/designs/mechs2/exosuits_components.dm
+++ b/code/modules/research/designs/mechs2/exosuits_components.dm
@@ -17,8 +17,10 @@
 /datum/design/research/item/mechfab/exosuit/basics/radio
 	build_path = /obj/item/robot_parts/robot_component/radio
 
-/datum/design/research/item/mechfab/robot/component/diagnosis_unit
+/datum/design/research/item/mechfab/exosuit/basics/diagnosis_unit
 	build_path = /obj/item/robot_parts/robot_component/diagnosis_unit
+
+
 
 //Armor
 /datum/design/research/item/mechfab/exosuit/armour
@@ -34,6 +36,23 @@
 /datum/design/research/item/mechfab/exosuit/armour/combat
 	build_path = /obj/item/robot_parts/robot_component/armour/exosuit/combat
 
+//Drill bits
+
+/datum/design/research/item/mechfab/exosuit/drillbit
+	category = "Exosuit Drill bits"
+	materials = list()
+
+/datum/design/research/item/mechfab/exosuit/drillbit/steel
+	build_path = /obj/item/material/drill_head/steel
+	materials = list(MATERIAL_STEEL = 6)
+
+/datum/design/research/item/mechfab/exosuit/drillbit/plasteel
+	build_path = /obj/item/material/drill_head/plasteel
+	materials = list(MATERIAL_PLASTEEL = 6)
+
+/datum/design/research/item/mechfab/exosuit/drillbit/diamond
+	build_path = /obj/item/material/drill_head/diamond
+	materials = list(MATERIAL_DIAMOND = 6)
 
 //Sensors
 /datum/design/research/item/mechfab/exosuit/sensors

--- a/code/modules/research/designs/mechs2/exosuits_components.dm
+++ b/code/modules/research/designs/mechs2/exosuits_components.dm
@@ -39,8 +39,7 @@
 //Drill bits
 
 /datum/design/research/item/mechfab/exosuit/drillbit
-	category = "Exosuit Drill bits"
-	materials = list()
+	category = "Exosuit Drill Bits"
 
 /datum/design/research/item/mechfab/exosuit/drillbit/steel
 	build_path = /obj/item/material/drill_head/steel

--- a/code/modules/research/designs/mechs2/exosuits_components.dm
+++ b/code/modules/research/designs/mechs2/exosuits_components.dm
@@ -20,8 +20,6 @@
 /datum/design/research/item/mechfab/exosuit/basics/diagnosis_unit
 	build_path = /obj/item/robot_parts/robot_component/diagnosis_unit
 
-
-
 //Armor
 /datum/design/research/item/mechfab/exosuit/armour
 	category = "Exosuit Armor"
@@ -37,7 +35,6 @@
 	build_path = /obj/item/robot_parts/robot_component/armour/exosuit/combat
 
 //Drill bits
-
 /datum/design/research/item/mechfab/exosuit/drillbit
 	category = "Exosuit Drill Bits"
 

--- a/code/modules/research/nodes/robotics.dm
+++ b/code/modules/research/nodes/robotics.dm
@@ -224,7 +224,10 @@
 		/datum/design/research/item/exosuit/extinguisher,
 		/datum/design/research/item/exosuit/hydraulic_clamp,
 		/datum/design/research/item/mechfab/exosuit/chassis/pod,
-		/datum/design/research/item/exosuit/weapon/plasma
+		/datum/design/research/item/exosuit/weapon/plasma,
+		/datum/design/research/item/mechfab/exosuit/drillbit/steel,
+		/datum/design/research/item/mechfab/exosuit/drillbit/plasteel,
+		/datum/design/research/item/mechfab/exosuit/drillbit/diamond
 	)
 
 /datum/technology/mech_teleporter_modules


### PR DESCRIPTION
## About The Pull Request

- Adds storage bags to each type of RIG in the game by default
- Increases medical/EVA/SCI RIG melee/ballistic armour by 10 because 10% proj resist on a light RIG seemed a bit low (light, unarmored 'punk' themed jackets are 20% resist.
- Buffs the mech flashlight, adds printable mech drill pieces to the exofab and makes the orderable cargo Ripley more viable by adding required parts.
- (QoL) adds a diagnosis unit to the mechfab exosuit tab

## Why It's Good For The Game

RIGs don't seem worth it currently if they don't come with a storage module, nobody wants to haul a bag in one hand everywhere they go or spend 30 minutes begging cargo/IH for a storage bag. Paramedic/Expedition/Light or even techno RIGs are very rarely seen anyway. Buffs a few under armored RIGs (light-EVA, medical and Science) to be more useful.

Mech flashlights seemed a bit dim compared to a heavy hand-held flashlight so I increased the brightness/range a bit to make it more comfortable to use in a dark environment. The orderable exosuit crate from classic cargo was missing almost every part necessary for it to function which should be fixed.

## Changelog
:cl:
balance: Buffs RIG armour values, adds storage modules to (hopefully) every RIG, buffs the mech flashlight. Makes the fugly MEO suit a bit faster.
tweak: Mech drillbits can be printed from the mechfab now and the orderable exosuit crate now contains all the necessary components.
/:cl:
