### PR TITLE
Reworks how acid takes armor into account , acid damage now gets reduced by bio armour

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -15,8 +15,8 @@
 	var/randpixel = 6
 	var/abstract = 0
 	var/r_speed = 1
-	var/health
-	var/max_health
+	var/health = 100
+	var/max_health = 100
 	var/burn_point
 	var/burning
 	var/hitsound = 'sound/weapons/genhit1.ogg'

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -332,64 +332,67 @@
 	M.take_organ_damage(0, (issmall(M) ? effect_multiplier * 2: effect_multiplier * power * 2))
 
 /datum/reagent/acid/affect_touch(mob/living/carbon/M, alien, effect_multiplier) // This is the most interesting
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(H.head)
-			if(H.head.unacidable)
-				to_chat(H, "<span class='danger'>Your [H.head] protects you from the acid.</span>")
-				remove_self(volume)
-				return
-			else if(volume > meltdose)
-				H << "<span class='danger'>Your [H.head] melts away!</span>"
-				qdel(H.head)
-				H.update_inv_head(1)
-				H.update_hair(1)
-				remove_self(meltdose)
-		if(volume <= 0)
-			return
-
-		if(H.wear_mask)
-			if(H.wear_mask.unacidable)
-				to_chat(H, "<span class='danger'>Your [H.wear_mask] protects you from the acid.</span>")
-				remove_self(volume)
-				return
-			else if(volume > meltdose)
-				H << "<span class='danger'>Your [H.wear_mask] melts away!</span>"
-				qdel(H.wear_mask)
-				H.update_inv_wear_mask(1)
-				H.update_hair(1)
-				remove_self(meltdose)
-		if(volume <= 0)
-			return
-
-		if(H.glasses)
-			if(H.glasses.unacidable)
-				H << "<span class='danger'>Your [H.glasses] partially protect you from the acid!</span>"
-				volume /= 2
-			else if(volume > meltdose)
-				H << "<span class='danger'>Your [H.glasses] melt away!</span>"
-				qdel(H.glasses)
-				H.update_inv_glasses(1)
-				remove_self(meltdose / 2)
-		if(volume <= 0)
-			return
-
-	if(volume < meltdose) // Not enough to melt anything
-		M.take_organ_damage(0, effect_multiplier * power * 0.2) //burn damage, since it causes chemical burns. Acid doesn't make bones shatter, like brute trauma would.
+	if(!ishuman(M))
+		M.apply_damage(volume * power * 0.2, BURN)
 		return
-	if(!M.unacidable && volume > 0)
-		if(ishuman(M) && volume >= meltdose)
-			var/mob/living/carbon/human/H = M
-			var/obj/item/organ/external/affecting = H.get_organ(BP_HEAD)
-			if(affecting)
-				if(affecting.take_damage(0, volume * power * 0.1))
-					H.UpdateDamageIcon()
-				if(prob(100 * volume / meltdose)) // Applies disfigurement
-					if (!(H.species && (H.species.flags & NO_PAIN)))
-						H.emote("scream")
-					H.status_flags |= DISFIGURED
-		else
-			M.take_organ_damage(0, volume * power * 0.1) // Balance. The damage is instant, so it's weaker. 10 units -> 5 damage, double for pacid. 120 units beaker could deal 60, but a) it's burn, which is not as dangerous, b) it's a one-use weapon, c) missing with it will splash it over the ground and d) clothes give some protection, so not everything will hit
+	var/mob/living/carbon/human/our_man = M
+	var/list/bodyparts = list(HEAD,UPPER_TORSO,LOWER_TORSO,ARM_LEFT,ARM_RIGHT,LEG_LEFT,LEG_RIGHT)
+	var/units_per_bodypart = volume / 7
+	var/list/obj/item/clothing/wearing_1 = list(
+		our_man.head,
+		our_man.glasses,
+		our_man.wear_suit,
+		our_man.shoes,
+		our_man.gloves
+	)
+	var/list/obj/item/clothing/wearing_2 = list(
+		our_man.wear_mask,
+		our_man.w_uniform,
+	)
+	message_admins("units per bodypart at [units_per_bodypart]")
+	remove_self(volume)
+	for(var/bodypart in bodyparts)
+		var/stop_loop = FALSE
+		var/units_for_this_part = units_per_bodypart
+		// handles first layer of clothing.
+		for(var/obj/item/clothing/C in wearing_1)
+			if(!(C.body_parts_covered & bodypart))
+				continue
+			if(C.unacidable || C.armor.bio > 99)
+				stop_loop = TRUE
+				continue
+			var/melting_requirement = (C.max_health / C.health) * (1 - C.armor.bio / 100) * meltdose
+			if(melting_requirement > units_per_bodypart)
+				C.health -= (C.max_health / meltdose) * (1 - C.armor.bio / 100) * units_per_bodypart
+				stop_loop = TRUE
+			else
+				units_for_this_part -= melting_requirement
+				our_man.remove_from_mob(C)
+				C.forceMove(NULLSPACE)
+				wearing_1 -= C
+				qdel(C)
+		if(stop_loop)
+			continue
+		// second layer of clothing.
+		for(var/obj/item/clothing/C in wearing_2)
+			if(!(C.body_parts_covered & bodypart))
+				continue
+			if(C.unacidable || C.armor.bio > 99)
+				stop_loop = TRUE
+				continue
+			var/melting_requirement = (C.max_health / C.health) * (1 - C.armor.bio / 100) * meltdose
+			if(melting_requirement > units_per_bodypart)
+				C.health -= (C.max_health / meltdose) * (1 - C.armor.bio / 100) * units_per_bodypart
+				stop_loop = TRUE
+			else
+				units_for_this_part -= melting_requirement
+				our_man.remove_from_mob(C)
+				C.forceMove(NULLSPACE)
+				wearing_2 -= C
+				qdel(C)
+		if(stop_loop)
+			continue
+		M.take_organ_damage(0, units_for_this_part * power * 0.1)
 
 /datum/reagent/acid/touch_obj(obj/O)
 	if(istype(O, /obj/effect/plant/hivemind))

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -358,7 +358,6 @@
 			if(!(C.body_parts_covered & bodypart))
 				continue
 			if(C.unacidable || C.armor.bio > 99)
-				to_chat(our_man, SPAN_DANGER("The [C.name] protects you from the acid!"))
 				stop_loop = TRUE
 				continue
 			var/melting_requirement = (C.max_health / C.health) * (1 - C.armor.bio / 100) * meltdose

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -378,7 +378,6 @@
 			if(!(C.body_parts_covered & bodypart))
 				continue
 			if(C.unacidable || C.armor.bio > 99)
-				to_chat(our_man, SPAN_DANGER("The [C.name] protects you from the acid!"))
 				stop_loop = TRUE
 				continue
 			var/melting_requirement = (C.max_health / C.health) * (1 - C.armor.bio / 100) * meltdose

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -383,7 +383,6 @@
 			var/melting_requirement = (C.max_health / C.health) * (1 - C.armor.bio / 100) * meltdose
 			if(melting_requirement > units_per_bodypart)
 				C.health -= (C.max_health / meltdose) * (1 - C.armor.bio / 100) * units_per_bodypart
-				to_chat(our_man, SPAN_DANGER("The [C.name] soaks in the acid, protecting you."))
 				stop_loop = TRUE
 			else
 				to_chat(our_man, SPAN_DANGER("The [C.name] melts under the action of acid."))

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -358,13 +358,16 @@
 			if(!(C.body_parts_covered & bodypart))
 				continue
 			if(C.unacidable || C.armor.bio > 99)
+				to_chat(our_man, SPAN_DANGER("The [C.name] protects you from the acid!"))
 				stop_loop = TRUE
 				continue
 			var/melting_requirement = (C.max_health / C.health) * (1 - C.armor.bio / 100) * meltdose
 			if(melting_requirement > units_per_bodypart)
 				C.health -= (C.max_health / meltdose) * (1 - C.armor.bio / 100) * units_per_bodypart
+				to_chat(our_man, SPAN_DANGER("The [C.name] soaks in the acid , protecting you."))
 				stop_loop = TRUE
 			else
+				to_chat(our_man, SPAN_DANGER("The [C.name] melts under the action of acid."))
 				units_for_this_part -= melting_requirement
 				our_man.remove_from_mob(C)
 				C.forceMove(NULLSPACE)
@@ -377,13 +380,16 @@
 			if(!(C.body_parts_covered & bodypart))
 				continue
 			if(C.unacidable || C.armor.bio > 99)
+				to_chat(our_man, SPAN_DANGER("The [C.name] protects you from the acid!"))
 				stop_loop = TRUE
 				continue
 			var/melting_requirement = (C.max_health / C.health) * (1 - C.armor.bio / 100) * meltdose
 			if(melting_requirement > units_per_bodypart)
 				C.health -= (C.max_health / meltdose) * (1 - C.armor.bio / 100) * units_per_bodypart
+				to_chat(our_man, SPAN_DANGER("The [C.name] soaks in the acid , protecting you."))
 				stop_loop = TRUE
 			else
+				to_chat(our_man, SPAN_DANGER("The [C.name] melts under the action of acid."))
 				units_for_this_part -= melting_requirement
 				our_man.remove_from_mob(C)
 				C.forceMove(NULLSPACE)

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -363,7 +363,6 @@
 			var/melting_requirement = (C.max_health / C.health) * (1 - C.armor.bio / 100) * meltdose
 			if(melting_requirement > units_per_bodypart)
 				C.health -= (C.max_health / meltdose) * (1 - C.armor.bio / 100) * units_per_bodypart
-				to_chat(our_man, SPAN_DANGER("The [C.name] soaks in the acid, protecting you."))
 				stop_loop = TRUE
 			else
 				to_chat(our_man, SPAN_DANGER("The [C.name] melts under the action of acid."))

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -386,7 +386,7 @@
 			var/melting_requirement = (C.max_health / C.health) * (1 - C.armor.bio / 100) * meltdose
 			if(melting_requirement > units_per_bodypart)
 				C.health -= (C.max_health / meltdose) * (1 - C.armor.bio / 100) * units_per_bodypart
-				to_chat(our_man, SPAN_DANGER("The [C.name] soaks in the acid , protecting you."))
+				to_chat(our_man, SPAN_DANGER("The [C.name] soaks in the acid, protecting you."))
 				stop_loop = TRUE
 			else
 				to_chat(our_man, SPAN_DANGER("The [C.name] melts under the action of acid."))

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -349,7 +349,6 @@
 		our_man.wear_mask,
 		our_man.w_uniform,
 	)
-	message_admins("units per bodypart at [units_per_bodypart]")
 	remove_self(volume)
 	for(var/bodypart in bodyparts)
 		var/stop_loop = FALSE

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -364,7 +364,7 @@
 			var/melting_requirement = (C.max_health / C.health) * (1 - C.armor.bio / 100) * meltdose
 			if(melting_requirement > units_per_bodypart)
 				C.health -= (C.max_health / meltdose) * (1 - C.armor.bio / 100) * units_per_bodypart
-				to_chat(our_man, SPAN_DANGER("The [C.name] soaks in the acid , protecting you."))
+				to_chat(our_man, SPAN_DANGER("The [C.name] soaks in the acid, protecting you."))
 				stop_loop = TRUE
 			else
 				to_chat(our_man, SPAN_DANGER("The [C.name] melts under the action of acid."))


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Acid now takes into account all the worn clothing's armour value instead of just checking if the head , glasses or mask is unacidable and stopping all damage. Acid now takes into account bio armour , along with the unacidable var.

## Why It's Good For The Game
Less insta-kill potential
https://cdn.discordapp.com/attachments/299262993617780737/1007051785317396600/2022-08-11_01-03-13.mp4
## Changelog
:cl:
balance: Acid now takes into account all worn clothing
balance: Acid now melts clothing before dealing damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
