### PR TITLE
Corrects some rig dispender things

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -280,7 +280,7 @@
 
 	interface_name = "integrated injector"
 	//Extra bit here to help get the idea that this one can inject
-	interface_desc = "Dispenses loaded chemicals directly into the wearer's bloodstream or pacients."
+	interface_desc = "Dispenses loaded chemicals directly into the wearer\'s bloodstream or patients."
 /*
 /obj/item/rig_module/chem_dispenser
 	name = "mounted chemical dispenser"

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -114,7 +114,7 @@
 	return 1
 
 /obj/item/rig_module/modular_injector
-	name = "mounted modular injector"
+	name = "mounted modular dispenser"
 	desc = "A specialized system for inserting chemicals"
 	icon_state = "injector"
 	usable = TRUE
@@ -124,8 +124,8 @@
 
 	engage_string = "Inject"
 
-	interface_name = "integrated injector"
-	interface_desc = "A chemical injector"
+	interface_name = "integrated dispenser"
+	interface_desc = "A chemical dispenser"
 	var/list/beakers = list()
 	var/max_beakers = 5
 	var/injection_amount = 5
@@ -144,6 +144,13 @@
 			var/obj/item/reagent_containers/beaker = new btype(src)
 			beaker.reagents.add_reagent(bdata[2], bdata[3])
 			accepts_item(beaker, null , TRUE)
+	//We need to do this to index are beakers
+	rebuild_charges()
+
+/obj/item/rig_module/modular_injector/New()
+	..()
+	//We need to do this to index are beakers
+	rebuild_charges()
 
 // Rebuilds charges , sad but necesarry due to how rig UI's get its data
 /obj/item/rig_module/modular_injector/proc/rebuild_charges()
@@ -241,10 +248,10 @@
 	return TRUE
 
 /obj/item/rig_module/modular_injector/combat
-	name = "mounted combat injector"
+	name = "mounted combat dispenser"
 	desc = "A specialized system for inserting chemicals meant for combat"
 	max_injection_amount = 30
-	max_beakers = 6
+	max_beakers = 12 //So you have a reason to get this over a medical one or default
 	initial_beakers = list(
 		list(/obj/item/reagent_containers/glass/beaker/large, "hyperzine", 60),
 		list(/obj/item/reagent_containers/glass/beaker/large, "tramadol", 60),
@@ -252,11 +259,17 @@
 		list(/obj/item/reagent_containers/glass/beaker/large, "tricordrazine", 60)
 	)
 
+	interface_name = "integrated combat dispenser"
+	interface_desc = "A chemical combat dispenser"
+
 /obj/item/rig_module/modular_injector/medical
 	name = "mounted medical injector"
 	desc = "A specialized system for inserting chemicals to pacients"
 	max_injection_amount = 60
 	max_beakers = 6
+	usable = FALSE
+	selectable = TRUE
+	disruptive = TRUE
 	initial_beakers = list(
 		list(/obj/item/reagent_containers/glass/beaker/large, "bicaridine", 60),
 		list(/obj/item/reagent_containers/glass/beaker/large, "inaprovaline",60),
@@ -264,6 +277,10 @@
 		list(/obj/item/reagent_containers/glass/beaker/large, "anti_toxin", 60),
 		list(/obj/item/reagent_containers/glass/beaker/large, "spaceacillin", 60)
 	)
+
+	interface_name = "integrated injector"
+	//Extra bit here to help get the idea that this one can inject
+	interface_desc = "Dispenses loaded chemicals directly into the wearer's bloodstream or pacients."
 /*
 /obj/item/rig_module/chem_dispenser
 	name = "mounted chemical dispenser"


### PR DESCRIPTION

## About The Pull Request

Dobles the beakers inside the combat rig to be completable with a normal medical injector
Makes medical rig injector able to inject people
Fixes a small indexing issue with pre-filled rig injectors and dispensers 
Adds different names for the rig dispensers and injector so in its list you can more at a glance tell what one your using and injecting

## Why It's Good For The Game

Combat injectors for rigs in its current state is a weaker medical, so its always a no brainer to get a medical one at this time then use a combat one, thats a bit silly it should have ups and downs to the medical one imo

Fixes are good so the medical rig injecter injects

## Changelog
:cl:

balance: combat dispenser now holds 12 beakers rather then 6!  - For Rigs
fix: Fixes medical injectors not injecting - For rigs
fix: Fixes all dispensers and chem injectors for rigs having the same name and desc in its menus - For Rigs
fix: Fixes a indexing bug with injectors and dispensers - For Rigs
/:cl:

## Well these are tested changes they are not tested on Eris's master, they should work fine tho
