### PR TITLE
Brings the C20 into line with naming convention. Abbreviates Moebius guns

### DIFF
--- a/code/modules/projectiles/guns/energy/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma.dm
@@ -90,7 +90,7 @@
 	set_item_state(null, back = TRUE)
 
 /obj/item/gun/energy/plasma/brigador
-	name = "Moebius PP \"Brigador\""
+	name = "ML PP \"Brigador\""
 	desc = "\"Moebius\" brand energy pistol, for personal overprotection."
 	icon = 'icons/obj/guns/energy/brigador.dmi'
 	icon_state = "brigador"

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -45,7 +45,7 @@
 	serial_type = "NT"
 
 /obj/item/gun/energy/stunrevolver/moebius
-	name = "Moebius SP \"Suez\""	//Ersatz name
+	name = "ML SP \"Suez\""	//Ersatz name
 	desc = "Also know as stunrevolver. A Moebius copy of the older and less precise Nanotrasen solution for non-lethal takedowns. This gun has smaller capacity in exchange for S-cells use."
 	icon = 'icons/obj/guns/energy/stunrevolver_moebius.dmi'
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_STEEL = 6, MATERIAL_SILVER = 2, MATERIAL_PLASTIC = 5)

--- a/code/modules/projectiles/guns/projectile/automatic/c20r.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/c20r.dm
@@ -63,7 +63,7 @@
 	update_icon()
 
 /obj/item/gun/projectile/automatic/c20r/moebius
-	name = "Moebius SMG .35 \"C-20M\""
+	name = "ML SMG .35 \"C-20M\""
 	desc = "The C-20M is a Moebius copy of the famous C-20r, a lightweight and robust bullpup SMG of ancient design. \
 			Famous as most used SMG by criminal organizations of various sorts. Uses .35 Auto rounds."
 	icon = 'icons/obj/guns/projectile/c20m.dmi'

--- a/code/modules/projectiles/guns/projectile/automatic/c20r.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/c20r.dm
@@ -1,8 +1,8 @@
 /obj/item/gun/projectile/automatic/c20r
-	name = "C-20r"
+	name = "S SMG .35 \"C-20r\""
 	desc = "The C-20r is a lightweight and robust bullpup SMG of ancient design, for when you REALLY need someone dead. \
 			Famous as most used SMG by criminal organizations of various sorts. Was recently reverse-engineered by Moebius \
-			almost completely from the scratch, introducing gun to the broad masses of customers. \
+			almost completely from the scratch, introducing gun to the broad masses of customers. This one however, is original. \
 			Has a '\"Scarborough Arms\" - Per falcis, per pravitas' buttstock stamp. Uses .35 Auto rounds."
 	icon = 'icons/obj/guns/projectile/cr20.dmi'
 	icon_state = "c20r"
@@ -63,7 +63,7 @@
 	update_icon()
 
 /obj/item/gun/projectile/automatic/c20r/moebius
-	name = "C-20M"
+	name = "Moebius SMG .35 \"C-20M\""
 	desc = "The C-20M is a Moebius copy of the famous C-20r, a lightweight and robust bullpup SMG of ancient design. \
 			Famous as most used SMG by criminal organizations of various sorts. Uses .35 Auto rounds."
 	icon = 'icons/obj/guns/projectile/c20m.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Brings the C20 into line with the standardised naming convention. Also clears up a misunderstanding about the C20r being a Moebius product.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I have a crippling phobia of inconsistencies and it is ruining my life.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The C20 is now in line with the standardised naming convention. Moebius gun products are now abbrviated to "ML"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
