### PR TITLE
Fix vagabond's cash bundle

### DIFF
--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -3,7 +3,6 @@
 /obj/item/spacecash
 	name = "coin"
 	desc = "It's worth something. Probably."
-	gender = PLURAL
 	icon = 'icons/obj/items.dmi'
 	icon_state = "spacecash1"
 	force = 1
@@ -48,21 +47,47 @@
 
 /obj/item/spacecash/bundle/update_icon()
 	cut_overlays()
-	var/sum = worth
-	var/num = 0
-	var/list/denominations = list(1000,500,200,100,50,20,10,5,1)
-	for(var/i in denominations)
-		while(sum >= i && num < 50)
-			sum -= i
-			num++
+	var/remaining_worth = worth
+	var/iteration = 0
+	var/coins_only = TRUE
+	var/list/coin_denominations = list(10, 5, 1)
+	var/list/banknote_denominations = list(1000, 500, 200, 100, 50, 20)
+	for(var/i in banknote_denominations)
+		while(remaining_worth >= i && iteration < 50)
+			remaining_worth -= i
+			iteration++
 			var/image/banknote = image('icons/obj/items.dmi', "spacecash[i]")
 			var/matrix/M = matrix()
 			M.Translate(rand(-6, 6), rand(-4, 8))
 			banknote.transform = M
 			overlays += banknote
+			coins_only = FALSE
 
-	name = "[worth] credit"
-	desc = "They are worth [worth] credits."
+	if(remaining_worth)
+		for(var/i in coin_denominations)
+			while(remaining_worth >= i && iteration < 50)
+				remaining_worth -= i
+				iteration++
+				var/image/coin = image('icons/obj/items.dmi', "spacecash[i]")
+				var/matrix/M = matrix()
+				M.Translate(rand(-6, 6), rand(-4, 8))
+				coin.transform = M
+				overlays += coin
+
+	if(coins_only)
+		if(worth == 1)
+			name = "coin"
+			desc = "A single credit."
+			gender = NEUTER
+
+		else
+			name = "coins"
+			desc = "Total of [worth] credits."
+			gender = PLURAL
+	else
+		name = "[worth] credits"
+		desc = "Cold hard cash."
+		gender = NEUTER
 
 
 /obj/item/spacecash/bundle/attack_self()
@@ -84,6 +109,7 @@
 	bundle.worth = amount
 	bundle.update_icon()
 	usr.put_in_hands(bundle)
+	update_icon()
 
 
 /obj/item/spacecash/bundle/Initialize()
@@ -133,7 +159,7 @@
 
 // Exists here specifically for vagabond since they do not have bank accounts and used to have around 800 credits.
 /obj/item/spacecash/bundle/vagabond/Initialize()
-	worth = rand(700,900)
+	worth = rand(700, 900)
 	. = ..()
 
 /obj/item/spacecash/bundle/c1000

--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -1,62 +1,54 @@
 #define CASH_PER_STAT 5000 // The cost of a single level of a statistic
 
 /obj/item/spacecash
-	name = "0 credit"
-	desc = "It's worth 0 credits."
+	name = "coin"
+	desc = "It's worth something. Probably."
 	gender = PLURAL
 	icon = 'icons/obj/items.dmi'
 	icon_state = "spacecash1"
-	opacity = 0
-	density = FALSE
-	anchored = FALSE
 	force = 1
-	throwforce = 1
 	throw_speed = 1
 	throw_range = 2
 	w_class = ITEM_SIZE_SMALL
 	bad_type = /obj/item/spacecash
-	spawn_tags = null
-	var/access = list()
-	access = access_crate_cash
 	var/worth = 0
 
-/obj/item/spacecash/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/spacecash))
-		if(istype(W, /obj/item/spacecash/ewallet))
-			return FALSE
 
+/obj/item/spacecash/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/spacecash) && !istype(W, /obj/item/spacecash/ewallet))
 		var/obj/item/spacecash/bundle/bundle
-		if(!istype(W, /obj/item/spacecash/bundle))
-			var/obj/item/spacecash/cash = W
-			user.drop_from_inventory(cash)
-			bundle = new (src.loc)
-			bundle.worth += cash.worth
-			qdel(cash)
-		else //is bundle
+		if(istype(W, /obj/item/spacecash/bundle))
 			bundle = W
-		bundle.worth += src.worth
+		else
+			var/obj/item/spacecash/cash = W
+			bundle = new (loc)
+			bundle.worth = cash.worth
+			user.drop_from_inventory(cash)
+			qdel(cash)
+
+		bundle.worth += worth
 		bundle.update_icon()
 		if(ishuman(user))
-			var/mob/living/carbon/human/h_user = user
-			h_user.drop_from_inventory(src)
-			h_user.drop_from_inventory(bundle)
-			h_user.put_in_hands(bundle)
-		to_chat(user, SPAN_NOTICE("You add [src.worth] credits worth of money to the bundles.<br>It holds [bundle.worth] credits now."))
+			var/mob/living/carbon/human/H = user
+			H.drop_from_inventory(src)
+			H.drop_from_inventory(bundle)
+			H.put_in_hands(bundle)
+		to_chat(user, SPAN_NOTICE("You add [worth] credits worth of money to the bundles.<br>It holds [bundle.worth] credits now."))
 		qdel(src)
+
 
 /obj/item/spacecash/Destroy()
 	. = ..()
-	worth = 0		// Prevents money from be duplicated anytime.
+	worth = 0 // Prevents money from be duplicated anytime.
+
 
 /obj/item/spacecash/bundle
-	name = "pile of credits"
 	icon_state = ""
-	desc = "They are worth 0 credits."
-	worth = 0
+
 
 /obj/item/spacecash/bundle/update_icon()
 	cut_overlays()
-	var/sum = src.worth
+	var/sum = worth
 	var/num = 0
 	var/list/denominations = list(1000,500,200,100,50,20,10,5,1)
 	for(var/i in denominations)
@@ -67,149 +59,104 @@
 			var/matrix/M = matrix()
 			M.Translate(rand(-6, 6), rand(-4, 8))
 			banknote.transform = M
-			src.overlays += banknote
-	if(num == 0) // Less than one credit, let's just make it look like 1 for ease
-		var/image/banknote = image('icons/obj/items.dmi', "spacecash1")
-		var/matrix/M = matrix()
-		M.Translate(rand(-6, 6), rand(-4, 8))
-		banknote.transform = M
-		src.overlays += banknote
-	src.desc = "They are worth [worth] credits."
-	if(worth in denominations)
-		src.name = "[worth] credit"
-	else
-		src.name = "pile of credits"
+			overlays += banknote
+
+	name = "[worth] credit"
+	desc = "They are worth [worth] credits."
+
 
 /obj/item/spacecash/bundle/attack_self()
-	var/amount = input(usr, "How many credits do you want to take? (0 to [src.worth])", "Take Money", 20) as num
-	amount = round(CLAMP(amount, 0, src.worth))
-	if(amount==0) return 0
+	var/amount = input(usr, "How many credits do you want to take? (0 to [worth])", "Take Money", 20) as num
+	amount = round(CLAMP(amount, 0, worth))
+	if(!amount)
+		return
+
 	else if(!Adjacent(usr))
 		to_chat(usr, SPAN_WARNING("You need to be in arm's reach for that!"))
 		return
 
-	src.worth -= amount
-	src.update_icon()
+	worth -= amount
 	if(!worth)
 		usr.drop_from_inventory(src)
 		qdel(src)
-	if(amount in list(1000,500,200,100,50,20,5,1))
-		var/cashtype = text2path("/obj/item/spacecash/bundle/c[amount]")
-		var/obj/cash = new cashtype (usr.loc)
-		usr.put_in_hands(cash)
-	else
-		var/obj/item/spacecash/bundle/bundle = new (usr.loc)
-		bundle.worth = amount
-		bundle.update_icon()
-		usr.put_in_hands(bundle)
+
+	var/obj/item/spacecash/bundle/bundle = new (usr.loc)
+	bundle.worth = amount
+	bundle.update_icon()
+	usr.put_in_hands(bundle)
+
 
 /obj/item/spacecash/bundle/Initialize()
 	. = ..()
+	update_icon()
 	AddComponent(/datum/component/inspiration, CALLBACK(src, .proc/return_stats))
 
 /// Returns a list to use with inspirations. It can be empty if there's not enough money in the bundle. Important side-effects: converts worth to points, thus reducing worth.
 /obj/item/spacecash/bundle/proc/return_stats()
 	RETURN_TYPE(/list)
-	var/points = min(worth/CASH_PER_STAT, 10) // capped at 10 points per bundle, costs 50k
+	var/points = min(worth / CASH_PER_STAT, 10) // capped at 10 points per bundle, costs 50k
 	var/list/stats = list()
 	// Distribute points evenly with random statistics. Just skips the loop if there's not enough money in the bundle, resulting in an empty list.
 	while(points > 0)
 		stats[pick(ALL_STATS)] += 1 // Picks a random stat, if not present it adds it with a value of 1, else it increases the value by 1
 		points--
-	worth -= points*CASH_PER_STAT
+	worth -= points * CASH_PER_STAT
 	update_icon()
 	if(!worth)
 		qdel(src)
 	return stats
 
+
 /obj/item/spacecash/bundle/c1
-	name = "1 credit"
-	icon_state = "spacecash1"
-	desc = "It's worth 1 credit."
 	worth = 1
 
 /obj/item/spacecash/bundle/c5
-	name = "5 credits"
-	icon_state = "spacecash5"
-	desc = "It's worth 5 credits."
 	worth = 5
 
 /obj/item/spacecash/bundle/c10
-	name = "10 credits"
-	icon_state = "spacecash10"
-	desc = "It's worth 10 credits."
 	worth = 10
 
 /obj/item/spacecash/bundle/c20
-	name = "20 credits"
-	icon_state = "spacecash20"
-	desc = "It's worth 20 credits."
 	worth = 20
 
 /obj/item/spacecash/bundle/c50
-	name = "50 credits"
-	icon_state = "spacecash50"
-	desc = "It's worth 50 credits."
 	worth = 50
 
 /obj/item/spacecash/bundle/c100
-	name = "100 credits"
-	icon_state = "spacecash100"
-	desc = "It's worth 100 credits."
 	worth = 100
 
 /obj/item/spacecash/bundle/c200
-	name = "200 credits"
-	icon_state = "spacecash200"
-	desc = "It's worth 200 credits."
 	worth = 200
 
 /obj/item/spacecash/bundle/c500
-	name = "500 credits"
-	icon_state = "spacecash500"
-	desc = "It's worth 500 credits."
 	worth = 500
 
-// exists here specifically for vagabond since they do not have bank accounts and used to have around 800 credits.
-/obj/item/spacecash/bundle/vagabond
-	name = "pile of credits"
-	icon_state = "spacecash500"
-
+// Exists here specifically for vagabond since they do not have bank accounts and used to have around 800 credits.
 /obj/item/spacecash/bundle/vagabond/Initialize()
-	var/rand_amount = rand(700,900)
-	desc = "They are worth [rand_amount] credits."
-	worth = rand_amount
+	worth = rand(700,900)
 	. = ..()
 
 /obj/item/spacecash/bundle/c1000
-	name = "1000 credits"
-	icon_state = "spacecash1000"
-	desc = "It's worth 1000 credits."
 	worth = 1000
 
-proc/spawn_money(var/sum, spawnloc, mob/living/carbon/human/human_user)
-	if(sum in list(1000,500,200,100,50,20,10,1))
-		var/cash_type = text2path("/obj/item/spacecash/bundle/c[sum]")
-		var/obj/cash = new cash_type (usr.loc)
-		if(ishuman(human_user) && !human_user.get_active_hand())
-			human_user.put_in_hands(cash)
-	else
-		var/obj/item/spacecash/bundle/bundle = new(spawnloc)
-		bundle.worth = sum
-		bundle.update_icon()
-		if(ishuman(human_user) && !human_user.get_active_hand())
-			human_user.put_in_hands(bundle)
-	return
+
+/proc/spawn_money(sum, spawnloc, mob/living/carbon/human/H)
+	var/obj/item/spacecash/bundle/bundle = new(spawnloc)
+	bundle.worth = sum
+	bundle.update_icon()
+	if(istype(H) && !H.get_active_hand())
+		H.put_in_hands(bundle)
+
 
 /obj/item/spacecash/ewallet
 	name = "Charge card"
 	icon_state = "efundcard"
 	desc = "A card that holds an amount of money."
-	var/owner_name = "" //So the ATM can set it so the EFTPOS can put a valid name on transactions.
+	var/owner_name = "" // So the ATM can set it so the EFTPOS can put a valid name on transactions.
 
 /obj/item/spacecash/ewallet/examine(mob/user)
 	..(user)
-	if(!(user in view(2)) && user!=src.loc) return
-	to_chat(user, "\blue Charge card's owner: [src.owner_name]. Credits remaining: [src.worth].")
+	if(user in view(2) || user == loc)
+		to_chat(user, span_blue("Charge card's owner: [owner_name]. Credits remaining: [worth]."))
 
 #undef CASH_PER_STAT


### PR DESCRIPTION
## About The Pull Request

Cash bundle that vagabonds receive on spawn always have appearance of a single banknote, regardless of how much money bundle actually contains. Not anymore.
Also changes bundle name and description if it contains only coins or a single coin.

## Why It's Good For The Game

Fixes cool.

## Changelog
:cl:
fix: icon of cash bundle that vagabonds spawn with
/:cl: