### PR TITLE
Tweaks Gun Part Cost and Amounts

### DIFF
--- a/code/datums/craft/crafting_items.dm
+++ b/code/datums/craft/crafting_items.dm
@@ -46,7 +46,7 @@
 	icon_state = "gun_part_1"
 	spawn_tags = SPAWN_TAG_GUN_PART
 	w_class = ITEM_SIZE_SMALL
-	matter = list(MATERIAL_PLASTEEL = 1.2)
+	matter = list(MATERIAL_PLASTEEL = 5)
 	var/generic = TRUE
 
 /obj/item/part/gun/Initialize()
@@ -81,7 +81,7 @@
 	var/suitable_part
 	var/view_only = 0
 	var/tags_to_spawn = list()
-	var/req_parts = 10
+	var/req_parts = 5
 	var/complete = FALSE
 	var/total_items = 20
 	var/list/items = list()

--- a/code/datums/craft/recipes/guns.dm
+++ b/code/datums/craft/recipes/guns.dm
@@ -104,7 +104,7 @@
 	name = "makeshift laser carbine"
 	result = /obj/item/gun/energy/laser/makeshift
 	steps = list(
-		list(/obj/item/part/gun, 4),
+		list(/obj/item/part/gun, 3),
 		list(QUALITY_ADHESIVE, 15, 70),
 		list(CRAFT_MATERIAL, 20, MATERIAL_STEEL),
 		list(QUALITY_WELDING, 10, 20),
@@ -117,7 +117,7 @@
 	name = "Makeshift AR .30 \"Kalash\""
 	result = /obj/item/gun/projectile/automatic/ak47/makeshift
 	steps = list(
-		list(/obj/item/part/gun, 4),
+		list(/obj/item/part/gun, 3),
 		list(QUALITY_ADHESIVE, 15, 70),
 		list(CRAFT_MATERIAL, 20, MATERIAL_STEEL),
 		list(QUALITY_WELDING, 10, 20),
@@ -129,7 +129,7 @@
 	name = "Handmade SMG .35 Auto \"Luty\""
 	result = /obj/item/gun/projectile/automatic/luty
 	steps = list(
-		list(/obj/item/part/gun, 3),
+		list(/obj/item/part/gun, 2),
 		list(QUALITY_ADHESIVE, 15, 70),
 		list(CRAFT_MATERIAL, 15, MATERIAL_STEEL),
 		list(QUALITY_WELDING, 10, 20),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
1. changed gun assembly required gun parts 10 -> 5
2. changed makeshift AK and laser gun parts required 4 -> 3, makeshift smg 3 -> 2
3. changed recycle cost of gun parts 1.2 -> 5

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
First, the gun part recyle part. Before, with Omni's initial implementation of the crafting station, gun part crafting was rng. with 5 plasteel, you could make 0-2+ gun parts, so to avoid plasteel multiplication the recycle cost was lowered to 1.2. Kirov fixed and changed it, so the cost is back up to 5 since 5 plasteel will only make 1 single gun part, and this way you can actually recycle makeshift guns found or crafted into other guns or plasteel not at a great loss.
Then, the gun assembly changes. As I said, Kirov made it so you can only craft 1 gun part per 5 plasteel instead of RNG. shame that with this change, a gun assembly costed 55 (!) plasteel: 50 for 10 gun parts, and 5 for the assembly frame in the crafting UI [before it could be as low as 20 plasteel or as high as 60+]. By making the required gun parts 5, it only costs 30 (25 + 5) plasteel. Why is this good? well longarm cost/recycle for 20 plasteel and pistols/smg cost/recyles for 12 plasteel. So you still cannot multiply plasteel or get more plasteel value in gun assembly, but at the same time it doesnt cost nearly 3 times as much for a longarm, or 4 times as much for a pistol/smg (but respectively 50% more and slightly over 2 times for a pistol/smg).
Thirdly, the reduced makeshift weapon gun part cost. The pistol and shotgun costed respectively 2 and 3 gun parts, or 10 and 15 plasteel, which was 2 and 5 less vs a non makeshift, non-shit version. The Ak and laser costed as much as the better, non-makeshift guns and the luty costed 3 more plasteel. Now all makeshift guns cost slightly less than a non-makeshift version to make, to represent their scrap and cheap nature.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: lowered by 1 makeshift ak, laser carbine and smg gun part requirements
balance: rebalanced gun part recycle cost
tweak: changed gun assembly require gun parts 10 -> 5
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
