### PR TITLE
Absolutely ruins mechs (Fixes mech targetting , and mech damage dealing)

### DIFF
--- a/code/modules/mechs/mech_damage.dm
+++ b/code/modules/mechs/mech_damage.dm
@@ -40,36 +40,69 @@
 	return def_zone //Careful with effects, mechs shouldn't be stunned
 
 /mob/living/exosuit/getarmor(def_zone, type)
-	. = ..()
 	if(body?.armor_plate)
 		var/body_armor = body.armor_plate?.armor.getRating(type)
-		if(body_armor) . += body_armor
+		if(body_armor) return body_armor
+	return 0
 
 /mob/living/exosuit/updatehealth()
 	if(body) maxHealth = body.mech_health
 	health = maxHealth - (getFireLoss() + getBruteLoss())
 
-/mob/living/exosuit/adjustFireLoss(amount, obj/item/mech_component/MC = pick(list(arms, legs, body, head)))
-	if(MC)
-		MC.take_burn_damage(amount)
-		MC.update_health()
+/mob/living/exosuit/adjustFireLoss(amount, obj/item/mech_component/MC = null)
+	if(!MC)
+		MC = pick(list(arms, legs, body, head))
+	MC.take_burn_damage(amount)
+	MC.update_health()
 
-/mob/living/exosuit/adjustBruteLoss(amount, obj/item/mech_component/MC = pick(list(arms, legs, body, head)))
-	if(MC)
-		MC.take_brute_damage(amount)
-		MC.update_health()
+/mob/living/exosuit/adjustBruteLoss(amount, obj/item/mech_component/MC = null)
+	if(!MC)
+		MC = pick(list(arms, legs, body, head))
+	MC.take_brute_damage(amount)
+	MC.update_health()
 
 /mob/living/exosuit/proc/zoneToComponent(zone)
 	switch(zone)
-		if(BP_EYES, BP_HEAD) return head
+		if(BP_EYES, BP_HEAD, BP_MOUTH) return head
 		if(BP_L_ARM, BP_R_ARM) return arms
-		if(BP_L_LEG, BP_R_LEG) return legs
+		if(BP_L_LEG, BP_R_LEG, BP_GROIN) return legs
 		else return body
 
 
 /mob/living/exosuit/apply_damage(damage = 0, damagetype = BRUTE, def_zone = null, sharp = FALSE, edge = FALSE, obj/used_weapon = null)
-	. = ..()
+	switch(damagetype)
+		if(BRUTE)
+			adjustBruteLoss(damage, def_zone)
+			return TRUE
+		if(BURN)
+			adjustFireLoss(damage, def_zone)
+			return TRUE
 	updatehealth()
+	return FALSE
+
+/mob/living/exosuit/bullet_act(obj/item/projectile/P, var/def_zone)
+	var/hit_dir = get_dir(P.starting, src)
+	def_zone = zoneToComponent(def_zone)
+
+	if (P.is_hot() >= HEAT_MOBIGNITE_THRESHOLD)
+		IgniteMob()
+	//Stun Beams
+	if(P.taser_effect)
+		qdel(P)
+		return TRUE
+
+	//Armor and damage
+	if(!P.nodamage)
+		hit_impact(P.get_structure_damage(), hit_dir)
+		for(var/damage_type in P.damage_types)
+			if(damage_type == HALLOSS)
+				continue // don't even bother
+			var/damage = P.damage_types[damage_type]
+			damage_through_armor(damage, damage_type, def_zone, P.check_armour, armour_pen = P.armor_penetration, used_weapon = P, sharp=is_sharp(P), edge=has_edge(P))
+
+	P.on_hit(src, def_zone)
+	return TRUE
+
 
 /mob/living/exosuit/getFireLoss()
 	var/total = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a few major issues with  mech damage dealing
1)Fixes the mech damage being distributed , by random picking
2)Fixes mechs not taking damage at all sometimes
3)Fixes aiming for the mouth /  groin attacking the body instead of head , and legs respectively.
4)Fixes attack zones not being translated for mechs
## Why It's Good For The Game
The mech nerf we all wanted

## Changelog
:cl:
fix: Bullets now hit mechs where you aimed them
fix: Mechs no longer magically soak up bullets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
