### PR TITLE
Gun frames in trash/maintenance spawn with 1-2 parts installed

### DIFF
--- a/code/datums/craft/gun_parts.dm
+++ b/code/datums/craft/gun_parts.dm
@@ -35,7 +35,7 @@
 	if(spawn_with_preinstalled_parts)
 		var/list/parts_list = list(pick(gripvars), mechanism, barrel)
 
-		parts_list -= pick(parts_list)
+		pick_n_take(parts_list)
 		if(prob(50))
 			parts_list -= pick(parts_list)
 

--- a/code/datums/craft/gun_parts.dm
+++ b/code/datums/craft/gun_parts.dm
@@ -91,9 +91,8 @@
 	if(istool(I))
 		if(I.get_tool_quality(QUALITY_SCREW_DRIVING))
 			var/list/possibles = contents.Copy()
-			possibles += "Cancel"
 			var/obj/item/part/gun/toremove = input("Which part would you like to remove?","Removing parts") in possibles
-			if(toremove == "Cancel")
+			if(!toremove)
 				return
 			if(I.use_tool(user, src, WORKTIME_INSTANT, QUALITY_SCREW_DRIVING, FAILCHANCE_ZERO, required_stat = STAT_MEC))
 				eject_item(toremove, user)

--- a/code/datums/craft/gun_parts.dm
+++ b/code/datums/craft/gun_parts.dm
@@ -37,7 +37,7 @@
 
 		pick_n_take(parts_list)
 		if(prob(50))
-			parts_list -= pick(parts_list)
+			pick_n_take(parts_list)
 
 		for(var/part in parts_list)
 			if(ispath(part, grip))

--- a/code/datums/craft/gun_parts.dm
+++ b/code/datums/craft/gun_parts.dm
@@ -21,6 +21,27 @@
 	var/barrel = /obj/item/part/gun/barrel
 	var/barrel_attached = FALSE
 
+/obj/item/part/gun/frame/New(loc, junk)
+	..()
+	if(junk)
+		var/list/parts_list = list(pick(gripvars), mechanism, barrel)
+
+		parts_list -= pick(parts_list)
+		if(prob(50))
+			parts_list -= pick(parts_list)
+
+		for(var/part in parts_list)
+			if(ispath(part, grip))
+				new part(src)
+				grip_attached = TRUE
+			if(ispath(part, barrel))
+				new part(src)
+				barrel_attached = TRUE
+			if(ispath(part, mechanism))
+				new part(src)
+				mechanism_attached = TRUE
+
+
 /obj/item/part/gun/frame/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/part/gun/grip))
 		if(grip_attached)
@@ -53,6 +74,23 @@
 			barrel_attached = TRUE
 			to_chat(user, SPAN_NOTICE("You have attached the barrel to \the [src]."))
 			return
+
+	if(istool(I))
+		if(I.get_tool_quality(QUALITY_SCREW_DRIVING))
+			var/list/possibles = contents.Copy()
+			possibles += "Cancel"
+			var/obj/item/part/gun/toremove = input("Which part would you like to remove?","Removing parts") in possibles
+			if(toremove == "Cancel")
+				return
+			if(I.use_tool(user, src, WORKTIME_INSTANT, QUALITY_SCREW_DRIVING, FAILCHANCE_ZERO, required_stat = STAT_MEC))
+				eject_item(toremove, user)
+				if(istype(toremove, grip))
+					grip_attached = FALSE
+				if(istype(toremove, barrel))
+					barrel_attached = FALSE
+				if(istype(toremove, mechanism))
+					mechanism_attached = FALSE
+
 	return ..()
 
 /obj/item/part/gun/frame/proc/handle_gripvar(obj/item/I, mob/living/user)

--- a/code/modules/scrap/scrap.dm
+++ b/code/modules/scrap/scrap.dm
@@ -146,7 +146,7 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 				true_loot_tags |= list(pickweight(rare_loot))
 			candidates = SSspawn_data.valid_candidates(true_loot_tags, restricted_tags - rare_loot, FALSE, 1, top_price, TRUE, list(/obj/item/stash_spawner))
 		var/loot_path = SSspawn_data.pick_spawn(candidates)
-		new loot_path(src)
+		new loot_path(src, junk = TRUE)
 		var/list/aditional_objects = SSspawn_data.all_accompanying_obj_by_path[loot_path]
 		if(islist(aditional_objects) && aditional_objects.len)
 			for(var/thing in aditional_objects)

--- a/code/modules/scrap/scrap.dm
+++ b/code/modules/scrap/scrap.dm
@@ -146,7 +146,7 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 				true_loot_tags |= list(pickweight(rare_loot))
 			candidates = SSspawn_data.valid_candidates(true_loot_tags, restricted_tags - rare_loot, FALSE, 1, top_price, TRUE, list(/obj/item/stash_spawner))
 		var/loot_path = SSspawn_data.pick_spawn(candidates)
-		new loot_path(src, junk = TRUE)
+		new loot_path(src)
 		var/list/aditional_objects = SSspawn_data.all_accompanying_obj_by_path[loot_path]
 		if(islist(aditional_objects) && aditional_objects.len)
 			for(var/thing in aditional_objects)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gun frames that spawn in trash piles or maintenance will come with part(s) preinstalled. One part is guaranteed and the second has a 50% of spawning. Additionally, using a screwdriver on the frame will let you take out any parts currently installed.

## Why It's Good For The Game

Reduces randomness in gun part hunting.

## Changelog
:cl:
tweak: gun parts can be removed from frames with a screwdriver
balance: maint/trash gun frames spawn with 1-2 parts installed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
