### PR TITLE
Add "Toggle Self Vision" verb

### DIFF
--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -680,6 +680,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	updateghostsight()
 	to_chat(usr, "You [(ghostvision?"now":"no longer")] have ghost vision.")
 
+/mob/observer/ghost/verb/toggle_selfsee()
+	set name = "Toggle Self Vision"
+	set desc = "Toggles your visibility."
+	set category = "Ghost"
+	alpha = alpha ? 0 : 127
+	to_chat(usr, "You are [alpha ? "now" : "no longer"] visible.")
+
 /mob/observer/ghost/verb/toggle_darkness()
 	set name = "Toggle Darkness"
 	set category = "Ghost"


### PR DESCRIPTION
## About The Pull Request

New verb in "ghost" tab, that makes player's ghost (in)visible when activated.

![image](https://user-images.githubusercontent.com/65828539/172975681-fedeaa26-c270-44bf-9cf4-e9c9da7c6946.png)

![image](https://user-images.githubusercontent.com/65828539/172975668-18d12eae-32e5-4b87-a7ba-bb24d1f5e259.png)

![image](https://user-images.githubusercontent.com/65828539/172975683-5898b43b-f1dc-46d6-ae5f-4b226c6943bd.png)


## Why It's Good For The Game

Quite convenient for making screenshots, and if you don't want your ghost to cover sprite of whoever you're following.

## Changelog
:cl:
add: toggle self vision verb
/:cl:


