### PR TITLE
Fixes smoke related problems (blattedin farm fix)

### DIFF
--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -169,8 +169,8 @@
 						if(H.wear_mask)
 							gasmask = H.wear_mask.item_flags & BLOCK_GAS_SMOKE_EFFECT			
 						if(!internals && !gasmask)
-							chemholder.reagents.trans_to_mob(H, 5, CHEM_INGEST, copy = FALSE)
-							chemholder.reagents.trans_to_mob(H, 5, CHEM_BLOOD, copy = FALSE)
+							chemholder.reagents.trans_to_mob(H, 5, CHEM_INGEST, copy = TRUE)
+							chemholder.reagents.trans_to_mob(H, 5, CHEM_BLOOD, copy = TRUE)
 				else if(isobj(A) && !A.simulated)
 					chemholder.reagents.touch_obj(A)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Due to balance concerns, in https://github.com/discordia-space/CEV-Eris/pull/7087 I made chemsmoke lose some of its reagents when it transferred them to a mob, in order to prevent duping. This caused the visible smoke to lose its reagents and color due to the reagents being transferred to mobs beforehand. This is why blattedin farms no longer work properly.

By not removing reagents from the smoke when it is transferred to a mob, this problem is solved. And no, this is not a balance problem, SPCR . That's because it's handled the same way with reagents being transferred to containers or splashed. In fact, the blattedin farms are technically dupes as well.

## Why It's Good For The Game

Blattedin farms work again, and smoke now has the correct color again. People complained about blattedin farms not working anymore

## Changelog
:cl:
tweak: makes smoke not lose reagents anymore when some are transferred to a mob.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
