### PR TITLE
Biomatter price update

### DIFF
--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -403,7 +403,7 @@
 	singular_name = "biomatter sheet"
 	icon_state = "sheet-biomatter"
 	default_type = MATERIAL_BIOMATTER
-	price_tag = 10
+	price_tag = 5
 	novariants = FALSE
 	var/biomatter_in_sheet = BIOMATTER_PER_SHEET // defined in solidifier.dm
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Halves the price of biomatter letting the minigame be faster and removing trade exploits. ouches no longer cost 400 credits to make and biomatter production is faster while still requiring setup time to reach full production capacity

## Why It's Good For The Game

Currently Biomatter has alot of exploits. Those are closed by the price nerf. This removed the CBT of waiting for 80 tics for the tank to fill up and lets you move on with the next part of your job.

## Changelog
:cl:
tweak: halved biomatter price
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
