### PR TITLE
Biotank bottleneck removal

### DIFF
--- a/code/modules/biomatter_manipulation/bioreactor/biotank.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/biotank.dm
@@ -66,7 +66,7 @@
 	if(!MS)
 		return
 	if(biotank.canister)
-		biotank.reagents.trans_to_holder(biotank.canister.reagents, 10)
+		biotank.reagents.trans_to_holder(biotank.canister.reagents, 100)
 
 
 /obj/machinery/multistructure/bioreactor_part/biotank_platform/attackby(var/obj/item/I, var/mob/user)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the bottle neck on biomatter production. This will make the bottleneck the amount of solidifiers you have. Goes with the price nerf.

## Why It's Good For The Game

Currently Biomatter has alot of exploits. Those are closed by the price nerf. This removed the CBT of waiting for 80 tics for the tank to fill up and lets you move on with the next part of your job.

## Changelog
:cl:
tweak: makes the biotank spit out biomatter faster
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
