### PR TITLE
Put fumo plushy back on the dorms table

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -4251,6 +4251,7 @@
 /area/eris/crew_quarters/sleep)
 "ajY" = (
 /obj/structure/table/standard,
+/obj/item/toy/plushie/fumo,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/eris/crew_quarters/sleep)
 "ajZ" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Put back fumo added by #7351 that was removed by #7367 because of git dark magic


## Changelog
:cl: Hyperio
fix: Fix fumo removal due to another map PR
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
