### PR TITLE
Add more egun and energy cell interactions

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -205,6 +205,18 @@
 	to_chat(user, SPAN_NOTICE("You insert [I] into [src]."))
 	return TRUE
 
+/obj/proc/replace_item(obj/item/I_old, obj/item/I_new, mob/living/user)
+	if(!I_old || !I_new || !istype(user) || user.stat || !user.Adjacent(I_new) || !user.Adjacent(I_old) || !user.unEquip(I_new))
+		return FALSE
+	I_new.forceMove(src)
+	user.put_in_hands(I_old)
+	playsound(src.loc, 'sound/weapons/guns/interact/pistol_magout.ogg', 75, 1)
+	spawn(2)
+		playsound(src.loc, 'sound/weapons/guns/interact/pistol_magin.ogg', 75, 1)
+	user.visible_message(
+		"[user] replaces [I_old] with [I_new] in [src].",
+		SPAN_NOTICE("You replace [I_old] with [I_new] in [src]."))
+	return TRUE
 
 //Returns the list of matter in this object
 //You can override it to customise exactly what is returned.

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -157,14 +157,21 @@
 		to_chat(usr, SPAN_WARNING("[src] is a disposable gun, it doesn't need more batteries."))
 		return
 
-	if(cell)
-		to_chat(usr, SPAN_WARNING("[src] is already loaded."))
-		return
+	if(istype(C, suitable_cell))
+		if(cell)
+			if(replace_item(cell, C, user))
+				cell = C
+				update_icon()
+		else if(insert_item(C, user))
+			cell = C
+			update_icon()
+	..()
 
-	if(istype(C, suitable_cell) && insert_item(C, user))
-		cell = C
+/obj/item/gun/energy/attack_self(mob/user)
+	if(!self_recharge && cell && cell.charge < charge_cost && eject_item(cell, user))
+		cell = null
 		update_icon()
-
+		return
 	..()
 
 /obj/item/gun/energy/ui_data(mob/user)


### PR DESCRIPTION
## About The Pull Request

Clicking with a cell on egun, that already have a cell inside, now replaces the cell.
Clicking Z with egun in hand will eject the cell, if it's not internal and have no charge for more shots.

![image](https://user-images.githubusercontent.com/65828539/172990506-ff4aa14c-330a-4966-8767-7f345b10e9b8.png)

![image](https://user-images.githubusercontent.com/65828539/172990635-4cf9d96f-32d2-4f9c-84a5-20cbdb06d486.png)

## Why It's Good For The Game

QoL functionality.

## Changelog
:cl:
add: more egun and energy cell interactions
/:cl:

