### PR TITLE
All NT disks brought through the EOTP are uncapped

### DIFF
--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -118,6 +118,7 @@
 /datum/armament/item/disk/New()
 	if (desc == initial(desc))
 		var/obj/item/computer_hardware/hard_drive/portable/design/D = path
+		D.license = -1
 		var/text = initial(D.disk_name)
 		if (text)
 			desc = text


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Any disk brought through the EOTP is uncapped

## Why It's Good For The Game
NT Disks that come from EOTP shouldn't be capped for the simple fact that getting the required power level takes a huge amount of time.
I also see no balance reason to have them limited , material scarcity is already enough.
It also lets them sell as much medicine or pouches as they want , finnaly , player interaction.
## Changelog
:cl:
balance: NT-disks brought through the EOTP have unlimited license points
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
