### PR TITLE
Melee grab specials: first aid, damage, flipping changes, COUNTERS

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -479,11 +479,20 @@ var/global/list/items_blood_overlay_by_type = list()
 							if(istype(S, /obj/structure/window))
 								visible_message(SPAN_WARNING("[grabbed] slams into the window!"))
 								grabbed.damage_through_armor(25, BRUTE, BP_CHEST, ARMOR_MELEE)
+								
 								moves = 3
 								break
 							if(istype(S, /obj/structure/railing))
 								visible_message(SPAN_WARNING("[grabbed] falls over the railing!"))
 								grabbed.forceMove(get_step(grabbed, whip_dir))
+
+								moves = 3
+								break
+							if(istype(S, /obj/structure/table))
+								visible_message(SPAN_WARNING("[grabbed] falls on the table!"))
+								grabbed.forceMove(get_step(grabbed, whip_dir))
+								grabbed.Weaken(5)
+
 								moves = 3
 								break
 						step_glide(grabbed, whip_dir,(DELAY2GLIDESIZE(0.2 SECONDS)))//very fast

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -475,18 +475,18 @@ var/global/list/items_blood_overlay_by_type = list()
 							grabbed.damage_through_armor(15, BRUTE, BP_CHEST, ARMOR_MELEE)
 							break
 						
-						else
-							for(var/obj/structure/S in get_step(grabbed, whip_dir))
-								switch(S)
-									if(/obj/structure/window)
-										visible_message(SPAN_WARNING("[grabbed] slams into the window!"))
-										grabbed.damage_through_armor(25, BRUTE, BP_CHEST, ARMOR_MELEE)
-										break
-									if(/obj/structure/railing)
-										visible_message(SPAN_WARNING("[grabbed] falls over the railing!"))
-										grabbed.forceMove(get_step(grabbed, whip_dir))
-										break
-						step_glide(grabbed, whip_dir,(DELAY2GLIDESIZE(0.1 SECONDS)))
+						for(var/obj/structure/S in get_step(grabbed, whip_dir))
+							if(istype(S, /obj/structure/window))
+								visible_message(SPAN_WARNING("[grabbed] slams into the window!"))
+								grabbed.damage_through_armor(25, BRUTE, BP_CHEST, ARMOR_MELEE)
+								moves = 3
+								break
+							if(istype(S, /obj/structure/railing))
+								visible_message(SPAN_WARNING("[grabbed] falls over the railing!"))
+								grabbed.forceMove(get_step(grabbed, whip_dir))
+								moves = 3
+								break
+						step_glide(grabbed, whip_dir,(DELAY2GLIDESIZE(0.2 SECONDS)))//very fast
 
 					//admin messaging
 					src.attack_log += text("\[[time_stamp()]\] <font color='red'>Irish-whipped [grabbed.name] ([grabbed.ckey])</font>")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -477,19 +477,19 @@ var/global/list/items_blood_overlay_by_type = list()
 						
 						for(var/obj/structure/S in get_step(grabbed, whip_dir))
 							if(istype(S, /obj/structure/window))
-								visible_message(SPAN_WARNING("[grabbed] slams into the window!"))
+								visible_message(SPAN_WARNING("[grabbed] slams into \the [S]!"))
 								grabbed.damage_through_armor(25, BRUTE, BP_CHEST, ARMOR_MELEE)
 								
 								moves = 3
 								break
 							if(istype(S, /obj/structure/railing))
-								visible_message(SPAN_WARNING("[grabbed] falls over the railing!"))
+								visible_message(SPAN_WARNING("[grabbed] falls over \the [S]!"))
 								grabbed.forceMove(get_step(grabbed, whip_dir))
 
 								moves = 3
 								break
 							if(istype(S, /obj/structure/table))
-								visible_message(SPAN_WARNING("[grabbed] falls on the table!"))
+								visible_message(SPAN_WARNING("[grabbed] falls on \the [S]!"))
 								grabbed.forceMove(get_step(grabbed, whip_dir))
 								grabbed.Weaken(5)
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -251,8 +251,8 @@
 				is_bleeding["[temp.name]"] = "<span class='danger'>[T.His] [temp.name] is bleeding!</span><br>"
 		else
 			wound_flavor_text["[temp.name]"] = ""
-		if(temp.dislocated == 2)
-			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.joint] is dislocated!</span><br>"
+		if(temp.nerve_struck == 2)
+			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.joint] is dangling uselessly!</span><br>"
 		if(((temp.status & ORGAN_BROKEN) && temp.brute_dam > temp.min_broken_damage) || (temp.status & ORGAN_MUTATED))
 			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] is dented and swollen!</span><br>"
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -692,9 +692,9 @@ var/list/rank_prefix = list(\
 		lastpuke = 1
 		if(!forced)
 			to_chat(src, SPAN_WARNING("You feel nauseous..."))
-			spawn(150)	//15 seconds until second warning
-				to_chat(src, SPAN_WARNING("You feel like you are about to throw up!"))
-				sleep(100)	//and you have 10 more for mad dash to the bucket
+			sleep(150)	//15 seconds until second warning
+			to_chat(src, SPAN_WARNING("You feel like you are about to throw up!"))
+			sleep(100)	//and you have 10 more for mad dash to the bucket
 		Stun(5)
 
 		src.visible_message(SPAN_WARNING("[src] throws up!"),SPAN_WARNING("You throw up!"))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1548,60 +1548,6 @@ var/list/rank_prefix = list(\
 	dodge_time = get_game_time()
 	confidence = FALSE
 
-/mob/living/carbon/human/proc/undislocate()
-	set category = "Object"
-	set name = "Undislocate Joint"
-	set desc = "Pop a joint back into place. Extremely painful."
-	set src in view(1)
-
-	if(!isliving(usr) || !usr.can_click())
-		return
-
-	usr.setClickCooldown(20)
-
-	if(usr.stat > 0)
-		to_chat(usr, "You are unconcious and cannot do that!")
-		return
-
-	if(usr.restrained())
-		to_chat(usr, "You are restrained and cannot do that!")
-		return
-
-	var/mob/S = src
-	var/mob/U = usr
-	var/self
-	if(S == U)
-		self = 1 // Removing object from yourself.
-
-	var/list/limbs = list()
-	for(var/limb in organs_by_name)
-		var/obj/item/organ/external/current_limb = organs_by_name[limb]
-		if(current_limb && current_limb.dislocated == 2)
-			limbs |= limb
-	var/choice = input(usr,"Which joint do you wish to relocate?") as null|anything in limbs
-
-	if(!choice)
-		return
-
-	var/obj/item/organ/external/current_limb = organs_by_name[choice]
-
-	if(self)
-		to_chat(src, SPAN_WARNING("You brace yourself to relocate your [current_limb.joint]..."))
-	else
-		to_chat(U, SPAN_WARNING("You begin to relocate [S]'s [current_limb.joint]..."))
-
-	if(!do_after(U, 30, src))
-		return
-	if(!choice || !current_limb || !S || !U)
-		return
-
-	if(self)
-		to_chat(src, SPAN_DANGER("You pop your [current_limb.joint] back in!"))
-	else
-		to_chat(U, SPAN_DANGER("You pop [S]'s [current_limb.joint] back in!"))
-		to_chat(S, SPAN_DANGER("[U] pops your [current_limb.joint] back in!"))
-	current_limb.undislocate()
-
 /mob/living/carbon/human/reset_view(atom/A, update_hud = 1)
 	..()
 	if(update_hud)
@@ -1739,8 +1685,8 @@ var/list/rank_prefix = list(\
 			status += "MISSING"
 		if(org.status & ORGAN_MUTATED)
 			status += "weirdly shapen"
-		if(org.dislocated == 2)
-			status += "dislocated"
+		if(org.nerve_struck == 2)
+			status += "torpid"
 		if(org.status & ORGAN_BROKEN)
 			status += "hurts when touched"
 		if(org.status & ORGAN_DEAD)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -682,7 +682,7 @@ var/list/rank_prefix = list(\
 		return FALSE
 	return TRUE
 
-/mob/living/carbon/human/vomit()
+/mob/living/carbon/human/vomit(var/forced = 0)
 
 	if(!check_has_mouth())
 		return
@@ -690,26 +690,27 @@ var/list/rank_prefix = list(\
 		return
 	if(!lastpuke)
 		lastpuke = 1
-		to_chat(src, SPAN_WARNING("You feel nauseous..."))
-		spawn(150)	//15 seconds until second warning
-			to_chat(src, SPAN_WARNING("You feel like you are about to throw up!"))
-			spawn(100)	//and you have 10 more for mad dash to the bucket
-				Stun(5)
+		if(!forced)
+			to_chat(src, SPAN_WARNING("You feel nauseous..."))
+			spawn(150)	//15 seconds until second warning
+				to_chat(src, SPAN_WARNING("You feel like you are about to throw up!"))
+				sleep(100)	//and you have 10 more for mad dash to the bucket
+		Stun(5)
 
-				src.visible_message(SPAN_WARNING("[src] throws up!"),SPAN_WARNING("You throw up!"))
-				playsound(loc, 'sound/effects/splat.ogg', 50, 1)
+		src.visible_message(SPAN_WARNING("[src] throws up!"),SPAN_WARNING("You throw up!"))
+		playsound(loc, 'sound/effects/splat.ogg', 50, 1)
 
-				var/turf/location = loc
-				if(istype(location, /turf/simulated))
-					location.add_vomit_floor(src, 1)
+		var/turf/location = loc
+		if(istype(location, /turf/simulated))
+			location.add_vomit_floor(src, 1)
 
-				adjustNutrition(-40)
-				adjustToxLoss(-3)
-				regen_slickness(-3)
-				dodge_time = get_game_time()
-				confidence = FALSE
-				spawn(350)	//wait 35 seconds before next volley
-					lastpuke = 0
+		adjustNutrition(-40)
+		adjustToxLoss(-3)
+		regen_slickness(-3)
+		dodge_time = get_game_time()
+		confidence = FALSE
+		spawn(350)	//wait 35 seconds before next volley
+			lastpuke = 0
 
 /mob/living/carbon/human/proc/morph()
 	set name = "Morph"

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -381,9 +381,9 @@
 	user.visible_message(SPAN_WARNING("[user] hits [src]'s [organ.joint] right in the nerve!")) //everyone knows where it is, obviously
 
 	organ.nerve_strike_add(1)
-	src.visible_message(SPAN_DANGER("[src]'s [organ.joint] [pick("jitters","convulses","stirs","shakes")] and dangles about!"), (SPAN_DANGER("\bold As [user]'s hit connects with your [organ.joint], you feel it painfully tingle before going numb!")))
+	src.visible_message(SPAN_DANGER("[src]'s [organ.joint] [pick("jitters","convulses","stirs","shakes")] and dangles about!"), (SPAN_DANGER("As [user]'s hit connects with your [organ.joint], you feel it painfully tingle before going numb!")))
 	playsound(user, 'sound/weapons/throwtap.ogg', 50, 1)
-	src.adjustHalLoss(rand(10,20))
+	src.damage_through_armor(rand(5,10), HALLOSS, target_zone, ARMOR_MELEE, wounding_multiplier = 2)
 
 	//kill the grab
 	user.drop_from_inventory(G)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -110,7 +110,7 @@
 			for(var/obj/item/grab/g in get_both_hands(src)) //countering a grab
 
 				if(g.counter_timer>0) //were we grabbed by src in a span of 3 seconds?
-					if(prob(max(50 + H.stats.getStat(STAT_ROB) - stats.getStat(STAT_ROB) ** 0.7, 1))) // Harder between low rob, easier between high rob wrestlers
+					if(prob(max(30 + H.stats.getStat(STAT_ROB) - stats.getStat(STAT_ROB) ** 0.7, 1))) // Harder between low rob, easier between high rob wrestlers
 						var/obj/item/grab/G = new /obj/item/grab(M, src)
 						if(!G)	//the grab will delete itself in New if affecting is anchored
 							return
@@ -132,7 +132,7 @@
 						return 1						
 
 					else //uh oh! our resist is now also on cooldown(we are dead)
-						setClickCooldown(20)
+						setClickCooldown(40)
 						visible_message(SPAN_WARNING("[M] tried to counter [src]'s grab, but failed!"))
 					
 				return

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -106,6 +106,36 @@
 			if(w_uniform)
 				w_uniform.add_fingerprint(M)
 
+
+			for(var/obj/item/grab/g in get_both_hands(src)) //countering a grab
+
+				if(g.counter_timer>0) //were we grabbed by src in a span of 3 seconds?
+					if(prob(max(50 + H.stats.getStat(STAT_ROB) - stats.getStat(STAT_ROB) ** 0.7, 1))) // Harder between low rob, easier between high rob wrestlers
+						var/obj/item/grab/G = new /obj/item/grab(M, src)
+						if(!G)	//the grab will delete itself in New if affecting is anchored
+							return
+						G.state = GRAB_AGGRESSIVE
+						M.put_in_active_hand(G)
+						G.synch()
+						LAssailant = M
+						H.regen_slickness() //sick skills!
+
+						break_all_grabs(H)
+
+						H.do_attack_animation(src)
+						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+						visible_message(SPAN_DANGER("With a quick grapple, [M] reversed [src]'s grab!"))
+						src.attack_log += "\[[time_stamp()]\] <font color='orange'>Counter-grabbed by [M.name] ([M.ckey])</font>"
+						M.attack_log += "\[[time_stamp()]\] <font color='red'>Counter-grabbed [src.name] ([src.ckey])</font>"
+						msg_admin_attack("[M] countered [src]'s grab.")
+						return 1						
+
+					else //uh oh! our resist is now also on cooldown(we are dead)
+						setClickCooldown(20)
+						visible_message(SPAN_WARNING("[M] tried to counter [src]'s grab, but failed!"))
+					
+				return
+			//usual grabs
 			var/obj/item/grab/G = new /obj/item/grab(M, src)
 			if(buckled)
 				to_chat(M, SPAN_NOTICE("You cannot grab [src], \he is buckled in!"))

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -109,7 +109,7 @@
 
 			for(var/obj/item/grab/g in get_both_hands(src)) //countering a grab
 
-				if(g.counter_timer>0) //were we grabbed by src in a span of 3 seconds?
+				if(g.counter_timer>0 && g.affecting == M) //were we grabbed by src in a span of 3 seconds?
 					if(prob(max(30 + H.stats.getStat(STAT_ROB) - stats.getStat(STAT_ROB) ** 0.7, 1))) // Harder between low rob, easier between high rob wrestlers
 						var/obj/item/grab/G = new /obj/item/grab(M, src)
 						if(!G)	//the grab will delete itself in New if affecting is anchored

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -115,6 +115,7 @@
 						if(!G)	//the grab will delete itself in New if affecting is anchored
 							return
 						G.state = GRAB_AGGRESSIVE
+						G.counter_timer = 0
 						M.put_in_active_hand(G)
 						G.synch()
 						LAssailant = M

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -289,7 +289,7 @@ meteor_act
 		if(!..(I, user, effective_force, hit_zone))
 			return FALSE
 
-		attack_joint(affecting, I) //but can dislocate joints
+		attack_joint(affecting, I) //but can dislocate(strike nerve) joints
 	else if(!..())
 		return FALSE
 
@@ -336,12 +336,12 @@ meteor_act
 	return TRUE
 
 /mob/living/carbon/human/proc/attack_joint(var/obj/item/organ/external/organ, var/obj/item/W)
-	if(!organ || (organ.dislocated == 2) || (organ.dislocated == -1) )
+	if(!organ || (organ.nerve_struck == 2) || (organ.nerve_struck == -1))
 		return FALSE
 	//There was blocked var, removed now. For the sake of game balance, it was just replaced by 2
 	if(prob(W.force / 2))
 		visible_message("<span class='danger'>[src]'s [organ.joint] [pick("gives way","caves in","crumbles","collapses")]!</span>")
-		organ.dislocate(1)
+		organ.nerve_strike_add(1)
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -126,7 +126,7 @@
 		if(!E || !(E.functions & BODYPART_GRASP) || (E.status & ORGAN_SPLINTED))
 			continue
 
-		if(E.is_broken() || E.is_dislocated() || E.limb_efficiency <= 50)
+		if(E.is_broken() || E.is_nerve_struck() || E.limb_efficiency <= 50)
 			switch(E.body_part)
 				if(ARM_LEFT)
 					if(!l_hand)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -400,7 +400,7 @@
 	//clicking on the victim while grabbing them
 	if(M == affecting)
 		if(ishuman(affecting))
-			var/obj/item/organ/hit_zone = assailant.targeted_organ
+			var/obj/item/organ/external/hit_zone = assailant.targeted_organ
 			flick(hud.icon_state, hud)
 			switch(assailant.a_intent)
 				if(I_HELP)
@@ -411,12 +411,17 @@
 						msg_admin_attack("[key_name(assailant)] Released from pin [key_name(affecting)]")
 						force_down = 0
 						return
-					if(hit_zone.status & ORGAN_BLEEDING)
-						slow_bleeding(affecting, assailant, hit_zone)
-					if(hit_zone == BP_MOUTH)
+					else if(hit_zone == BP_MOUTH)
 						force_vomit(affecting, assailant)
-					else
-						inspect_organ(affecting, assailant, hit_zone)
+					else 
+						if(ishuman(affecting))
+							var/mob/living/carbon/human/H = affecting
+							for(hit_zone in H.get_damaged_organs(1, 0))
+								if(hit_zone.status & ORGAN_BLEEDING)
+									visible_message(SPAN_WARNING("slow_bleeding"))
+									slow_bleeding(affecting, assailant, hit_zone)
+								else
+									inspect_organ(affecting, assailant, hit_zone)
 
 				if(I_GRAB)
 					jointlock(affecting, assailant, hit_zone)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -414,14 +414,14 @@
 					else if(hit_zone == BP_MOUTH)
 						force_vomit(affecting, assailant)
 					else 
-						if(ishuman(affecting))
-							var/mob/living/carbon/human/H = affecting
-							for(hit_zone in H.get_damaged_organs(1, 0))
-								if(hit_zone.status & ORGAN_BLEEDING)
-									visible_message(SPAN_WARNING("slow_bleeding"))
-									slow_bleeding(affecting, assailant, hit_zone)
-								else
-									inspect_organ(affecting, assailant, hit_zone)
+						var/mob/living/carbon/human/H = affecting
+						var/obj/item/organ/external/o = H.get_organ(hit_zone)
+						
+						if(o.status & ORGAN_BLEEDING)
+							visible_message(SPAN_WARNING("slow_bleeding"))
+							slow_bleeding(affecting, assailant, o)
+						else
+							inspect_organ(affecting, assailant, hit_zone)
 
 				if(I_GRAB)
 					jointlock(affecting, assailant, hit_zone)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -421,7 +421,6 @@
 						var/obj/item/organ/external/o = H.get_organ(hit_zone)
 						
 						if(o.status & ORGAN_BLEEDING)
-							visible_message(SPAN_WARNING("slow_bleeding"))
 							slow_bleeding(affecting, assailant, o)
 						else
 							inspect_organ(affecting, assailant, hit_zone)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -28,8 +28,11 @@
 	var/last_hit_zone = 0
 	var/force_down //determines if the affecting mob will be pinned to the ground
 	var/dancing //determines if assailant and affecting keep looking at each other.
-				//Basically a wrestling position
 
+	var/counter_timer = 3 SECONDS //sets to 3 seconds after being grabbed
+
+/obj/item/grab/proc/tick()
+	counter_timer--
 
 /obj/proc/affect_grab(var/mob/user, var/mob/target, var/state)
 	return FALSE

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -400,7 +400,7 @@
 	//clicking on the victim while grabbing them
 	if(M == affecting)
 		if(ishuman(affecting))
-			var/hit_zone = assailant.targeted_organ
+			var/obj/item/organ/hit_zone = assailant.targeted_organ
 			flick(hud.icon_state, hud)
 			switch(assailant.a_intent)
 				if(I_HELP)
@@ -411,7 +411,12 @@
 						msg_admin_attack("[key_name(assailant)] Released from pin [key_name(affecting)]")
 						force_down = 0
 						return
-					inspect_organ(affecting, assailant, hit_zone)
+					if(hit_zone.status & ORGAN_BLEEDING)
+						slow_bleeding(affecting, assailant, hit_zone)
+					if(hit_zone == BP_MOUTH)
+						force_vomit(affecting, assailant)
+					else
+						inspect_organ(affecting, assailant, hit_zone)
 
 				if(I_GRAB)
 					jointlock(affecting, assailant, hit_zone)
@@ -422,9 +427,11 @@
 					else if(hit_zone == BP_HEAD)
 						headbutt(affecting, assailant)
 					else if(hit_zone == BP_CHEST)
-						suplex(affecting, assailant)
+						if(state < GRAB_NECK)
+							dropkick(affecting, assailant)
+						else suplex(affecting, assailant)
 					else if(hit_zone == BP_GROIN)
-						dropkick(affecting, assailant)
+						gut_punch(affecting, assailant)
 					else
 						dislocate(affecting, assailant, hit_zone)
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -31,8 +31,9 @@
 
 	var/counter_timer = 3 SECONDS //sets to 3 seconds after being grabbed
 
-/obj/item/grab/proc/tick()
+/obj/item/grab/Process()
 	counter_timer--
+	..()
 
 /obj/proc/affect_grab(var/mob/user, var/mob/target, var/state)
 	return FALSE

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -441,7 +441,7 @@
 					else if(hit_zone == BP_GROIN)
 						gut_punch(affecting, assailant)
 					else
-						dislocate(affecting, assailant, hit_zone)
+						nerve_strike(affecting, assailant, hit_zone)
 
 				if(I_DISARM)
 					pin_down(affecting, assailant)

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -43,27 +43,21 @@
 		if(!bad)
 			to_chat(user, SPAN_NOTICE("[H]'s skin is normal."))
 
-/obj/item/grab/proc/slow_bleeding(mob/living/carbon/human/H, mob/user, var/target_zone)
-	var/obj/item/organ/external/E = H.get_organ(target_zone)
+/obj/item/grab/proc/slow_bleeding(mob/living/carbon/human/H, mob/user, var/obj/item/organ/external/bodypart)
 
-	if(BP_IS_SILICON(E))
-		to_chat(user, SPAN_WARNING("[E.name] is robotic, and direct pressure cannot stop the bleeding!"))
+	if(bodypart.is_stump() || !bodypart)
+		to_chat(user, SPAN_WARNING("They are missing that limb!"))
 		return
 	else
-		if(E.is_stump() && E.parent)
-			to_chat(user, SPAN_WARNING("They are missing that limb!"))
+		visible_message(SPAN_WARNING("[user] starts putting pressure on [H]'s wounds to stop the wounds on \his [bodypart.name] from bleeding!"))
+		if(!do_mob(user, H, 50))//5 seconds
+			to_chat(user, SPAN_NOTICE("You must stand still to stop the bleeding."))
 			return
-		if(E.status & ORGAN_BLEEDING)
-			visible_message(SPAN_WARNING("[user] starts putting pressure on [H]'s wounds to stop the wounds on \his [E.name] from bleeding!"))
-			if(!do_mob(user, H, 10))
-				to_chat(user, SPAN_NOTICE("You must stand still to stop the bleeding."))
-				return
-			else
-				visible_message(SPAN_NOTICE("[user] finishes putting pressure on [H]'s wounds."))
-				for(var/datum/wound/W in E.wounds)
-					W.current_stage++
-					W.bleed_timer -= 5
-
+		else
+			visible_message(SPAN_NOTICE("[user] finishes putting pressure on [H]'s wounds."))
+			for(var/datum/wound/W in bodypart.wounds)
+				W.current_stage++
+				W.bleed_timer -= 5
 	//do not kill the grab
 
 

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -66,7 +66,7 @@
 	visible_message(SPAN_WARNING("[attacker] places a finger in [target]'s throat, trying to induce vomiting."))//ewwies
 	attacker.next_move = world.time + 10 //1 second, also should prevent user from triggering this repeatedly
 	for(var/obj/item/protection in list(target.head, target.wear_mask, target.glasses))
-		if(protection && (protection.body_parts_covered & EYES))
+		if(protection && (protection.body_parts_covered & FACE))
 			to_chat(attacker, SPAN_DANGER("You can't induce vomiting while [target]'s mouth is covered."))
 			return
 

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -78,7 +78,7 @@
 		to_chat(attacker, SPAN_WARNING("You require a better grab to do this."))
 		return
 	var/obj/item/organ/external/organ = target.get_organ(check_zone(target_zone))
-	if(!organ || organ.dislocated == -1)
+	if(!organ || organ.nerve_struck == -1)
 		return
 
 	if(!do_after(attacker, 7 SECONDS, target))
@@ -207,10 +207,7 @@
 	qdel(src)
 	return
 
-/obj/item/grab/proc/dislocate(mob/living/carbon/human/target, mob/living/attacker, var/target_zone)
-	if(state < GRAB_NECK)
-		to_chat(attacker, SPAN_WARNING("You require a better grab to do this."))
-		return
+/obj/item/grab/proc/nerve_strike(mob/living/carbon/human/target, mob/living/attacker, var/target_zone)
 	if(target.grab_joint(attacker, target_zone))
 		return
 

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -43,6 +43,42 @@
 		if(!bad)
 			to_chat(user, SPAN_NOTICE("[H]'s skin is normal."))
 
+/obj/item/grab/proc/slow_bleeding(mob/living/carbon/human/H, mob/user, var/target_zone)
+	var/obj/item/organ/external/E = H.get_organ(target_zone)
+
+	if(BP_IS_SILICON(E))
+		to_chat(user, SPAN_WARNING("[E.name] is robotic, and direct pressure cannot stop the bleeding!"))
+		return
+	else
+		if(E.is_stump() && E.parent)
+			to_chat(user, SPAN_WARNING("They are missing that limb!"))
+			return
+		if(E.status & ORGAN_BLEEDING)
+			visible_message(SPAN_WARNING("[user] starts putting pressure on [H]'s wounds to stop the wounds on \his [E.name] from bleeding!"))
+			if(!do_mob(user, H, 10))
+				to_chat(user, SPAN_NOTICE("You must stand still to stop the bleeding."))
+				return
+			else
+				visible_message(SPAN_NOTICE("[user] finishes putting pressure on [H]'s wounds."))
+				for(var/datum/wound/W in E.wounds)
+					W.current_stage++
+					W.bleed_timer -= 5
+
+	//do not kill the grab
+
+
+/obj/item/grab/proc/force_vomit(mob/living/carbon/human/target, mob/attacker)
+	//no check for grab levels
+	visible_message(SPAN_WARNING("[attacker] places a finger in [target]'s throat, trying to induce vomiting."))//ewwies
+	attacker.next_move = world.time + 10 //1 second, also should prevent user from triggering this repeatedly
+	if(do_after(attacker, 10, progress=0) && target)
+		//vomiting sets on cd for 35 secs, which means it's impossible to spam this
+		target.vomit(TRUE)
+		//admin messaging
+		attacker.attack_log += text("\[[time_stamp()]\] <font color='red'>Induced vomiting [target.name] ([target.ckey])</font>")
+		target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Forced to vomit by [attacker.name] ([attacker.ckey])</font>")
+		//do not kill the grab
+
 /obj/item/grab/proc/jointlock(mob/living/carbon/human/target, mob/attacker, var/target_zone)
 	if(state < GRAB_AGGRESSIVE)
 		to_chat(attacker, SPAN_WARNING("You require a better grab to do this."))
@@ -98,7 +134,7 @@
 	target.throw_at(get_edge_target_turf(target, kick_dir), 3, 1)
 	//deal damage AFTER the kick
 	var/damage = attacker.stats.getStat(STAT_ROB) / 3
-	target.damage_through_armor(damage, BRUTE, BP_GROIN, ARMOR_MELEE)
+	target.damage_through_armor(damage, BRUTE, BP_CHEST, ARMOR_MELEE)
 	attacker.regen_slickness()
 	//admin messaging
 	attacker.attack_log += text("\[[time_stamp()]\] <font color='red'>Dropkicked [target.name] ([target.ckey])</font>")
@@ -131,6 +167,21 @@
 		attacker.drop_from_inventory(src)
 		loc = null
 		qdel(src)
+
+/obj/item/grab/proc/gut_punch(mob/living/carbon/human/target, mob/living/carbon/human/attacker)
+	//no check for grab levels
+	visible_message(SPAN_DANGER("[attacker] thrusts \his fist in [target]'s guts!"))
+	var/damage = max(1, (25 - target.stats.getStat(STAT_TGH) / 2))//50+ TGH = 1 dmg
+	target.damage_through_armor(damage, BRUTE, BP_GROIN, ARMOR_MELEE)
+	//vomiting goes on cd for 35 secs, which means it's impossible to spam this
+	target.vomit(TRUE)
+	//admin messaging
+	attacker.attack_log += text("\[[time_stamp()]\] <font color='red'>Gutpunched [target.name] ([target.ckey])</font>")
+	target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Gutpunched by [attacker.name] ([attacker.ckey])</font>")
+	//kill the grab
+	attacker.drop_from_inventory(src)
+	loc = null
+	qdel(src)
 
 /obj/item/grab/proc/headbutt(mob/living/carbon/human/target, mob/living/carbon/human/attacker)
 	if(!istype(attacker))
@@ -204,7 +255,7 @@
 
 	if(can_eat)
 		var/mob/living/carbon/attacker = user
-		user.visible_message(SPAN_DANGER("[user] is attempting to devour [target]!"))
+		user.visible_message(SPAN_DANGER("[user] is atEting to devour [target]!"))
 		if(can_eat == 2)
 			if(!do_mob(user, target, 30)) return
 		else

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -65,7 +65,12 @@
 	//no check for grab levels
 	visible_message(SPAN_WARNING("[attacker] places a finger in [target]'s throat, trying to induce vomiting."))//ewwies
 	attacker.next_move = world.time + 10 //1 second, also should prevent user from triggering this repeatedly
-	if(do_after(attacker, 10, progress=0) && target)
+	for(var/obj/item/protection in list(target.head, target.wear_mask, target.glasses))
+		if(protection && (protection.body_parts_covered & EYES))
+			to_chat(attacker, SPAN_DANGER("You can't induce vomiting while [target]'s mouth is covered."))
+			return
+
+	if(do_after(attacker, 40, progress=0) && target)
 		//vomiting sets on cd for 35 secs, which means it's impossible to spam this
 		target.vomit(TRUE)
 		//admin messaging
@@ -128,7 +133,7 @@
 		kick_dir = turn(kick_dir, 180)
 	target.throw_at(get_edge_target_turf(target, kick_dir), 3, 1)
 	//deal damage AFTER the kick
-	var/damage = attacker.stats.getStat(STAT_ROB) / 3
+	var/damage = max(1, min(30, (attacker.stats.getStat(STAT_ROB) / 3)))
 	target.damage_through_armor(damage, BRUTE, BP_CHEST, ARMOR_MELEE)
 	attacker.regen_slickness()
 	//admin messaging

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -165,8 +165,8 @@
 /obj/item/grab/proc/gut_punch(mob/living/carbon/human/target, mob/living/carbon/human/attacker)
 	//no check for grab levels
 	visible_message(SPAN_DANGER("[attacker] thrusts \his fist in [target]'s guts!"))
-	var/damage = max(1, (25 - target.stats.getStat(STAT_TGH) / 2))//50+ TGH = 1 dmg
-	target.damage_through_armor(damage, BRUTE, BP_GROIN, ARMOR_MELEE)
+	var/damage = max(1, (20 - target.stats.getStat(STAT_TGH) / 2))//40+ TGH = 1 dmg
+	target.damage_through_armor(damage, BRUTE, BP_GROIN, ARMOR_MELEE, wounding_multiplier = 2)
 	//vomiting goes on cd for 35 secs, which means it's impossible to spam this
 	target.vomit(TRUE)
 	//admin messaging

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -63,13 +63,12 @@
 
 /obj/item/grab/proc/force_vomit(mob/living/carbon/human/target, mob/attacker)
 	//no check for grab levels
-	visible_message(SPAN_WARNING("[attacker] places a finger in [target]'s throat, trying to induce vomiting."))//ewwies
-	attacker.next_move = world.time + 10 //1 second, also should prevent user from triggering this repeatedly
+	attacker.next_move = world.time + 40 //4 seconds, also should prevent user from triggering this repeatedly
 	for(var/obj/item/protection in list(target.head, target.wear_mask, target.glasses))
 		if(protection && (protection.body_parts_covered & FACE))
 			to_chat(attacker, SPAN_DANGER("You can't induce vomiting while [target]'s mouth is covered."))
 			return
-
+	visible_message(SPAN_WARNING("[attacker] places a finger in [target]'s throat, trying to induce vomiting."))//ewwies
 	if(do_after(attacker, 40, progress=0) && target)
 		//vomiting sets on cd for 35 secs, which means it's impossible to spam this
 		target.vomit(TRUE)

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -249,7 +249,7 @@
 
 	if(can_eat)
 		var/mob/living/carbon/attacker = user
-		user.visible_message(SPAN_DANGER("[user] is atEting to devour [target]!"))
+		user.visible_message(SPAN_DANGER("[user] is attempting to devour [target]!"))
 		if(can_eat == 2)
 			if(!do_mob(user, target, 30)) return
 		else

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -84,8 +84,9 @@
 	if(!do_after(attacker, 7 SECONDS, target))
 		to_chat(attacker, SPAN_WARNING("You must stand still to jointlock [target]!"))
 	else
-		visible_message(SPAN_WARNING("[attacker] [pick("bent", "twisted")] [target]'s [organ.name] into a jointlock!"))
+		visible_message(SPAN_WARNING("With a forceful twist, [attacker] bents [target]'s [organ.name] into a painful jointlock!"))
 		to_chat(target, SPAN_DANGER("You feel extreme pain!"))
+		playsound(loc, 'sound/weapons/jointORbonebreak.ogg', 50, 1, -1)
 		affecting.adjustHalLoss(rand(30, 40))
 
 /obj/item/grab/proc/attack_eye(mob/living/carbon/human/target, mob/living/carbon/human/attacker)
@@ -147,11 +148,12 @@
 	attacker.next_move = world.time + 20 //2 seconds, also should prevent user from triggering this repeatedly
 	if(do_after(attacker, 20, progress=0) && target)
 		visible_message(SPAN_DANGER("...And falls backwards, slamming the opponent back onto the floor!"))
-		var/damage = min(65, attacker.stats.getStat(STAT_ROB) + 15)
+		target.SpinAnimation(5,1)
+		var/damage = min(80, attacker.stats.getStat(STAT_ROB) + 15) //WE ARE GONNA KILL YOU
 		target.damage_through_armor(damage, BRUTE, BP_CHEST, ARMOR_MELEE) //crunch
 		attacker.Weaken(2)
 		target.Stun(6)
-		playsound(loc, 'sound/weapons/pinground.ogg', 50, 1, -1)
+		playsound(loc, 'sound/weapons/jointORbonebreak.ogg', 50, 1, -1)
 		attacker.regen_slickness()
 		//admin messaging
 		attacker.attack_log += text("\[[time_stamp()]\] <font color='red'>Suplexed [target.name] ([target.ckey])</font>")
@@ -165,7 +167,7 @@
 /obj/item/grab/proc/gut_punch(mob/living/carbon/human/target, mob/living/carbon/human/attacker)
 	//no check for grab levels
 	visible_message(SPAN_DANGER("[attacker] thrusts \his fist in [target]'s guts!"))
-	var/damage = max(1, (20 - target.stats.getStat(STAT_TGH) / 2))//40+ TGH = 1 dmg
+	var/damage = max(1, (10 - target.stats.getStat(STAT_TGH) / 4))//40+ TGH = 1 dmg
 	target.damage_through_armor(damage, BRUTE, BP_GROIN, ARMOR_MELEE, wounding_multiplier = 2)
 	//vomiting goes on cd for 35 secs, which means it's impossible to spam this
 	target.vomit(TRUE)
@@ -192,6 +194,7 @@
 
 	target.damage_through_armor(damage, BRUTE, BP_HEAD, ARMOR_MELEE)
 	attacker.damage_through_armor(10, BRUTE, BP_HEAD, ARMOR_MELEE)
+	target.make_dizzy(15)
 
 	if(!victim_armor && target.headcheck(BP_HEAD) && prob(damage))
 		target.apply_effect(20, PARALYZE)

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -110,7 +110,7 @@ see multiz/movement.dm for some info.
 		return
 
 
-	// No gravit, No fall.
+	// No gravity, No fall.
 	if(!has_gravity(src))
 		return
 
@@ -152,10 +152,22 @@ see multiz/movement.dm for some info.
 					"You hear a soft whoosh.[M.stat ? "" : ".. and some screaming."]"
 				)
 			else
-				M.visible_message(
-					"\The [mover] falls from the deck above and slams into \the [below]!",
-					"You land on \the [below].", "You hear a soft whoosh and a crunch"
-				)
+				for(var/mob/living/m in below)
+					if(istype(m))//is m real?
+
+						if(ishuman(mover))//REAL SHIT
+							var/mob/living/carbon/human/H = mover
+							if(H.a_intent == I_HURT && !(m == H))
+								M.visible_message(
+									SPAN_DANGER("\The [mover] falls from the deck above and slams elbow-first into [m]!"),
+									SPAN_DANGER("You slam elbow-first into [m]!"),
+									SPAN_NOTICE("You hear a soft whoosh and a crunch.")
+									)
+					else
+						M.visible_message(
+							"\The [mover] falls from the deck above and slams into \the [below]!",
+							"You land on \the [below].", "You hear a soft whoosh and a crunch."
+						)
 
 		// Handle people getting hurt, it's funny!
 		mover.fall_impact(src, below)
@@ -164,6 +176,12 @@ see multiz/movement.dm for some info.
 
 		for(var/mob/living/M in below)
 			var/fall_damage = mover.get_fall_damage()
+			
+			if(ishuman(mover))
+				var/mob/living/carbon/human/H = mover
+				if(H.a_intent == I_HURT)
+					fall_damage = (H.mob_size + (min(min(H.stats.getStat(STAT_ROB), 1), 60) / 2)) //max is 50(a lot)
+
 			if(M == mover)
 				continue
 			if(M.getarmor(BP_HEAD, ARMOR_MELEE) < fall_damage || ismob(mover))

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -66,7 +66,7 @@
 	var/cannot_break		// Impossible to fracture.
 	var/joint = "joint"		// Descriptive string used in dislocation.
 	var/amputation_point	// Descriptive string used in amputation.
-	var/dislocated = 0		// If you target a joint, you can dislocate the limb, impairing it's usefulness and causing pain
+	var/nerve_struck = 0	// If you target a joint, you can strike the limb's nerve, impairing it's usefulness and causing pain for 10 seconds
 	var/encased				// Needs to be opened with a saw to access certain organs.
 
 	var/cavity_name = "cavity"				// Name of body part's cavity, displayed during cavity implant surgery
@@ -122,7 +122,7 @@
 
 	src.max_damage = desc.max_damage
 	src.min_broken_damage = desc.min_broken_damage
-	src.dislocated = desc.dislocated
+	src.nerve_struck = desc.nerve_struck
 	src.vital = desc.vital
 	src.cannot_amputate = desc.cannot_amputate
 
@@ -332,7 +332,7 @@
 			spawn(10)
 				qdel(spark_system)
 		. += 2
-	if(is_dislocated())
+	if(is_nerve_struck())
 		. += 1
 	if(status & ORGAN_SPLINTED)
 		. += 0.5
@@ -344,37 +344,39 @@
 
 	. += tally
 
-/obj/item/organ/external/proc/is_dislocated()
-	if(dislocated > 0)
+/obj/item/organ/external/proc/is_nerve_struck()
+	if(nerve_struck > 0)
 		return 1
 	if(parent)
-		return parent.is_dislocated()
+		return parent.is_nerve_struck()
 	return 0
 
-/obj/item/organ/external/proc/dislocate(var/primary)
-	if(dislocated != -1)
+/obj/item/organ/external/proc/nerve_strike_add(var/primary)
+	if(nerve_struck != -1)
 		if(primary)
-			dislocated = 2
+			nerve_struck = 2
 		else
-			dislocated = 1
-	owner.verbs |= /mob/living/carbon/human/proc/undislocate
-	if(children && children.len)
-		for(var/obj/item/organ/external/child in children)
-			child.dislocate()
+			nerve_struck = 1
 
-/obj/item/organ/external/proc/undislocate()
-	if(dislocated != -1)
-		dislocated = 0
 	if(children && children.len)
 		for(var/obj/item/organ/external/child in children)
-			if(child.dislocated == 1)
-				child.undislocate()
+			child.nerve_strike_add()
+
+	spawn(100)
+		nerve_strike_remove()
+
+/obj/item/organ/external/proc/nerve_strike_remove()
+	if(nerve_struck != -1)
+		nerve_struck = 0
+	if(children && children.len)
+		for(var/obj/item/organ/external/child in children)
+			if(child.nerve_struck == 1)
+				child.nerve_strike_remove()
 	if(owner)
 		owner.shock_stage += 20
 		for(var/obj/item/organ/external/limb in owner.organs)
-			if(limb.dislocated == 2)
+			if(limb.nerve_struck == 2)
 				return
-		owner.verbs -= /mob/living/carbon/human/proc/undislocate
 
 /obj/item/organ/external/proc/setBleeding()
 	if(BP_IS_ROBOTIC(src) || !owner || (owner.species.flags & NO_BLOOD))
@@ -981,7 +983,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		return english_list(flavor_text)
 
 /obj/item/organ/external/is_usable()
-	return !is_dislocated() && !(status & (ORGAN_MUTATED|ORGAN_DEAD))
+	return !is_nerve_struck() && !(status & (ORGAN_MUTATED|ORGAN_DEAD))
 
 /obj/item/organ/external/proc/has_internal_bleeding()
 	for(var/datum/wound/W in wounds)

--- a/code/modules/organs/external/stump.dm
+++ b/code/modules/organs/external/stump.dm
@@ -1,6 +1,6 @@
 /obj/item/organ/external/stump
 	name = "limb stump"
-	dislocated = -1
+	nerve_struck = -1
 
 /obj/item/organ/external/stump/New(var/mob/living/carbon/holder, var/OD, var/obj/item/organ/external/limb)
 	if(istype(limb))

--- a/code/modules/organs/external/subtypes/robotic.dm
+++ b/code/modules/organs/external/subtypes/robotic.dm
@@ -2,7 +2,7 @@
 	name = "robotic"
 	force_icon = 'icons/mob/human_races/cyberlimbs/generic.dmi'
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
-	dislocated = -1
+	nerve_struck = -1 // no nerves here
 	nature = MODIFICATION_SILICON
 	armor = list(melee = 2, bullet = 2, energy = 2, bomb = 10, bio = 100, rad = 100)
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2) // Multiplied by w_class

--- a/code/modules/organs/external/subtypes/unbreakable.dm
+++ b/code/modules/organs/external/subtypes/unbreakable.dm
@@ -1,4 +1,4 @@
 // Slime limbs.
 /obj/item/organ/external/unbreakable
 	cannot_break = 1
-	dislocated = -1
+	nerve_struck = -1

--- a/code/modules/organs/organ_description.dm
+++ b/code/modules/organs/organ_description.dm
@@ -9,7 +9,7 @@
 
 	var/max_damage = 0
 	var/min_broken_damage = 30
-	var/dislocated = 0
+	var/nerve_struck = 0 // can only activate on natural arms/legs
 	var/vital = FALSE
 	var/cannot_amputate = FALSE
 
@@ -38,7 +38,7 @@
 
 	max_damage = 100
 	min_broken_damage = 60
-	dislocated = -1
+	nerve_struck = -1
 	vital = TRUE
 	cannot_amputate = TRUE
 
@@ -61,7 +61,7 @@
 
 	max_damage = 100
 	min_broken_damage = 60
-	dislocated = -1
+	nerve_struck = -1
 
 	w_class = ITEM_SIZE_BULKY
 	max_volume = ITEM_SIZE_COLOSSAL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a comical amount of new grab specials, as well as a way to counter grabs the COOL WAY:tm:

## Aggressive grab specials

Irish whip: Changes flipping humans (spin-held-item with grabs) to irish whip instead of forceresting them; irish whip gives 40 external recoil and sends the victim __walking__ behind the attacker for 3 tiles; unique interactions(damage) for walls, windows, tables and railings in the way: walls deal low damage, windows deal medium damage, railings and tables flip over.

Gut punch: Punch the victim in lower body(harm intent, any grab level) to deal damage depending on their TGH and force-vomit them. Force-vomiting cannot be spammed due to hardcoded CD(35 seconds), but the special can be used indefinitely. Has a wounding multiplier of 2.

Jointlocks give better(I quote, "more gory") feedback.

Suplex is buffed(max damage 80 instead of 65), it also gives better(gory) feedback.

Headbutt makes the victim dizzy for 15 seconds. Can be lowered to 5.

Dropkicking now shares the same bodypart aim slot as suplex(BP_CHEST).

Elbow dropping - on harm intent, when you drop on some schmuck from an upper Z-level, you deal damage to them depending on your ROB stat. Deals quite a lot, actually. Monkeys can also do this... Oh no.

Dislocating is gone.

Instead of dislocating, you can strike the nerve of the targeted bodypart to **temporarily**(10 seconds) disable it. Can be used at any grab level. Deals 5-10 pain damage with wounding multiplier of 2. Btw it now actually tells admins that this happened. Dislocating didn't say anything.

![image](https://user-images.githubusercontent.com/112724221/188641277-a37d5d6c-8fb8-44db-9ee9-9dc67ea45d0c.png)


## First aid grab specials

Force vomiting: With help intent and any grab level, you can aim at someone's mouth to induce vomiting(the nonviolent way). Cannot be spammed due to hardcoded CD(35 seconds), but can be used indefinitely.

Applying pressure: With help intent and any grab level, you can aim at the bodypart with bleeding wounds to increase their current bleeding stage and lower their bleeding timer.

## Countering crab specials
![image](https://user-images.githubusercontent.com/112724221/188496884-d5a322e9-8816-42c0-af5e-077140e00f2d.png)
![image](https://user-images.githubusercontent.com/112724221/188497327-b7fb2533-6562-4915-a83b-70a31c6750cb.png)
![image](https://user-images.githubusercontent.com/112724221/188497364-5873d7ad-4f1f-49a8-af0c-30a3aab87d1d.png)

Grabs now have a 'counter_timer' variable, which activates every time someone grabs someone else(duh) for 3 seconds. During that window, if the attacked clicks on the aggressor with grab intent and empty hand(and passes a ROB_stat check(hard formula(blame humon))), the attacked can COUNTER the grab and instantly get an aggressive one on the attacker.

HOWEVER, countering requires the attacker to not only click on our aggressor with an active hand, it also needs the aggressor to have a grab in their hands! (Don't put this pro move in the changelog pls)
Which means, if the aggressor quickly grabs the victim, and then drops the grab, but the victim tries to counter that, they would instead grab the aggressor, which would activate their counter timer!
By doing so, the agressor counters the attacker's counter with a counter, which itself is a high risk righ reward move.

## Why It's Good For The Game grab specials
More grabs, more utility, better melee. ~~As usual, it's balanced because 'funny gun go brr'~~

~~Since I am more than sure that these specials in their current form are overpowered as fuck, I am open to balancing suggestions.~~ I am still open to balancing suggestions, but I have changed my opinions, and now these specials are completely fine in my opinion. Because gun go brr.

As for why dislocating was reworked, it was NOT viable at all for a neck grab(very long activate time, and, you know, neck level grab), it was NOT fun to play against(it was PERMANENT, until you either fixed yourself up or someone ALLOWED you to play the game and help you undislocate them; I'm not saying nerve striking is fun to play against), and, most importantly, __it was NOT usable in a fight.__ When you get someone to a neck level grab, you can force them to rest, which means the fight is over and you win. As such, dislocating was nothing but a tool for griefing someone who went AFK, or unconscious after being paincritted.
This is not a SALT PR moment, since I've never(ever) met someone who used dislocation. Just fixing up retarded bay12 game design.

## Changelog Kegdo
:cl: Kegdo
add: irish whip on humanoid spinning grab special
add: gut punch grab special
add: first aid grab specials
add: countering grab specials
add: nerve strike grab specials
add: grab special grab special
add: elbow drops, more feedback for jointlock grab special and suplex grab special
balance: buffed the damage of suplex grab special
tweak: dropkick grab special shares the same aim slot as suplex grab special
del: flipping on humanoid spinning grab special
del: dislocating grab special
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
