### PR TITLE
Buffs fragmentation nades(Fragmentation nades now create a weak explosion around them, and bounce off when thrown from above)

### DIFF
--- a/code/game/objects/items/weapons/grenades/frag.dm
+++ b/code/game/objects/items/weapons/grenades/frag.dm
@@ -22,15 +22,13 @@
 	if(!O) return
 
 	if(num_fragments)
-		var/lying = FALSE
+		var/ontop = FALSE
 		if(isturf(src.loc))
 			for(var/mob/living/M in O)
-				//lying on a frag grenade while the grenade is on the ground causes you to absorb most of the shrapnel.
-				//you will most likely be dead, but others nearby will be spared the fragments that hit you instead.
-				if(M.lying)
-					lying = TRUE
+				ontop = TRUE
+				break
 
-		if(!lying)
+		if(!ontop)
 			fragment_explosion(O, spread_range, fragment_type, num_fragments, fragment_damage, damage_step)
 		else
 			fragment_explosion(O, 0, fragment_type, num_fragments, fragment_damage, damage_step)

--- a/code/game/objects/items/weapons/grenades/frag.dm
+++ b/code/game/objects/items/weapons/grenades/frag.dm
@@ -9,6 +9,7 @@
 	var/num_fragments = 50  //total number of fragments produced by the grenade
 	var/fragment_damage = 15
 	var/damage_step = 8      //projectiles lose a fragment each time they travel this distance. Can be a non-integer.
+	var/blast_radius = 2// they still create a small , weak blast around
 
 	//The radius of the circle used to launch projectiles. Lower values mean less projectiles are used but if set too low gaps may appear in the spread pattern
 	var/spread_range = 7
@@ -33,6 +34,8 @@
 			fragment_explosion(O, spread_range, fragment_type, num_fragments, fragment_damage, damage_step)
 		else
 			fragment_explosion(O, 0, fragment_type, num_fragments, fragment_damage, damage_step)
+	if(blast_radius)
+		explosion(O, 0, 0, blast_radius, adminlog = "Frag nade explosion", z_transfer = FALSE)
 
 	qdel(src)
 
@@ -44,6 +47,7 @@
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTEEL = 2, MATERIAL_PLASMA = 2, MATERIAL_PLASTIC = 3, MATERIAL_SILVER = 2)
 	num_fragments = 25
 	fragment_damage = 10
+	blast_radius = 2
 	damage_step = 7
 
 /obj/item/grenade/frag/sting
@@ -54,6 +58,7 @@
 	fragment_type = /obj/item/projectile/bullet/pellet/fragment/rubber
 	num_fragments = 25
 	fragment_damage = 5
+	blast_radius = 0
 	damage_step = 12
 	spread_range = 7
 
@@ -65,5 +70,6 @@
 	fragment_type = /obj/item/projectile/bullet/pellet/fragment/rubber/weak
 	num_fragments = 25
 	fragment_damage = 10
+	blast_radius = 0
 	damage_step = 8
 	spread_range = 7

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -106,7 +106,7 @@
 		if(bonk.incapacitated(INCAPACITATION_GROUNDED))
 			return
 		bonk.apply_damage(2, BRUTE, BP_HEAD, FALSE , FALSE, src)
-		bonk.visible_message(SPAN_DANGER("[src] falls from above and bonks [bonk.name] on his head!"), SPAN_DANGER("[src] falls on your head and bounces to the side!"), "You hear something round hitting someone's head", 5)
+		bonk.visible_message(SPAN_DANGER("[src] falls from above and bonks [bonk.name] on \his head!"), SPAN_DANGER("[src] falls on your head and bounces to the side!"), "You hear a dull thud.", 5)
 		var/turf/random = pick(orange(1, dest))
 		forceMove(random)
 

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -97,3 +97,14 @@
 	walk(src, null, null)
 	..()
 	return
+
+/obj/item/grenade/fall_impact(turf/from, turf/dest)
+	..()
+	var/found = dest.contents.Find(/mob/living/carbon/human)
+	if(found)
+		var/mob/living/carbon/human/bonk = dest.contents[found]
+		bonk.apply_damage(2, BRUTE, BP_HEAD, FALSE , FALSE, src)
+		bonk.visible_message(SPAN_DANGER("[src] falls from above and bonks [bonk.name] on his head!"), SPAN_DANGER("[src] falls on your head and bounces to the side!"), "You hear something round hitting someone's head", 5)
+		var/turf/random = pick(orange(1, dest))
+		forceMove(random)
+

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -103,6 +103,8 @@
 	var/found = dest.contents.Find(/mob/living/carbon/human)
 	if(found)
 		var/mob/living/carbon/human/bonk = dest.contents[found]
+		if(bonk.incapacitated(INCAPACITATION_GROUNDED))
+			return
 		bonk.apply_damage(2, BRUTE, BP_HEAD, FALSE , FALSE, src)
 		bonk.visible_message(SPAN_DANGER("[src] falls from above and bonks [bonk.name] on his head!"), SPAN_DANGER("[src] falls on your head and bounces to the side!"), "You hear something round hitting someone's head", 5)
 		var/turf/random = pick(orange(1, dest))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Frag nades now create a 2-tile radius explosion around then
Frag nades also completly obliterate anyone thats sitting above them now.
Frag nades thrown from above now will bounce to the side of someone's head.
## Why It's Good For The Game
People can stand ontop and suffer nothing. 
## Changelog
:cl:
balance : Frag nades now create a very weak explosion around themselves when detonating
balance : frag nades now will obliterate anyone standing ontop
balance: Grenades that are thrown above people will bounce to the side.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
