### PR TITLE
readds the chameleon satchel

### DIFF
--- a/code/datums/uplink/stealth and camouflage items.dm
+++ b/code/datums/uplink/stealth and camouflage items.dm
@@ -24,7 +24,7 @@
 	name = "Chameleon Kit"
 	desc = "Comes with all the clothes you need to impersonate most people. Acting lessons sold separately. Wearing the uniform will allow for quick switching between appearances."
 	item_cost = 5
-	path = /obj/item/storage/backpack/chameleon
+	path = /obj/item/storage/box/syndie_kit/chameleon
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_MARSHAL,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 
 /datum/uplink_item/item/stealth_items/cleanup

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -142,6 +142,7 @@
 	new /obj/item/clothing/gloves/chameleon(src)
 	new /obj/item/clothing/mask/chameleon(src)
 	new /obj/item/clothing/glasses/chameleon(src)
+	new /obj/item/storage/backpack/satchel/chameleon(src)
 	new /obj/item/gun/energy/chameleon(src)
 	new /obj/item/device/radio/headset/chameleon(src)
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -134,7 +134,11 @@
 	new /obj/item/clothing/suit/space/syndicate/uplink(src)
 	new /obj/item/clothing/head/space/syndicate/uplink(src)
 
-/obj/item/storage/backpack/chameleon/populate_contents()
+/obj/item/storage/box/syndie_kit/chameleon
+	name = "chameleon kit"
+	desc = "Comes with all the clothes you need to impersonate most people. Acting lessons sold separately. Wearing the uniform will allow for quick switching between appearances."
+
+/obj/item/storage/box/syndie_kit/chameleon/populate_contents()
 	new /obj/item/clothing/under/chameleon(src)
 	new /obj/item/clothing/head/chameleon(src)
 	new /obj/item/clothing/suit/chameleon(src)
@@ -142,6 +146,7 @@
 	new /obj/item/clothing/gloves/chameleon(src)
 	new /obj/item/clothing/mask/chameleon(src)
 	new /obj/item/clothing/glasses/chameleon(src)
+	new /obj/item/storage/backpack/chameleon(src)
 	new /obj/item/storage/backpack/satchel/chameleon(src)
 	new /obj/item/gun/energy/chameleon(src)
 	new /obj/item/device/radio/headset/chameleon(src)

--- a/code/modules/acting/acting_items.dm
+++ b/code/modules/acting/acting_items.dm
@@ -15,8 +15,8 @@
 	if(active)
 		active = 0
 		spawn(30)
-			new /obj/item/storage/backpack/chameleon(loc)
-			src.visible_message("\The [src] beeps, dispensing a backpack onto the floor.", "You hear a beeping sound followed by a thumping noise of some kind.")
+			new /obj/item/storage/box/syndie_kit/chameleon(loc)
+			src.visible_message("\The [src] beeps, dispensing a small box onto the floor.", "You hear a beeping sound followed by a thumping noise of some kind.")
 			active = 1
 
 /obj/machinery/acting/changer

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -294,6 +294,14 @@ GLOBAL_LIST_INIT(chameleon_key_to_path, list(
 	rarity_value = 50
 	chameleon_type = "back"
 
+/obj/item/storage/backpack/satchel/chameleon
+	name = "grey satchel"
+	icon_state = "satchel"
+	desc = "A satchel outfitted with cloaking tech. It seems to have a small dial inside, kept away from the storage."
+	spawn_blacklisted = TRUE
+	spawn_tags = SPAWN_TAG_BACKPACK_CHAMELEON
+	chameleon_type = "back"
+
 /obj/item/clothing/gloves/chameleon
 	name = "black gloves"
 	icon_state = "black"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -232,6 +232,6 @@ other types of metals and chemistry for reagents).
 	name = "Holographic equipment kit"
 	desc = "A kit of dangerous, high-tech equipment with changeable looks."
 	req_tech = list(TECH_COVERT = 2)
-	build_path = /obj/item/storage/backpack/chameleon
+	build_path = /obj/item/storage/box/syndie_kit/chameleon
 	sort_string = "VASBA"
 */

--- a/code/modules/research/designs/illegal.dm
+++ b/code/modules/research/designs/illegal.dm
@@ -1,6 +1,6 @@
 /datum/design/research/item/chameleon_kit
 	name = "Chameleon Kit"
-	build_path = /obj/item/storage/backpack/chameleon
+	build_path = /obj/item/storage/box/syndie_kit/chameleon
 
 /datum/design/research/item/night_goggles
 	name = "Night Vison Goggles"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

readds the chameleon satchel to the chameleon kit. the kit now comes in a box again because of this.

## Why It's Good For The Game

Being able to choose between using satchel or backpack functionality when wearing chameleon clothes good.

## Changelog
:cl:
tweak: The chameleon kit now comes in a box instead of in a backpack, and contains both a satchel and a backpack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
