### PR TITLE
Reduces Junk Tractor Cooldown

### DIFF
--- a/code/modules/dungeons/junk_tractor_beam.dm
+++ b/code/modules/dungeons/junk_tractor_beam.dm
@@ -99,7 +99,7 @@
 	var/list/jf_pool = list()  // Pool of junk fields you can choose from
 
 	var/beam_cooldown_start = 0  // Starting time of the cooldown for the progress bar
-	var/beam_cooldown_time = 5 MINUTES
+	var/beam_cooldown_time = 3 MINUTES
 	var/beam_capture_time = 20 SECONDS
 
 	var/list/preloaded_25_25 = list()  // Need to preload maps in SOUTH direction


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simply changes the tractor cooldown after you release a junk field from 5 -> 3 minutes

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The days of the old junk beacon creating a 5x5 grid of trash piles at your feet are gone. Now you have to navigate a new map with lots of swathes of zero G ground, no atmosphere and dangerous fauna. A reduction to 3 minutes isn't much and it wont buff junking, just help reset the field faster if someone looted it already.
It might be worth to add breathable atmosphere to the beacon so that roaches dont suffocate and die. Pressure is livable, and roaches and spiders can be added as extra danger outside carps and bears simple mobs. Extra traps such as the new mines and old bear traps should be considered as well.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tractor cool down lowered from 5 to 3 minutes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
