### PR TITLE
Fixes technomancer radio broadcasting , makes eyes less susceptible to eye damage

### DIFF
--- a/code/game/objects/items/devices/techno_tribalism.dm
+++ b/code/game/objects/items/devices/techno_tribalism.dm
@@ -16,6 +16,7 @@
 	var/max_count = 5
 	var/cooldown = 20 MINUTES
 	var/obj/item/device/radio/internal_radio
+	var/radio_broadcasting = TRUE
 
 /obj/item/device/techno_tribalism/New()
 	..()
@@ -24,7 +25,7 @@
 /obj/item/device/techno_tribalism/Initialize()
 	..()
 	internal_radio = new /obj/item/device/radio{channels=list("Engineering")}(src)
-	internal_radio.broadcasting = TRUE
+	radio_broadcasting = TRUE
 
 /obj/item/device/techno_tribalism/Destroy()
 	for(var/mob/living/carbon/human/H in viewers(get_turf(src)))
@@ -39,7 +40,7 @@
 	if(user.a_intent == I_HELP && W.get_tool_quality(QUALITY_SCREW_DRIVING))
 		if(internal_radio.broadcasting == FALSE)
 			to_chat(user, "You reenable the [src]'s internal radio broadcaster")
-			internal_radio.broadcasting = TRUE
+			radio_broadcasting = TRUE
 	if(user.a_intent != I_DISARM)
 		to_chat(user, "You need to be in a disarming stance to insert items into the [src]")
 		return FALSE
@@ -193,13 +194,14 @@
 		visible_message("\icon The [src] beeps, \"The [src] needs time to cooldown.\".")
 
 /obj/item/device/techno_tribalism/proc/alert_technomancers()
-	if(internal_radio.broadcasting)
+	if(radio_broadcasting)
 		internal_radio.autosay("The [src]'s cooldown has expired. It is ready to produce another oddity", "Techno-Tribalism enforcer", "Engineering", TRUE)
 
 /obj/item/device/techno_tribalism/emp_act(severity)
 	..()
 	if(severity)
-		internal_radio.broadcasting = FALSE // lets people emp to prevent broadcasting
+		// lets people emp to prevent broadcasting
+		radio_broadcasting = FALSE
 
 /obj/item/device/techno_tribalism/examine(user)
 	..()

--- a/code/game/objects/items/devices/techno_tribalism.dm
+++ b/code/game/objects/items/devices/techno_tribalism.dm
@@ -38,7 +38,7 @@
 	if(nt_sword_attack(W, user))
 		return FALSE
 	if(user.a_intent == I_HELP && W.get_tool_quality(QUALITY_SCREW_DRIVING))
-		if(internal_radio.broadcasting == FALSE)
+		if(radio_broadcasting == FALSE)
 			to_chat(user, "You reenable the [src]'s internal radio broadcaster")
 			radio_broadcasting = TRUE
 	if(user.a_intent != I_DISARM)

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -9,6 +9,8 @@
 	max_blood_storage = 10
 	oxygen_req = 1
 	nutriment_req = 1
+	min_bruised_damage = 40
+	min_broken_Damage = 70
 	var/eyes_color = "#000000"
 	var/robo_color = "#000000"
 	var/cache_key = BP_EYES

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -10,7 +10,7 @@
 	oxygen_req = 1
 	nutriment_req = 1
 	min_bruised_damage = 40
-	min_broken_Damage = 70
+	min_broken_damage = 70
 	var/eyes_color = "#000000"
 	var/robo_color = "#000000"
 	var/cache_key = BP_EYES


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Eyes now need 70 eye damage to go broken , instead of 30.
Technomancer radio no longer brodcasts all conversations near it

## Why It's Good For The Game
Flashes too op , radio is not a CIA machine


## Changelog
:cl:
fix: Fixed techno-radio broadcasting
balance: Made eyes take double the damage to be broken,
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
