### PR TITLE
Weakens no longer paralyse robots

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -93,10 +93,10 @@
 
 
 	if (src.stat != 2) //Alive.
-		if (src.paralysis || src.stunned || !src.has_power || src.weakened) //Stunned etc.
+		if (src.weakened > 0)
+			AdjustWeakened(-1)
+		if (src.paralysis || src.stunned || !src.has_power) //Stunned etc.
 			src.stat = 1
-			if (src.weakened > 0)
-				AdjustWeakened(-1)
 			if (src.stunned > 0)
 				AdjustStunned(-1)
 			if (src.paralysis > 0)
@@ -269,7 +269,7 @@
 			weaponlock_time = 120
 
 /mob/living/silicon/robot/update_lying_buckled_and_verb_status()
-	if(paralysis || stunned || weakened || buckled || lockcharge || !is_component_functioning("actuator")) canmove = FALSE
+	if(paralysis || stunned || buckled || lockcharge || !is_component_functioning("actuator")) canmove = FALSE
 	else canmove = TRUE
 	return canmove
 

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -29,6 +29,8 @@
 	tally += speed //This var is a placeholder
 	if(module_active && istype(module_active,/obj/item/borg/combat/mobility)) //And so is this silly check
 		tally-=1
+	if(weakened)
+		tally += weakened / 2 // flashes significantly slow robots.
 	tally /= speed_factor
 	return tally
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Weakening a robot no longer paralyses it , instead it gives them a high slowdown and forces them to drop equipment.


## Why It's Good For The Game
Having a flash is the cheapest instant-win against any robots , with a flash , a person can just keep using it on a robot and beat them to death with a crowbar, the same is not available for humans , which can reduce its effects by wearing sunglasses , and don't get paralyzed for 12 seconds everytime they get flashed.
This makes it so flashes are no longer a instant win and the death of all robots, but still a viable weapon for self-defense and escape if necesarry.
## Changelog
:cl:
balance: Stuns / Flashes no longer paralyse robots , instead it forces them to drop all items and gives them a major amount of slowdown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
