### PR TITLE
Plant stacking fix

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -292,7 +292,7 @@
 
 	if(seed.get_trait(TRAIT_SPREAD) > 0)
 		var/turf/current_turf = get_turf(user)
-		if(locate(/obj/machinery/portable_atmospherics/hydroponics/soil/invisible) in current_turf.contents)	// Prevents infinite plant stacking
+		if(!locate(/obj/machinery/portable_atmospherics/hydroponics/soil/invisible) in current_turf.contents)	// Prevents infinite plant stacking
 			to_chat(user, SPAN_NOTICE("You plant the [src.name]."))
 			new /obj/machinery/portable_atmospherics/hydroponics/soil/invisible(current_turf,src.seed)
 			qdel(src)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -293,10 +293,9 @@
 	if(seed.get_trait(TRAIT_SPREAD) > 0)
 		var/turf/current_turf = get_turf(user)
 		if(!locate(/obj/machinery/portable_atmospherics/hydroponics/soil/invisible) in current_turf.contents)	// Prevents infinite plant stacking
-			to_chat(user, SPAN_NOTICE("You plant the [src.name]."))
-			new /obj/machinery/portable_atmospherics/hydroponics/soil/invisible(current_turf,src.seed)
+			to_chat(user, SPAN_NOTICE("You plant the [src]."))
+			new /obj/machinery/portable_atmospherics/hydroponics/soil/invisible(current_turf, seed)
 			qdel(src)
-		return
 
 /obj/item/reagent_containers/food/snacks/grown/pre_pickup(mob/user)
 	if(!seed)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -291,9 +291,11 @@
 		return
 
 	if(seed.get_trait(TRAIT_SPREAD) > 0)
-		to_chat(user, SPAN_NOTICE("You plant the [src.name]."))
-		new /obj/machinery/portable_atmospherics/hydroponics/soil/invisible(get_turf(user),src.seed)
-		qdel(src)
+		var/turf/current_turf = get_turf(user)
+		if(locate(/obj/machinery/portable_atmospherics/hydroponics/soil/invisible) in current_turf.contents)	// Prevents infinite plant stacking
+			to_chat(user, SPAN_NOTICE("You plant the [src.name]."))
+			new /obj/machinery/portable_atmospherics/hydroponics/soil/invisible(current_turf,src.seed)
+			qdel(src)
 		return
 
 /obj/item/reagent_containers/food/snacks/grown/pre_pickup(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a check for existing invisible soil when planting a seed with TRAIT_SPREAD > 0.

## Why It's Good For The Game

Removes exploitable behavior from the game.

## Changelog
:cl:
fix: added check for existing invisible soil when planting a seed with TRAIT_SPREAD > 0
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
