### PR TITLE
Reduces the fire delay for most pistols and revolvers , and a set of energy guns.

### DIFF
--- a/code/modules/projectiles/guns/energy/crossbow.dm
+++ b/code/modules/projectiles/guns/energy/crossbow.dm
@@ -13,6 +13,7 @@
 	fire_sound = 'sound/weapons/Genhit.ogg'
 	projectile_type = /obj/item/projectile/energy/bolt
 	self_recharge = 1
+	fire_delay = 3
 	charge_meter = 0
 	charge_cost = 200
 	price_tag = 2500

--- a/code/modules/projectiles/guns/energy/decloner.dm
+++ b/code/modules/projectiles/guns/energy/decloner.dm
@@ -8,6 +8,7 @@
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 4, TECH_POWER = 3)
 	can_dual = TRUE
 	projectile_type = /obj/item/projectile/energy/declone
+	fire_delay = 4
 	charge_cost = 100
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_PLASTIC = 10, MATERIAL_URANIUM = 8, MATERIAL_SILVER = 2)
 	price_tag = 1500

--- a/code/modules/projectiles/guns/energy/egun.dm
+++ b/code/modules/projectiles/guns/energy/egun.dm
@@ -16,6 +16,7 @@
 	modifystate = "energystun"
 	item_modifystate = "stun"
 	init_recoil = SMG_RECOIL(1)
+	fire_delay = 3
 
 	init_firemodes = list(
 		STUNBOLT,
@@ -49,6 +50,7 @@
 	suitable_cell = /obj/item/cell/small
 	cell_type = /obj/item/cell/small
 	init_recoil = HANDGUN_RECOIL(1)
+	fire_delay = 5
 
 	serial_type = "FS"
 

--- a/code/modules/projectiles/guns/energy/nt_svalinn.dm
+++ b/code/modules/projectiles/guns/energy/nt_svalinn.dm
@@ -14,6 +14,7 @@
 	can_dual = TRUE
 	zoom_factor = 0
 	damage_multiplier = 1
+	fire_delay = 4
 	matter = list(MATERIAL_PLASTEEL = 8, MATERIAL_WOOD = 4, MATERIAL_SILVER = 2)
 	price_tag = 1000
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -15,7 +15,7 @@
 	suitable_cell = /obj/item/cell/small
 	cell_type = /obj/item/cell/small
 	projectile_type = /obj/item/projectile/bullet/shotgun
-	fire_delay = 12 //Equivalent to a pump then fire time
+	fire_delay = 8 //Equivalent to a pump then fire time
 	fire_sound = 'sound/weapons/guns/fire/energy_shotgun.ogg'
 	init_firemodes = list(
 		list(mode_name="Buckshot", mode_desc="Fires a buckshot synth-shell", projectile_type=/obj/item/projectile/bullet/pellet/shotgun, charge_cost=50, icon="kill"),

--- a/code/modules/projectiles/guns/energy/sniperrifle.dm
+++ b/code/modules/projectiles/guns/energy/sniperrifle.dm
@@ -10,7 +10,7 @@
 	projectile_type = /obj/item/projectile/beam/sniper
 	slot_flags = SLOT_BACK
 	charge_cost = 300
-	fire_delay = 35
+	fire_delay = 12
 	force = 10
 	w_class = ITEM_SIZE_BULKY
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 8, MATERIAL_SILVER = 9, MATERIAL_URANIUM = 6)

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -8,6 +8,7 @@
 	price_tag = 2000
 	fire_sound = 'sound/weapons/Taser.ogg'
 	can_dual = TRUE
+	fire_delay = 4
 	projectile_type = /obj/item/projectile/beam/stun
 	wield_delay = 0.3 SECOND
 	wield_delay_factor = 0.2 // 20 vig

--- a/code/modules/projectiles/guns/energy/toxgun.dm
+++ b/code/modules/projectiles/guns/energy/toxgun.dm
@@ -12,4 +12,5 @@
 	projectile_type = /obj/item/projectile/energy/plasma
 	init_recoil = HANDGUN_RECOIL(1)
 	serial_type = "ML"
+	fire_delay = 5
 

--- a/code/modules/projectiles/guns/energy/xray.dm
+++ b/code/modules/projectiles/guns/energy/xray.dm
@@ -13,3 +13,4 @@
 	twohanded = TRUE
 	init_recoil = RIFLE_RECOIL(1)
 	serial_type = "ML"
+	fire_delay = 3

--- a/code/modules/projectiles/guns/projectile/battle_rifle/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/battle_rifle/boltgun.dm
@@ -11,7 +11,7 @@
 	slot_flags = SLOT_BACK
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	caliber = CAL_LRIFLE
-	fire_delay = 8
+	fire_delay = 5
 	damage_multiplier = 1.4
 	style_damage_multiplier = 5
 	penetration_multiplier = 1.5

--- a/code/modules/projectiles/guns/projectile/battle_rifle/kovacs.dm
+++ b/code/modules/projectiles/guns/projectile/battle_rifle/kovacs.dm
@@ -24,7 +24,7 @@
 	penetration_multiplier = 1.4 //35
 	init_recoil = RIFLE_RECOIL(1)
 	zoom_factor = 0.6
-	fire_delay = 6.5
+	fire_delay = 4
 	gun_parts = list(/obj/item/part/gun/frame/kovacs = 1, /obj/item/part/gun/grip/serb = 1, /obj/item/part/gun/mechanism/autorifle = 1, /obj/item/part/gun/barrel/srifle = 1)
 	serial_type = "SA"
 

--- a/code/modules/projectiles/guns/projectile/pistol/avasarala.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/avasarala.dm
@@ -17,6 +17,7 @@
 	can_dual = TRUE
 	damage_multiplier = 1.45
 	penetration_multiplier = 1.35
+	fire_delay = 4
 	init_recoil = HANDGUN_RECOIL(0.9)
 
 	fire_sound = 'sound/weapons/guns/fire/hpistol_fire.ogg'

--- a/code/modules/projectiles/guns/projectile/pistol/giskard.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/giskard.dm
@@ -18,6 +18,7 @@
 	price_tag = 400
 	damage_multiplier = 1.3
 	penetration_multiplier = 0.8
+	fire_delay = 3
 	init_recoil = HANDGUN_RECOIL(0.7)
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
 	gun_parts = list(/obj/item/part/gun/frame/giskard = 1, /obj/item/part/gun/grip/wood = 1, /obj/item/part/gun/mechanism/pistol = 1, /obj/item/part/gun/barrel/pistol = 1)

--- a/code/modules/projectiles/guns/projectile/pistol/lamia.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/lamia.dm
@@ -21,7 +21,7 @@
 	cocked_sound = 'sound/weapons/guns/interact/hpistol_cock.ogg'
 	damage_multiplier = 1.4
 	penetration_multiplier = 1.4
-	fire_delay = 5
+	fire_delay = 4
 	init_recoil = HANDGUN_RECOIL(0.4)
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE

--- a/code/modules/projectiles/guns/projectile/pistol/lamia.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/lamia.dm
@@ -21,6 +21,7 @@
 	cocked_sound = 'sound/weapons/guns/interact/hpistol_cock.ogg'
 	damage_multiplier = 1.4
 	penetration_multiplier = 1.4
+	fire_delay = 5
 	init_recoil = HANDGUN_RECOIL(0.4)
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE

--- a/code/modules/projectiles/guns/projectile/pistol/mandella.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mandella.dm
@@ -21,6 +21,7 @@
 	proj_step_multiplier = 0.8
 	damage_multiplier = 1.6
 	penetration_multiplier = 3
+	fire_delay = 4
 	init_recoil = HANDGUN_RECOIL(0.6)
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE

--- a/code/modules/projectiles/guns/projectile/pistol/paco.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/paco.dm
@@ -20,6 +20,7 @@
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
 	damage_multiplier = 1.5
 	penetration_multiplier = 0.9
+	fire_delay = 5
 	init_recoil = HANDGUN_RECOIL(1)
 	gun_tags = list(GUN_SILENCABLE)
 

--- a/code/modules/projectiles/guns/projectile/revolver/consul.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/consul.dm
@@ -13,6 +13,7 @@
 	price_tag = 1700
 	damage_multiplier = 1.35
 	penetration_multiplier = 1.5
+	fire_delay = 4
 	init_recoil = HANDGUN_RECOIL(1)
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
 	gun_parts = list(/obj/item/part/gun/frame/consul = 1, /obj/item/part/gun/grip/rubber = 1, /obj/item/part/gun/mechanism/revolver = 1, /obj/item/part/gun/barrel/magnum = 1)

--- a/code/modules/projectiles/guns/projectile/revolver/deckard.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/deckard.dm
@@ -12,6 +12,7 @@
 	fire_sound = 'sound/weapons/guns/fire/deckard_fire.ogg'
 	damage_multiplier = 1.45
 	penetration_multiplier = 1.65
+	fire_delay = 3
 	init_recoil = HANDGUN_RECOIL(1)
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
 	gun_parts = list(/obj/item/part/gun/frame/deckard = 1, /obj/item/part/gun/grip/wood = 1, /obj/item/part/gun/mechanism/revolver = 1, /obj/item/part/gun/barrel/magnum = 1)

--- a/code/modules/projectiles/guns/projectile/revolver/havelock.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/havelock.dm
@@ -15,6 +15,7 @@
 	price_tag = 600
 	damage_multiplier = 1.4 //because pistol round
 	penetration_multiplier = 1.4
+	fire_delay = 3
 	init_recoil = HANDGUN_RECOIL(0.6)
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE

--- a/code/modules/projectiles/guns/projectile/revolver/mateba.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/mateba.dm
@@ -8,6 +8,7 @@
 	price_tag = 3000 //more op and rare than miller, hits as hard as a Miller and doesn't struggle with armor, good luck finding it
 	damage_multiplier = 1.75
 	penetration_multiplier = 1.5
+	fire_delay = 4
 	init_recoil = HANDGUN_RECOIL(1.2)
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Brings guns firing speed on par with full autos.

## Why It's Good For The Game
Most guns are far below full autos ,this brings those more niche guns up to power.
Where the old fire delay is not mentioned , it used to be 6.
## Changelog
:cl:
balance: Energy crossbow bow now has 3 MS delay
balance: Decloner gun has 4 MS delay
balance:  Spider rose has 3 MS delay
balance: Counselor has 4 MS delay
balance: Svallin has 4 MS delay
balance : Shellshock fire delay is now 8 MS (From 12)
balance: Valkrie fire delay is now 12 MS (from 35)
balance: Kovacs fire delay is now  4 (from 6.5)
balance: Moebius plasma gun now has 5 MS delay
balance: Boltguns now have 5 MS fire delay (From 8)
balance: Avasarala now has 4 MS fire delay
balance: Lamia now has 4 MS fire delay
balance: Giskard now has 3 MS fire delay
balance:Mandella now has 4 MS fire delay
balance: Paco has 5 MS fire delay
balance: Consul has 4 MS fire delay
balance: Deckard has 3 MS fire delay
balance :Havelock has 3 MS fire delay
balance: Mateba now has 4 MS fire delay
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
