### PR TITLE
Fixes organ naming , bluespace short-wave radio

### DIFF
--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -50,7 +50,7 @@
 		if(prints_prosthetics)
 			O.nature = MODIFICATION_SILICON
 			O.icon_state = "[O.icon_state]_robotic"
-			O.name = "robotic + [O.name]"
+			O.name = "robotic [O.name]"
 		else if(loaded_dna)
 			visible_message("<span class='notice'>The printer injects the stored DNA into the biomass.</span>.")
 			O.transplant_data = list()

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -778,15 +778,15 @@ var/global/list/default_medbay_channels = list(
 	var/bluespace_cooldown = 10 MINUTES
 	var/last_bluespace = 0
 	var/bluespace_items = list(
-		25 = /obj/item/computer_hardware/hard_drive/portable/design/guns/dallas,
-		25 = /obj/item/gun/energy/plasma/stranger,
-		25 = /obj/machinery/artifact, // joy
-		5 = /obj/item/computer_hardware/hard_drive/portable/design/guns/fs_wintermute,
-		5 = /obj/item/computer_hardware/hard_drive/portable/design/excelsior/ak47,
-		5 = /datum/armament/item/disk/nt_lightfall,
-		1 = /obj/item/cell/small/hyper,
-		1 = /obj/item/cell/medium/hyper,
-		1 = /obj/item/bluespace_crystal
+		/obj/item/computer_hardware/hard_drive/portable/design/guns/dallas = 25,
+		/obj/item/gun/energy/plasma/stranger = 25,
+		/obj/machinery/artifact = 25,
+		/obj/item/computer_hardware/hard_drive/portable/design/guns/fs_wintermute = 5,
+		/obj/item/computer_hardware/hard_drive/portable/design/excelsior/ak47 = 5,
+		/obj/item/computer_hardware/hard_drive/portable/design/nt/nt_lightfall = 5,
+		/obj/item/cell/small/hyper = 1,
+		/obj/item/cell/medium/hyper = 1,
+		/obj/item/bluespace_crystal = 1
 	)
 	w_class = ITEM_SIZE_BULKY
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the guild radio and robotic organs
## Why It's Good For The Game

Fix good

## Changelog
:cl:

fix: Fixed shortwave radio not spawning bluespace items
fix: Fixed organ naming having a + in the middle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
