### PR TITLE
Adds sanity and logging to the recycle vendor

### DIFF
--- a/code/game/machinery/recycle_vendor.dm
+++ b/code/game/machinery/recycle_vendor.dm
@@ -154,6 +154,10 @@
 	stored_item_fluff = "Material composition:"
 	stored_item_materials = stored_item_object.get_matter()
 
+	if(stored_item_object.contents.len)	// Storage items are too resource intensive to check (populate_contents() means we have to create new instances of every object within the initial object)
+		stored_item_fluff += "<br>ERROR Storage Item Nesting Detected."
+		return
+
 	for(var/i in stored_item_materials)
 		if(i in materials_supported)
 			if(i in materials_allowed)
@@ -179,12 +183,12 @@
 		flick("recycle_screen_red", overlays[1])
 		return
 
+	vagabond_charity_budget -= stored_item_value
+	var/datum/transaction/T = new(-stored_item_value, "", "Recycling payout for [stored_item_object.name]", src)
+	T.apply_to(merchants_pocket)
+
 	qdel(stored_item_object)
 	stored_item_object = null
-
-	vagabond_charity_budget -= stored_item_value
-	var/datum/transaction/T = new(-stored_item_value, "", "Recycling payout", src)
-	T.apply_to(merchants_pocket)
 
 	for(var/i in stored_item_materials)
 		if(i in materials_stored)


### PR DESCRIPTION

## About The Pull Request

Makes the recycle vendor when giving you payments log what was scrapped for guild to see what items are being recycled when not around, or the IH when investigating and need to see if someone sold their weapon in that.

Removes an exploit allowing of destruction of nested items in bags or boxes via selling them full in the recycle vendor

## Why It's Good For The Game

Investigation RP shouldnt lead to a cold trail do to someone selling their bag inside a fancy vender
Exploits are bad and we shouldnt allow such easy destruction of tons of items all in 3 clicks

## Changelog
:cl:
balance: recycle vendor now logs what is buy'ed
fix: Fixed mass selling stored items recycle vendor, note this didnt give you wealth for items inside nested items
/:cl:
