### PR TITLE
[Not tested]The latest nerf from the thing that killed me (Makes acid take into account clothing properly)

### DIFF
--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -52,7 +52,7 @@
 #define CE_BLOODCLOT 	"bloodclot"	// Promote healing but thickens blood, slows and stops bleeding (range 0 - 1)
 #define CE_OXYGENATED    "oxygen"       // Dexalin.
 #define CE_PURGER "purger"	//Purger
-#define CE_NOWITHDRAW "no_withdrawal" 
+#define CE_NOWITHDRAW "no_withdrawal"
 #define CE_VOICEMIMIC "voice_mimic"
 #define CE_DYNAMICFINGERS "dynfingers"
 

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -455,3 +455,8 @@ Proc for attack log creation, because really why not
 	if(isnull(choice) || src.incapacitated() || (required_item && !GLOB.hands_state.can_use_topic(required_item,src)))
 		return null
 	return choice
+
+
+
+
+

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1348,4 +1348,18 @@ var/list/FLOORITEMS = list(
 		generated_code += "[generate_single_gun_number()]" // cast to string
 	return generated_code
 
+/obj/item/clothing/proc/get_count_of_covered_limbs(mob/living/carbon/human/M)
+	if(!ishuman(M))
+		return 0
+	if(!M.contents.Find(src))
+		return 0
+	var/list/bodyparts = list(HEAD,UPPER_TORSO,LOWER_TORSO,ARM_LEFT,ARM_RIGHT,LEG_LEFT,LEG_RIGHT)
+	var/count
+
+	for(var/bodypart in bodyparts)
+		if(body_parts_covered & bodypart)
+			count++
+	return count
+
+
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Acid no longer teleports instantly to the players skins and melts them from the inside . it now must go layer by layer until it has its effect applied

## Why It's Good For The Game
Polyacid 120u beakers should be no longer a easy insta-kill + its funny to strip people of their armor with acid.
## Changelog
:cl:
bal: Acid now melts clothes before dealing damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
