### PR TITLE
Fixes cover functionality when overshooting [RTM]

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -313,6 +313,20 @@
 
 	var/result = PROJECTILE_FORCE_MISS
 
+	if(target_mob != original) // If mob was not clicked on / is not an NPC's target, checks if the mob is concealed by cover
+		var/turf/cover_loc = get_step(get_turf(target_mob), get_dir(get_turf(target_mob), starting))
+		for(var/obj/O in cover_loc)
+			if(istype(O,/obj/structure/low_wall) || istype(O,/obj/machinery/deployable/barrier) || istype(O,/obj/structure/barricade) || istype(O,/obj/structure/table))
+				if(!silenced)
+					visible_message(SPAN_NOTICE("\The [target_mob] ducks behind \the [O], narrowly avoiding \the [src]!"))
+				return FALSE
+		for(var/obj/structure/table/O in get_turf(target_mob))
+			if(istype(O) && O.flipped && (get_dir(get_turf(target_mob), starting) == O.dir))
+				if(!silenced)
+					visible_message(SPAN_NOTICE("\The [target_mob] ducks behind \the [O], narrowly avoiding \the [src]!"))
+				return FALSE
+
+
 	if(iscarbon(target_mob))
 		var/mob/living/carbon/C = target_mob
 		var/obj/item/shield/S


### PR DESCRIPTION
## About The Pull Request

When a bullet reaches someone behind cover, the bullet will always miss unless they are the intended target (were directly clicked on, or an NPC is targeting them).

Tested on test server.

## Why It's Good For The Game

Removes an exploit, makes cover more effective, especially against sprayfire. Does not prevent long-range snipers from shooting over cover, and if they aimed correctly, will still enable them to hit someone directly behind cover.

## Changelog
:cl:
add: Cover properly triggers when overshooting
/:cl: