### PR TITLE
The Grand Glove Update , The mega balance PR , The fix eris needed. 

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -308,6 +308,7 @@
 #include "code\datums\autolathe\tools.dm"
 #include "code\datums\components\_component.dm"
 #include "code\datums\components\clothing_sanity_protection.dm"
+#include "code\datums\components\clothing_affect_stat.dm"
 #include "code\datums\components\fabric.dm"
 #include "code\datums\craft\crafting_items.dm"
 #include "code\datums\craft\gun_parts.dm"

--- a/code/datums/components/clothing_affect_stat.dm
+++ b/code/datums/components/clothing_affect_stat.dm
@@ -1,0 +1,44 @@
+// possible skills
+// STAT_MEC STAT_COG STAT_VIG STAT_BIO STAT_TGH STAT_ROB
+
+/datum/component/clothing_stat_affecting
+	var/list/affecting_stats = list()
+	var/mob/living/carbon/human/current_user
+
+/datum/component/clothing_stat_affecting/Initialize(list/value , usefull = 0)
+	if(!(istype(parent, /obj/item/clothing)))
+		return COMPONENT_INCOMPATIBLE
+	affecting_stats = value
+	var/atom/current_parent = parent
+	var/description = "This item influences the following skills by the following amounts \n"
+	for(var/affected in affecting_stats)
+		message_admins("received stats - [affected] / [affecting_stats]")
+		description += "[affected] by [affecting_stats[affected]] \n"
+	current_parent.description_info += description
+	RegisterSignal(current_parent, COMSIG_CLOTH_EQUIPPED, .proc/handle_stat_changes)
+
+/datum/component/clothing_stat_affecting/proc/handle_stat_changes(mob/living/carbon/human/user)
+	var/obj/item/current_parent = parent
+	if(current_parent.is_worn())
+		RegisterSignal(user, COMSIG_CLOTH_DROPPED, .proc/handle_stat_removal)
+		current_user = user
+		for(var/affected in affecting_stats)
+			current_user.stats.addTempStat(affected, affecting_stats[affected], INFINITY, "[parent]")
+
+/datum/component/clothing_stat_affecting/proc/handle_stat_removal()
+	for(var/affected in affecting_stats)
+		current_user.stats.removeTempStat(affected, "[parent]")
+	UnregisterSignal(current_user, COMSIG_CLOTH_DROPPED)
+	current_user = null
+
+// Remove any references to avoid hard dels
+/datum/component/clothing_stat_affecting/Destroy()
+	if(current_user)
+		for(var/affected in affecting_stats)
+			current_user.stats.removeTempStat(affected, "[parent]")
+		UnregisterSignal(current_user, COMSIG_CLOTH_DROPPED)
+		current_user = null
+	UnregisterSignal(parent, COMSIG_CLOTH_EQUIPPED)
+	var/atom/current_parent = parent
+	current_parent.description_info = initial(current_parent.description_info)
+	..()

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -7,6 +7,11 @@
 	price_tag = 500
 	style = STYLE_HIGH
 
+/obj/item/clothing/gloves/captain/Initialize()
+	..()
+	// corporate gloves!
+	AddComponent(/datum/component/clothing_stat_affecting, list(STAT_VIG = 10, STAT_TGH = 5))
+
 /obj/item/clothing/gloves/insulated
 	desc = "These gloves will protect the wearer from electric shock."
 	name = "insulated gloves"
@@ -18,6 +23,11 @@
 	price_tag = 200
 	spawn_tags = SPAWN_TAG_GLOVES_INSULATED
 	style = STYLE_NEG_HIGH // very powergame much unstylish... literal power this time
+
+/obj/item/clothing/gloves/insulated/Initialize()
+	..()
+	// harder to aim with and do surgery . duh.
+	AddComponent(/datum/component/clothing_stat_affecting, list(STAT_VIG = -15, STAT_BIO = -15))
 
 /obj/item/clothing/gloves/insulated/cheap                          //Cheap Chinese Crap
 	desc = "These gloves are cheap copies of the coveted gloves, no way this can end badly."
@@ -46,6 +56,10 @@
 	heat_protection = ARMS
 	max_heat_protection_temperature = GLOVES_MAX_HEAT_PROTECTION_TEMPERATURE
 
+/obj/item/clothing/gloves/thick/Initialize()
+	..()
+	AddComponent(/datum/component/clothing_stat_affecting, list(STAT_VIG = -10, STAT_BIO = -8, STAT_MEC = 10))
+
 /obj/item/clothing/gloves/security
 	name = "security gloves"
 	desc = "Padded security gloves."
@@ -59,6 +73,10 @@
 	heat_protection = ARMS
 	max_heat_protection_temperature = GLOVES_MAX_HEAT_PROTECTION_TEMPERATURE
 	price_tag = 100
+
+/obj/item/clothing/gloves/security/Initialize()
+	..()
+	AddComponent(/datum/component/clothing_stat_affecting, list(STAT_BIO = -15, STAT_MEC = -5))
 
 /obj/item/clothing/gloves/security/ironhammer
 	name = "operator's gloves"
@@ -74,6 +92,11 @@
 	siemens_coefficient = 0
 	price_tag = 500
 
+/obj/item/clothing/gloves/security/tactical/Initialize()
+	..()
+	// special mercenary gloves
+	AddComponent(/datum/component/clothing_stat_affecting, list(STAT_VIG = 10, STAT_BIO = -10))
+
 /obj/item/clothing/gloves/latex
 	name = "latex gloves"
 	desc = "Sterile latex gloves."
@@ -84,6 +107,10 @@
 	permeability_coefficient = 0.01
 	germ_level = 0
 	price_tag = 50
+
+/obj/item/clothing/gloves/latex/Initialize()
+	..()
+	AddComponent(/datum/component/clothing_stat_affecting, list(STAT_BIO = 10))
 
 /obj/item/clothing/gloves/latex/nitrile
 	name = "nitrile gloves"
@@ -100,6 +127,10 @@
 	permeability_coefficient = 0.05
 	siemens_coefficient = 0.50 //thick work gloves
 	price_tag = 50
+
+/obj/item/clothing/gloves/botanic_leather/Initialize()
+	..()
+	AddComponent(/datum/component/clothing_stat_affecting, list(STAT_VIG = -5, STAT_BIO = 5, STAT_MEC = -5))
 
 /obj/item/clothing/gloves/fingerless
 	name = "fingerless gloves"
@@ -120,6 +151,11 @@
 	item_state = "germangloves"
 	armor = list(melee = 10, bullet = 0, energy = 25, bomb = 0, bio = 0, rad = 0)
 
+/obj/item/clothing/gloves/german/Initialize()
+	..()
+	// military gloves , duh
+	AddComponent(/datum/component/clothing_stat_affecting, list(STAT_VIG = 5, STAT_BIO = -10))
+
 /obj/item/clothing/gloves/knuckles
 	name = "knuckle gloves"
 	desc = "Gloves with additional reinforcment on the knuckles."
@@ -128,3 +164,8 @@
 	style = STYLE_HIGH
 	armor = list(melee = 20, bullet = 5, energy = 0, bomb = 0, bio = 0, rad = 0)
 	price_tag = 500
+
+/obj/item/clothing/gloves/knuckles/Initialize()
+	..()
+	// KNUCKLEEES!
+	AddComponent(/datum/component/clothing_stat_affecting, list(STAT_VIG = -10, STAT_ROB = 10))

--- a/code/modules/clothing/gloves/stungloves.dm
+++ b/code/modules/clothing/gloves/stungloves.dm
@@ -16,6 +16,7 @@
 /obj/item/clothing/gloves/stungloves/Initialize()
 	. = ..()
 	cell = new /obj/item/cell/medium/high(src)
+	AddComponent(/datum/component/clothing_stat_affecting, list(STAT_BIO = -10)) // affects ability to do surgery
 	update_icon()
 
 /obj/item/clothing/gloves/stungloves/get_cell()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gloves now affect stats!
Captain gloves now give 10 vig and 5 tgh
Insuls reduce bio and vigilance by 15
Thick gloves reduce vig by 10 , bio by 8 , but increase mec by 10
Security gloves decrease bio by 15 and mec by 5
tactical security gloves increase vig by 10 and decrease bio by 10 (the ones the serbs get)
Latex gloves increase bio by 10
botanic gloves reduce vig and mec by 5 , and increase bio by 5
German gloves/  Whatever the german faction is named increase vig by 5 and reduce bio by 10
Knuckle gloves reduce vig by 10 and increase rob by 10
IH stungloves reduce bio by 10


## Why It's Good For The Game
Makes other glove types more attractive  + makes people use departamental clothing more.
+ I find it very dumb that the only dominating glove type that everyone strives to wear is insulated gloves . Each should have its own pair of weaknesses and advantages.

## Changelog
:cl:
add: Added the stat-affecting component that can be applied to any clothing
add: Added skill-effects to all gloves , these can be seen on the Examine tab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
