### PR TITLE
Add automatic use of ashtrays

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -122,6 +122,13 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/turf/location = get_turf(src)
 	smoketime--
 	if(smoketime < 0)
+		if(ishuman(loc))
+			var/mob/living/carbon/human/H = loc
+			if(!H.stat)
+				for(var/obj/item/material/ashtray/A in view(1, loc))
+					if(A.contents.len < A.max_butts)
+						A.attackby(src, loc)
+						return
 		die()
 		return
 	if(location)


### PR DESCRIPTION
## About The Pull Request

If player's cigarette goes out near an ashtray - they will use it, instead of dropping cigarette on the floor.

## Why It's Good For The Game

Muh roleplay.

## Changelog
:cl:
add: ashtrays being used automatically
/:cl: