### PR TITLE
Removes pointless ion storm code

### DIFF
--- a/code/game/gamemodes/events/ion_storm.dm
+++ b/code/game/gamemodes/events/ion_storm.dm
@@ -15,7 +15,6 @@
 
 
 /datum/event/ionstorm
-	var/botEmagChance = 0.5
 	var/list/players = list()
 
 /datum/event/ionstorm/setup()
@@ -100,12 +99,6 @@
 					"admin","ponies","heresy","meow","Pun Pun","monkey","Ian","moron","pizza","message","spam",\
 					"director", "Hello", "Hi!"," ","nuke","crate","dwarf","xeno")
 
-/datum/event/ionstorm/tick()
-	if(botEmagChance)
-		for(var/obj/machinery/bot/bot in world)
-			if(prob(botEmagChance))
-				bot.emag_act(1)
-
 /datum/event/ionstorm/end()
 	spawn(rand(5000,8000))
 		if(prob(50))
@@ -134,7 +127,7 @@
 	return default_if_none
 
 
-/proc/IonStorm(botEmagChance = 10)
+/proc/IonStorm()
 
 /*Deuryn's current project, notes here for those who care.
 Revamping the random laws so they don't suck.
@@ -238,8 +231,3 @@ Would like to add a law like "Law x is _______" where x = a number, and _____ is
 					to_chat(M, "\red THE STATION IS [who2pref] [who2]...LAWS UPDATED")
 					to_chat(M, "<br>")
 					M.add_ion_law("THE STATION IS [who2pref] [who2]")
-
-	if(botEmagChance)
-		for(var/obj/machinery/bot/bot in world)
-			if(prob(botEmagChance))
-				bot.emag_act()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -165,7 +165,7 @@ ADMIN_VERB_ADD(/client/proc/cmd_admin_add_random_ai_law, R_FUN, FALSE)
 	if(show_log == "Yes")
 		command_announcement.Announce("Ion storm detected near the ship. Please check all AI-controlled equipment for errors.", "Anomaly Alert", new_sound = 'sound/AI/ionstorm.ogg')
 
-	IonStorm(0)
+	IonStorm()
 
 
 /*

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -296,7 +296,7 @@
 
 /obj/item/electronics/ai_module/broken/transmitInstructions(mob/living/silicon/ai/target, mob/sender)
 	..()
-	IonStorm(0)
+	IonStorm()
 	explosion(sender.loc, 1, 1, 1, 3)
 	sender.drop_from_inventory(src)
 	QDEL_NULL(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ion storm ticks were eating up a lot of server resources because they were searching the entire world for /obj/machinery/bot objects to emag. Mulebots are our only objects of that type and are rarely used at that. This PR removes that behavior.

## Why It's Good For The Game

Optimization.

## Changelog
:cl:
fix: Removed worldwide check for deprecated object type
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
