### PR TITLE
Rig Removal Now Drilling Instead Of Welding (Reverts #7389)

### DIFF
--- a/code/modules/surgery/hardsuit.dm
+++ b/code/modules/surgery/hardsuit.dm
@@ -1,7 +1,7 @@
 //Procedures in this file: hardsuit removal
 
 /datum/old_surgery_step/hardsuit
-	required_tool_quality = QUALITY_WELDING
+	required_tool_quality = QUALITY_DRILLING //Prevent conflict with healing, ported from ThePainkiller PR on Sojourn
 	required_stat = STAT_MEC
 
 	can_infect = 0
@@ -16,8 +16,8 @@
 
 /datum/old_surgery_step/hardsuit/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message(
-		SPAN_NOTICE("[user] starts cutting through the support systems of [target]'s [target.back] with \the [tool]."),
-		SPAN_NOTICE("You start cutting through the support systems of [target]'s [target.back] with \the [tool].")
+		SPAN_NOTICE("[user] starts drilling through the support systems of [target]'s [target.back] with \the [tool]."),
+		SPAN_NOTICE("You start drilling through the support systems of [target]'s [target.back] with \the [tool].")
 	)
 	..()
 
@@ -27,8 +27,8 @@
 		return
 	rig.reset()
 	user.visible_message(
-		SPAN_NOTICE("[user] has cut through the support systems of [target]'s [rig] with \the [tool]."),
-		SPAN_NOTICE("You have cut through the support systems of [target]'s [rig] with \the [tool].")
+		SPAN_NOTICE("[user] has drilled through the support systems of [target]'s [rig] with \the [tool]."),
+		SPAN_NOTICE("You have drilled through the support systems of [target]'s [rig] with \the [tool].")
 	)
 
 /datum/old_surgery_step/hardsuit/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/robotic_damage.dm
+++ b/code/modules/surgery/robotic_damage.dm
@@ -45,8 +45,6 @@
 
 /datum/surgery_step/robotic/fix_brute/can_use(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
 	if(..())
-		if(organ.owner.wearing_rig)
-			return FALSE
 		if(organ.brute_dam <= 0)
 			to_chat(user, SPAN_NOTICE("The hull of [organ.get_surgery_name()] is undamaged!"))
 			return SURGERY_FAILURE

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -226,8 +226,8 @@ proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool, var/surgery
 				return TRUE
 
 			if(QUALITY_WELDING)
-				try_surgery_step(/datum/surgery_step/robotic/fix_brute, user, tool)
-				return TRUE
+				if(try_surgery_step(/datum/surgery_step/robotic/fix_brute, user, tool))
+					return TRUE
 
 			if(ABORT_CHECK)
 				return TRUE

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -226,8 +226,8 @@ proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool, var/surgery
 				return TRUE
 
 			if(QUALITY_WELDING)
-				if(try_surgery_step(/datum/surgery_step/robotic/fix_brute, user, tool))
-					return TRUE
+				try_surgery_step(/datum/surgery_step/robotic/fix_brute, user, tool)
+				return TRUE
 
 			if(ABORT_CHECK)
 				return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR reverts SPCR's PR below
https://github.com/discordia-space/CEV-Eris/pull/7389
As the PR above broke healing for FBPs as long as they wore rigs, making them attempt to cut through the rig when using a welder.
He was made aware of this after the merge, but declined to fix the new bug that came from it.

So this PR ports changes made in the PR below by https://github.com/ThePainkiller
https://github.com/sojourn-13/sojourn-station/pull/1579
Which change the quality needed to remove hardsuits from FBPs forcibly to drilling. This bypasses the bug that SPCR's PR fixed.

Note that you will need a tool with only drilling, which limits this to the surgical drill. Trying to use a combi driver or electric screwdriver will open the FBPs torso instead.
I'm fine with this since surgical drills are underused anyway, are not rare by any means and can be printed to my knowledge.
Currently you can get surgical drills from;
- Medical surgery.
- IronHammer surgery.
- Old medbay in maints.
- Spawns in deep maints surgery.
- Surgery kits which any antagonist with an uplink can spawn in.
- Trash piles as mentioned before.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The previous change fucked over FBP players trying to heal themselves in rigs, and the coder was unwilling to make a fix for it.
This change allows FBP players to heal themselves and lets an underused tool have more relevance.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Changed the quality needed for rig removal from welding to drilling
add: Changed the flavour text shown to the player to reference drilling rather than welding
del: Reverts the old PR fix
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
