### PR TITLE
Add cyberplant colors customization 

### DIFF
--- a/code/game/objects/structures/cyberplants.dm
+++ b/code/game/objects/structures/cyberplants.dm
@@ -8,6 +8,7 @@
 	var/emagged = FALSE
 	var/interference = FALSE
 	var/icon/plant = null
+	var/custom_color
 	var/plant_color
 	var/glow_color
 	var/hologram_opacity = 0.85
@@ -47,7 +48,7 @@
 	if (!plant)
 		return
 
-	plant.ChangeOpacity(hologram_opacity)
+//	plant.ChangeOpacity(hologram_opacity)
 	overlays += plant
 
 /obj/structure/cyberplant/proc/change_plant(var/state)
@@ -58,18 +59,13 @@
 		return
 
 	if(!color)
-		color = pick(possible_colors)
+		color = custom_color ? custom_color : pick(possible_colors)
 
 	glow_color = color
 	plant_color = color
 	plant.ColorTone(color)
 
-	set_light(l_color=color)
-
-/obj/structure/cyberplant/attack_hand(var/mob/user)
-	if(!interference)
-		change_plant()
-		update_icon()
+	set_light(l_color = color)
 
 /obj/structure/cyberplant/attackby(obj/item/I, mob/user )
 	if(istype(I, /obj/item/card/id))
@@ -81,6 +77,14 @@
 			if(prob(10))
 				to_chat(user, "<i>You hear soft giggle</i>")
 			rollback()
+
+/obj/structure/cyberplant/attack_hand(mob/user)
+	var/color_of_choice = input("Choose a color.", "\"FluorescEnt\" configuration", custom_color) as color|null
+	custom_color = color_of_choice
+	if(!interference)
+		change_plant()
+		change_color()
+		update_icon()
 
 /obj/structure/cyberplant/proc/prepare_icon(var/state)
 	if(!state)
@@ -110,6 +114,7 @@
 		COLOR_LIGHTING_CYAN_BRIGHT
 	)
 	update_icon()
+
 /obj/structure/cyberplant/emag_act()
 	if(emagged)
 		return
@@ -135,25 +140,25 @@
 	if(!interference)
 		interference = TRUE
 		spawn(0)
-			if (QDELETED(src))
+			if(QDELETED(src))
 				return
 
 			overlays.Cut()
 			set_light(0, 0)
 			sleep(3)
-			if (QDELETED(src))
+			if(QDELETED(src))
 				return
 
 			overlays += plant
 			set_light(brightness_on, brightness_on/2)
 			sleep(3)
-			if (QDELETED(src))
+			if(QDELETED(src))
 				return
 
 			overlays -= plant
 			set_light(0, 0)
 			sleep(3)
-			if (QDELETED(src))
+			if(QDELETED(src))
 				return
 
 			change_color()
@@ -162,6 +167,6 @@
 
 			interference = FALSE
 
-/obj/structure/cyberplant/Crossed(var/mob/living/L)
-	if (istype(L))
+/obj/structure/cyberplant/Crossed(mob/living/L)
+	if(istype(L))
 		doInterference()


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. Colors automatically toned down to prevent cringe.

![image](https://user-images.githubusercontent.com/65828539/173045543-da568e22-c77d-4953-9805-6a8edb45ecc7.png)

![image](https://user-images.githubusercontent.com/65828539/173045555-35dfcf57-5d99-4790-9748-d6a5a5986d80.png)

![image](https://user-images.githubusercontent.com/65828539/173045569-8cd91de5-d2b7-4432-abe3-59d13d772850.png)

![image](https://user-images.githubusercontent.com/65828539/173045586-698fefe0-a90e-4677-b2ac-031ad6890d66.png)

![image](https://user-images.githubusercontent.com/65828539/173045604-11332391-ca01-4204-922b-0ca3aea16c61.png)


## Why It's Good For The Game

Mildly useful functionality.

## Changelog
:cl:
add: flourescent color customization
/:cl:
