### PR TITLE
Fixes the ammo pouch being able to hold drum mags

### DIFF
--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -208,7 +208,8 @@
 		/obj/item/ammo_magazine/ammobox,
 		/obj/item/ammo_magazine/srifle/drum,
 		/obj/item/ammo_magazine/lrifle/drum,
-		/obj/item/ammo_magazine/lrifle/pk
+		/obj/item/ammo_magazine/lrifle/pk,
+		/obj/item/ammo_magazine/maxim
 		)
 
 /obj/item/storage/pouch/tubular

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -204,6 +204,13 @@
 		/obj/item/cell/medium
 		)
 
+	cant_hold = list(
+		/obj/item/ammo_magazine/ammobox,
+		/obj/item/ammo_magazine/srifle/drum,
+		/obj/item/ammo_magazine/lrifle/drum,
+		/obj/item/ammo_magazine/lrifle/pk
+		)
+
 /obj/item/storage/pouch/tubular
 	name = "tubular pouch"
 	desc = "Can hold five cylindrical and small items, including but not limiting to flares, glowsticks, syringes and even hatton tubes or rockets."

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -427,6 +427,7 @@
 	matter = list(MATERIAL_STEEL = 20)
 	ammo_type = /obj/item/ammo_casing/lrifle
 	max_ammo = 96
+	w_class = ITEM_SIZE_NORMAL
 	ammo_states = list(96)
 
 /obj/item/ammo_magazine/maxim/rubber


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title
![image](https://user-images.githubusercontent.com/6613514/184395212-85cfc466-e997-421f-b262-9f9ca08f0dd4.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Normal sized items should not fit in a pouch.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Ammo pouches can no longer hold ammo boxes and drum magazines.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
