### PR TITLE
Tweak captain and FO headsets

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -76,7 +76,7 @@
 /obj/item/device/encryptionkey/heads/captain
 	name = "Eris captain's encryption key"
 	icon_state = "cap_cypherkey"
-	channels = list("Command" = 1, "Security" = 1, "Engineering" = 0, "NT Voice" = 0, "Science" = 0, "Medical" = 0, "Supply" = 0, "Service" = 0)
+	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "NT Voice" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1)
 
 /obj/item/device/encryptionkey/heads/ai_integrated
 	name = "ai integrated encryption key"
@@ -112,7 +112,7 @@
 /obj/item/device/encryptionkey/heads/hop
 	name = "First Officer's encryption key"
 	icon_state = "hop_cypherkey"
-	channels = list("Command" = 1, "Security" = 1, "Engineering" = 0, "NT Voice" = 0, "Science" = 0, "Medical" = 0, "Supply" = 0, "Service" = 0)
+	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "NT Voice" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1)
 
 /obj/item/device/encryptionkey/heads/merchant
 	name = "Asters Merchant radio encryption key"


### PR DESCRIPTION
## About The Pull Request

Captain and FO have access to all frequencies, but most have to be enabled manually, which is quite annoying.
This PR makes all channels enabled by default.

![image](https://user-images.githubusercontent.com/65828539/172982376-fcceaa45-46db-4c83-9616-5d5badf4a346.png)


## Why It's Good For The Game

QoL change.

## Changelog
:cl:
tweak: captain and fo start with all channel in their headsets enabled by default
/:cl:

