### PR TITLE
Buffs giga-lenses

### DIFF
--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -101,8 +101,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_DAMAGE_MULT = 1.3,
-		GUN_UPGRADE_CHARGECOST = 2
+		GUN_UPGRADE_DAMAGE_MULT = 1.3
 		)
 	I.gun_loc_tag = GUN_BARREL
 	I.req_gun_tags = list(GUN_ENERGY)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Giga lenses now no longer increase power usage
## Why It's Good For The Game
Giga lenses are very rare , and ontop of this , double cost for 30% damage buff sucks ass. Most guns don't have such debilitating downsides on their upgrades , so neither should lasers.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Giga lenses no longer double charge cost on laser weapins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
