### PR TITLE
Fire rework

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -2,18 +2,18 @@
 #define HUMAN_MAX_OXYLOSS 1 //Defines how much oxyloss humans can get per tick. A tile with no air at all (such as space) applies this value, otherwise it's a percentage of it.
 #define HUMAN_CRIT_MAX_OXYLOSS ( 2 / 6) //The amount of damage you'll get when in critical condition. We want this to be a 5 minute deal = 300s. There are 50HP to get through, so (1/6)*last_tick_duration per second. Breaths however only happen every 4 ticks. last_tick_duration = ~2.0 on average
 
-#define HEAT_DAMAGE_LEVEL_1 2 //Amount of damage applied when your body temperature just passes the 360.15k safety point
-#define HEAT_DAMAGE_LEVEL_2 4 //Amount of damage applied when your body temperature passes the 400K point
-#define HEAT_DAMAGE_LEVEL_3 8 //Amount of damage applied when your body temperature passes the 1000K point
+#define HEAT_DAMAGE_LEVEL_1 1 //Amount of damage applied when your body temperature just passes the 360.15k safety point
+#define HEAT_DAMAGE_LEVEL_2 2 //Amount of damage applied when your body temperature passes the 400K point
+#define HEAT_DAMAGE_LEVEL_3 3 //Amount of damage applied when your body temperature passes the 1000K point
 
 #define COLD_DAMAGE_LEVEL_1 0.5 //Amount of damage applied when your body temperature just passes the 260.15k safety point
 #define COLD_DAMAGE_LEVEL_2 1.5 //Amount of damage applied when your body temperature passes the 200K point
 #define COLD_DAMAGE_LEVEL_3 3 //Amount of damage applied when your body temperature passes the 120K point
 
 //Note that gas heat damage is only applied once every FOUR ticks.
-#define HEAT_GAS_DAMAGE_LEVEL_1 2 //Amount of damage applied when the current breath's temperature just passes the 360.15k safety point
-#define HEAT_GAS_DAMAGE_LEVEL_2 4 //Amount of damage applied when the current breath's temperature passes the 400K point
-#define HEAT_GAS_DAMAGE_LEVEL_3 8 //Amount of damage applied when the current breath's temperature passes the 1000K point
+#define HEAT_GAS_DAMAGE_LEVEL_1 1 //Amount of damage applied when the current breath's temperature just passes the 360.15k safety point
+#define HEAT_GAS_DAMAGE_LEVEL_2 2 //Amount of damage applied when the current breath's temperature passes the 400K point
+#define HEAT_GAS_DAMAGE_LEVEL_3 3 //Amount of damage applied when the current breath's temperature passes the 1000K point
 
 #define COLD_GAS_DAMAGE_LEVEL_1 0.5 //Amount of damage applied when the current breath's temperature just passes the 260.15k safety point
 #define COLD_GAS_DAMAGE_LEVEL_2 1.5 //Amount of damage applied when the current breath's temperature passes the 200K point
@@ -607,8 +607,15 @@
 				burn_dam = HEAT_DAMAGE_LEVEL_1
 			if(species.heat_level_2 to species.heat_level_3)
 				burn_dam = HEAT_DAMAGE_LEVEL_2
+				fire_stacks += 1
 			if(species.heat_level_3 to INFINITY)
 				burn_dam = HEAT_DAMAGE_LEVEL_3
+				fire_stacks += 3
+
+		IgniteMob() // Ignites oil or other firestacks, damage increased while on fire
+		if(on_fire)
+			burn_dam = burn_dam * 2
+
 		take_overall_damage(burn=burn_dam, used_weapon = "High Body Temperature")
 		fire_alert = max(fire_alert, FIRE_ALERT_HOT)
 
@@ -623,8 +630,17 @@
 					burn_dam = COLD_DAMAGE_LEVEL_1
 				if(species.cold_level_3 to species.cold_level_2)
 					burn_dam = COLD_DAMAGE_LEVEL_2
+					fire_stacks -= 1
 				if(species.cold_level_2 to species.cold_level_1)
 					burn_dam = COLD_DAMAGE_LEVEL_3
+					fire_stacks -= 3
+
+			if(bodytemperature <= species.cold_level_2)
+				if(on_fire)
+					burn_dam += 30 // Temperature shock
+
+			ExtinguishMob()
+
 			take_overall_damage(burn=burn_dam, used_weapon = "Low Body Temperature")
 			fire_alert = max(fire_alert, FIRE_ALERT_COLD)
 
@@ -682,8 +698,6 @@
 
 	if (abs(body_temperature_difference) < 0.5)
 		return //fuck this precision
-	if (on_fire)
-		return //too busy for pesky metabolic regulation
 
 	if(bodytemperature < species.cold_level_1) //260.15 is 310.15 - 50, the temperature where you start to feel effects.
 		if(nutrition >= 2) //If we are very, very cold we'll use up quite a bit of nutriment to heat us up.
@@ -1123,16 +1137,6 @@
 	if(..())
 		speech_problem_flag = 1
 	return stuttering
-
-/mob/living/carbon/human/handle_fire()
-	if(..())
-		return
-
-	var/burn_temperature = fire_burn_temperature()
-	var/thermal_protection = get_heat_protection(burn_temperature)
-
-	if (thermal_protection < 1 && bodytemperature < burn_temperature)
-		bodytemperature += round(BODYTEMP_HEATING_MAX*(1-thermal_protection), 1)
 
 /mob/living/carbon/human/rejuvenate()
 	sanity.setLevel(sanity.max_level)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -128,7 +128,7 @@
 		to_chat(src, SPAN_WARNING("You have been hit by [P]!"))
 		qdel(P)
 		return TRUE
-	
+
 	if(P.agony > 0)
 		hit_impact(P.agony, hit_dir)
 		damage_through_armor(P.agony, HALLOSS, def_zone, P.check_armour, armour_pen = P.armor_penetration, used_weapon = P, sharp = is_sharp(P), edge = has_edge(P))
@@ -323,7 +323,7 @@
 /mob/living/proc/ExtinguishMob()
 	if(on_fire)
 		on_fire = FALSE
-		fire_stacks = 0
+		fire_stacks = max(0, fire_stacks - 3)
 		set_light(max(0, light_range - 3))
 		update_fire()
 
@@ -342,6 +342,10 @@
 	else if(fire_stacks <= 0)
 		ExtinguishMob() //Fire's been put out.
 		return 1
+
+	fire_stacks-- // The fire will slowly die out
+	fire_stacks = CLAMP(fire_stacks, -5, 5) // Limit stacks
+	take_overall_damage(burn=8, used_weapon = "Thermal Burns")
 
 	var/datum/gas_mixture/G = loc.return_air() // Check if we're standing in an oxygenless environment
 	if(G.gas["oxygen"] < 1)


### PR DESCRIPTION
## About The Pull Request

Implements a new way for fire to work. Fire no longer causes heat, instead damages directly, as well as increases damage from the environment (for humans).

Heat does now cause you to catch on fire, but burning dissipates over time. This means if you heat up enough and catch on fire, after a while the fire will burn out, avoiding the monkeys burning for hours incident.

Some weapons, specifically plasma and more specifically heatwave-based weapons will now cause the body temperature of targets to boost up, which can as a result ignite them and do considerable damage over time. Also, beware the ultra-modded industrial welder.

Flamethrowers are capable of quickly igniting large areas, and rapidly raising body temperature, while lacking any actual direct damage.

- [ ] Part 1: Body temperature and fire handling, fire causes burn damage

- [ ] Part 2: Fire damage for weapons

- [ ] Part 3: Flamethrower rework

## Why It's Good For The Game

Fire is fun, heat damage is bad.

## Changelog
:cl:
balance: fire overhaul
/:cl: