### PR TITLE
Solar fix

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -71,7 +71,8 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		if(prob(10))
 			for(var/mob/living/carbon/human/H in viewers(user))
 				SEND_SIGNAL(H, SWORD_OF_TRUTH_OF_DESTRUCTION, src)
-				eotp.addObservation(200)
+				if(eotp)
+					eotp.addObservation(200)
 			qdel(src)
 		. = TRUE
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -71,6 +71,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		if(prob(10))
 			for(var/mob/living/carbon/human/H in viewers(user))
 				SEND_SIGNAL(H, SWORD_OF_TRUTH_OF_DESTRUCTION, src)
+				eotp.addObservation(200)
 			qdel(src)
 		. = TRUE
 

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -60,7 +60,7 @@
 /obj/machinery/power/solar/attackby(obj/item/I, mob/user)
 
 	if(QUALITY_PRYING in I.tool_qualities)
-		if(I.use_tool(user, src, WORKTIME_NEAR_INSTANT, QUALITY_WELDING, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
+		if(I.use_tool(user, src, WORKTIME_NEAR_INSTANT, QUALITY_PRYING, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
 			var/obj/item/solar_assembly/S = locate() in src
 			if(S)
 				S.loc = src.loc
@@ -200,7 +200,7 @@
 	icon = 'icons/obj/power.dmi'
 	icon_state = "sp_base"
 	item_state = "electropack"
-	w_class = ITEM_SIZE_BULKY // Pretty big!
+	w_class = ITEM_SIZE_HUGE // Pretty big!
 	anchored = FALSE
 	var/tracker = 0
 	var/glass_type = null
@@ -237,14 +237,14 @@
 		if(QUALITY_BOLT_TURNING)
 			if(I.use_tool(user, src, WORKTIME_NEAR_INSTANT, tool_type, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
 				anchored = !anchored
-				user.visible_message(SPAN_NOTICE("[user] [anchored ? "un" : ""]wrenches the solar assembly into place."))
+				user.visible_message(SPAN_NOTICE("[user] [anchored ? "" : "un"]wrenches the solar assembly into place."))
 				return
 			return
 
 		if(ABORT_CHECK)
 			return
 
-	if(anchored && !isturf(loc))
+	if(anchored && isturf(loc))
 		if(istype(I, /obj/item/stack/material) && (I.get_material_name() == MATERIAL_GLASS || I.get_material_name() == MATERIAL_RGLASS))
 			var/obj/item/stack/material/S = I
 			if(S.use(2))

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -294,6 +294,8 @@
 	var/nexttime = 0		// time for a panel to rotate of 1� in manual tracking
 	var/obj/machinery/power/tracker/connected_tracker = null
 	var/list/connected_panels = list()
+	var/icon_keyboard ="generic_key"
+	var/icon_screen ="generic"
 
 /obj/machinery/power/solar_control/drain_power()
 	return -1
@@ -350,23 +352,29 @@
 
 /obj/machinery/power/solar_control/Initialize()
 	. = ..()
+	update_icon()
 	if(!connect_to_network()) return
 	set_panels(cdir)
 
-/obj/machinery/power/solar_control/on_update_icon()
-	if(stat & BROKEN)
-		icon_state = "broken"
-		cut_overlays()
-		return
+/obj/machinery/power/solar_control/update_icon()
+	overlays.Cut()
 	if(stat & NOPOWER)
-		icon_state = "c_unpowered"
-		cut_overlays()
+		set_light(0)
+		if(icon_keyboard)
+			overlays += image(icon,"[icon_keyboard]_off")
+		update_openspace()
 		return
-	icon_state = "solar"
-	cut_overlays()
-	if(cdir > -1)
-		add_overlays(image('icons/obj/computer.dmi', "solcon-o", FLY_LAYER, angle2dir(cdir)))
-	return
+	else
+		set_light(light_range_on, light_power_on)
+
+	if(stat & BROKEN)
+		overlays += image(icon,"[icon_state]_broken")
+	else
+		overlays += image(icon,icon_screen)
+
+	if(icon_keyboard)
+		overlays += image(icon, icon_keyboard)
+	update_openspace()
 
 /obj/machinery/power/solar_control/attack_hand(mob/user)
 	if(!..())
@@ -506,6 +514,10 @@
 /obj/machinery/power/solar_control/power_change()
 	..()
 	update_icon()
+	if(stat & NOPOWER)
+		set_light(0)
+	else
+		set_light(light_range_on, light_power_on)
 
 
 /obj/machinery/power/solar_control/proc/broken()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -294,8 +294,8 @@
 	var/nexttime = 0		// time for a panel to rotate of 1� in manual tracking
 	var/obj/machinery/power/tracker/connected_tracker = null
 	var/list/connected_panels = list()
-	var/icon_keyboard ="generic_key"
-	var/icon_screen ="generic"
+	var/icon_keyboard = "generic_key"
+	var/icon_screen = "generic"
 
 /obj/machinery/power/solar_control/drain_power()
 	return -1
@@ -368,9 +368,9 @@
 		set_light(light_range_on, light_power_on)
 
 	if(stat & BROKEN)
-		overlays += image(icon,"[icon_state]_broken")
+		overlays += image(icon," [icon_state]_broken")
 	else
-		overlays += image(icon,icon_screen)
+		overlays += image(icon, icon_screen)
 
 	if(icon_keyboard)
 		overlays += image(icon, icon_keyboard)


### PR DESCRIPTION
## About The Pull Request
Fixes Solars. Previously (Since about 2017, it seems.) it was impossible to create a solar array due to the inability to add glass to the solar assembly. It was impossible to disassemble a solar array without breaking one (If an admin ever spawned on during that time). if you wrenched down a solar array it said you unwrenched it, and vice versa. Adding a solar array to a bag makes it impossible to remove, not to mention you could wrench and unwrench it in a bag. I have no idea how to fix that last one, so I just increased the size of the assembly to not fit in bags. Still can fit a good 10+ in lockers, and more in crates. Looks big enough to not feasibly fit in a bag, anyways. The sprite for the Solar Control Console was fixed from a red "X" To the default computer console sprite

## Why It's Good For The Game

Fixing a power generator system is good, right? We loose a singularity engine from the cargo changes and get a functioning solar array to fill it's place.. 

## Changelog
:cl:

tweak: Solar Assembly changed from Bulky to Huge
fix: Solar Arrays can be made
fix: Solar Arrays can be disassembled
fix: Wrenching Solar Assemblies gives the correct text.
fix: Solar Control Console given a working default sprite

/:cl:

