### PR TITLE
Stranger gun update+Necklace fix

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -118,6 +118,7 @@
 #define COMSIG_REMOVE "uninstall"
 #define COMSIG_ITEM_DROPPED	"item_dropped"					//from  /obj/item/tool/attackby(): Called to remove an upgrade
 #define COMSIG_ITEM_PICKED "item_picked"
+#define COMSIG_ODDITY_USED "used_oddity"                    //from /datum/sanity/proc/oddity_stat_up(): called to notify the used oddity it was used.
 
 // /obj/item/clothing signals
 #define COMSIG_CLOTH_DROPPED "cloths_missing"

--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -371,7 +371,7 @@
 	if(GLOB.bluespace_entropy > GLOB.bluespace_hazard_threshold*0.7)
 		to_chat(user, SPAN_NOTICE("Has it always shone so brightly?"))
 
-	if(my_area.bluespace_entropy > my_area.bluespace_hazard_threshold*0.95 || GLOB.bluespace_hazard_threshold > GLOB.bluespace_hazard_threshold*0.95)
+	if(my_area.bluespace_entropy > my_area.bluespace_hazard_threshold*0.95 || GLOB.bluespace_entropy > GLOB.bluespace_hazard_threshold*0.95)
 		to_chat(user, SPAN_NOTICE("You can see an inscription in some language unknown to you."))
 
 /obj/item/oddity/broken_necklace/Destroy()

--- a/code/modules/mob/living/simple_animal/hostile/stranger.dm
+++ b/code/modules/mob/living/simple_animal/hostile/stranger.dm
@@ -118,7 +118,7 @@
 
 /obj/item/gun/energy/plasma/stranger
 	name = "unknown plasma gun"
-	desc = "A plasma gun with unknown origins."
+	desc = "A plasma gun with unknown origins, it seems to always spark a different feeling in those inspired by it."
 	icon = 'icons/obj/guns/energy/lancer.dmi'
 	icon_state = "lancer"
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 8, MATERIAL_SILVER = 7, MATERIAL_URANIUM = 8, MATERIAL_GOLD = 4)

--- a/code/modules/mob/living/simple_animal/hostile/stranger.dm
+++ b/code/modules/mob/living/simple_animal/hostile/stranger.dm
@@ -118,7 +118,7 @@
 
 /obj/item/gun/energy/plasma/stranger
 	name = "unknown plasma gun"
-	desc = "A plasma gun from unknown origin"
+	desc = "A plasma gun with unknown origins."
 	icon = 'icons/obj/guns/energy/lancer.dmi'
 	icon_state = "lancer"
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 8, MATERIAL_SILVER = 7, MATERIAL_URANIUM = 8, MATERIAL_GOLD = 4)
@@ -160,3 +160,44 @@
 		set_item_state("-[item_modifystate]")
 	if(!ignore_inhands)
 		update_wear_icon()
+
+/obj/item/gun/energy/plasma/stranger/examine(user, distance)
+	. = ..()
+	var/area/my_area = get_area(src)
+	switch(my_area.bluespace_entropy)
+		if(0 to my_area.bluespace_hazard_threshold*0.3)
+			to_chat(user, SPAN_NOTICE("It's fading out."))
+		if(my_area.bluespace_hazard_threshold*0.7 to INFINITY)
+			to_chat(user, SPAN_NOTICE("It's occasionally pulsing with energy."))
+	if(GLOB.bluespace_entropy > GLOB.bluespace_hazard_threshold*0.7)
+		to_chat(user, SPAN_NOTICE("It glows with an inner radiance."))
+	if(my_area.bluespace_entropy > my_area.bluespace_hazard_threshold*0.95 || GLOB.bluespace_entropy > GLOB.bluespace_hazard_threshold*0.95)
+		to_chat(user, SPAN_NOTICE("The energy surrounding it is overwhelming to the point of feeling warm in your hands."))
+
+
+
+/obj/item/gun/energy/plasma/stranger/proc/chaos()
+	var/list/stats = ALL_STATS
+	var/list/final_oddity = list()
+	var/stat = pick(stats)
+	final_oddity += stat
+	var/area/my_area = get_area(src)
+	var/bluespacemodifier = round(my_area.bluespace_entropy/(my_area.bluespace_hazard_threshold/4))
+	final_oddity[stat] = 6 + bluespacemodifier
+	my_area.bluespace_entropy = max(0, my_area.bluespace_entropy - (6 + bluespacemodifier))
+	var/datum/component/inspiration/odd = GetComponent(/datum/component/inspiration)
+	odd.stats = final_oddity
+
+/obj/item/gun/energy/plasma/stranger/New()
+	. = ..()
+	AddComponent(/datum/component/inspiration, list())
+	RegisterSignal(src, COMSIG_ODDITY_USED, .proc/chaos)
+	chaos()
+
+/obj/item/gun/energy/plasma/stranger/attack_hand(mob/user)
+	. = ..()
+	if(!ishuman(user))
+		return
+	else
+		var/mob/living/carbon/human/H = user
+		H.sanity.valid_inspirations |= src

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -274,6 +274,7 @@
 		if(I.perk)
 			if(owner.stats.addPerk(I.perk))
 				I.perk = null
+		SEND_SIGNAL(O, COMSIG_ODDITY_USED)
 		for(var/mob/living/carbon/human/H in viewers(owner))
 			SEND_SIGNAL(H, COMSIG_HUMAN_ODDITY_LEVEL_UP, owner, O)
 


### PR DESCRIPTION
## About The Pull Request

Gives the stranger's plasma gun the properties of an oddity, along with randomizing the single stat on the gun on oddity use+fixes the issues with the broken necklace's description, which led to two different descriptions being documented on it, along with adding this feature to the stranger's plasma gun.
The randomization required the creation of a define, if this is too much, i can replace the single stat randomization for 3 stats that are affected by entropy the same way as currently.

## Why It's Good For The Game

Honestly, it makes the stranger more interesting in terms of loot.

## Changelog
:cl:
add: Stranger's gun has oddity properties and randomizes said properties.
fix: broken necklace's description.
/:cl:

