### PR TITLE
Fixes FPB hardsuit gaming(Also revives old surgery by accident)

### DIFF
--- a/code/modules/surgery/robotic_damage.dm
+++ b/code/modules/surgery/robotic_damage.dm
@@ -45,7 +45,7 @@
 
 /datum/surgery_step/robotic/fix_brute/can_use(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
 	if(..())
-		if(user != organ.owner && user.a_intent != I_HELP)
+		if(organ.owner.wearing_rig)
 			return FALSE
 		if(organ.brute_dam <= 0)
 			to_chat(user, SPAN_NOTICE("The hull of [organ.get_surgery_name()] is undamaged!"))

--- a/code/modules/surgery/robotic_damage.dm
+++ b/code/modules/surgery/robotic_damage.dm
@@ -45,6 +45,8 @@
 
 /datum/surgery_step/robotic/fix_brute/can_use(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
 	if(..())
+		if(user != organ.owner && user.a_intent != I_HELP)
+			return FALSE
 		if(organ.brute_dam <= 0)
 			to_chat(user, SPAN_NOTICE("The hull of [organ.get_surgery_name()] is undamaged!"))
 			return SURGERY_FAILURE

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -226,8 +226,8 @@ proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool, var/surgery
 				return TRUE
 
 			if(QUALITY_WELDING)
-				try_surgery_step(/datum/surgery_step/robotic/fix_brute, user, tool)
-				return TRUE
+				if(try_surgery_step(/datum/surgery_step/robotic/fix_brute, user, tool))
+					return TRUE
 
 			if(ABORT_CHECK)
 				return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If you are on harm intent , you will not attempt to weld the target FBP and you won't stop other surgeries from being checked.
This doesn't apply to the owner ,the owner will always try to weld themselves.
This also fixes old surgery not being considered if there was a existing surgery step, even if the existing one was not possible.

## Why It's Good For The Game
Exploiters been having fun with it for too long.
## Changelog
:cl:
fix: FIxed hardsuits not being removeable from FBP's backs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
