### PR TITLE
flash-protected sunglasses for head stuff and fix desc.

### DIFF
--- a/code/datums/outfits/jobs/guild.dm
+++ b/code/datums/outfits/jobs/guild.dm
@@ -6,7 +6,7 @@
 	name = OUTFIT_JOB_NAME("Guild Merchant")
 	uniform = /obj/item/clothing/under/rank/cargotech
 	shoes = /obj/item/clothing/shoes/color/brown
-	glasses = /obj/item/clothing/glasses/sunglasses
+	glasses = /obj/item/clothing/glasses/sunglasses/big
 	suit = /obj/item/clothing/suit/storage/qm_coat
 	l_hand = /obj/item/clipboard
 	id_type = /obj/item/card/id/car

--- a/code/modules/client/preference_setup/loadout/lists/eyegear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/eyegear.dm
@@ -64,6 +64,6 @@
 /datum/gear/eyes/shades/big
 	display_name = "Sunglasses, fat"
 	path = /obj/item/clothing/glasses/sunglasses/big
-	allowed_roles = list("Ironhammer Operative","Ironhammer Commander","Ironhammer Gunnery Sergeant","Captain","First Officer","Quartermaster","Ironhammer Inspector")
+	allowed_roles = list("Ironhammer Operative","Ironhammer Commander","Ironhammer Gunnery Sergeant","Captain","First Officer","Ironhammer Inspector","Guild Merchant","Moebius Biolab Officer","Moebius Expedition Overseer","Technomancer Exultant","Club Manager","NeoTheology Preacher")
 
 

--- a/code/modules/clothing/glasses/misc.dm
+++ b/code/modules/clothing/glasses/misc.dm
@@ -66,7 +66,7 @@
 	body_parts_covered = 0
 
 /obj/item/clothing/glasses/sunglasses
-	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding reduces many flashes."
+	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Doesn't really protects from flashes, but stylish."
 	name = "sunglasses"
 	icon_state = "sun"
 	item_state = "sunglasses"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gave the heads the opportunity to take in loadout glasses, with flash protection. Guild Merchant now has normal protective glasses in preloadout. I changed the name of ordinary glasses so that there would be no misunderstandings.

## Why It's Good For The Game

Fixes good. Protection from flashes for command stuff is also not bad.

## Changelog
:cl:

add: The ability to take glasses that protect from flash for heads of departments/
fix: Sunglasses desc.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
