### PR TITLE
adding 2 stack`s plasma r glass on techno table

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -79851,6 +79851,12 @@
 /obj/item/stack/material/plastic{
 	amount = 120
 	},
+/obj/item/stack/material/glass/plasmarglass{
+	amount = 120
+	},
+/obj/item/stack/material/glass/plasmarglass{
+	amount = 120
+	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/breakroom)
 "dJg" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adding 2 stack`s plasma r glass on techno table.
![image](https://user-images.githubusercontent.com/66647116/171861728-7a5b6629-2b08-48a7-bedf-5c77dd4ede00.png)

## Why It's Good For The Game

Well suited for repairing already broken glass or for building a new SM. In view of the complexity of the getting, I just added a couple of stacks on the table, this should be enough.

## Changelog
:cl:
add: 2 stack`s plasma r glass on techno table
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
