### PR TITLE
Sword of Truth adds Observation

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -71,7 +71,8 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		if(prob(10))
 			for(var/mob/living/carbon/human/H in viewers(user))
 				SEND_SIGNAL(H, SWORD_OF_TRUTH_OF_DESTRUCTION, src)
-				eotp.addObservation(200)
+				if(eotp)
+					eotp.addObservation(200)
 			qdel(src)
 		. = TRUE
 


### PR DESCRIPTION
## About The Pull Request

The Sword of Truth, when destroying a faction artifact, adds 200 observation to the Eye.
The observation given is of course not set in stone, if a reduction or addition is deemed needed. The observation addition is not temporary. Increasing observation by 1/9 of the maximum seemed fair enough, due to the difficulty of obtaining one and the faction conflict it has the means to cause.

## Why It's Good For The Game

Each other faction's mean of destroying a faction oddity benefits the faction in some way. The Guild gets credits, Moebius gets research, the Technomancers get a better oddity. This seemed the best way to continue that trend.

## Changelog
:cl:
tweak: Sword of Truth adds 200 Observation upon faction oddity destruction.
/:cl: