### PR TITLE
Powered Crossbow Update - After Feedback and Live Tests

### DIFF
--- a/code/datums/craft/recipes/guns.dm
+++ b/code/datums/craft/recipes/guns.dm
@@ -90,7 +90,15 @@
 		list(QUALITY_WELDING, 10, "time" = 30),
 		list(/obj/item/stack/cable_coil, 10, "time" = 10),
 		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTIC, "time" = 10),
+		list(CRAFT_MATERIAL, 2, MATERIAL_GLASS, "time" = 20),
 		list(QUALITY_SCREW_DRIVING, 5, 10, "time" = 3))
+
+/datum/craft_recipe/gun/crossbow_bolt
+	name = "crossbow bolt"
+	result = /obj/item/ammo_casing/crossbow/bolt/prespawned
+	steps = list(
+		list(/obj/item/stack/rods, 5, "time" = 1),
+		list(QUALITY_HAMMERING, 5, 10, "time" = 10)) 
 
 /datum/craft_recipe/gun/makeshiftlaser
 	name = "makeshift laser carbine"

--- a/code/datums/craft/recipes/weapon.dm
+++ b/code/datums/craft/recipes/weapon.dm
@@ -76,13 +76,6 @@
 		list(QUALITY_HAMMERING, 10, "time" = 20)
 	)
 
-/datum/craft_recipe/weapon/crossbow_bolt
-	name = "crossbow bolt"
-	result = /obj/item/ammo_casing/crossbow/bolt
-	steps = list(
-		list(/obj/item/stack/rods, 1, "time" = 1),
-		list(QUALITY_HAMMERING, 5, 10)) 
-
 /datum/craft_recipe/weapon/knife_blade
 	name = "knife blade"
 	result = /obj/item/material/butterflyblade

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -585,7 +585,11 @@
 	matter = list(MATERIAL_STEEL = 1)
 	is_caseless = TRUE
 	maxamount = 5
+	sharp = TRUE
 
 	sprite_update_spawn = TRUE
 	sprite_max_rotate = 32
 	sprite_scale = 1
+
+/obj/item/ammo_casing/crossbow/bolt/prespawned
+	amount = 5

--- a/code/modules/projectiles/guns/energy/poweredcrossbow.dm
+++ b/code/modules/projectiles/guns/energy/poweredcrossbow.dm
@@ -10,7 +10,7 @@
 	fire_delay = 6 //Lowered to match plasma weapons
 	fire_sound = 'sound/weapons/tablehit1.ogg'
 	init_firemodes = list(
-		list(mode_name="Bolt", mode_desc="Fires a charged quarrel", projectile_type=/obj/item/projectile/bullet/bolt, charge_cost=50, icon="kill"),)
+		list(mode_name = "Bolt", mode_desc = "Fires a charged quarrel", projectile_type = /obj/item/projectile/bullet/bolt, charge_cost = 50, icon = "kill"))
 	price_tag = 200
 	spawn_tags = SPAWN_TAG_GUN_HANDMADE
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 5, MATERIAL_WOOD = 5)

--- a/code/modules/projectiles/guns/energy/poweredcrossbow.dm
+++ b/code/modules/projectiles/guns/energy/poweredcrossbow.dm
@@ -1,19 +1,20 @@
 /obj/item/gun/energy/poweredcrossbow
 	name = "powered crossbow"
-	desc = "An handmade crossbow linked to an attached power cell, a weapon of desperation and ingenuity."
+	desc = "An handmade crossbow linked to an attached power cell, a weapon of desperation and ingenuity. There is a rudimentary scope built into the design."
 	icon = 'icons/obj/guns/energy/poweredcrossbow.dmi'
 	icon_state = "crossbow"
 	item_state = "crossbow"
 	flags = CONDUCT
 	slot_flags = SLOT_BACK
 	wielded_item_state = "_doble"
-	fire_delay = 12 //Equivalent to a pump then fire time
+	fire_delay = 6 //Lowered to match plasma weapons
 	fire_sound = 'sound/weapons/tablehit1.ogg'
 	init_firemodes = list(
-		list(mode_name="Bolt", mode_desc="Fires a charged quarrel", projectile_type=/obj/item/projectile/bullet/bolt, charge_cost=100, icon="kill"),)
+		list(mode_name="Bolt", mode_desc="Fires a charged quarrel", projectile_type=/obj/item/projectile/bullet/bolt, charge_cost=50, icon="kill"),)
 	price_tag = 200
 	spawn_tags = SPAWN_TAG_GUN_HANDMADE
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 5, MATERIAL_WOOD = 5)
+	zoom_factor = 0.5
 	var/obj/item/ammo_casing/crossbow/bolt/bolt
 	var/is_drawn
 	init_recoil = RIFLE_RECOIL(1)
@@ -28,14 +29,20 @@
 		var/obj/item/ammo_casing/crossbow/bolt/B = I
 		bolt = new B.type()
 		bolt.amount = 1
-		(B.amount > 1) ? B.amount-- : qdel(B)
+		if(B.amount > 1) 
+			B.amount-- 
+			B.update_icon()
+		else
+			qdel(B)
+		to_chat(user, SPAN_NOTICE("You load a bolt into the powered crossbow!"))
 	else
 		..()
 
 /obj/item/gun/energy/poweredcrossbow/attack_hand(mob/living/user)
-	if(bolt)
+	if(bolt && is_held())
 		user.put_in_active_hand(bolt)
 		bolt = null
+		to_chat(user, SPAN_NOTICE("You unload a bolt from the powered crossbow!"))
 	else
 		..()
 

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -329,13 +329,16 @@ There are important things regarding this file:
 	recoil = 1 // Pop
 
 /obj/item/projectile/bullet/bolt
+	icon_state = "SpearFlight"
 	name = "bolt"
-	armor_penetration = 20
+	damage_types = list(BRUTE = 55)
+	armor_penetration = 30
+	embed = FALSE
 	can_ricochet = TRUE
 	recoil = 3
 	style_damage = 40
 
 /obj/item/projectile/bullet/bolt/on_hit(mob/living/target, def_zone = BP_CHEST)
     if(istype(target))
-        var/obj/item/stack/rods/R = new(null)
+        var/obj/item/ammo_casing/crossbow/bolt/R = new(null)
         target.embed(R, def_zone)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR updates the merged Powered Crossbow with some QoL feedback suggestions, buffs, and observations made after using the crossbow last launch.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Bolt projectile sprite was changed to something more fitting:
![crossbowpath](https://user-images.githubusercontent.com/103066653/179883830-2712e761-4525-42d3-b995-2b002f373dff.png)

## Why It's Good For The Game
Community feedback after testing is good indicator of what players want.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Recipe for crossbow bolts moved to guns section, right under powered crossbow.
tweak: Crossbow recipe edited slightly to include glass, representing a poor scope.
tweak: Crossbow has a minor zoom factor now, 3 spaces when used.
tweak: Bolts now embed on hit and can be extracted from kills in bolt form to be used again. Prior to this they turned into metal rods on hits.
tweak: Embedded bolts are sharp, dealing pain, brute and toxin like normal shrapnel if you run without removing them. They can be removed via surgery or right clicking to yank.
tweak: Recipe for bolts costs the same, but you now spend 5 metal rods to make a handful of 5 bolts rather than 5 individual bolts, less clicks on players side.
tweak: You now get chat messages telling you when you load or unload a bolt to/from the crossbow.
tweak: Remaining bolt stack sprite properly updates when loading the crossbow with a single one.
tweak: You now only unload a bolt from the crossbow if you interact with an empty hand on a loaded crossbow you are currently holding.
balance: Energy use of powered crossbow was made more efficient, 50 instead of 100.
balance: Fire Delay of powered crossbow was lowered, 6 instead of 12.
balance: Projectile damage of powered crossbow was buffed, 40 -> 55.
balance: Projectile penetration of powered crossbow was buffed 20 -> 30.
imageadd: Bolt projectile sprite was changed to something more fitting

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
