### PR TITLE
Yet another Major Gun Rebalance ( Fixes several issues with gun code,  full auto is now based off fire_delay)

### DIFF
--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -52,7 +52,7 @@
 #define FULL_AUTO_600		list(mode_name = "full auto",  mode_desc = "600 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 1  , icon="auto", damage_mult_add = -0.2)
 #define FULL_AUTO_800		list(mode_name = "fuller auto",  mode_desc = "800 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 0.8, icon="auto", damage_mult_add = -0.2)
 
-#define SEMI_AUTO_NODELAY	list(mode_name = "semiauto",  mode_desc = "Fire as fast as you can pull the trigger", burst=1, fire_delay=0, move_delay=null, icon="semi")
+#define SEMI_AUTO_300	list(mode_name = "semiauto",  mode_desc = "Fire as fast as you can pull the trigger", burst=1, fire_delay=2, move_delay=null, icon="semi")
 
 //Cog firemode
 #define BURST_2_BEAM		list(mode_name="2-beam bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, move_delay=2, icon="burst", damage_mult_add = -0.2)

--- a/code/datums/datum_click_handlers.dm
+++ b/code/datums/datum_click_handlers.dm
@@ -113,7 +113,7 @@
 	if(target)
 		owner.mob.face_atom(target)
 		do_fire()
-		spawn(reciever.burst_delay) shooting_loop()
+		spawn(reciever.fire_delay) shooting_loop()
 
 /datum/click_handler/fullauto/MouseDrag(over_object, src_location, over_location, src_control, over_control, params)
 	src_location = resolve_world_target(src_location)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -429,8 +429,7 @@
 		next_fire_time = world.time + fire_delay
 		user.setClickCooldown(fire_delay)
 
-	//user.setClickCooldown()
-	//user.set_move_cooldown(move_delay)
+	user.set_move_cooldown(move_delay)
 	if(muzzle_flash)
 		set_light(0)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -416,20 +416,21 @@
 			update_icon()
 
 		if(i < burst)
+			next_fire_time = world.time + shoot_time
 			sleep(burst_delay)
 
 		if(!(target && target.loc))
 			target = targloc
 			pointblank = 0
-
-	//update timing
-	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
-	user.set_move_cooldown(move_delay)
 	if(!twohanded && user.stats.getPerk(PERK_GUNSLINGER))
-		next_fire_time = world.time + fire_delay - fire_delay * 0.33
+		next_fire_time = world.time + fire_delay * 0.66
+		user.setClickCooldown(fire_delay * 0.66)
 	else
 		next_fire_time = world.time + fire_delay
+		user.setClickCooldown(fire_delay)
 
+	//user.setClickCooldown()
+	//user.set_move_cooldown(move_delay)
 	if(muzzle_flash)
 		set_light(0)
 

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -20,7 +20,7 @@
 	gun_parts = list(/obj/item/part/gun = 3 ,/obj/item/stack/material/steel = 15)
 	init_firemodes = list(
 		FULL_AUTO_400,
-		SEMI_AUTO_NODELAY,
+		SEMI_AUTO_300,
 		BURST_3_ROUND,
 		BURST_5_ROUND
 		)

--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -29,7 +29,7 @@
 
 	init_firemodes = list(
 		FULL_AUTO_400,
-		SEMI_AUTO_NODELAY,
+		SEMI_AUTO_300,
 		BURST_5_ROUND
 		)
 	spawn_blacklisted = TRUE
@@ -170,7 +170,7 @@
 	gun_tags = list(GUN_FA_MODDABLE)
 
 	init_firemodes = list(
-		SEMI_AUTO_NODELAY,
+		SEMI_AUTO_300,
 		BURST_3_ROUND,
 		BURST_5_ROUND
 	)
@@ -255,7 +255,7 @@
 	gun_tags = list(GUN_FA_MODDABLE)
 
 	init_firemodes = list(
-		SEMI_AUTO_NODELAY	//too poorly made for burst or automatic
+		SEMI_AUTO_300	//too poorly made for burst or automatic
 	)
 	spawn_blacklisted = FALSE
 	spawn_tags = SPAWN_TAG_GUN_HANDMADE

--- a/code/modules/projectiles/guns/projectile/automatic/atreides.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/atreides.dm
@@ -25,7 +25,7 @@
 
 	init_firemodes = list(
 		FULL_AUTO_400,
-		SEMI_AUTO_NODELAY,
+		SEMI_AUTO_300,
 		)
 
 /obj/item/gun/projectile/automatic/atreides/update_icon()

--- a/code/modules/projectiles/guns/projectile/automatic/c20r.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/c20r.dm
@@ -32,7 +32,7 @@
 
 	init_firemodes = list(
 		FULL_AUTO_400,
-		SEMI_AUTO_NODELAY,
+		SEMI_AUTO_300,
 		)
 
 	serial_type = "S"

--- a/code/modules/projectiles/guns/projectile/automatic/dallas.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/dallas.dm
@@ -32,7 +32,7 @@
 
 	init_firemodes = list(
 		FULL_AUTO_400,
-		SEMI_AUTO_NODELAY,
+		SEMI_AUTO_300,
 		)
 
 	serial_type = "PAR"

--- a/code/modules/projectiles/guns/projectile/automatic/drozd.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/drozd.dm
@@ -24,7 +24,7 @@
 
 	init_firemodes = list(
 		FULL_AUTO_300,
-		SEMI_AUTO_NODELAY
+		SEMI_AUTO_300
 		)
 	gun_parts = list(/obj/item/part/gun/frame/drozd = 1, /obj/item/part/gun/grip/excel = 1, /obj/item/part/gun/mechanism/smg = 1, /obj/item/part/gun/barrel/magnum = 1)
 

--- a/code/modules/projectiles/guns/projectile/automatic/luty.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/luty.dm
@@ -20,7 +20,7 @@
 
 	init_firemodes = list(
 		FULL_AUTO_400,
-		SEMI_AUTO_NODELAY,
+		SEMI_AUTO_300,
 		)
 
 	can_dual = 1

--- a/code/modules/projectiles/guns/projectile/automatic/molly.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/molly.dm
@@ -21,7 +21,7 @@
 	gun_tags = list(GUN_SILENCABLE)
 	init_firemodes = list(
 		FULL_AUTO_400,
-		SEMI_AUTO_NODELAY,
+		SEMI_AUTO_300,
 		)
 
 	can_dual = 1

--- a/code/modules/projectiles/guns/projectile/automatic/sol.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sol.dm
@@ -23,7 +23,7 @@
 	gun_tags = list(GUN_FA_MODDABLE)
 
 	init_firemodes = list(
-		SEMI_AUTO_NODELAY,
+		SEMI_AUTO_300,
 		BURST_3_ROUND,
 		BURST_3_ROUND_RAPID
 		)

--- a/code/modules/projectiles/guns/projectile/automatic/straylight.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/straylight.dm
@@ -24,7 +24,7 @@
 
 	init_firemodes = list(
 		FULL_AUTO_600,
-		SEMI_AUTO_NODELAY
+		SEMI_AUTO_300
 		)
 
 	wield_delay = 0 // Super weak SMG

--- a/code/modules/projectiles/guns/projectile/automatic/sts35.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts35.dm
@@ -27,7 +27,7 @@
 
 	init_firemodes = list(
 		FULL_AUTO_400,
-		SEMI_AUTO_NODELAY,
+		SEMI_AUTO_300,
 		BURST_3_ROUND
 		)
 	gun_parts = list(/obj/item/part/gun/frame/sts35 = 1, /obj/item/part/gun/grip/black = 1, /obj/item/part/gun/mechanism/autorifle = 1, /obj/item/part/gun/barrel/lrifle = 1)

--- a/code/modules/projectiles/guns/projectile/automatic/type17.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/type17.dm
@@ -25,7 +25,7 @@
 	spawn_tags = SPAWN_TAG_GUN_OS
 	init_firemodes = list(
 		BURST_3_ROUND,
-        SEMI_AUTO_NODELAY,
+        SEMI_AUTO_300,
 		FULL_AUTO_400
 		)
 	spawn_blacklisted = TRUE //until loot rework

--- a/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
@@ -22,7 +22,7 @@
 	init_recoil = RIFLE_RECOIL(0.65)
 	silenced = TRUE
 	init_firemodes = list(
-		SEMI_AUTO_NODELAY,
+		SEMI_AUTO_300,
 		BURST_2_ROUND
 		)
 	gun_parts = list(/obj/item/part/gun/frame/vintorez = 1, /obj/item/part/gun/grip/excel = 1, /obj/item/part/gun/mechanism/autorifle = 1, /obj/item/part/gun/barrel/srifle = 1)

--- a/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
@@ -27,7 +27,7 @@
 	gun_tags = list(GUN_SILENCABLE)
 
 	init_firemodes = list(
-		SEMI_AUTO_NODELAY,
+		SEMI_AUTO_300,
 		BURST_3_ROUND,
 		FULL_AUTO_400
 		)

--- a/code/modules/projectiles/guns/projectile/automatic/z8.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/z8.dm
@@ -26,7 +26,7 @@
 	gun_tags = list(GUN_FA_MODDABLE)
 
 	init_firemodes = list(
-		SEMI_AUTO_NODELAY,
+		SEMI_AUTO_300,
 		BURST_3_ROUND,
 		list(mode_name="fire grenades", mode_desc="Unlocks the underbarrel grenade launcher", burst=null, fire_delay=null, move_delay=null,  icon="grenade", use_launcher=1)
 		)

--- a/code/modules/projectiles/guns/projectile/automatic/zoric.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/zoric.dm
@@ -23,7 +23,7 @@
 
 	init_firemodes = list(
 		FULL_AUTO_300,
-		SEMI_AUTO_NODELAY,
+		SEMI_AUTO_300,
 		)
 	gun_tags = list(GUN_SILENCABLE)
 	gun_parts = list(/obj/item/part/gun/frame/zoric = 1, /obj/item/part/gun/grip/serb = 1, /obj/item/part/gun/mechanism/smg = 1, /obj/item/part/gun/barrel/magnum = 1)

--- a/code/modules/projectiles/guns/projectile/battle_rifle/type47.dm
+++ b/code/modules/projectiles/guns/projectile/battle_rifle/type47.dm
@@ -24,7 +24,7 @@
 	gun_tags = list(GUN_SILENCABLE)
 	gun_parts = list(/obj/item/part/gun = 2 ,/obj/item/stack/material/plasteel = 6)
 	init_firemodes = list(
-		SEMI_AUTO_NODELAY,
+		SEMI_AUTO_300,
 		BURST_3_ROUND,
 		FULL_AUTO_600
 		)

--- a/code/modules/projectiles/guns/projectile/pistol/selfload.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/selfload.dm
@@ -23,7 +23,7 @@
 
 	gun_tags = list(GUN_SILENCABLE)
 	init_firemodes = list(
-		SEMI_AUTO_NODELAY,
+		SEMI_AUTO_300,
 		FULL_AUTO_800
 		)
 
@@ -69,7 +69,7 @@
 	price_tag = 1400
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2, TECH_COVERT = 3)
 	init_firemodes = list(
-		SEMI_AUTO_NODELAY
+		SEMI_AUTO_300
 		)
 	gun_parts = list(/obj/item/part/gun/frame/makarov = 1, /obj/item/part/gun/grip/excel = 1, /obj/item/part/gun/mechanism/pistol = 1, /obj/item/part/gun/barrel/pistol = 1)
 

--- a/code/modules/projectiles/guns/projectile/pistol/type62.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/type62.dm
@@ -23,7 +23,7 @@
 	init_firemodes = list(
 		FULL_AUTO_600,
 		FULL_AUTO_800,
-		SEMI_AUTO_NODELAY
+		SEMI_AUTO_300
         )
 	spawn_tags = SPAWN_TAG_GUN_OS
 	price_tag = 3000

--- a/code/modules/projectiles/guns/projectile/pistol/type90.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/type90.dm
@@ -24,7 +24,7 @@
 	reload_sound = 'sound/weapons/guns/interact/pistol_magin.ogg'
 	cocked_sound = 'sound/weapons/guns/interact/pistol_cock.ogg'
 	init_firemodes = list(
-        SEMI_AUTO_NODELAY,
+        SEMI_AUTO_300,
 		BURST_3_ROUND_DAMAGE
 //		WEAPON_CHARGE    // charge mode on balistics doesnt work. need to make a balistic version of it -Valo
         )

--- a/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
@@ -26,7 +26,7 @@
 					//while also preserving ability to shoot as fast as you can click and maintain recoil good enough
 	init_firemodes = list(
 		FULL_AUTO_400,
-		SEMI_AUTO_NODELAY
+		SEMI_AUTO_300
 		)
 	gun_parts = list(/obj/item/part/gun/frame/bojevic = 1, /obj/item/part/gun/grip/serb = 1, /obj/item/part/gun/mechanism/shotgun = 1, /obj/item/part/gun/barrel/shotgun = 1)
 	serial_type = "SA"

--- a/code/modules/projectiles/guns/projectile/shotgun/bull.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/bull.dm
@@ -21,7 +21,7 @@
 	penetration_multiplier = 0.75
 	init_recoil = CARBINE_RECOIL(1.5)
 	burst_delay = null
-	fire_delay = null
+	fire_delay = 4
 	bulletinsert_sound = 'sound/weapons/guns/interact/shotgun_insert.ogg'
 	fire_sound = 'sound/weapons/guns/fire/shotgunp_fire.ogg'
 	move_delay = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Burst fire can no longer be stacked
Full auto's fire delay is now based on the shown value , and not on the guns burst_delay
Guns  are no longer hard-locked to the 4 second delay between attacks.The fire_delay is now properly applied
Bull no longer has 0 fire_delay (since you can insta-fire all shots with the new fix)
SEMI_AUTO_NODELAY changed to SEMI_AUTO_300 since it now has the same firerate as a 300 shot auto would.

Related video : https://cdn.discordapp.com/attachments/299262993617780737/1004766001642086540/2022-08-04_18-00-08.mp4



## Why It's Good For The Game
Any gun that would get lower than 4 MS fire delay would have its effects not applied , this made most pistols underwhelming even with upgrades meant to make them better.
Makes Semi-Auto properly apply its delay if its firerate is under 4 MS.

## Changelog
:cl:
fix: Burst fire can no longer stack
fix: Full auto fire_delay is now based on the shown value , no longer on the gun's burst_delay
fix: Guns are no longer hard locked to a 4 MS fire_delay.
balance: Bull shotgun now has a fire_delay of 2 MS.
balance: SEMI_AUTO_NODELAY has been changed to SEMI_AUTO_300, with a firerate delay of 2 MS
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
