### PR TITLE
Burrows no longer spawn on tiles with cables or pipes

### DIFF
--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -17,8 +17,7 @@
 //The old behaviour returned zero if there were any simulated atoms at all, even pipes and wires
 //Now it just finds if the tile is blocked by anything solid.
 //Edit by SCPR - 2022
-//Made it check for cables and pipes , because having pipes / cables randomly unwired because of it can be very fustrating
-//For technomancers.
+//Made it check for cables and pipes, because having pipes / cables randomly unwired because of it can be very frustrating for technomancers.
 /proc/turf_clear(turf/T)
 	if (T.density)
 		return FALSE

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -22,7 +22,7 @@
 	if (T.density)
 		return FALSE
 	for(var/atom/A in T)
-		if(istype(A, /obj/structure/cable) || istype(A,/obj/machinery/atmospherics/pipe ))
+		if(istype(A, /obj/structure/cable) || istype(A, /obj/machinery/atmospherics/pipe))
 			return FALSE
 		if(A.density)
 			return FALSE

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -16,10 +16,15 @@
 //This proc is used in only two places, ive changed it to make more sense
 //The old behaviour returned zero if there were any simulated atoms at all, even pipes and wires
 //Now it just finds if the tile is blocked by anything solid.
+//Edit by SCPR - 2022
+//Made it check for cables and pipes , because having pipes / cables randomly unwired because of it can be very fustrating
+//For technomancers.
 /proc/turf_clear(turf/T)
 	if (T.density)
 		return FALSE
 	for(var/atom/A in T)
+		if(istype(A, /obj/structure/cable) || istype(A,/obj/machinery/atmospherics/pipe ))
+			return FALSE
 		if(A.density)
 			return FALSE
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes burrowns no longer spawn on tiles with cables or pipes

## Why It's Good For The Game
Shouldn't have vital pipes or cables ruined round-start cause funny burrow RNG

## Changelog
:cl:
balance: Burrows can no longer spawn ontop of cables / pipes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
