### PR TITLE
Debugger saner values

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -1,4 +1,4 @@
-#define SHEET_MATERIAL_AMOUNT 2000
+#define SHEET_MATERIAL_AMOUNT 1
 
 #define TECH_MATERIAL "materials"
 #define TECH_ENGINEERING "engineering"

--- a/code/modules/integrated_electronics/core/debugger.dm
+++ b/code/modules/integrated_electronics/core/debugger.dm
@@ -8,7 +8,7 @@
 	w_class = ITEM_SIZE_SMALL
 	var/data_to_write = null
 	var/accepting_refs = FALSE
-	matter = list(MATERIAL_STEEL = 1000, MATERIAL_GLASS = 500, MATERIAL_PLASTIC = 500)
+	matter = list(MATERIAL_STEEL = 1, MATERIAL_GLASS = 2, MATERIAL_PLASTIC = 2)
 	var/copy_values = FALSE
 	var/copy_id = FALSE
 	var/datum/weakref/idlock = null


### PR DESCRIPTION
## About The Pull Request

Decreases the amount of plastic, glass and steel needed for making(and deconstucting) a debugger in integrated electronics


## Why It's Good For The Game

Sane values in case somewhere to find or want to make these should be gained

## Changelog
:cl:
fix: Debugging tool for integrated electronics now has saner values of materials
fix: Printing integrated electronics no longer doups materals
/:cl:
