### PR TITLE
Removes construction Cyborg , general changes to cyborg specialization loadouts

### DIFF
--- a/code/datums/craft/recipes/floor.dm
+++ b/code/datums/craft/recipes/floor.dm
@@ -318,5 +318,3 @@
 	steps = list(
 		list(/obj/item/stack/rods, 2, "time" = 10)
 	)
-
-

--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -304,3 +304,11 @@
 	can_hold = list(
 		/obj/item/stack/material
 		)
+
+/obj/item/gripper/loader
+	name = "advanced sheet loader"
+	desc = "A advanced version of the sheet loader , can be used to creat objects of the desired material"
+	icon_state = "gripper-sheet"
+	can_hold = list(
+		/obj/item/stack/material
+	)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -586,6 +586,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/device/t_scanner(src)
 	src.modules += new /obj/item/device/scanner/gas(src)
 	src.modules += new /obj/item/taperoll/engineering(src)
+	src.modules += new /obj/item/rcd/borg(src) // added from construction model , makes life less painfull for borgs.
 	src.modules += new /obj/item/gripper(src)
 	src.modules += new /obj/item/gripper/loader(src) // replaced the no_use , so they can build stuff.
 	src.modules += new /obj/item/device/lightreplacer(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -7,7 +7,7 @@ var/global/list/robot_modules = list(
 	"Medical" 		= /obj/item/robot_module/medical/general,
 	"Security" 		= /obj/item/robot_module/security/general,
 	"Engineering"	= /obj/item/robot_module/engineering/general,
-	"Construction"	= /obj/item/robot_module/engineering/construction,
+	//"Construction"	= /obj/item/robot_module/engineering/construction, commented out due to redundancy
 	"Custodial" 	= /obj/item/robot_module/custodial
 	//"Combat" 		= /obj/item/robot_module/combat,
 	)
@@ -265,9 +265,12 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/extinguisher(src)
 	src.modules += new /obj/item/tool/wrench/robotic(src)
 	src.modules += new /obj/item/tool/crowbar/robotic(src)
+	src.modules += new /obj/item/tool/screwdriver/robotic(src)
+	src.modules += new /obj/item/tool/wirecutters/robotic(src)
 	src.modules += new /obj/item/device/scanner/health(src)
 	src.modules += new /obj/item/gripper(src)
 	src.modules += new /obj/item/device/t_scanner(src)
+	src.modules += new /obj/item/soap(src)
 	src.emag = new /obj/item/melee/energy/sword(src)
 
 	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(10000)
@@ -341,7 +344,7 @@ var/global/list/robot_modules = list(
 	src.emag.reagents.add_reagent("pacid", 250)
 	src.emag.name = "Polyacid spray"
 
-	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(10000)
+	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(20000)
 	synths += medicine
 
 	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
@@ -400,8 +403,8 @@ var/global/list/robot_modules = list(
 	subsystems = list(/datum/nano_module/crew_monitor)
 
 
-	health = 270 //Tough
-	speed_factor = 1.3 //Turbospeed!
+	health = 200 //Tough
+	speed_factor = 1.5 //Turbospeed!
 	power_efficiency = 1.2 //Good for long journeys
 
 	stat_modifiers = list(
@@ -435,7 +438,7 @@ var/global/list/robot_modules = list(
 	src.emag.reagents.add_reagent("pacid", 250)
 	src.emag.name = "Polyacid spray"
 
-	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(15000)
+	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(10000)
 	synths += medicine
 
 	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
@@ -502,7 +505,7 @@ var/global/list/robot_modules = list(
 		STAT_COG = 20,
 		STAT_MEC = 40
 	)
-
+/* Removed - Too niche. Features moved to engineering
 /obj/item/robot_module/engineering/construction
 	name = "construction robot module"
 	no_slip = 1
@@ -574,6 +577,7 @@ var/global/list/robot_modules = list(
 
 	..(R)
 
+*/
 /obj/item/robot_module/engineering/general/New(var/mob/living/silicon/robot/R)
 	src.modules += new /obj/item/device/flash(src)
 	src.modules += new /obj/item/borg/sight/meson(src)
@@ -583,7 +587,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/device/scanner/gas(src)
 	src.modules += new /obj/item/taperoll/engineering(src)
 	src.modules += new /obj/item/gripper(src)
-	src.modules += new /obj/item/gripper/no_use/loader(src)
+	src.modules += new /obj/item/gripper/loader(src) // replaced the no_use , so they can build stuff.
 	src.modules += new /obj/item/device/lightreplacer(src)
 	src.modules += new /obj/item/device/pipe_painter(src)
 	src.modules += new /obj/item/device/floor_painter(src)
@@ -593,16 +597,16 @@ var/global/list/robot_modules = list(
 
 	var/datum/matter_synth/metal = new /datum/matter_synth/metal(60000)
 	var/datum/matter_synth/glass = new /datum/matter_synth/glass(40000)
-	var/datum/matter_synth/plasteel = new /datum/matter_synth/plasteel(20000)
+//	var/datum/matter_synth/plasteel = new /datum/matter_synth/plasteel(20000) commented out , they should acquire this on their own since it is tough
 	var/datum/matter_synth/wire = new /datum/matter_synth/wire(45)
-	var/datum/matter_synth/wood = new /datum/matter_synth/wood(20000)
-	var/datum/matter_synth/plastic = new /datum/matter_synth/plastic(15000)
+//	var/datum/matter_synth/wood = new /datum/matter_synth/wood(20000)
+//	var/datum/matter_synth/plastic = new /datum/matter_synth/plastic(15000)
 	synths += metal
 	synths += glass
-	synths += plasteel
+//	synths += plasteel
 	synths += wire
-	synths += wood
-	synths += plastic
+//	synths += wood
+//	synths += plastic
 
 	var/obj/item/matter_decompiler/MD = new /obj/item/matter_decompiler(src)
 	MD.metal = metal
@@ -633,21 +637,21 @@ var/global/list/robot_modules = list(
 	RG.synths = list(metal, glass)
 	src.modules += RG
 
-	var/obj/item/stack/material/cyborg/plasteel/PL = new (src)
-	PL.synths = list(plasteel)
-	src.modules += PL
+	//var/obj/item/stack/material/cyborg/plasteel/PL = new (src)
+	//PL.synths = list(plasteel)
+	//src.modules += PL
 
-	var/obj/item/stack/material/cyborg/wood/W = new (src)
-	W.synths = list(wood)
-	src.modules += W
+	//var/obj/item/stack/material/cyborg/wood/W = new (src)
+	//W.synths = list(wood)
+	//src.modules += W
 
-	var/obj/item/stack/material/cyborg/plastic/PS = new (src)
-	PS.synths = list(plastic)
-	src.modules += PS
+	//var/obj/item/stack/material/cyborg/plastic/PS = new (src)
+	//PS.synths = list(plastic)
+	//src.modules += PS
 
-	var/obj/item/stack/tile/wood/cyborg/FWT = new (src)
-	FWT.synths = list(wood)
-	src.modules += FWT
+	//var/obj/item/stack/tile/wood/cyborg/FWT = new (src)
+	//FWT.synths = list(wood)
+	//src.modules += FWT
 
 	..(R)
 
@@ -674,8 +678,8 @@ var/global/list/robot_modules = list(
 	can_be_pushed = 0
 	supported_upgrades = list(/obj/item/borg/upgrade/tasercooler,/obj/item/borg/upgrade/jetpack)
 
-	health = 300 //Very tanky!
-	speed_factor = 0.85 //Kinda slow
+	health = 250 //Very tanky! Toned down from 300 to 250
+	speed_factor = 1 // Decent speed , but not as fast as a person.
 	power_efficiency = 1.15 //Decent
 
 	desc = "Focused on keeping the peace and fighting off threats to the ship, the security module is a \
@@ -738,7 +742,7 @@ var/global/list/robot_modules = list(
 					"Sleek" = "sleekjanitor",
 					"Maid" = "maidbot"
 					)
-	health = 250 //Bulky
+	health = 200 //Slightly tougher to resist maintenance.
 	speed_factor = 1.0 // Normal speed, its a cleaning unit and you wouldnt choose it if you sweep floors with ultra slow movement
 	power_efficiency = 0.8 //Poor
 
@@ -886,8 +890,8 @@ var/global/list/robot_modules = list(
 					"Heavy" = "heavymine",
 					"Spider" = "spidermining"
 				)
-	health = 250 //Pretty tough
-	speed_factor = 0.9 //meh
+	health = 400 //Tougher than security models , but it faces a lot of dangers if mining rocks with the drill.
+	speed_factor = 0.7 //meh
 	power_efficiency = 1.5 //Best efficiency
 
 	stat_modifiers = list(

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -21,7 +21,12 @@
 	reagent_ids = list("bicaridine", "kelotane", "anti_toxin", "dexalin", "inaprovaline", "tramadol", "spaceacillin", "stoxin")
 
 /obj/item/reagent_containers/borghypo/rescue
-	reagent_ids = list("tricordrazine", "inaprovaline", "tramadol")
+	reagent_ids = list("dexalin", "inaprovaline", "paracetamol", "iron", "quickclot")
+	// dexalin - prevent dying from oxyloss
+	// iron - replenish oxy
+	// inaprov - stabilize
+	// paracetamol - prevent pain knockout ? don't think it really belongs.
+	// quickclot - stop bleeding temporarily
 
 /obj/item/reagent_containers/borghypo/New()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the construction cyborg specialization
Adds RCD and a useable sheet loader to the engineering model , removes plastell , plastic and wood synthethization from the engi cybrog.
Doubles the amount of trauma/burn kits the medical cyborg can use (from 10 to 20)
Reduces the amount of trauma kits the rescue cyborg has (from 15 to 10)
Changes the reagents the rescue cyborg can synthethize from tricord inaprovaline and tramadol to inaprovaline , quickclot , dexalin iron and paracetamol,
Reduced the health of the security cyborg from 300 to 250
Increased security cyborg speed from 0.85 to 1
Increased miner cyborg health from 250 to 400
reduced miner cyborg health from 0.9 to 0.7
Gave the general cyborg more tools.(screwdriver , wirecutter and soap)

## Why It's Good For The Game
Construction was just engineering++ with more slowdown.
Security cyborgs will never catch their victim and were far too fanky.
Medical cyborgs had far too few trauma kits to treat a ruined person , while rescue cyborgs had enough for all wounds.
The rescue cyborg synthethizer was not suited for emergency fixing , it is now far more suited for it.
Miner cyborgs were not rebalanced for the new mining update.

## Changelog
:cl:
del: Removed construction cyborg
balance: Gave engineering cyborgs a RCD and a useable sheet loder.
balance: Removed plasteel , plastic and wood from engi-cyborg synthethizer
balance: Medical cyborg now has the capacity for 20 trauma kits (From 10)
balance: Rescue cyborg now has less capacity for trauma kits(from 15 to 10)
balance: Rescue cyborg now can synthethize quickclot , paracetamol , iron and dexalin 
balance: Rescue cyborg can no longer synthethize tricordrazine and tramadol.
balance: Miner cyborg now has 400 health , but 0.7 speed modifier (from 250 Health and 0.9)
balance: Security cyborg now has 250 health and 1 speed modifier(from 300 health and 0.85)
balance:General cyborg was given more tools (Screwdriver and wirecutter, soap)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
