### PR TITLE
stops disposal from accessing null

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1349,8 +1349,6 @@
 	pipe_dir = dir
 	
 	INVOKE_ASYNC(src, .proc/getlinked)
-		getlinked()
-
 	update()
 
 /obj/structure/disposalpipe/trunk/Destroy()

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1344,19 +1344,20 @@
 	icon_state = "pipe-t"
 	var/obj/linked 	// the linked obj/machinery/disposal or obj/disposaloutlet
 
-/obj/structure/disposalpipe/trunk/New()
-	..()
+/obj/structure/disposalpipe/trunk/Initialize()
+	. = ..()
 	pipe_dir = dir
-	spawn(1)
+	
+	INVOKE_ASYNC(src, .proc/getlinked)
 		getlinked()
 
 	update()
-	return
 
 /obj/structure/disposalpipe/trunk/Destroy()
 	// Unlink trunk and disposal so that objets are not sent to nullspace
-	var/obj/machinery/disposal/D = linked
-	D.trunk = null
+	if (linked)
+		var/obj/machinery/disposal/D = linked
+		D.trunk = null
 	linked = null
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes trunks accessing bins that is never linked

fixes the issue at https://github.com/discordia-space/CEV-Eris/pull/7406

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
