### PR TITLE
Mech nerfs ( Mechs heavy legs and combat legs are now slower)

### DIFF
--- a/code/modules/mechs/premade/combat.dm
+++ b/code/modules/mechs/premade/combat.dm
@@ -92,10 +92,10 @@
 	exosuit_desc_string = "sleek hydraulic legs"
 	desc = "These combat legs are both fast and durable, thanks to a generous plasteel reinforcement and aerodynamic design."
 	icon_state = "combat_legs"
-	move_delay = 2
+	move_delay = 3
 	power_use = 20
 	matter = list(MATERIAL_STEEL = 15)
-	turn_delay = 1 // Better than light , turns fast and costs a lot
+	turn_delay = 2 // Better than light , turns fast and costs a lot
 	max_damage = 100
 	power_use = 25
 	matter = list(MATERIAL_STEEL = 15, MATERIAL_PLASTEEL = 5, MATERIAL_PLASMA = 5, MATERIAL_DIAMOND = 2) // Expensive because durable.

--- a/code/modules/mechs/premade/heavy.dm
+++ b/code/modules/mechs/premade/heavy.dm
@@ -59,7 +59,7 @@
 	exosuit_desc_string = "heavy legs"
 	desc = "Exosuit actuators struggle to move these armored legs, and they're even worse at turning."
 	icon_state = "heavy_legs"
-	move_delay = 7
+	move_delay = 5
 	turn_delay = 4 // Turning should be easy , moving not.
 	max_damage = 200
 	power_use = 100

--- a/code/modules/mechs/premade/heavy.dm
+++ b/code/modules/mechs/premade/heavy.dm
@@ -59,8 +59,8 @@
 	exosuit_desc_string = "heavy legs"
 	desc = "Exosuit actuators struggle to move these armored legs, and they're even worse at turning."
 	icon_state = "heavy_legs"
-	move_delay = 5
-	turn_delay = 2 // Turning should be easy , moving not.
+	move_delay = 7
+	turn_delay = 4 // Turning should be easy , moving not.
 	max_damage = 200
 	power_use = 100
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_URANIUM = 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases turn rate and the move delay on the heavy legs and combat legs of mechs

## Why It's Good For The Game
Someone (cough cough the guy doing Mech PR's lately) has been overbuffing mechs, my changes were within the idea of them standing at a reasonable balance level , at which they currently are not.  Mechs are way too fast and way too powerfull as is , especially with the now HUMUNGOUS module health they get since the (cough cough , mech pr guy) bufffed them.

## Changelog
:cl:
balance: Heavy mech legs are now slower and turn twice as slow.
balance : Combat mech legs are now slower and turn slower
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
