### PR TITLE
Increase resuscitator timer

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -218,7 +218,7 @@
 
 #define RANDOM_BLOOD_TYPE pick(4;"O-", 36;"O+", 3;"A-", 28;"A+", 1;"B-", 20;"B+", 1;"AB-", 5;"AB+")
 
-#define NECROZTIME 	(5 MINUTES)
+#define NECROZTIME 	(15 MINUTES)
 
 
 


### PR DESCRIPTION
## About The Pull Request

Increased time when player character could be revived from 5 to 15 minutes.

## Why It's Good For The Game

Being brought back from the dead feels good, staying permanently dead is not so much.
Shocking, but nerfing resuscitator didn't force people to "just play NT lol".

## Changelog
:cl:
tweak: resuscitator could be used 15 minutes after person's death
/:cl: