### PR TITLE
Ruins z-levels(You can no longer fall on non-climbable structures)

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -209,6 +209,7 @@
 	if(anchored)
 		return FALSE
 
+
 	if(throwing > 0)
 		return FALSE
 
@@ -236,7 +237,15 @@
 /mob/living/carbon/human/can_fall(turf/below, turf/simulated/open/dest = src.loc)
 	if (CanAvoidGravity())
 		return FALSE
-	// Special condition for jetpack mounted folk!
+	// can't fall on walls anymore
+	var/turf/true_below = GetBelow(src)
+	for(var/obj/structure/possible_blocker in true_below.contents)
+		if(possible_blocker.density)
+			if(possible_blocker.climbable)
+				continue
+			else
+				return FALSE
+
 	if (!restrained())
 		var/tile_view = view(src, 1)
 		var/obj/item/clothing/shoes/magboots/MB = shoes
@@ -251,7 +260,7 @@
 					return FALSE
 				for(var/turf/simulated/wall/W in tile_view)
 					return FALSE
-          
+
 	return ..()
 
 /mob/living/carbon/human/bst/can_fall()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Players may no longer FALL ontop of non-climbable structures (Windows , Walls) , they will still however fall on climbalbe sturctures ( Low-walls , tables)
## Why It's Good For The Game
No more wall clipping
## Changelog
:cl:
balance: Mobs can no longer fall into walls or any fully dense structres.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
