### PR TITLE
Fix runtime in mob_helpers.dm

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -593,6 +593,8 @@ proc/is_blind(A)
 	embedded = list()
 
 /mob/proc/skill_to_evade_traps()
+	if(Master.current_runlevel != RUNLEVEL_GAME)
+		return 100
 	var/prob_evade = 0
 	var/base_prob_evade = 30
 	if(MOVING_DELIBERATELY(src))


### PR DESCRIPTION

## About The Pull Request

Relatively rare (540 cases in over two years) runtime, that occurs when a mouse crosses a trap before game is fully initialized.

## Why It's Good For The Game

Fixes cool.

## Changelog
:cl:
fix: runtime in mob_helpers.dm
/:cl:

