### PR TITLE
Fix hostile mobs ignoring non-targeted projectiles

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -364,3 +364,8 @@
 
 /mob/living/carbon/superior_animal/getarmor(def_zone, type)
 	return armor.getRating(type)
+
+/mob/living/carbon/superior_animal/CanPass(atom/mover)
+	if(istype(mover, /obj/item/projectile))
+		return stat ? TRUE : FALSE
+	. = ..()


### PR DESCRIPTION
## About The Pull Request

Currently bullets flying past hostile mobs won't connect, unless mob have been clicked at, which is pretty dumb and unfun.
Projectile is not guaranteed to hit, bullet's just won't ignore mobs completely.

https://user-images.githubusercontent.com/65828539/173418691-93ac4157-4130-402e-93a8-3c2583968786.mp4


https://user-images.githubusercontent.com/65828539/173419495-0ffbef55-e0ae-4d97-b103-613f98c065c5.mp4



## Why It's Good For The Game

Fixes cool.

## Changelog
:cl:
fix: hostile mobs ignoring non-targeted projectiles
/:cl:

