### PR TITLE
Fix frequency runtimes in atmos machineries

### DIFF
--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -681,7 +681,7 @@
 	power_draw_idle = 5
 	power_draw_per_use = 40
 	cooldown_per_use = 5
-	var/frequency = 1441
+	var/frequency = 1457
 	var/code = 30
 	var/datum/radio_frequency/radio_connection
 	var/hearing_range = 1
@@ -695,8 +695,6 @@
 
 /obj/item/integrated_circuit/input/signaler/Destroy()
 	SSradio.remove_object(src,frequency)
-	QDEL_NULL(radio_connection)
-	frequency = 0
 	return ..()
 
 /obj/item/integrated_circuit/input/signaler/on_data_written()


### PR DESCRIPTION
## About The Pull Request

Switch frequency of integrated circuits to 1457 (the frequency used by other small devices of that kind like remote signaling devices or computer network cards).
Fix their Destroy function to be in line with other devices that listen to a radio frequency.

## Why It's Good For The Game

Stop the thousands of runtimes in atmos machines

## Changelog
:cl: Hyperio
tweak: Switch frequency of integrated circuits to 1457
tweak: Modify the Destroy function of integrated circuits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
