### PR TITLE
Fix runtime in mob_helpers.dm

### DIFF
--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -24,5 +24,5 @@
 #define MOVE_INTENT_EXERTIVE   0x0002
 #define MOVE_INTENT_QUICK      0x0004
 
-#define MOVING_DELIBERATELY(X) (X.move_intent?.flags & MOVE_INTENT_DELIBERATE)
+#define MOVING_DELIBERATELY(X) (X ? X.move_intent?.flags & MOVE_INTENT_DELIBERATE : TRUE)
 #define MOVING_QUICKLY(X) (X.move_intent?.flags & MOVE_INTENT_QUICK)


### PR DESCRIPTION
## About The Pull Request

It's mice trying to evade traps before initialization again. Should prevent uncommon runtime on roundstart.

![image](https://user-images.githubusercontent.com/65828539/176797435-38200d8c-e505-46bc-b172-4076719beaa5.png)

## Why It's Good For The Game

Fixes cool.

## Changelog
:cl:
fix: runtime in mob_helpers.dm
/:cl:
