### PR TITLE
Cover no longer works if the target is not near it

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -165,7 +165,7 @@ for reference:
 /obj/structure/barricade/proc/check_cover(obj/item/projectile/P, turf/from)
 	if (get_dist(P.starting, loc) <= 1) //Cover won't help you if people are THIS close
 		return TRUE
-	if (get_dist(loc, P.trajectory.target) > 1 ) // Target turf must be adjaecet for it to count as cover
+	if(get_dist(loc, P.trajectory.target) > 1 ) // Target turf must be adjacent for it to count as cover
 		return TRUE
 	var/valid = FALSE
 	var/distance = get_dist(P.last_interact,loc)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -164,11 +164,13 @@ for reference:
 
 /obj/structure/barricade/proc/check_cover(obj/item/projectile/P, turf/from)
 	if (get_dist(P.starting, loc) <= 1) //Cover won't help you if people are THIS close
-		return 1
+		return TRUE
+	if (get_dist(loc, P.trajectory.target) > 1 ) // Target turf must be adjaecet for it to count as cover
+		return TRUE
 	var/valid = FALSE
 	var/distance = get_dist(P.last_interact,loc)
 	if(!P.def_zone)
-		return 1 // Emitters, or anything with no targeted bodypart will always bypass the cover
+		return TRUE // Emitters, or anything with no targeted bodypart will always bypass the cover
 	P.check_hit_zone(loc, distance)
 
 	var/targetzone = check_zone(P.def_zone)
@@ -187,8 +189,8 @@ for reference:
 		else
 			visible_message(SPAN_WARNING("[src] breaks down!"))
 			qdel(src)
-			return 1
-	return 1
+			return TRUE
+	return TRUE
 
 //Actual Deployable machinery stuff
 /obj/machinery/deployable
@@ -338,6 +340,8 @@ for reference:
 /obj/machinery/deployable/barrier/proc/check_cover(obj/item/projectile/P, turf/from)
 	if (get_dist(P.starting, loc) <= 1) //Cover won't help you if people are THIS close
 		return 1
+	if (get_dist(loc, P.trajectory.target) > 1 ) // Target turf must be adjaecet for it to count as cover
+		return TRUE
 	var/valid = FALSE
 	var/distance = get_dist(P.last_interact,loc)
 	if(!P.def_zone)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -340,7 +340,7 @@ for reference:
 /obj/machinery/deployable/barrier/proc/check_cover(obj/item/projectile/P, turf/from)
 	if (get_dist(P.starting, loc) <= 1) //Cover won't help you if people are THIS close
 		return 1
-	if (get_dist(loc, P.trajectory.target) > 1 ) // Target turf must be adjaecet for it to count as cover
+	if(get_dist(loc, P.trajectory.target) > 1 ) // Target turf must be adjacent for it to count as cover
 		return TRUE
 	var/valid = FALSE
 	var/distance = get_dist(P.last_interact,loc)

--- a/code/game/objects/structures/low_wall.dm
+++ b/code/game/objects/structures/low_wall.dm
@@ -153,7 +153,7 @@
 /obj/structure/low_wall/proc/check_cover(obj/item/projectile/P, turf/from)
 	if (get_dist(P.starting, loc) <= 1) //Tables won't help you if people are THIS close
 		return 1
-	if (get_dist(loc, P.trajectory.target) > 1 ) // Target turf must be adjaecet for it to count as cover
+	if(get_dist(loc, P.trajectory.target) > 1 ) // Target turf must be adjacent for it to count as cover
 		return TRUE
 	var/valid = FALSE
 	var/distance = get_dist(P.last_interact,loc)

--- a/code/game/objects/structures/low_wall.dm
+++ b/code/game/objects/structures/low_wall.dm
@@ -153,6 +153,8 @@
 /obj/structure/low_wall/proc/check_cover(obj/item/projectile/P, turf/from)
 	if (get_dist(P.starting, loc) <= 1) //Tables won't help you if people are THIS close
 		return 1
+	if (get_dist(loc, P.trajectory.target) > 1 ) // Target turf must be adjaecet for it to count as cover
+		return TRUE
 	var/valid = FALSE
 	var/distance = get_dist(P.last_interact,loc)
 

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -23,7 +23,7 @@
 /obj/structure/table/proc/check_cover(obj/item/projectile/P, turf/from)
 	if (get_dist(P.starting, loc) <= 1) //Tables won't help you if people are THIS close
 		return TRUE
-	if (get_dist(loc, P.trajectory.target) > 1 ) // Target turf must be adjaecet for it to count as cover
+	if(get_dist(loc, P.trajectory.target) > 1 ) // Target turf must be adjacent for it to count as cover
 		return TRUE
 	var/valid = FALSE
 	var/distance = get_dist(P.last_interact,loc)

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -22,12 +22,14 @@
 //checks if projectile 'P' from turf 'from' can hit whatever is behind the table. Returns 1 if it can, 0 if bullet stops.
 /obj/structure/table/proc/check_cover(obj/item/projectile/P, turf/from)
 	if (get_dist(P.starting, loc) <= 1) //Tables won't help you if people are THIS close
-		return 1
+		return TRUE
+	if (get_dist(loc, P.trajectory.target) > 1 ) // Target turf must be adjaecet for it to count as cover
+		return TRUE
 	var/valid = FALSE
 	var/distance = get_dist(P.last_interact,loc)
 	if(!P.def_zone)
-		return 1 // Emitters, or anything with no targeted bodypart will always bypass the cover
-	P.check_hit_zone(loc, distance)
+		return TRUE // Emitters, or anything with no targeted bodypart will always bypass the cover
+	//P.check_hit_zone(loc, distance)
 
 	var/targetzone = check_zone(P.def_zone)
 	if (targetzone in list(BP_R_LEG, BP_L_LEG))

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -29,7 +29,7 @@
 	var/distance = get_dist(P.last_interact,loc)
 	if(!P.def_zone)
 		return TRUE // Emitters, or anything with no targeted bodypart will always bypass the cover
-	//P.check_hit_zone(loc, distance)
+	P.check_hit_zone(loc, distance)
 
 	var/targetzone = check_zone(P.def_zone)
 	if (targetzone in list(BP_R_LEG, BP_L_LEG))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cover no longer applies if the target is not near any cover
## Why It's Good For The Game
>Prepare to do epic valkyrie shot  1-2 tiles behind a low-wall using the scope
>The low wall blocks the shot, even if its aimed at chest  and if the target is not near any cover, because the target zone gets changed

## Changelog
:cl:
balance: Cover now only works if the target is adjacent to it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
