### PR TITLE
Blacklists broken huds form spawning

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -72,6 +72,9 @@
 	desc = "Flash-resistant goggles with inbuilt combat and security information."
 	icon_state = "swatgoggles"
 
+/obj/item/clothing/glasses/hud/broken
+	spawn_blacklisted = TRUE //To stop the broken huds form spawning i.g - Messes with loot spawns for a broken item
+
 /obj/item/clothing/glasses/hud/broken/process_hud(mob/M)
 	process_broken_hud(M, 1)
 


### PR DESCRIPTION
## About The Pull Request

Simply blacklists the spawn of the broken broke huds form spawning

## Why It's Good For The Game

Firstly there is absolutely no reason for this to be spawning, secondly it will screw up loot and make all these items more common, thirdly, this is possibly a direct violation to contributing guidelines, I should try reading them.
https://wiki.cev-eris.com/Content_GuidelinesEn

![image](https://user-images.githubusercontent.com/30435998/166094248-f91c7882-f058-4f61-8a51-9465506c2dcf.png)


## Changelog
:cl:
fix: Broken, broken huds no longer spawn.
/:cl:
