### PR TITLE
Eris Med 12(Fixes blood not processing in dead bodies)

### DIFF
--- a/code/modules/reagents/reagents/core.dm
+++ b/code/modules/reagents/reagents/core.dm
@@ -10,6 +10,7 @@
 	glass_icon_state = "glass_red"
 	glass_name = "tomato juice"
 	glass_desc = "Are you sure this is tomato juice?"
+	affects_dead = TRUE
 	nerve_system_accumulations = 0
 
 /datum/reagent/organic/blood/initialize_data(var/newdata)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes blood actually apply itself to dead bodies

## Why It's Good For The Game
People shouldn't perma die due to having drained blood
## Changelog
:cl:
balance: Blood can now be replenished in dead people.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
