### PR TITLE
Excelsior and Neotheo Voidsuit Buffs

### DIFF
--- a/code/modules/clothing/spacesuits/void/excelsior.dm
+++ b/code/modules/clothing/spacesuits/void/excelsior.dm
@@ -14,8 +14,8 @@
 
 	armor = list(
 		melee = 40,
-		bullet = 40,
-		energy = 50,
+		bullet = 50,
+		energy = 55,
 		bomb = 25,
 		bio = 100,
 		rad = 75
@@ -74,8 +74,8 @@
 	slowdown = 0.2
 	w_class = ITEM_SIZE_NORMAL
 	armor = list(
-		melee = 45,
-		bullet = 45,
+		melee = 40,
+		bullet = 50,
 		energy = 55,
 		bomb = 25,
 		bio = 100,

--- a/code/modules/clothing/spacesuits/void/excelsior.dm
+++ b/code/modules/clothing/spacesuits/void/excelsior.dm
@@ -74,9 +74,9 @@
 	slowdown = 0.2
 	w_class = ITEM_SIZE_NORMAL
 	armor = list(
-		melee = 40,
-		bullet = 40,
-		energy = 50,
+		melee = 45,
+		bullet = 45,
+		energy = 55,
 		bomb = 25,
 		bio = 100,
 		rad = 75

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -1,5 +1,5 @@
 // Ship voidsuits
-//Engineering rig
+//Engineering void
 /obj/item/clothing/head/space/void/engineering
 	name = "Technomancer voidsuit helmet"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment. Has radiation shielding."
@@ -49,7 +49,7 @@
 	accompanying_object = null
 	spawn_blacklisted = TRUE
 
-//Old engineering rig
+//Old engineering void
 /obj/item/clothing/head/space/void/engineeringold
 	name = "outdated Technomancer voidsuit helmet"
 	desc = "This visor has a few more options in its shape than its more newer version."
@@ -306,7 +306,7 @@
 	price_tag = 200
 	armor = list(
 		melee = 40,
-		bullet = 55,
+		bullet = 50,
 		energy = 60,
 		bomb = 40,
 		bio = 100,
@@ -358,7 +358,7 @@
 	)
 	armor = list(
 		melee = 40,
-		bullet = 55,
+		bullet = 50,
 		energy = 60,
 		bomb = 40, //platinum price justifies bloated stats
 		bio = 100,
@@ -438,8 +438,8 @@
 	flags_inv = BLOCKHAIR
 	armor = list(
 		melee = 55,
-		bullet = 50,
-		energy = 45,
+		bullet = 45,
+		energy = 50,
 		bomb = 30,
 		bio = 100,
 		rad = 50
@@ -458,8 +458,8 @@
 	flags_inv = HIDEGLOVES|HIDEJUMPSUIT|HIDETAIL
 	armor = list(
 	    melee = 55,
-		bullet = 50,
-		energy = 45,
+		bullet = 45,
+		energy = 50,
 		bomb = 30,
 		bio = 100,
 		rad = 50

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -437,7 +437,7 @@
 	action_button_name = "Toggle Helmet Light"
 	flags_inv = BLOCKHAIR
 	armor = list(
-		melee = 55,
+		melee = 50,
 		bullet = 45,
 		energy = 45,
 		bomb = 30,
@@ -457,7 +457,7 @@
 	slowdown = 0.3
 	flags_inv = HIDEGLOVES|HIDEJUMPSUIT|HIDETAIL
 	armor = list(
-	    melee = 55,
+	    melee = 50,
 		bullet = 45,
 		energy = 45,
 		bomb = 30,

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -439,7 +439,7 @@
 	armor = list(
 		melee = 55,
 		bullet = 45,
-		energy = 50,
+		energy = 45,
 		bomb = 30,
 		bio = 100,
 		rad = 50
@@ -459,7 +459,7 @@
 	armor = list(
 	    melee = 55,
 		bullet = 45,
-		energy = 50,
+		energy = 45,
 		bomb = 30,
 		bio = 100,
 		rad = 50

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -1,4 +1,4 @@
-// Station voidsuits
+// Ship voidsuits
 //Engineering rig
 /obj/item/clothing/head/space/void/engineering
 	name = "Technomancer voidsuit helmet"
@@ -306,7 +306,7 @@
 	price_tag = 200
 	armor = list(
 		melee = 40,
-		bullet = 50,
+		bullet = 55,
 		energy = 60,
 		bomb = 40,
 		bio = 100,
@@ -358,7 +358,7 @@
 	)
 	armor = list(
 		melee = 40,
-		bullet = 50,
+		bullet = 55,
 		energy = 60,
 		bomb = 40, //platinum price justifies bloated stats
 		bio = 100,
@@ -404,7 +404,7 @@
 		energy = 30,
 		bomb = 25,
 		bio = 100,
-		rad = 0
+		rad = 5
 	)
 	light_overlay = "helmet_light_dual"
 	siemens_coefficient = 0.8
@@ -421,7 +421,7 @@
 		energy = 30,
 		bomb = 25,
 		bio = 100,
-		rad = 0
+		rad = 5
 	)
 	siemens_coefficient = 0.8
 	helmet = /obj/item/clothing/head/space/void/riggedvoidsuit
@@ -437,9 +437,9 @@
 	action_button_name = "Toggle Helmet Light"
 	flags_inv = BLOCKHAIR
 	armor = list(
-		melee = 40,
-		bullet = 40,
-		energy = 40,
+		melee = 55,
+		bullet = 50,
+		energy = 45,
 		bomb = 30,
 		bio = 100,
 		rad = 50
@@ -453,13 +453,13 @@
 	desc = "A voidsuit designed by NeoTheology with a most holy mix of biomatter and inorganic matter."
 	icon_state = "ntvoid"
 	item_state = "ntvoid"
-	matter = list(MATERIAL_PLASTEEL = 8, MATERIAL_STEEL = 10, MATERIAL_BIOMATTER = 35)
+	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_STEEL = 10, MATERIAL_BIOMATTER = 35)
 	slowdown = 0.3
 	flags_inv = HIDEGLOVES|HIDEJUMPSUIT|HIDETAIL
 	armor = list(
-	    melee = 40,
-		bullet = 40,
-		energy = 40,
+	    melee = 55,
+		bullet = 50,
+		energy = 45,
 		bomb = 30,
 		bio = 100,
 		rad = 50

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -453,7 +453,7 @@
 	desc = "A voidsuit designed by NeoTheology with a most holy mix of biomatter and inorganic matter."
 	icon_state = "ntvoid"
 	item_state = "ntvoid"
-	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_STEEL = 10, MATERIAL_BIOMATTER = 35)
+	matter = list(MATERIAL_PLASTEEL = 8, MATERIAL_STEEL = 10, MATERIAL_BIOMATTER = 35)
 	slowdown = 0.3
 	flags_inv = HIDEGLOVES|HIDEJUMPSUIT|HIDETAIL
 	armor = list(


### PR DESCRIPTION
some small buffs to the Combat Oriented Void suits to make them more viable compared to BP and Style Dodge

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Some of the combat void suits (NT and Excel) felt underpowered compared to their competition with style dodge and full armor vests. so I gave them some small buffs to hopefully increase use of void suits and make them somewhat viable in combat once again.
suggested by BeadsJR
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
the excel and NT void were previously the exact same armor as the lowest tier of armor vest. so nobody would ever wear them. they should now be slightly better than that
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: small buffs to Excelsior and Neotheo Voidsuit to compete with basic armor vests
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
