### PR TITLE
Fix jumping over deployable barriers

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -290,16 +290,11 @@ for reference:
 		icon_state = "barrier[locked]"
 
 /obj/machinery/deployable/barrier/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)//So bullets will fly over and stuff.
-
 	if(istype(mover,/obj/item/projectile))
 		return (check_cover(mover,target))
 
-	if(air_group || (height==0))
-		return 1
-	if(istype(mover) && mover.checkpass(PASSTABLE))
-		return 1
-	else
-		return 0
+	if(air_group || (height==0) || istype(mover))
+		return TRUE
 
 /obj/machinery/deployable/barrier/proc/explode()
 

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -296,6 +296,11 @@ for reference:
 	if(air_group || (height==0))
 		return TRUE
 
+	if(ishuman(mover))
+		var/mob/living/carbon/human/H = mover
+		if(H.checkpass(PASSTABLE) && H.stats?.getPerk(PERK_PARKOUR))
+			return TRUE
+
 /obj/machinery/deployable/barrier/proc/explode()
 
 	visible_message(SPAN_DANGER("[src] blows apart!"))

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -293,7 +293,7 @@ for reference:
 	if(istype(mover,/obj/item/projectile))
 		return (check_cover(mover,target))
 
-	if(air_group || (height==0) || istype(mover))
+	if(air_group || (height==0))
 		return TRUE
 
 /obj/machinery/deployable/barrier/proc/explode()


### PR DESCRIPTION
## About The Pull Request

Deployable barriers stopped being an obstacle with implementation of diving/sliding PR, which is clearly unintended change.

UPD: Players with "Parkour" perk still able to jump over barricades, because why not.

![image](https://user-images.githubusercontent.com/65828539/165680669-79fa3721-4e1c-49c3-a01d-6b25eac7c839.png)


## Why It's Good For The Game

Fixes cool.

## Changelog
:cl:
fix: no longer can jump over security barrier
/:cl:

