### PR TITLE
Buff respawn timer reduction

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -160,11 +160,14 @@
 #define MINISYNTH	"minisynth"//Used for drones and pAIs
 
 #define ANIMAL_SPAWN_DELAY 5 MINUTES
-#define DRONE_SPAWN_DELAY  10 MINUTES
+#define DRONE_SPAWN_DELAY  5 MINUTES
 
-#define CRYOPOD_SPAWN_BONUS	20 MINUTES//Going to sleep in a cryopod takes this much off your respawn time in minutes
-#define CRYOPOD_SPAWN_BONUS_DESC	"20 minutes"	//Tells players how long they have until respawn.
-
+#define CRYOPOD_HEALTHY_RESPAWN_BONUS	25 MINUTES // Going to sleep in a cryopod in perfect health takes this much off player's respawn time
+#define CRYOPOD_WOUNDED_RESPAWN_BONUS	20 MINUTES // Less timer reduction if went to cryo with any health condition
+#define MORGUE_RESPAWN_BONUS			15 MINUTES // Low effort corpse handling
+#define BIOREACTOR_RESPAWN_BONUS		15 MINUTES // Low effort corpse handling
+#define COFFIN_RESPAWN_BONUS			25 MINUTES // High effort corpse handling
+#define COLLECTIVISED_RESPAWN_BONUS		15 MINUTES // Seize the means of respawning
 
 // Incapacitation flags, used by the mob/proc/incapacitated() proc
 #define INCAPACITATION_NONE 0

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -346,19 +346,18 @@
 
 	//When the occupant is put into storage, their respawn time is reduced.
 	//This check exists for the benefit of people who get put into cryostorage while SSD and come back later
-	if (occupant.in_perfect_health())
-		if (occupant.mind && occupant.mind.key)
-
-			//Whoever inhabited this body is long gone, we need some black magic to find where and who they are now
-			var/mob/M = key2mob(occupant.mind.key)
-			if (istype(M))
-				if (!(M.get_respawn_bonus("CRYOSLEEP")))
-					//We send a message to the occupant's current mob - probably a ghost, but who knows.
-					to_chat(M, SPAN_NOTICE("Because your body was put into cryostorage, your crew respawn time has been reduced by [CRYOPOD_SPAWN_BONUS_DESC]."))
-					M << 'sound/effects/magic/blind.ogg' //Play this sound to a player whenever their respawn time gets reduced
-
-				//Going safely to cryo will allow the patient to respawn more quickly
-				M.set_respawn_bonus("CRYOSLEEP", CRYOPOD_SPAWN_BONUS)
+	if(occupant.mind && occupant.mind.key)
+		//Whoever inhabited this body is long gone, we need some black magic to find where and who they are now
+		var/mob/M = key2mob(occupant.mind.key)
+		if(istype(M) && !M.get_respawn_bonus("CRYOSLEEP"))
+			if(M.in_perfect_health())
+				//We send a message to the occupant's current mob - probably a ghost, but who knows.
+				to_chat(M, SPAN_NOTICE("Because your body was put into cryostorage in good health, your crew respawn time has been reduced by [(CRYOPOD_HEALTHY_RESPAWN_BONUS)/600] minutes."))
+				M.set_respawn_bonus("CRYOSLEEP", CRYOPOD_HEALTHY_RESPAWN_BONUS)
+			else
+				to_chat(M, SPAN_NOTICE("Because your body was put into cryostorage in poor health, your crew respawn time has been reduced by [(CRYOPOD_WOUNDED_RESPAWN_BONUS)/600] minutes."))
+				M.set_respawn_bonus("CRYOSLEEP", CRYOPOD_WOUNDED_RESPAWN_BONUS)
+			M << 'sound/effects/magic/blind.ogg' //Play this sound to a player whenever their respawn time gets reduced
 
 	// This despawn is not a gib() in this sense, it is used to remove objectives tied on these despawned mobs in cryos
 	occupant.despawn()
@@ -527,14 +526,15 @@
 
 		new_occupant.forceMove(src)
 
-		if (notifications)
+		if(notifications)
 			to_chat(occupant, SPAN_NOTICE("[on_enter_occupant_message]"))
 			to_chat(occupant, SPAN_NOTICE("<b>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</b>"))
-		if (occupant.in_perfect_health() && notifications)
-			to_chat(occupant, SPAN_NOTICE("<b>Your respawn time will be reduced by 20 minutes, allowing you to respawn as a crewmember much more quickly.</b>"))
-		else if (notifications)
-			to_chat(occupant, SPAN_DANGER("<b>Because you are not in perfect health, going into cryosleep will not reduce your crew respawn time. \
-			If you wish to respawn as a different crewmember, you should treat your injuries at medical first</b>"))
+			if(occupant.in_perfect_health())
+				to_chat(occupant, SPAN_NOTICE("<b>Your respawn time will be reduced by [(CRYOPOD_HEALTHY_RESPAWN_BONUS)/600] minutes, allowing you to respawn as a crewmember much more quickly.</b>"))
+			else
+				to_chat(occupant, SPAN_NOTICE("<b>Your respawn time will be reduced by [(CRYOPOD_WOUNDED_RESPAWN_BONUS)/600] minutes, allowing you to respawn as a crewmember much more quickly.</b>"))
+				to_chat(occupant, SPAN_DANGER("<b>Because you are not in perfect health, respawn time reduction is low. \
+				If you wish to respawn as a different crewmember sooner, you should treat your injuries first</b>"))
 
 	else
 		if(!QDELETED(occupant))

--- a/code/game/machinery/excelsior/ex_teleporter.dm
+++ b/code/game/machinery/excelsior/ex_teleporter.dm
@@ -338,9 +338,9 @@ var/global/excelsior_last_draft = 0
 	playsound(src.loc, 'sound/machines/ping.ogg', 50, 1, -3)
 /obj/machinery/complant_teleporter/proc/teleport_out(var/mob/living/affecting, var/mob/living/user)
 	flick("teleporting", src)
-	to_chat(affecting, SPAN_NOTICE("You have been teleported to haven, your crew respawn time is reduced by 15 minutes."))
+	to_chat(affecting, SPAN_NOTICE("You have been teleported to haven, your crew respawn time is reduced by [(COLLECTIVISED_RESPAWN_BONUS)/600] minutes."))
 	visible_message("\the [src] teleporter closes and [affecting] disapears.")
-	affecting.set_respawn_bonus("TELEPORTED_TO_EXCEL", 15 MINUTES)
+	affecting.set_respawn_bonus("TELEPORTED_TO_EXCEL", COLLECTIVISED_RESPAWN_BONUS)
 	affecting << 'sound/effects/magic/blind.ogg'  //Play this sound to a player whenever their respawn time gets reduced
 	qdel(affecting)
 /obj/machinery/complant_teleporter/proc/request_reinforcements(var/mob/living/user)

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -25,11 +25,11 @@
 	if (occupant && occupant.is_dead())
 		var/mob/M = key2mob(occupant.mind.key)
 		//We send a message to the occupant's current mob - probably a ghost, but who knows.
-		to_chat(M, SPAN_NOTICE("Your remains have been committed to the void. Your crew respawn time has been reduced by 15 minutes."))
+		to_chat(M, SPAN_NOTICE("Your remains have been committed to the void. Your crew respawn time has been reduced by [(COFFIN_RESPAWN_BONUS)/600] minutes."))
 		M << 'sound/effects/magic/blind.ogg' //Play this sound to a player whenever their respawn time gets reduced
 
 		//A proper funeral for the corpse allows a faster respawn
-		M.set_respawn_bonus("CORPSE_HANDLING", 15 MINUTES)
+		M.set_respawn_bonus("CORPSE_HANDLING", COFFIN_RESPAWN_BONUS)
 
 		qdel(occupant)
 		qdel(src)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -147,11 +147,11 @@
 		if (M.get_respawn_bonus("CORPSE_HANDLING"))
 			return // we got this one already
 		//We send a message to the occupant's current mob - probably a ghost, but who knows.
-		to_chat(M, SPAN_NOTICE("Your remains have been collected and properly stored. Your crew respawn time is reduced by 10 minutes."))
+		to_chat(M, SPAN_NOTICE("Your remains have been collected and properly stored. Your crew respawn time is reduced by [(MORGUE_RESPAWN_BONUS)/600] minutes."))
 		
 		M << 'sound/effects/magic/blind.ogg' //Play this sound to a player whenever their respawn time gets reduced
 
-		M.set_respawn_bonus("CORPSE_HANDLING", 10 MINUTES)
+		M.set_respawn_bonus("CORPSE_HANDLING", MORGUE_RESPAWN_BONUS)
 		to_chat(user, SPAN_NOTICE("The corpse's spirit feels soothed and pleased."))
 
 

--- a/code/modules/biomatter_manipulation/bioreactor/platform.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/platform.dm
@@ -110,9 +110,9 @@
 				continue
 		if(H && H.mind && H.mind.key && H.stat == DEAD)
 			var/mob/M = key2mob(H.mind.key)
-			to_chat(M, SPAN_NOTICE("Your remains have been dissolved and reused. Your crew respawn time is reduced by 10 minutes."))
+			to_chat(M, SPAN_NOTICE("Your remains have been dissolved and reused. Your crew respawn time is reduced by [(BIOREACTOR_RESPAWN_BONUS)/600] minutes."))
 			M << 'sound/effects/magic/blind.ogg'  //Play this sound to a player whenever their respawn time gets reduced
-			M.set_respawn_bonus("CORPSE_DISSOLVING", 10 MINUTES)
+			M.set_respawn_bonus("CORPSE_DISSOLVING", BIOREACTOR_RESPAWN_BONUS)
 		
 	qdel(object)
 	//now let's add some dirt to the glass

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -31,10 +31,10 @@ var/global/list/empty_playable_ai_cores = list()
 	var/mob/M = key2mob(mind.key)
 
 	//We send a message to the occupant's current mob - probably a ghost, but who knows.
-	to_chat(M, SPAN_NOTICE("You have entered intelligence storage, your crew respawn time has been reduced by [CRYOPOD_SPAWN_BONUS_DESC]."))
+	to_chat(M, SPAN_NOTICE("You have entered intelligence storage, your crew respawn time has been reduced by [(CRYOPOD_HEALTHY_RESPAWN_BONUS)/600] minutes."))
 	M << 'sound/effects/magic/blind.ogg' //Play this sound to a player whenever their respawn time gets reduced
 
-	M.set_respawn_bonus("SILICON_STORAGE", CRYOPOD_SPAWN_BONUS)
+	M.set_respawn_bonus("SILICON_STORAGE", CRYOPOD_HEALTHY_RESPAWN_BONUS)
 
 
 	//Handle job slot/tater cleanup.

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -155,11 +155,14 @@ Works together with spawning an observer, noted above.
 
 		//Set the respawn bonus from ghosting while in cryosleep.
 		//This is duplicated in the cryopod code for robustness. The message will not display twice
-		if (istype(loc, /obj/machinery/cryopod) && in_perfect_health())
-			if (!get_respawn_bonus("CRYOSLEEP"))
-				to_chat(src, SPAN_NOTICE("Because you ghosted from a cryopod in good health, your crew respawn time has been reduced by [CRYOPOD_SPAWN_BONUS_DESC]."))
-				src << 'sound/effects/magic/blind.ogg' //Play this sound to a player whenever their respawn time gets reduced
-			set_respawn_bonus("CRYOSLEEP", CRYOPOD_SPAWN_BONUS)
+		if(istype(loc, /obj/machinery/cryopod) && !get_respawn_bonus("CRYOSLEEP"))
+			if(in_perfect_health())
+				to_chat(src, SPAN_NOTICE("Because you ghosted from a cryopod in good health, your crew respawn time has been reduced by [(CRYOPOD_HEALTHY_RESPAWN_BONUS)/600] minutes."))
+				set_respawn_bonus("CRYOSLEEP", CRYOPOD_HEALTHY_RESPAWN_BONUS)
+			else
+				to_chat(src, SPAN_NOTICE("Because you ghosted from a cryopod in poor health, your crew respawn time has been reduced by [(CRYOPOD_WOUNDED_RESPAWN_BONUS)/600] minutes."))
+				set_respawn_bonus("CRYOSLEEP", CRYOPOD_WOUNDED_RESPAWN_BONUS)
+			src << 'sound/effects/magic/blind.ogg' //Play this sound to a player whenever their respawn time gets reduced
 
 		ghost.ckey = ckey
 		ghost.client = client


### PR DESCRIPTION
## About The Pull Request

Drone respawn timer - 5 minutes.

Human respawn timer reduction:

Went in cryo healthy - 25 minutes.
Went in cryo wounded - 20 minutes.
Put in the morgue - 15 minutes.
Dissolved in bioreactor - 15 minutes.
Stolen by commies - 15 minutes.
Spaced in a coffin - 25 minutes.

## Why It's Good For The Game

Keeping players out of the game benefits literally nobody, currently players are unlikely to stick around and wait for long respawn timer.

## Changelog
:cl:
tweak: increased respawn timer reduction from most sources
/:cl:

