### PR TITLE
Style buffs (Fixes technomancer attire being horrid)

### DIFF
--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -89,16 +89,17 @@
 	light_overlay = "technohelmet_light"
 	brightness_on = 4
 	armor = list(
-		melee = 35,
+		melee = 30,
 		bullet = 30,
-		energy = 40,
-		bomb = 20,
+		energy = 10,
+		bomb = 50,
 		bio = 0,
-		rad = 30
+		rad = 80
 	)//Mix between hardhat.dm armor values, helmet armor values in armor.dm, and armor values for TM void helmet in station.dm.
 	flash_protection = FLASH_PROTECTION_MAJOR
 	price_tag = 500
 	style_coverage = COVERS_WHOLE_HEAD
+	style = STYLE_NONE
 
 /obj/item/clothing/head/armor/helmet/technomancer/New()
 	. = ..()

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -513,17 +513,17 @@
 //Technomancer armor
 /obj/item/clothing/suit/storage/vest/insulated
 	name = "insulated technomancer armor"
-	desc = "A set of armor insulated against heat and electrical shocks, shielded against radiation, and protected against energy weapon projectiles."
+	desc = "A set of armor insulated against heat and electrical shocks, shielded against radiation, and protected against blunt hits."
 	icon_state = "armor_engineering"
 	item_state = "armor_engineering"
 	blood_overlay_type = "armor"
 	armor = list(
-		melee = 35,
+		melee = 30,
 		bullet = 30,
-		energy = 40,
-		bomb = 20,
+		energy = 10,
+		bomb = 50,
 		bio = 0,
-		rad = 30
+		rad = 80
 	)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	item_flags = DRAG_AND_DROP_UNEQUIP
@@ -534,6 +534,7 @@
 	//Used ablative gear armor values and technomancer helmet/voidsuit values.
 	slowdown = LIGHT_SLOWDOWN
 	stiffness = LIGHT_STIFFNESS
+	style = STYLE_NONE
 
 /*
  * Reactive Armor


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Technomancer armor no longer wrecks style, however its armour rating has been changed to 30 melle , 30 bullet , 10 energy  , 50 bomb , 80 rad. (from  35 melle , 30 bullet , 40 energy , 20 bomb , 30 rad)

## Why It's Good For The Game
Imagine being forced to wear vagabond attire , while IH inspector gets max style with armor ontop.
## Changelog
:cl:
balance: Techomancer armour ratings tweaked to be more usefull to their job ,  technomaner armor style loss removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
