### PR TITLE
Brings .35 and .40 Speedloaders in line with the stripper clips

### DIFF
--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -443,6 +443,7 @@
 	matter = list(MATERIAL_STEEL = 3)
 	ammo_type = /obj/item/ammo_casing/pistol
 	max_ammo = 6
+	w_class = ITEM_SIZE_TINY
 	rarity_value = 6.66
 	ammo_states = list(1, 2, 3, 4, 5, 6)
 
@@ -475,6 +476,7 @@
 	ammo_type = /obj/item/ammo_casing/magnum
 	matter = list(MATERIAL_STEEL = 3)
 	max_ammo = 6
+	w_class = ITEM_SIZE_TINY
 	spawn_tags = SPAWN_TAG_AMMO_IH
 	rarity_value = 5
 	ammo_states = list(1, 2, 3, 4, 5, 6)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Revolver speedloaders are now tiny, instead of small

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
1. The rifle speedloaders (stripper clips) were tiny but the rev ones didnt get updated
2. a bullet pile of 10-15 rounds is tiny, while a speedloader of 6 rounds is small. 
3. it will make speedloaders more worth using, instead of having 30 rounds in two bullet piles for the same size a single speedloaders.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: speedloaders are now tiny sized from small
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
