### PR TITLE
Adds the ability to put small and medium cells in ammo pouches.

### DIFF
--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -199,7 +199,9 @@
 
 	can_hold = list(
 		/obj/item/ammo_magazine,
-		/obj/item/ammo_casing
+		/obj/item/ammo_casing,
+		/obj/item/cell/small,
+		/obj/item/cell/medium
 		)
 
 /obj/item/storage/pouch/tubular


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR allows small and medium cells to fit in ammo pouches.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Energy guns are not favored at the moment and while you can carry engineering pouches for cells, they limit the ability to carry a mixed loadout while keeping the majority of your ammo in one place. This hopes to fix that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Small and Medium cells now fit in ammo pouches.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
