### PR TITLE
Add "Follow player" verb

### DIFF
--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -331,7 +331,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/observer/ghost/verb/follow_mob(input in getmobs()) ////// Follow mobs on list
 	set category = "Ghost"
 	set name = "Follow mob" // "Haunt"
-	set desc = "."
+	set desc = "Follow and haunt a mob."
 
 	var/target = getmobs()[input]
 	if(!target) return

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -310,16 +310,28 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/observer/ghost/verb/Follow(atom/A as mob|obj in view(usr.client)) ////// Follow verb in context menu
 	set category ="Ghost"
-	set name = "Follow"
+	set name = ".Follow"
 	if(following)
 		stop_following()
 	var/target = A
 	ManualFollow(target)
 
+/mob/observer/ghost/verb/follow_player() ////// Follow mobs on list
+	set category = "Ghost"
+	set name = "Follow player"
+
+	var/list/player_controlled_mobs = list()
+
+	for(var/mob/M in sortNames(SSmobs.mob_list))
+		if(M.ckey && !isnewplayer(M))
+			player_controlled_mobs.Add(M)
+
+	ManualFollow(input("Follow and haunt a player", "Follow player") as anything in player_controlled_mobs)
+
 /mob/observer/ghost/verb/follow_mob(input in getmobs()) ////// Follow mobs on list
 	set category = "Ghost"
 	set name = "Follow mob" // "Haunt"
-	set desc = "Follow and haunt a mob."
+	set desc = "."
 
 	var/target = getmobs()[input]
 	if(!target) return

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -316,7 +316,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/target = A
 	ManualFollow(target)
 
-/mob/observer/ghost/verb/follow_player() ////// Follow mobs on list
+/mob/observer/ghost/verb/follow_player()
 	set category = "Ghost"
 	set name = "Follow player"
 


### PR DESCRIPTION
## About The Pull Request

New "Follow player" verb that is similar to "Follow mob", but only shows mobs that have a `ckey` assigned to them, so user don't have to scroll trough a ton of roaches, monkeys and other mobs to find a fellow human.

Removed "Follow" verb from ghost menu, now it's only visible on right click, as it should.
When called from ghost menu, it showed a list of every mob and object in view, which is pretty useless and only used by mistake.

## Why It's Good For The Game

QoL is good.

## Changelog
:cl:
add: "follow player" verb to ghost panel
tweak: "follow" verb no longer visible in ghost panel
/:cl:
