### PR TITLE
BalanceHotfix for Rapid Crossbow (RXB)

### DIFF
--- a/code/modules/projectiles/guns/energy/rapidcrossbow.dm
+++ b/code/modules/projectiles/guns/energy/rapidcrossbow.dm
@@ -7,10 +7,12 @@
 	flags = CONDUCT
 	slot_flags = SLOT_BACK|SLOT_BELT|SLOT_HOLSTER 
 	wielded_item_state = "_doble"
+	damage_multiplier = 0.8
+	penetration_multiplier = 0.9
 	fire_delay = 6
 	fire_sound = 'sound/weapons/tablehit1.ogg'
 	init_firemodes = list(
-		list(mode_name = "Bolt", mode_desc = "Fires a flashforged quarrel", projectile_type = /obj/item/projectile/bullet/bolt, charge_cost = 50, icon = "kill"))
+		list(mode_name = "Bolt", mode_desc = "Fires a flashforged quarrel", projectile_type = /obj/item/projectile/bullet/bolt, charge_cost = 100, icon = "kill"))
 	price_tag = 2000
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASMA = 8, MATERIAL_URANIUM = 8, MATERIAL_STEEL = 2)
 	init_recoil = HANDGUN_RECOIL(1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Minor Balance change to RXB 
- Damage lowered from 55 > 44
- Penetration lowered from 30 > 20
- Chargecost increased from 50 >100

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Community feedback was valid for balance.
Acts more like a six shooter now with a basic cell.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: RXB damage now 44 instead of 55
balance: RXB ap now 27 instead of 30
balance: RXB charge cost now 100 instead of 50
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
