### PR TITLE
Fixes covering mouth

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -183,7 +183,7 @@
 	return verb
 
 /mob/living/carbon/human/handle_speech_problems(var/message, var/verb)
-	if(silent || (sdisabilities & MUTE))
+	if(silent)
 		message = ""
 		speech_problem_flag = 1
 		to_chat(src, SPAN_WARNING("You can't speak!"))

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -183,9 +183,10 @@
 	return verb
 
 /mob/living/carbon/human/handle_speech_problems(var/message, var/verb)
-//	if(silent || (sdisabilities & MUTE))
-//		message = ""
-//		speech_problem_flag = 1
+	if(silent || (sdisabilities & MUTE))
+		message = ""
+		speech_problem_flag = 1
+		to_chat(src, SPAN_WARNING("You can't speak!"))
 	if(istype(wear_mask, /obj/item/clothing/mask))
 		var/obj/item/clothing/mask/M = wear_mask
 		if(M.voicechange)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Uncomments part of code, enables people to gag other people via covering mouth and some chems again, adds a little feedback to it.

## Why It's Good For The Game

https://user-images.githubusercontent.com/57810301/183472476-35b4f9cd-d0d8-49b9-8a08-c5313772a3cd.mp4
(I don't know why this fancy video isn't displaying properly but it shows that this fix is working)
(being silent after leaving grab is part of `silent` code, I dunno)
Fixes good



## Changelog
:cl:
fix: You can once more cover people mouths to make them shut up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
