### PR TITLE
Once again , removes hardstun from Weaken()

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -176,10 +176,10 @@
 	if ((incapacitation_flags & INCAPACITATION_STUNNED) && stunned)
 		return 1
 
-	if ((incapacitation_flags & INCAPACITATION_SOFTLYING) && (resting))
+	if ((incapacitation_flags & INCAPACITATION_SOFTLYING) && (resting || weakened))
 		return 1
 
-	if ((incapacitation_flags & INCAPACITATION_FORCELYING) && (weakened || pinned.len))
+	if ((incapacitation_flags & INCAPACITATION_FORCELYING) && pinned.len)
 		return 1
 
 	if ((incapacitation_flags & INCAPACITATION_UNCONSCIOUS) && (stat || paralysis || sleeping || (status_flags & FAKEDEATH)))
@@ -752,8 +752,9 @@ All Canmove setting in this proc is temporary. This var should not be set from h
 			lying = 0
 
 	//Temporarily moved here from the various life() procs
-	//I'm fixing stuff incrementally so this will likely find a better home.
+	//I'm fixing stuff incrementally so this will likely find a better home.s
 	//It just makes sense for now. ~Carn
+	// Fuck you Carn its been more than 6 years and people still lag from your shitty forced icon updates . SPCR -2022
 	if( update_icon )	//forces a full overlay update
 		update_icon = 0
 		regenerate_icons()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -752,7 +752,7 @@ All Canmove setting in this proc is temporary. This var should not be set from h
 			lying = 0
 
 	//Temporarily moved here from the various life() procs
-	//I'm fixing stuff incrementally so this will likely find a better home.s
+	//I'm fixing stuff incrementally so this will likely find a better home.
 	//It just makes sense for now. ~Carn
 	// Fuck you Carn its been more than 6 years and people still lag from your shitty forced icon updates . SPCR -2022
 	if( update_icon )	//forces a full overlay update


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Returns Weaken() to not being a hardstun , we have Paralyse() for that you fucking cunts that don't adhere to STANDARDS
PR'ed this a long time ago and was accepted , and then reverted in le funny RTM combat update.

## Why It's Good For The Game
TRIPPING ON PLATING WAS NEVER INTENDED TO LOCK YOU IN PLACE FOR A WHOPPING 6 SECONDS, Or geting crushed by a door.. or anything that weakened. 

## Changelog
:cl:
balance: You can once again , move while Weakened()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
