### PR TITLE
Fix roach layers

### DIFF
--- a/code/__DEFINES/_planes+layers.dm
+++ b/code/__DEFINES/_planes+layers.dm
@@ -67,19 +67,19 @@ What is the naming convention for planes or layers?
 //The full list of planes and layers needs ported
 #define HIDING_MOB_PLANE              -1//-16 on bay.
 
-	#define HIDING_MOB_LAYER    2.54	//-0 on bay
+#define HIDING_MOB_LAYER    2.54	//-0 on bay
 
 #define LYING_MOB_PLANE               -1 //-14 on bay// other mobs that are lying down.
 
-	#define LYING_MOB_LAYER 3.8 //0 on bay
+#define LYING_MOB_LAYER 3.8 //0 on bay
 
 #define LYING_HUMAN_PLANE             -1 //-13 on bay// humans that are lying down
 
-	#define LYING_HUMAN_LAYER 3.8 //0 on bay
+#define LYING_HUMAN_LAYER 3.8 //0 on bay
 
-	//discordia-space/CEV-Eris/issues/2051
-	#define ABOVE_LYING_MOB_LAYER 3.85 
-	#define ABOVE_LYING_HUMAN_LAYER 3.85 
+//discordia-space/CEV-Eris/issues/2051
+#define ABOVE_LYING_MOB_LAYER 3.85
+#define ABOVE_LYING_HUMAN_LAYER 3.85
 
 #define BLACKNESS_PLANE 0 //To keep from conflicts with SEE_BLACKNESS internals
 #define SPACE_LAYER 1.8

--- a/code/modules/mob/living/carbon/superior_animal/defense.dm
+++ b/code/modules/mob/living/carbon/superior_animal/defense.dm
@@ -238,7 +238,7 @@
 
 /mob/living/carbon/superior_animal/rejuvenate()
 	density = initial(density)
-	layer = initial(layer)
+	reset_layer()
 
 	. = ..()
 

--- a/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
@@ -60,8 +60,11 @@
 	.=..()
 	if(.)
 		for (var/mob/living/carbon/superior_animal/roach/fuhrer/F in range(src,8))
-			F.distress_call()
+			if(!F.stat)
+				F.distress_call()
 
-	if(prob(3))
-		visible_message(SPAN_DANGER("\the [src] hacks up a tape!"))
-		new /obj/item/music_tape(get_turf(src))
+		layer = BELOW_MOB_LAYER // Below stunned roaches
+
+		if(prob(3))
+			visible_message(SPAN_DANGER("\the [src] hacks up a tape!"))
+			new /obj/item/music_tape(get_turf(src))

--- a/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
@@ -60,8 +60,7 @@
 	.=..()
 	if(.)
 		for (var/mob/living/carbon/superior_animal/roach/fuhrer/F in range(src,8))
-			if(!F.stat)
-				F.distress_call()
+			F.distress_call()
 
 		layer = BELOW_MOB_LAYER // Below stunned roaches
 


### PR DESCRIPTION
## About The Pull Request

Makes dead roaches always display under stunned roaches, with conscious roaches always being on top.

![image](https://user-images.githubusercontent.com/65828539/169974219-4973dea4-0a97-4423-be83-3a14be3a98f5.png)


## Why It's Good For The Game

Pretty sure dead roaches not meant to be on top, that's just inconvenient.

## Changelog
:cl:
fix: live roaches sometimes displaying below dead roaches
/:cl:

