### PR TITLE
Vending machine tweaks

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -144,7 +144,7 @@
 	var/seconds_electrified = 0 //Shock customers like an airlock.
 	var/shoot_inventory = 0 //Fire items at customers! We're broken!
 
-	var/custom_vendor = TRUE //If it's custom, it can be loaded with stuff as long as it's unlocked.
+	var/custom_vendor = FALSE //If it's custom, it can be loaded with stuff as long as it's unlocked.
 	var/locked = TRUE
 	var/datum/money_account/machine_vendor_account //Owner of this vendomat. Used for access.
 	var/datum/money_account/earnings_account //Money flows in and out of this account.
@@ -182,10 +182,6 @@
 
 	if(product_ads)
 		ads_list += splittext(src.product_ads, ";")
-
-	if(!machine_vendor_account && vendor_department)
-		earnings_account = department_accounts[vendor_department]
-		machine_vendor_account = department_accounts[vendor_department]
 
 	build_inventory()
 	power_change()
@@ -967,6 +963,22 @@
 	product_ads = "Only the finest!;Have some tools.;The most robust equipment.;The finest gear in space!"
 	auto_price = FALSE
 
+/obj/machinery/vending/drink_showcase
+	name = "Club Cocktail Showcase"
+	desc = "A vending machine to showcase cocktails."
+	icon_state = "showcase"
+	var/icon_fill = "showcase-fill"
+	vend_delay = 15
+	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
+	vendor_department = DEPARTMENT_CIVILIAN
+	custom_vendor = TRUE
+	can_stock = list(/obj/item/reagent_containers/glass, /obj/item/reagent_containers/food/drinks, /obj/item/reagent_containers/food/condiment)
+
+/obj/machinery/vending/drink_showcase/update_icon()
+	..()
+	if(contents.len && !(stat & NOPOWER))
+		overlays += image(icon, icon_fill)
+
 /obj/machinery/vending/coffee
 	name = "Hot Drinks machine"
 	desc = "A vending machine which dispenses hot drinks."
@@ -1153,6 +1165,8 @@
 	contraband = list(/obj/item/reagent_containers/pill/tox = 3,/obj/item/reagent_containers/pill/stox = 4,/obj/item/reagent_containers/pill/antitox = 6)
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 	auto_price = FALSE
+	custom_vendor = TRUE // Chemists can load it for MDs
+	can_stock = list(/obj/item/reagent_containers/glass, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/pill, /obj/item/stack/medical, /obj/item/bodybag, /obj/item/device/scanner/health, /obj/item/reagent_containers/hypospray, /obj/item/storage/pill_bottle)
 
 
 //This one's from bay12
@@ -1172,6 +1186,8 @@
 	light_color = COLOR_LIGHTING_GREEN_BRIGHT
 	icon_deny = "wallmed-deny"
 	product_ads = "Self-medication can be healthy!;Natural chemicals!;This stuff saves lives.;Don't you want some?;Hook it up to your veins!"
+	custom_vendor = TRUE // Chemists can load it for customers
+	can_stock = list(/obj/item/reagent_containers/glass, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/pill, /obj/item/stack/medical, /obj/item/bodybag, /obj/item/device/scanner/health, /obj/item/reagent_containers/hypospray, /obj/item/storage/pill_bottle)
 
 /obj/machinery/vending/wallmed/minor
 	products = list(
@@ -1363,10 +1379,11 @@
 	/obj/item/reagent_containers/food/drinks/mug/teacup = 10)
 	contraband = list(/obj/item/material/kitchen/rollingpin = 2, /obj/item/tool/knife/butch = 2)
 	auto_price = FALSE
+	always_open = TRUE
 
 /obj/machinery/vending/sovietsoda
 	name = "BODA"
-	desc = "An old sweet water vending machine,how did this end up here?"
+	desc = "An old sweet water vending machine, how did this end up here?"
 	icon_state = "sovietsoda"
 	product_ads = "For Tsar and Country.;Have you fulfilled your nutrition quota today?;Very nice!;We are simple people, for this is all we eat.;If there is a person, there is a problem. If there is no person, then there is no problem."
 	products = list(/obj/item/reagent_containers/food/drinks/drinkingglass/soda = 30)
@@ -1455,6 +1472,7 @@
 	contraband = list(/obj/item/implant/core_implant/cruciform = 3)
 	prices = list(/obj/item/book/ritual/cruciform = 500, /obj/item/storage/fancy/candle_box = 200, /obj/item/reagent_containers/food/drinks/bottle/ntcahors = 250,
 				/obj/item/implant/core_implant/cruciform = 1000)
+	custom_vendor = TRUE // So they can sell pouches and other printed goods, if they bother to stock them
 
 /obj/machinery/vending/powermat
 	name = "Asters Guild Power-Mat"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1474,30 +1474,27 @@
 				/obj/item/implant/core_implant/cruciform = 1000)
 	custom_vendor = TRUE // So they can sell pouches and other printed goods, if they bother to stock them
 
-/obj/machinery/vending/theomat/try_to_buy(obj/item/W, var/datum/data/vending_product/R, var/mob/user)
-	var/obj/item/implant/core_implant/cruciform/CI
+/obj/machinery/vending/theomat/try_to_buy(obj/item/W, datum/data/vending_product/R, mob/user)
 	var/bingo = FALSE
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		CI = H.get_core_implant(/obj/item/implant/core_implant/cruciform)
-		if(!CI)
-			bingo = TRUE
-		if(istype(H.get_active_hand(), /obj/item/clothing/accessory/cross))
+		if(is_neotheology_disciple(H))
 			bingo = TRUE
 
-		if(istype(H.wear_mask, /obj/item/clothing/accessory/cross))
+		else if(istype(H.get_active_hand(), /obj/item/clothing/accessory/cross))
 			bingo = TRUE
 
-		var/obj/item/clothing/C = H.w_uniform
-		if(istype(C))
+		else if(istype(H.wear_mask, /obj/item/clothing/accessory/cross))
+			bingo = TRUE
+
+		else if(H.w_uniform && istype(H.w_uniform, obj/item/clothing))
+			var/obj/item/clothing/C = H.w_uniform
 			for(var/obj/item/I in C.accessories)
 				if(istype(I, /obj/item/clothing/accessory/cross))
 					bingo = TRUE
 					break
-	if(!bingo)
-		to_chat(user, SPAN_WARNING("[src] flashes a message: Theo-Mat detected no cruciform."))
-		return
-	..()
+
+	bingo ? ..() : to_chat(user, SPAN_WARNING("[src] flashes a message: Unauthorized Access."))
 
 /obj/machinery/vending/powermat
 	name = "Asters Guild Power-Mat"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1474,7 +1474,7 @@
 				/obj/item/implant/core_implant/cruciform = 1000)
 	custom_vendor = TRUE // So they can sell pouches and other printed goods, if they bother to stock them
 
-/obj/machinery/vending/theomat/try_to_buy(obj/item/W, datum/data/vending_product/R, mob/user)
+/obj/machinery/vending/theomat/proc/check_NT(mob/user)
 	var/bingo = FALSE
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -1494,7 +1494,18 @@
 					bingo = TRUE
 					break
 
-	bingo ? ..() : to_chat(user, SPAN_WARNING("[src] flashes a message: Unauthorized Access."))
+	if(bingo)
+		return TRUE
+	to_chat(user, SPAN_WARNING("[src] flashes a message: Unauthorized Access."))
+	return FALSE
+
+/obj/machinery/vending/theomat/vend(datum/data/vending_product/R, mob/user)
+	if(check_NT(user))
+		..()
+
+/obj/machinery/vending/theomat/try_to_buy(obj/item/W, var/datum/data/vending_product/R, var/mob/user)
+	if(check_NT(user))
+		..()
 
 /obj/machinery/vending/powermat
 	name = "Asters Guild Power-Mat"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -211,9 +211,6 @@
 	if(!earnings_account)
 		to_chat(user, SPAN_WARNING("[src] flashes a message: Vendomat not registered to an account."))
 		return
-	if(!earnings_account)
-		to_chat(user, SPAN_WARNING("[src] flashes a message: Vendomat not registered to an account."))
-		return
 	if(vendor_department)
 		to_chat(user, SPAN_WARNING("[src] flashes a message: Vendomat not authorized to accept sales. Please contact a member of [GLOB.all_departments[vendor_department]]."))
 		return

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -148,7 +148,7 @@
 	var/locked = TRUE
 	var/datum/money_account/machine_vendor_account //Owner of this vendomat. Used for access.
 	var/datum/money_account/earnings_account //Money flows in and out of this account.
-	var/vendor_department = null //If set, members can manage this vendomat. earnings_account is set to the department's account automatically.
+	var/vendor_department = DEPARTMENT_GUILD //If set, members can manage this vendomat. earnings_account is set to the department's account automatically.
 	var/buying_percentage = 0 //If set, the vendomat will accept people selling items to it, and in return will give (percentage * listed item price) in cash
 	var/scan_id = 1
 	var/auto_price = TRUE //The vendomat will automatically set prices on products if their price is not specified.
@@ -168,9 +168,6 @@
 
 /obj/machinery/vending/Initialize()
 	..()
-	if(!machine_vendor_account && vendor_department)
-		earnings_account = department_accounts[vendor_department]
-		machine_vendor_account = department_accounts[vendor_department]
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/vending/LateInitialize()
@@ -185,6 +182,10 @@
 
 	if(product_ads)
 		ads_list += splittext(src.product_ads, ";")
+
+	if(!machine_vendor_account && vendor_department)
+		earnings_account = department_accounts[vendor_department]
+		machine_vendor_account = department_accounts[vendor_department]
 
 	build_inventory()
 	power_change()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -144,7 +144,7 @@
 	var/seconds_electrified = 0 //Shock customers like an airlock.
 	var/shoot_inventory = 0 //Fire items at customers! We're broken!
 
-	var/custom_vendor = FALSE //If it's custom, it can be loaded with stuff as long as it's unlocked.
+	var/custom_vendor = TRUE //If it's custom, it can be loaded with stuff as long as it's unlocked.
 	var/locked = TRUE
 	var/datum/money_account/machine_vendor_account //Owner of this vendomat. Used for access.
 	var/datum/money_account/earnings_account //Money flows in and out of this account.
@@ -168,6 +168,9 @@
 
 /obj/machinery/vending/Initialize()
 	..()
+	if(!machine_vendor_account && vendor_department)
+		earnings_account = department_accounts[vendor_department]
+		machine_vendor_account = department_accounts[vendor_department]
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/vending/LateInitialize()
@@ -814,16 +817,15 @@
 
 	//Pitch to the people!  Really sell it!
 	if(((last_slogan + slogan_delay) <= world.time) && (slogan_list.len > 0 || custom_vendor) && (!shut_up) && prob(5))
-		if(custom_vendor && product_records.len)
+		if(slogan_list.len)
+			var/slogan = pick(slogan_list)
+			speak(slogan)
+			last_slogan = world.time
+		else if(custom_vendor && product_records.len)
 			var/datum/data/vending_product/advertised = pick(product_records)
 			if(advertised)
 				var/advertisement = "[pick("Come get","Come buy","Buy","Sale on","We have")] \an [advertised.product_name], [pick("for only","only","priced at")] [advertised.price] credits![pick(" What a deal!"," Can you believe it?","")]"
 				speak(advertisement)
-				last_slogan = world.time
-		else
-			if(slogan_list.len)
-				var/slogan = pick(slogan_list)
-				speak(slogan)
 				last_slogan = world.time
 
 	if(shoot_inventory && prob(2))

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -211,6 +211,9 @@
 	if(!earnings_account)
 		to_chat(user, SPAN_WARNING("[src] flashes a message: Vendomat not registered to an account."))
 		return
+	if(!earnings_account)
+		to_chat(user, SPAN_WARNING("[src] flashes a message: Vendomat not registered to an account."))
+		return
 	if(vendor_department)
 		to_chat(user, SPAN_WARNING("[src] flashes a message: Vendomat not authorized to accept sales. Please contact a member of [GLOB.all_departments[vendor_department]]."))
 		return
@@ -1473,6 +1476,31 @@
 	prices = list(/obj/item/book/ritual/cruciform = 500, /obj/item/storage/fancy/candle_box = 200, /obj/item/reagent_containers/food/drinks/bottle/ntcahors = 250,
 				/obj/item/implant/core_implant/cruciform = 1000)
 	custom_vendor = TRUE // So they can sell pouches and other printed goods, if they bother to stock them
+
+/obj/machinery/vending/theomat/try_to_buy(obj/item/W, var/datum/data/vending_product/R, var/mob/user)
+	var/obj/item/implant/core_implant/cruciform/CI
+	var/bingo = FALSE
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		CI = H.get_core_implant(/obj/item/implant/core_implant/cruciform)
+	if(!CI)
+		bingo = TRUE
+	if(istype(H.get_active_hand(), /obj/item/clothing/accessory/cross))
+		bingo = TRUE
+
+	if(istype(H.wear_mask, /obj/item/clothing/accessory/cross))
+		bingo = TRUE
+
+	var/obj/item/clothing/C = H.w_uniform
+	if(istype(C))
+		for(var/obj/item/I in C.accessories)
+			if(istype(I, /obj/item/clothing/accessory/cross))
+				bingo = TRUE
+				break
+	if(!bingo)
+		to_chat(user, SPAN_WARNING("[src] flashes a message: Theo-Mat detected no cruciform."))
+		return
+	..()
 
 /obj/machinery/vending/powermat
 	name = "Asters Guild Power-Mat"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1167,7 +1167,7 @@
 	auto_price = FALSE
 	custom_vendor = TRUE // Chemists can load it for MDs
 	can_stock = list(/obj/item/reagent_containers/glass, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/pill, /obj/item/stack/medical, /obj/item/bodybag, /obj/item/device/scanner/health, /obj/item/reagent_containers/hypospray, /obj/item/storage/pill_bottle)
-
+	vendor_department = DEPARTMENT_MEDICAL
 
 //This one's from bay12
 /obj/machinery/vending/plasmaresearch
@@ -1188,6 +1188,7 @@
 	product_ads = "Self-medication can be healthy!;Natural chemicals!;This stuff saves lives.;Don't you want some?;Hook it up to your veins!"
 	custom_vendor = TRUE // Chemists can load it for customers
 	can_stock = list(/obj/item/reagent_containers/glass, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/pill, /obj/item/stack/medical, /obj/item/bodybag, /obj/item/device/scanner/health, /obj/item/reagent_containers/hypospray, /obj/item/storage/pill_bottle)
+	vendor_department = DEPARTMENT_MEDICAL
 
 /obj/machinery/vending/wallmed/minor
 	products = list(
@@ -1255,7 +1256,6 @@
 		/obj/item/reagent_containers/hypospray/autoinjector/hyperzine = 500,
 		/obj/item/reagent_containers/hypospray/autoinjector/drugs = 500,
 		)
-	vendor_department = DEPARTMENT_MEDICAL
 	auto_price = FALSE
 
 /obj/machinery/vending/security

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1487,7 +1487,7 @@
 		else if(istype(H.wear_mask, /obj/item/clothing/accessory/cross))
 			bingo = TRUE
 
-		else if(H.w_uniform && istype(H.w_uniform, obj/item/clothing))
+		else if(H.w_uniform && istype(H.w_uniform, /obj/item/clothing))
 			var/obj/item/clothing/C = H.w_uniform
 			for(var/obj/item/I in C.accessories)
 				if(istype(I, /obj/item/clothing/accessory/cross))

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1480,20 +1480,20 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		CI = H.get_core_implant(/obj/item/implant/core_implant/cruciform)
-	if(!CI)
-		bingo = TRUE
-	if(istype(H.get_active_hand(), /obj/item/clothing/accessory/cross))
-		bingo = TRUE
+		if(!CI)
+			bingo = TRUE
+		if(istype(H.get_active_hand(), /obj/item/clothing/accessory/cross))
+			bingo = TRUE
 
-	if(istype(H.wear_mask, /obj/item/clothing/accessory/cross))
-		bingo = TRUE
+		if(istype(H.wear_mask, /obj/item/clothing/accessory/cross))
+			bingo = TRUE
 
-	var/obj/item/clothing/C = H.w_uniform
-	if(istype(C))
-		for(var/obj/item/I in C.accessories)
-			if(istype(I, /obj/item/clothing/accessory/cross))
-				bingo = TRUE
-				break
+		var/obj/item/clothing/C = H.w_uniform
+		if(istype(C))
+			for(var/obj/item/I in C.accessories)
+				if(istype(I, /obj/item/clothing/accessory/cross))
+					bingo = TRUE
+					break
 	if(!bingo)
 		to_chat(user, SPAN_WARNING("[src] flashes a message: Theo-Mat detected no cruciform."))
 		return

--- a/code/modules/economy/economy_misc.dm
+++ b/code/modules/economy/economy_misc.dm
@@ -92,7 +92,11 @@ var/global/datum/computer_file/data/email_account/service/payroll/payroll_mailer
 		create_department_account(GLOB.all_departments[d])
 
 	station_account = department_accounts[DEPARTMENT_COMMAND]
-	
+
+	for(var/obj/machinery/vending/V in GLOB.machines)
+		if(V.vendor_department)
+			V.earnings_account = department_accounts[V.vendor_department]
+
 	current_date_string = "[num2text(rand(1,31))] [pick("January","February","March","April","May","June","July","August","September","October","November","December")], [game_year]"
 
 	economy_init = 1

--- a/code/modules/economy/economy_misc.dm
+++ b/code/modules/economy/economy_misc.dm
@@ -92,12 +92,7 @@ var/global/datum/computer_file/data/email_account/service/payroll/payroll_mailer
 		create_department_account(GLOB.all_departments[d])
 
 	station_account = department_accounts[DEPARTMENT_COMMAND]
-	vendor_account = department_accounts[DEPARTMENT_GUILD] //Vendors are operated by the guild and purchases pay into their stock
-
-	for(var/obj/machinery/vending/V in GLOB.machines)
-		if(!V.custom_vendor)
-			V.earnings_account = V.vendor_department ? department_accounts[V.vendor_department] : vendor_account
-
+	
 	current_date_string = "[num2text(rand(1,31))] [pick("January","February","March","April","May","June","July","August","September","October","November","December")], [game_year]"
 
 	economy_init = 1

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -52796,7 +52796,7 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/hallway/side/bridgehallway)
 "cxm" = (
-/obj/machinery/smartfridge/drinks,
+/obj/machinery/vending/drink_showcase,
 /obj/machinery/alarm{
 	pixel_y = 26
 	},


### PR DESCRIPTION
## About The Pull Request

Converts some of the on-ship vending machines into custom ones 

- medbay's supply vendor (products remain free and requiring access)
- the MiniMed in medbay lobby
- the NeoTheology Theo-Mat

Also replaces the drink showcase minifridge with a vending machine of identical appearance.

The medbay vendors can only be supplied with medical equipment and chem containers, while the drink showcase continues to only hold items it used to be able to, meaning glasses, drinks and condiments.

The NT vending machine is not locked and can hold any item. It is now only able to serve disciplines however.

## Why It's Good For The Game

The medbay vending machines will experience a large QoL improvement, allowing the inner one to retain use through restocks as the round goes on, and the lobby one to distribute chems to the crew, while making profit for the department.

The NT vending machine sees little use beyond being a cahors dispenser, by allowing it to be stocked with products, NT will be able to supply more items to their followers.
The lock to cruciform prevents NT from completely bypassing Guild, but allows them to underprice items to encourage joining the Church, as well as allows ~disloyal~ entrepreneur disciplines to resell the cheap items at a profit.

The more than usually unused club showcase is pretty much worthless beyond storing large amounts of alcohol, which can be effortlessly accessed by anyone and stolen from. By turning it into a vending machine, the Club can prevent them from being taken, while still keeping them on display, or use the vending machine as a way to sell booze while they are busy somewhere else.
Since it cannot sell food or other similar goods, it should not immediately replace the need for a vending machine, which they can already construct using the vending machine board in their storageroom.

## Changelog
:cl:
tweak: Turned the Club showcase into a custom vending machine
tweak: Turned the medical vending machines into custom ones, allowing stocking them with chems and supplies
tweak: Turned the Theo-Mat vending machine into a custom one, allowing stocking with the products of NeoTheology
spellcheck: Fixed a few typos for vending machines
code: Changed some vending machine code
balance: TheoMat now only serves the cruciformed
/:cl: