### PR TITLE
Fix toxic revenger affecting robots and fbp

### DIFF
--- a/code/datums/perks/oddity.dm
+++ b/code/datums/perks/oddity.dm
@@ -193,8 +193,9 @@
 	for(var/mob/living/carbon/human/H in viewers(5, holder))
 		if(H.stat == DEAD || H.internal || H.stats.getPerk(PERK_TOXIC_REVENGER) || H.species.flags & NO_BREATHE)
 			continue
-		if(H.head?.item_flags & BLOCK_GAS_SMOKE_EFFECT || H.wear_mask?.item_flags & BLOCK_GAS_SMOKE_EFFECT)
+		if(H.head?.item_flags & BLOCK_GAS_SMOKE_EFFECT || H.wear_mask?.item_flags & BLOCK_GAS_SMOKE_EFFECT || BP_IS_ROBOTIC(H.get_organ(BP_CHEST)))
 			continue
+
 		H.reagents?.add_reagent("toxin", 5)
 		H.emote("cough")
 		to_chat(H, SPAN_WARNING("[holder] emits a strange smell."))

--- a/code/datums/perks/oddity.dm
+++ b/code/datums/perks/oddity.dm
@@ -190,16 +190,14 @@
 	if(world.time < initial_time + cooldown)
 		return
 	initial_time = world.time
-	for(var/mob/living/L in viewers(holder, 5))
-		if(!L)
+	for(var/mob/living/carbon/human/H in viewers(5, holder))
+		if(H.stat == DEAD || H.internal || H.stats.getPerk(PERK_TOXIC_REVENGER) || H.species.flags & NO_BREATHE)
 			continue
-		if(ishuman(L))
-			var/mob/living/carbon/human/H = L
-			if(H.stat == DEAD || H.internal || H.stats.getPerk(PERK_TOXIC_REVENGER) || (H.species.flags & NO_BREATHE))
-				continue
-		L.reagents?.add_reagent("toxin", 5)
-		L.emote("cough")
-		to_chat(L, SPAN_WARNING("[holder] emits a strange smell."))
+		if(H.head?.item_flags & BLOCK_GAS_SMOKE_EFFECT || H.wear_mask?.item_flags & BLOCK_GAS_SMOKE_EFFECT)
+			continue
+		H.reagents?.add_reagent("toxin", 5)
+		H.emote("cough")
+		to_chat(H, SPAN_WARNING("[holder] emits a strange smell."))
 
 /datum/perk/oddity/absolute_grab
 	name = "Absolute Grab"


### PR DESCRIPTION
## About The Pull Request

What it says on the tin, robots and FBPs no longer get toxins from stinky vagabonds.
Also makes gasmasks actually work against that perk.

## Why It's Good For The Game

Fixes cool.

## Changelog
:cl:
fix: toxic revenger affecting robots and fbp
/:cl:
