### PR TITLE
Disables Map APC/Atmos testing

### DIFF
--- a/code/modules/unit_tests/map_tests.dm
+++ b/code/modules/unit_tests/map_tests.dm
@@ -3,6 +3,11 @@
  *  Zone checks / APC / Scrubber / Vent.
  */
 
+
+// Commented out due to its high unreliability (caused by the way world initialization is caused and how unreliable SSradio is itself)
+// Should be brought back once we get proper framework for checking an Area's APC and air alarms.
+
+/*
 /datum/unit_test/area_contents/Run()
 	var/static/list/exempt_areas = typesof(
 		/area/space, /area/skipjack_station,
@@ -23,6 +28,7 @@
 		if(A.z == 1 && !(A.type in exempt_areas))
 			TEST_ASSERT(!isnull(A.apc) || (A.type in exempt_from_apc), "[A.name]([A.type]) lacks an APC.")
 			TEST_ASSERT((A.air_scrub_info?.len && A.air_vent_info?.len) || (A.type in exempt_from_atmos), "[A.name]([A.type]) lacks an air scrubber [(!A.air_scrub_info?.len && !A.air_vent_info?.len) ? "and" : "or"] a vent.")
+*/
 
 /*
 /datum/unit_test/wire_stacking/Run()

--- a/code/modules/unit_tests/map_tests.dm
+++ b/code/modules/unit_tests/map_tests.dm
@@ -5,7 +5,7 @@
 
 
 // Commented out due to its high unreliability (caused by the way world initialization is caused and how unreliable SSradio is itself)
-// Should be brought back once we get proper framework for checking an Area's APC and air alarms.
+// Should be brought back once we get proper framework for checking an Area's APC and air alarms. - SPCR 2022
 
 /*
 /datum/unit_test/area_contents/Run()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It only gives False Positives and i can't be bothered to fix the underlying issue.

## Why It's Good For The Game
We have junkyard for this.

## Changelog
:cl:
removal: Removed unit testing for area APC &  Scrubbers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
