### PR TITLE
Remove APC access requirement for rebooting

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -938,6 +938,12 @@
 	if(!can_use(usr, 1))
 		return TRUE
 
+	else if( href_list["reboot"] )
+		failure_timer = 0
+		update_icon()
+		update()
+		return TRUE
+
 	if(!issilicon(usr) && (locked && !emagged))
 		// Shouldn't happen, this is here to prevent href exploits
 		to_chat(usr, "You must unlock the panel to use this!")
@@ -945,11 +951,6 @@
 
 	if (href_list["lock"])
 		coverlocked = !coverlocked
-
-	else if( href_list["reboot"] )
-		failure_timer = 0
-		update_icon()
-		update()
 
 	else if (href_list["breaker"])
 		toggle_breaker()


### PR DESCRIPTION
## About The Pull Request

Unlocking APC, or having access to it at all, is no longer required for rebooting it after blackout event.

![image](https://user-images.githubusercontent.com/65828539/172978947-9f9490ab-dcc4-4fbd-8cf4-5e41817b7a4b.png)

![image](https://user-images.githubusercontent.com/65828539/172978931-2c828a9b-1350-462c-a229-f9eb71bdf498.png)

## Why It's Good For The Game

QoL change.

## Changelog
:cl:
tweak: lifted apc access requirement for rebooting
/:cl:

