### PR TITLE
Grab speed now also depends on the target's robustness. Flip_in_hand no longer forces humans to lie down.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -458,6 +458,8 @@ var/global/list/items_blood_overlay_by_type = list()
 				visible_message(SPAN_WARNING("[src] picks up, spins, and drops [grabbed]."), SPAN_WARNING("You pick up, spin, and drop [grabbed]."))
 				grabbed.external_recoil(60)
 				grabbed.Weaken(1)
+				if(!ishuman(grabbed))
+					grabbed.resting = TRUE
 				grabbed.update_lying_buckled_and_verb_status()
 				unEquip(inhand_grab)
 		else

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -458,7 +458,6 @@ var/global/list/items_blood_overlay_by_type = list()
 				visible_message(SPAN_WARNING("[src] picks up, spins, and drops [grabbed]."), SPAN_WARNING("You pick up, spin, and drop [grabbed]."))
 				grabbed.external_recoil(60)
 				grabbed.Weaken(1)
-				grabbed.resting = TRUE
 				grabbed.update_lying_buckled_and_verb_status()
 				unEquip(inhand_grab)
 		else

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -274,9 +274,9 @@
 		// Negative ROB is a flat warmup increase
 		warmup_increase = assailant_stat
 	if(affecting_stat > 0)
-		warmup_increase = affecting_stat ** 0.8
+		warmup_increase += affecting_stat ** 0.8
 	else
-		warmup_increase = -(affecting_stat ** 0.6)
+		warmup_increase += -(affecting_stat ** 0.6)
 
 	var/total_warmup = max(0, UPGRADE_WARMUP + round(warmup_increase))
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -276,7 +276,7 @@
 	if(affecting_stat > 0)
 		warmup_increase += affecting_stat ** 0.8
 	else
-		warmup_increase += -(affecting_stat ** 0.6)
+		warmup_increase += affecting_stat ** 0.6
 
 	var/total_warmup = max(0, UPGRADE_WARMUP + round(warmup_increase))
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -272,7 +272,7 @@
 		warmup_increase = -(assailant_stat ** 0.8)
 	else
 		// Negative ROB is a flat warmup increase
-		warmup_increase = assailant_stat
+		warmup_increase = abs(assailant_stat)
 	if(affecting_stat > 0)
 		warmup_increase += affecting_stat ** 0.8
 	else

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -265,6 +265,7 @@
 
 	// Adjust the grab warmup using assailant's ROB stat
 	var/assailant_stat = assailant?.stats.getStat(STAT_ROB)
+	var/affecting_stat = affecting?.stats.getStat(STAT_ROB)
 	var/warmup_increase
 	if(assailant_stat > 0)
 		// Positive ROB decreases warmup, but not linearly
@@ -272,6 +273,10 @@
 	else
 		// Negative ROB is a flat warmup increase
 		warmup_increase = assailant_stat
+	if(affecting_stat > 0)
+		warmup_increase = affecting_stat ** 0.8
+	else
+		warmup_increase -(affecting_stat ** 0.6)
 
 	var/total_warmup = max(0, UPGRADE_WARMUP + round(warmup_increase))
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -276,7 +276,7 @@
 	if(affecting_stat > 0)
 		warmup_increase = affecting_stat ** 0.8
 	else
-		warmup_increase -(affecting_stat ** 0.6)
+		warmup_increase = -(affecting_stat ** 0.6)
 
 	var/total_warmup = max(0, UPGRADE_WARMUP + round(warmup_increase))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Grab speed now takes into account the affected's robustness, increasing its speed.
Flip_in_hand no longer forcibly rests people.
## Why It's Good For The Game
Instant-grabs are bad for the game , and flip-in-hand was just obscure abuse.
## Changelog
:cl:
balance: Grab speed also takes the affected's robustnesss into account now
balance: flip-in-hand no longer forces people to rest
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
