### PR TITLE
Taping cameras now uses up tape

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -195,7 +195,7 @@
 				taped = TRUE
 				icon_state = "camera_taped"
 				to_chat(user, "You taped the camera.")
-				desc = "It's used to monitor rooms. It's covered with something sticky."
+				desc = "It's used to monitor rooms. Its lens is covered with sticky tape."
 				return
 
 		if(ABORT_CHECK)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -145,9 +145,10 @@
 	update_coverage()
 	// DECONSTRUCTION
 
-	var/list/usable_qualities = list(QUALITY_SCREW_DRIVING)
+	var/list/usable_qualities = list(QUALITY_SCREW_DRIVING,QUALITY_SEALING)
 	if((wires.CanDeconstruct() || (stat & BROKEN)))
 		usable_qualities.Add(QUALITY_WELDING)
+
 
 	var/tool_type = I.get_tool_type(user, usable_qualities, src)
 	switch(tool_type)
@@ -184,6 +185,17 @@
 				return
 			return
 
+		if(QUALITY_SEALING && !taped)
+			var/obj/item/tool/our_tape = I
+			if(our_tape.check_tool_effects(user, 70))
+				our_tape.consume_resources(70, user) //70 = 10.5 units of tape , normally
+				set_status(0)
+				taped = TRUE
+				icon_state = "camera_taped"
+				to_chat(user, "You taped the camera")
+				desc = "It's used to monitor rooms. It's covered with something sticky."
+				return
+
 		if(ABORT_CHECK)
 			return
 
@@ -195,9 +207,9 @@
 	else if (can_use() && isliving(user) && user.a_intent != I_HURT)
 		var/mob/living/U = user
 		var/list/mob/viewers = list()
-		if(istype(I, /obj/item/ducttape )|| istype(I, /obj/item/tool/tape_roll))
+		if(istype(I, /obj/item/ducttape))
 			set_status(0)
-			taped = 1
+			taped = TRUE
 			icon_state = "camera_taped"
 			to_chat(U, "You taped the camera")
 			desc = "It's used to monitor rooms. It's covered with something sticky."

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -185,7 +185,9 @@
 				return
 			return
 
-		if(QUALITY_SEALING && !taped)
+		if(QUALITY_SEALING)
+			if(taped)
+				return
 			var/obj/item/tool/our_tape = I
 			if(our_tape.check_tool_effects(user, 70))
 				our_tape.consume_resources(70, user) //70 = 10.5 units of tape , normally

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -194,7 +194,7 @@
 				set_status(0)
 				taped = TRUE
 				icon_state = "camera_taped"
-				to_chat(user, "You taped the camera")
+				to_chat(user, "You taped the camera.")
 				desc = "It's used to monitor rooms. It's covered with something sticky."
 				return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Taping up cameras now uses your duct tape
## Why It's Good For The Game
Should have a cost.

## Changelog
:cl:
balance: Duct taping a camera now costs 10.5 units of duct tape.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
