### PR TITLE
Menace rebalance(Now it truly is a death squad chemical!)

### DIFF
--- a/code/modules/reagents/reagents/stims.dm
+++ b/code/modules/reagents/reagents/stims.dm
@@ -363,6 +363,7 @@
 	if(prob(5 - (2 * M.stats.getMult(STAT_TGH))))
 		M.paralysis = max(M.paralysis, 20)
 
+// if psionics ever get added , this should awaken them.
 /datum/reagent/stim/party_drops
 	name = "Party Drops"
 	id = "party drops"
@@ -397,6 +398,7 @@
 	if(prob(5))
 		M.vomit()
 
+#define MENACE_HEALTH_BUFF 100
 /datum/reagent/stim/menace
 	name = "MENACE"
 	id = "menace"
@@ -408,6 +410,24 @@
 	nerve_system_accumulations = 90
 	addiction_chance = 70
 
+/datum/reagent/stim/menace/on_mob_add(mob/living/L)
+	. = ..()
+	var/mob/living/carbon/human/dreamer = L
+	if(!istype(L))
+		return
+	dreamer.adjustMaxHealth(MENACE_HEALTH_BUFF) // should be tougher, after all its a death wish
+	dreamer.heal_overall_damage(MENACE_HEALTH_BUFF, MENACE_HEALTH_BUFF) // just so they start at full power
+
+/datum/reagent/stim/menace/on_mob_delete(mob/living/L)
+	. = ..()
+	var/mob/living/carbon/human/dreamer = L
+	if(!istype(L))
+		return
+	dreamer.adjustMaxHealth(-MENACE_HEALTH_BUFF)
+	dreamer.adjustToxLoss(MENACE_HEALTH_BUFF * 0.3) // 30 tox damage , so people don't game this
+	dreamer.Paralyse(3)
+
+
 /datum/reagent/stim/menace/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_VIG, STAT_LEVEL_EXPERT * effect_multiplier, STIM_TIME, "menace")
 	M.stats.addTempStat(STAT_TGH, STAT_LEVEL_EXPERT * effect_multiplier, STIM_TIME, "menace")
@@ -417,6 +437,14 @@
 	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "menace")
 	M.slurring = max(M.slurring, 30)
 	M.add_chemical_effect(CE_SPEECH_VOLUME, 4)
+	// fully numbs pain
+	M.add_chemical_effect(CE_PAINKILLER,150 * effect_multiplier)
+	// ain't got time for bleeding or viruses
+	M.add_chemical_effect(CE_ANTIBIOTIC, 50 * effect_multiplier) // not great , but stops infections
+	M.add_chemical_effect(CE_BLOODRESTORE, 2 * effect_multiplier) // can bleed some
+	// in the future , this should add a special perk , maybe called "Death Wish"
+	// that can go indepth and remove even more downsides of taking damage
+	// or have special interactions with guns / CQC (Auto-reload , parrying)
 	sanity_gain = 1
 
 /datum/reagent/stim/menace/withdrawal_act(mob/living/carbon/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Menace has been changed to provide players with 100 more health upon insertion and to have a blood restoring , painkiller effect ( twice as strong as oxy) aswell as a slight  antibiotic effect
On adding to someones body , it increases the health by 100 and also heals 100 brute and 100 burn, for that epic comeback.
On removal from blood , its health effect is removed , and the person using it  deals 40 damage and  paralyses the user.

## Why It's Good For The Game
It uses 90 NSA , and only blocked people from using painkillers and other very vital chemicals during combat(which made everyone not want to use it ) , with these changes , it should find more uses in general , especially that it now protects from bleeding and pain

## Changelog
:cl:
balance: Menace now is slightly antibiotic , replenishes blood and increases the max health of the user while its being metabolized.
balance: Menace now adds 100 health upon being ingested , and also heals 100 brute and 100 burn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
