### PR TITLE
Aberrant Organs - surgery buttons and RNG reduction

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2742,6 +2742,7 @@
 #include "code\modules\surgery\autodoc.dm"
 #include "code\modules\surgery\hardsuit.dm"
 #include "code\modules\surgery\internal.dm"
+#include "code\modules\surgery\mods.dm"
 #include "code\modules\surgery\old_surgery.dm"
 #include "code\modules\surgery\organic.dm"
 #include "code\modules\surgery\organic_damage.dm"

--- a/code/datums/autolathe/organ.dm
+++ b/code/datums/autolathe/organ.dm
@@ -23,6 +23,10 @@
 	materials = list(MATERIAL_BIOMATTER = 30)
 	build_path = /obj/item/organ/internal/liver
 
+/datum/design/organ/stomach
+	materials = list(MATERIAL_BIOMATTER = 10)
+	build_path = /obj/item/organ/internal/stomach
+
 /datum/design/organ/eyes
 	materials = list(MATERIAL_BIOMATTER = 10)
 	build_path = /obj/item/organ/internal/eyes

--- a/code/modules/aberrants/organs/design_disks/designs.dm
+++ b/code/modules/aberrants/organs/design_disks/designs.dm
@@ -143,8 +143,26 @@
 	category = "Inputs"
 	starts_unlocked = TRUE
 
-/datum/design/organ/teratoma/input/reagents
-	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents
+/datum/design/organ/teratoma/input/reagents_roach
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/roach
+
+/datum/design/organ/teratoma/input/reagents_spider
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/spider
+
+/datum/design/organ/teratoma/input/reagents_toxin
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/toxin
+
+/datum/design/organ/teratoma/input/reagents_edible
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/edible
+
+/datum/design/organ/teratoma/input/reagents_alcohol
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/alcohol
+
+/datum/design/organ/teratoma/input/reagents_drugs
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/drugs
+
+/datum/design/organ/teratoma/input/reagents_dispenser
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/dispenser
 
 /datum/design/organ/teratoma/input/damage
 	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/damage
@@ -154,10 +172,29 @@
 
 
 /datum/design/organ/teratoma/input/uncommon
+	category = "Inputs II"
 	starts_unlocked = FALSE
 
-/datum/design/organ/teratoma/input/uncommon/reagents
-	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/uncommon
+/datum/design/organ/teratoma/input/uncommon/reagents_roach
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/uncommon/roach
+
+/datum/design/organ/teratoma/input/uncommon/reagents_spider
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/uncommon/spider
+
+/datum/design/organ/teratoma/input/uncommon/reagents_toxin
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/uncommon/toxin
+
+/datum/design/organ/teratoma/input/uncommon/reagents_edible
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/uncommon/edible
+
+/datum/design/organ/teratoma/input/uncommon/reagents_alcohol
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/uncommon/alcohol
+
+/datum/design/organ/teratoma/input/uncommon/reagents_drugs
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/uncommon/drugs
+
+/datum/design/organ/teratoma/input/uncommon/reagents_dispenser
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/uncommon/dispenser
 
 /datum/design/organ/teratoma/input/uncommon/damage
 	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/damage/uncommon
@@ -167,10 +204,29 @@
 
 
 /datum/design/organ/teratoma/input/rare
+	category = "Inputs III"
 	starts_unlocked = FALSE
 
-/datum/design/organ/teratoma/input/rare/reagents
-	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/rare
+/datum/design/organ/teratoma/input/rare/reagents_roach
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/rare/roach
+
+/datum/design/organ/teratoma/input/rare/reagents_spider
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/rare/spider
+
+/datum/design/organ/teratoma/input/rare/reagents_toxin
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/rare/toxin
+
+/datum/design/organ/teratoma/input/rare/reagents_edible
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/rare/edible
+
+/datum/design/organ/teratoma/input/rare/reagents_alcohol
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/rare/alcohol
+
+/datum/design/organ/teratoma/input/rare/reagents_drugs
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/rare/drugs
+
+/datum/design/organ/teratoma/input/rare/reagents_dispenser
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/rare/dispenser
 
 /datum/design/organ/teratoma/input/rare/damage
 	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/input/damage/rare
@@ -198,46 +254,96 @@
 	category = "Outputs"
 	starts_unlocked = TRUE
 
-/datum/design/organ/teratoma/output/reagents_blood
-	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood
+/datum/design/organ/teratoma/output/reagents_blood_roach
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/roach
 
-/datum/design/organ/teratoma/output/reagents_ingest
-	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest
+/datum/design/organ/teratoma/output/reagents_blood_drugs
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/drugs
 
-/datum/design/organ/teratoma/output/chemical_effects
-	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects
+/datum/design/organ/teratoma/output/reagents_blood_medicine_simple
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/medicine_simple
+	starts_unlocked = FALSE
+
+/datum/design/organ/teratoma/output/reagents_blood_medicine_intermediate
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/medicine_intermediate
+	starts_unlocked = FALSE
+
+/datum/design/organ/teratoma/output/reagents_ingest_edible
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest/edible
+
+/datum/design/organ/teratoma/output/reagents_ingest_alcohol
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest/alcohol
+
+/datum/design/organ/teratoma/output/chemical_effects_type_1
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects/type_1
+
+/datum/design/organ/teratoma/output/chemical_effects_type_2
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects/type_2
+	starts_unlocked = FALSE
 
 /datum/design/organ/teratoma/output/stat_boost
 	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/stat_boost
 
 
 /datum/design/organ/teratoma/output/uncommon
+	category = "Outputs II"
 	starts_unlocked = FALSE
 
-/datum/design/organ/teratoma/output/uncommon/reagents_blood
-	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/uncommon
+/datum/design/organ/teratoma/output/uncommon/reagents_blood_roach
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/uncommon/roach
 
-/datum/design/organ/teratoma/output/uncommon/reagents_ingest
-	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest/uncommon
+/datum/design/organ/teratoma/output/uncommon/reagents_blood_drugs
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/uncommon/drugs
 
-/datum/design/organ/teratoma/output/uncommon/chemical_effects
-	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects/uncommon
+/datum/design/organ/teratoma/output/uncommon/reagents_blood_medicine_simple
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/uncommon/medicine_simple
+
+/datum/design/organ/teratoma/output/uncommon/reagents_blood_medicine_intermediate
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/uncommon/medicine_intermediate
+
+/datum/design/organ/teratoma/output/uncommon/reagents_ingest_edible
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest/uncommon/edible
+
+/datum/design/organ/teratoma/output/uncommon/reagents_ingest_alcohol
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest/uncommon/alcohol
+
+/datum/design/organ/teratoma/output/uncommon/chemical_effects_type_1
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects/uncommon/type_1
+
+/datum/design/organ/teratoma/output/uncommon/chemical_effects_type_2
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects/uncommon/type_2
 
 /datum/design/organ/teratoma/output/uncommon/stat_boost
 	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/stat_boost/uncommon
 
 
 /datum/design/organ/teratoma/output/rare
+	category = "Outputs III"
 	starts_unlocked = FALSE
 
-/datum/design/organ/teratoma/output/rare/reagents_blood
-	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/rare
+/datum/design/organ/teratoma/output/rare/reagents_blood_roach
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/rare/roach
 
-/datum/design/organ/teratoma/output/rare/reagents_ingest
-	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest/rare
+/datum/design/organ/teratoma/output/rare/reagents_blood_drugs
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/rare/drugs
 
-/datum/design/organ/teratoma/output/rare/chemical_effects
-	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects/rare
+/datum/design/organ/teratoma/output/rare/reagents_blood_medicine_simple
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/rare/medicine_simple
+
+/datum/design/organ/teratoma/output/rare/reagents_blood_medicine_intermediate
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/rare/medicine_intermediate
+
+/datum/design/organ/teratoma/output/rare/reagents_ingest_edible
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest/rare/edible
+
+/datum/design/organ/teratoma/output/rare/reagents_ingest_alcohol
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest/rare/alcohol
+
+/datum/design/organ/teratoma/output/rare/chemical_effects_type_1
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects/rare/type_1
+
+/datum/design/organ/teratoma/output/rare/chemical_effects_type_2
+	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects/rare/type_2
 
 /datum/design/organ/teratoma/output/rare/stat_boost
 	build_path = /obj/item/organ/internal/scaffold/aberrant/teratoma/output/stat_boost/rare

--- a/code/modules/aberrants/organs/design_disks/disks.dm
+++ b/code/modules/aberrants/organs/design_disks/disks.dm
@@ -20,14 +20,22 @@
 	disk_name = "Oh My Guts! DIY Organs"
 	designs = list(
 		/datum/design/organ/scaffold,
-		/datum/design/organ/teratoma/input/reagents,
+		/datum/design/organ/teratoma/input/reagents_roach,
+		/datum/design/organ/teratoma/input/reagents_spider,
+		/datum/design/organ/teratoma/input/reagents_toxin,
+		/datum/design/organ/teratoma/input/reagents_edible,
+		/datum/design/organ/teratoma/input/reagents_alcohol,
+		/datum/design/organ/teratoma/input/reagents_drugs,
+		/datum/design/organ/teratoma/input/reagents_dispenser,
 		/datum/design/organ/teratoma/input/damage,
 		/datum/design/organ/teratoma/input/power_source,
 		/datum/design/organ/teratoma/process/map,
 		/datum/design/organ/teratoma/process/condense,
-		/datum/design/organ/teratoma/output/reagents_blood,
-		/datum/design/organ/teratoma/output/reagents_ingest,
-		/datum/design/organ/teratoma/output/chemical_effects,
+		/datum/design/organ/teratoma/output/reagents_blood_roach,
+		/datum/design/organ/teratoma/output/reagents_blood_drugs,
+		/datum/design/organ/teratoma/output/reagents_ingest_edible,
+		/datum/design/organ/teratoma/output/reagents_ingest_alcohol,
+		/datum/design/organ/teratoma/output/chemical_effects_type_1,
 		/datum/design/organ/teratoma/output/stat_boost
 	)
 
@@ -35,16 +43,28 @@
 	disk_name = "Oh My Guts! Bespoke Teratomas"
 	license = 10
 	designs = list(
-		/datum/design/organ/teratoma/input/uncommon/reagents,
+		/datum/design/organ/teratoma/special/chemical_effect,
+		/datum/design/organ/teratoma/special/stat_boost,
+		/datum/design/organ/teratoma/output/reagents_blood_medicine_simple,
+		/datum/design/organ/teratoma/output/chemical_effects_type_2,
+		/datum/design/organ/teratoma/input/uncommon/reagents_roach,
+		/datum/design/organ/teratoma/input/uncommon/reagents_spider,
+		/datum/design/organ/teratoma/input/uncommon/reagents_toxin,
+		/datum/design/organ/teratoma/input/uncommon/reagents_edible,
+		/datum/design/organ/teratoma/input/uncommon/reagents_alcohol,
+		/datum/design/organ/teratoma/input/uncommon/reagents_drugs,
+		/datum/design/organ/teratoma/input/uncommon/reagents_dispenser,
 		/datum/design/organ/teratoma/input/uncommon/damage,
 		/datum/design/organ/teratoma/input/uncommon/power_source,
 		/datum/design/organ/teratoma/process/boost,
-		/datum/design/organ/teratoma/output/uncommon/reagents_blood,
-		/datum/design/organ/teratoma/output/uncommon/reagents_ingest,
-		/datum/design/organ/teratoma/output/uncommon/chemical_effects,
-		/datum/design/organ/teratoma/output/uncommon/stat_boost,
-		/datum/design/organ/teratoma/special/chemical_effect,
-		/datum/design/organ/teratoma/special/stat_boost
+		/datum/design/organ/teratoma/output/uncommon/reagents_blood_roach,
+		/datum/design/organ/teratoma/output/uncommon/reagents_blood_drugs,
+		/datum/design/organ/teratoma/output/uncommon/reagents_blood_medicine_simple,
+		/datum/design/organ/teratoma/output/uncommon/reagents_ingest_edible,
+		/datum/design/organ/teratoma/output/uncommon/reagents_ingest_alcohol,
+		/datum/design/organ/teratoma/output/uncommon/chemical_effects_type_1,
+		/datum/design/organ/teratoma/output/uncommon/chemical_effects_type_2,
+		/datum/design/organ/teratoma/output/uncommon/stat_boost
 	)
 
 /obj/item/computer_hardware/hard_drive/portable/design/omg/teratoma_rare
@@ -52,12 +72,24 @@
 	license = 10
 	designs = list(
 		/datum/design/organ/scaffold/rare,
-		/datum/design/organ/teratoma/input/rare/reagents,
+		/datum/design/organ/teratoma/output/reagents_blood_medicine_intermediate,
+		/datum/design/organ/teratoma/output/uncommon/reagents_blood_medicine_intermediate,
+		/datum/design/organ/teratoma/input/rare/reagents_roach,
+		///datum/design/organ/teratoma/input/rare/reagents_spider,		// Not enough spider chems in the pool
+		/datum/design/organ/teratoma/input/rare/reagents_toxin,
+		/datum/design/organ/teratoma/input/rare/reagents_edible,
+		/datum/design/organ/teratoma/input/rare/reagents_alcohol,
+		/datum/design/organ/teratoma/input/rare/reagents_drugs,
+		/datum/design/organ/teratoma/input/rare/reagents_dispenser,
 		/datum/design/organ/teratoma/input/rare/damage,
 		/datum/design/organ/teratoma/input/rare/power_source,
-		/datum/design/organ/teratoma/output/rare/reagents_blood,
-		/datum/design/organ/teratoma/output/rare/reagents_ingest,
-		/datum/design/organ/teratoma/output/rare/chemical_effects,
+		/datum/design/organ/teratoma/output/rare/reagents_blood_roach,
+		/datum/design/organ/teratoma/output/rare/reagents_blood_drugs,
+		/datum/design/organ/teratoma/output/rare/reagents_blood_medicine_intermediate,
+		/datum/design/organ/teratoma/output/rare/reagents_ingest_edible,
+		/datum/design/organ/teratoma/output/rare/reagents_ingest_alcohol,
+		/datum/design/organ/teratoma/output/rare/chemical_effects_type_1,
+		/datum/design/organ/teratoma/output/rare/chemical_effects_type_2,
 		/datum/design/organ/teratoma/output/rare/stat_boost
 	)
 

--- a/code/modules/aberrants/organs/internal/teratoma.dm
+++ b/code/modules/aberrants/organs/internal/teratoma.dm
@@ -55,7 +55,7 @@
 				input_mode = pick(CHEM_TOUCH, CHEM_INGEST, CHEM_BLOOD)
 			if(!specific_input_type_pool?.len)
 				var/list/possible_reagent_classes = list()
-				possible_reagent_classes |= list(REAGENTS_ROACH, REAGENTS_SPIDER)
+				possible_reagent_classes |= list(REAGENTS_ROACH, REAGENTS_SPIDER, REAGENTS_DISPENSER, REAGENTS_TOXIN)
 				if(input_mode == CHEM_INGEST)
 					possible_reagent_classes |= list(REAGENTS_EDIBLE, REAGENTS_ALCOHOL)
 				if(input_mode == CHEM_BLOOD)
@@ -66,11 +66,7 @@
 		if(/obj/item/modification/organ/internal/output/reagents_blood)
 			if(!output_pool?.len)
 				var/list/possible_reagent_classes = list()
-				possible_reagent_classes |= list(REAGENTS_DRUGS, REAGENTS_ROACH)
-				if(req_num_outputs > 1)			// > 1 means uncommon or rare
-					possible_reagent_classes |= list(REAGENTS_MEDICINE_SIMPLE)
-				else if(req_num_outputs > 2)	// > means rare
-					possible_reagent_classes |= list(REAGENTS_MEDICINE_INTERMEDIATE)
+				possible_reagent_classes |= list(REAGENTS_DRUGS, REAGENTS_ROACH, REAGENTS_MEDICINE_SIMPLE, REAGENTS_MEDICINE_INTERMEDIATE)
 				output_pool = pick(possible_reagent_classes)
 			if(!output_info?.len)
 				for(var/i in 1 to req_num_outputs)
@@ -79,11 +75,7 @@
 		if(/obj/item/modification/organ/internal/output/reagents_ingest)
 			if(!output_pool?.len)
 				var/list/possible_reagent_classes = list()
-				possible_reagent_classes |= list(REAGENTS_EDIBLE, REAGENTS_ALCOHOL, REAGENTS_ROACH)
-				if(req_num_outputs > 1)			// > 1 means uncommon or rare
-					possible_reagent_classes |= list(REAGENTS_MEDICINE_SIMPLE)
-				else if(req_num_outputs > 2)	// > means rare
-					possible_reagent_classes |= list(REAGENTS_MEDICINE_INTERMEDIATE)
+				possible_reagent_classes |= list(REAGENTS_EDIBLE, REAGENTS_ALCOHOL, REAGENTS_ROACH, REAGENTS_MEDICINE_SIMPLE, REAGENTS_MEDICINE_INTERMEDIATE)
 				output_pool = pick(possible_reagent_classes)
 			if(!output_info?.len)
 				for(var/i in 1 to req_num_outputs)
@@ -92,18 +84,18 @@
 		if(/obj/item/modification/organ/internal/output/chemical_effects)
 			if(!output_pool?.len)
 				var/list/possible_hormone_types = list()
-				possible_hormone_types = list(TYPE_1_HORMONES)
-				if(req_num_outputs > 1)			// > 1 means uncommon or rare
-					possible_hormone_types |= list(TYPE_2_HORMONES)
+				possible_hormone_types = list(TYPE_1_HORMONES, TYPE_2_HORMONES)
 				output_pool = pick(possible_hormone_types)
-			for(var/i in 1 to req_num_outputs)
-				output_info += NOT_USED
+			if(!output_info?.len)
+				for(var/i in 1 to req_num_outputs)
+					output_info += NOT_USED
 
 		if(/obj/item/modification/organ/internal/output/stat_boost)
 			if(!output_pool?.len)
 				output_pool = ALL_STATS
-			for(var/i in 1 to req_num_outputs)
-				output_info += 3
+			if(!output_info?.len)
+				for(var/i in 1 to req_num_outputs)
+					output_info += 3
 
 	..()
 
@@ -129,6 +121,7 @@
 	name = "throbbing teratoma (input)"
 	req_num_inputs = 4
 
+
 /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents
 	name = "metabolic teratoma"
 	description_info = "A teratoma that houses a metabolic organoid. Use a laser cutting tool to remove the organoid (50 BIO recommended).\n\n\
@@ -137,6 +130,35 @@
 						When the correct reagent is in the correct holder, the reagent will be removed at a rate equal to its metabolism times \
 						the length of the organ\'s cooldown in ticks. Then, the process will trigger."
 	input_mod_path = /obj/item/modification/organ/internal/input/reagents
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/roach
+	name = "metabolic teratoma (roach)"
+	specific_input_type_pool = REAGENTS_ROACH
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/spider
+	name = "metabolic teratoma (spider)"
+	specific_input_type_pool = REAGENTS_SPIDER
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/toxin
+	name = "metabolic teratoma (toxins)"
+	specific_input_type_pool = REAGENTS_TOXIN
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/edible
+	name = "metabolic teratoma (edible)"
+	specific_input_type_pool = REAGENTS_EDIBLE
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/alcohol
+	name = "metabolic teratoma (alcohol)"
+	specific_input_type_pool = REAGENTS_ALCOHOL
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/drugs
+	name = "metabolic teratoma (drugs)"
+	specific_input_type_pool = REAGENTS_DRUGS
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/dispenser
+	name = "metabolic teratoma (chemical)"
+	specific_input_type_pool = REAGENTS_DISPENSER
+
 
 /obj/item/organ/internal/scaffold/aberrant/teratoma/input/damage
 	name = "nociceptive teratoma"
@@ -159,6 +181,34 @@
 	name = "bulging metabolic teratoma"
 	req_num_inputs = 2
 
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/uncommon/roach
+	name = "bulging metabolic teratoma (roach)"
+	specific_input_type_pool = REAGENTS_ROACH
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/uncommon/spider
+	name = "bulging metabolic teratoma (spider)"
+	specific_input_type_pool = REAGENTS_SPIDER
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/uncommon/toxin
+	name = "bulging metabolic teratoma (toxins)"
+	specific_input_type_pool = REAGENTS_TOXIN
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/uncommon/edible
+	name = "bulging metabolic teratoma (edible)"
+	specific_input_type_pool = REAGENTS_EDIBLE
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/uncommon/alcohol
+	name = "bulging metabolic teratoma (alcohol)"
+	specific_input_type_pool = REAGENTS_ALCOHOL
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/uncommon/drugs
+	name = "bulging metabolic teratoma (drugs)"
+	specific_input_type_pool = REAGENTS_DRUGS
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/uncommon/dispenser
+	name = "bulging metabolic teratoma (chemical)"
+	specific_input_type_pool = REAGENTS_DISPENSER
+
 /obj/item/organ/internal/scaffold/aberrant/teratoma/input/damage/uncommon
 	name = "bulging nociceptive teratoma"
 	req_num_inputs = 2
@@ -171,6 +221,35 @@
 /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/rare
 	name = "throbbing metabolic teratoma"
 	req_num_inputs = 4
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/rare/roach
+	name = "throbbing metabolic teratoma (roach)"
+	specific_input_type_pool = REAGENTS_ROACH
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/rare/spider
+	name = "throbbing metabolic teratoma (spider)"
+	specific_input_type_pool = REAGENTS_SPIDER
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/rare/toxin
+	name = "throbbing metabolic teratoma (toxins)"
+	specific_input_type_pool = REAGENTS_TOXIN
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/rare/edible
+	name = "throbbing metabolic teratoma (edible)"
+	specific_input_type_pool = REAGENTS_EDIBLE
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/rare/alcohol
+	name = "throbbing metabolic teratoma (alcohol)"
+	specific_input_type_pool = REAGENTS_ALCOHOL
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/rare/drugs
+	name = "throbbing metabolic teratoma (drugs)"
+	specific_input_type_pool = REAGENTS_DRUGS
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents/rare/dispenser
+	name = "throbbing metabolic teratoma (chemical)"
+	specific_input_type_pool = REAGENTS_DISPENSER
+
 
 /obj/item/organ/internal/scaffold/aberrant/teratoma/input/damage/rare
 	name = "throbbing nociceptive teratoma"
@@ -228,6 +307,22 @@
 	req_num_outputs = 1
 	output_mod_path = /obj/item/modification/organ/internal/output/reagents_blood
 
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/roach
+	name = "hepatic teratoma (roach)"
+	output_pool = REAGENTS_ROACH
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/drugs
+	name = "hepatic teratoma (drugs)"
+	output_pool = REAGENTS_DRUGS
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/medicine_simple
+	name = "hepatic teratoma (medicine)"
+	output_pool = REAGENTS_MEDICINE_SIMPLE
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/medicine_intermediate
+	name = "hepatic teratoma (medicine II)"
+	output_pool = REAGENTS_MEDICINE_INTERMEDIATE
+
 /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest
 	name = "gastric teratoma"
 	description_info = "A teratoma that houses a gastric organoid. Use a laser cutting tool to remove the organoid (50 BIO recommended).\n\n\
@@ -236,6 +331,14 @@
 	req_num_outputs = 1
 	output_mod_path = /obj/item/modification/organ/internal/output/reagents_ingest
 
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest/edible
+	name = "gastric teratoma (edible)"
+	output_pool = REAGENTS_EDIBLE
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest/alcohol
+	name = "gastric teratoma (alcohol)"
+	output_pool = REAGENTS_ALCOHOL
+
 /obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects
 	name = "endocrinal teratoma"
 	description_info = "A teratoma that houses an endocrinal organoid. Use a laser cutting tool to remove the organoid (50 BIO recommended).\n\n\
@@ -243,6 +346,14 @@
 						Produces hormones in the bloodstream when triggered."
 	req_num_outputs = 1
 	output_mod_path = /obj/item/modification/organ/internal/output/chemical_effects
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects/type_1
+	name = "endocrinal teratoma (type 1)"
+	output_pool = TYPE_1_HORMONES
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects/type_2
+	name = "endocrinal teratoma (type 2)"
+	output_pool = TYPE_2_HORMONES
 
 /obj/item/organ/internal/scaffold/aberrant/teratoma/output/stat_boost
 	name = "intracrinal teratoma"
@@ -257,13 +368,45 @@
 	name = "bulging hepatic teratoma"
 	req_num_outputs = 2
 
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/uncommon/roach
+	name = "bulging hepatic teratoma (roach)"
+	output_pool = REAGENTS_ROACH
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/uncommon/drugs
+	name = "bulging hepatic teratoma (drugs)"
+	output_pool = REAGENTS_DRUGS
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/uncommon/medicine_simple
+	name = "bulging hepatic teratoma (medicine)"
+	output_pool = REAGENTS_MEDICINE_SIMPLE
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/uncommon/medicine_intermediate
+	name = "bulging hepatic teratoma (medicine II)"
+	output_pool = REAGENTS_MEDICINE_INTERMEDIATE
+
 /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest/uncommon
 	name = "bulging gastric teratoma"
 	req_num_outputs = 2
 
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest/uncommon/edible
+	name = "bulging gastric teratoma (edible)"
+	output_pool = REAGENTS_EDIBLE
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest/uncommon/alcohol
+	name = "bulging gastric teratoma (alcohol)"
+	output_pool = REAGENTS_ALCOHOL
+
 /obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects/uncommon
 	name = "bulging endocrinal teratoma"
 	req_num_outputs = 2
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects/uncommon/type_1
+	name = "bulging endocrinal teratoma (type 1)"
+	output_pool = TYPE_1_HORMONES
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects/uncommon/type_2
+	name = "bulging endocrinal teratoma (type 2)"
+	output_pool = TYPE_2_HORMONES
 
 /obj/item/organ/internal/scaffold/aberrant/teratoma/output/stat_boost/uncommon
 	name = "bulging intracrinal teratoma"
@@ -274,13 +417,45 @@
 	name = "throbbing hepatic teratoma"
 	req_num_outputs = 4
 
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/rare/roach
+	name = "throbbing hepatic teratoma (roach)"
+	output_pool = REAGENTS_ROACH
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/rare/drugs
+	name = "throbbing hepatic teratoma (drugs)"
+	output_pool = REAGENTS_DRUGS
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/rare/medicine_simple
+	name = "throbbing hepatic teratoma (medicine)"
+	output_pool = REAGENTS_MEDICINE_SIMPLE
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood/rare/medicine_intermediate
+	name = "throbbing hepatic teratoma (medicine II)"
+	output_pool = REAGENTS_MEDICINE_INTERMEDIATE
+
 /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest/rare
 	name = "throbbing gastric teratoma"
 	req_num_outputs = 4
 
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest/rare/edible
+	name = "throbbing gastric teratoma (edible)"
+	output_pool = REAGENTS_EDIBLE
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest/rare/alcohol
+	name = "throbbing gastric teratoma (alcohol)"
+	output_pool = REAGENTS_ALCOHOL
+
 /obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects/rare
 	name = "throbbing endocrinal teratoma"
 	req_num_outputs = 4
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects/rare/type_1
+	name = "throbbing endocrinal teratoma (type 1)"
+	output_pool = TYPE_1_HORMONES
+
+/obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects/rare/type_2
+	name = "throbbing endocrinal teratoma (type 2)"
+	output_pool = TYPE_2_HORMONES
 
 /obj/item/organ/internal/scaffold/aberrant/teratoma/output/stat_boost/rare
 	name = "throbbing intracrinal teratoma"

--- a/code/modules/aberrants/organs/machinery/regurgitator.dm
+++ b/code/modules/aberrants/organs/machinery/regurgitator.dm
@@ -167,7 +167,7 @@
 	SSnano.update_uis(src)
 
 /obj/machinery/reagentgrinder/industrial/regurgitator/bottle()
-	biomatter_counter -= 60		// Flesh cubes have 60 biomatter
+	biomatter_counter = max(biomatter_counter - 60, 0)		// Flesh cubes have 60 biomatter
 	addtimer(CALLBACK(src, .proc/spit), 1 SECONDS, TIMER_STOPPABLE)
 
 /obj/machinery/reagentgrinder/industrial/regurgitator/proc/spit()

--- a/code/modules/organs/internal/bones.dm
+++ b/code/modules/organs/internal/bones.dm
@@ -42,6 +42,18 @@
 				"step" = /datum/surgery_step/robotic/fix_bone
 			)))
 	else
+		if(item_upgrades.len < max_upgrades)
+			actions_list.Add(list(list(
+				"name" = "Attach Mod",
+				"organ" = "\ref[src]",
+				"step" = /datum/surgery_step/attach_mod
+			)))
+		if(item_upgrades.len)
+			actions_list.Add(list(list(
+				"name" = "Remove Mod",
+				"organ" = "\ref[src]",
+				"step" = /datum/surgery_step/remove_mod
+			)))
 		actions_list.Add(list(list(
 			"name" = (parent.status & ORGAN_BROKEN) ? "Mend" : "Break",
 			"organ" = "\ref[src]",

--- a/code/modules/organs/surgery_helpers.dm
+++ b/code/modules/organs/surgery_helpers.dm
@@ -82,11 +82,31 @@
 			"step" = /datum/surgery_step/robotic/connect_organ
 		)))
 	else
+		var/is_aberrant = istype(src, /obj/item/organ/internal/scaffold)
+		if(item_upgrades.len < max_upgrades)
+			actions_list.Add(list(list(
+				"name" = is_aberrant ? "Attach Mod/Organoid" : "Attach Mod",
+				"organ" = "\ref[src]",
+				"step" = /datum/surgery_step/attach_mod
+			)))
+		if(item_upgrades.len)
+			actions_list.Add(list(list(
+				"name" = is_aberrant ? "Remove Mod/Organoid" : "Remove Mod",
+				"organ" = "\ref[src]",
+				"step" = /datum/surgery_step/remove_mod
+			)))
+		if(is_aberrant)	// Currently, scaffolds are the only type that warrant examining in-body
+			actions_list.Add(list(list(
+				"name" = "Examine",
+				"organ" = "\ref[src]",
+				"step" = /datum/surgery_step/examine
+			)))
 		actions_list.Add(list(list(
 			"name" = (status & ORGAN_CUT_AWAY) ? "Attach" : "Separate",
 			"organ" = "\ref[src]",
 			"step" = (status & ORGAN_CUT_AWAY) ? /datum/surgery_step/attach_organ : /datum/surgery_step/detach_organ
 		)))
+
 
 	return actions_list
 

--- a/code/modules/surgery/mods.dm
+++ b/code/modules/surgery/mods.dm
@@ -1,0 +1,85 @@
+/datum/surgery_step/attach_mod
+	allowed_tools = list(/obj/item/modification/organ/internal = 100)
+	target_organ_type = /obj/item/organ/internal
+	duration = 0
+	blood_level = 1
+
+/datum/surgery_step/attach_mod/require_tool_message(mob/living/user)
+	to_chat(user, SPAN_WARNING("You need an organ modification or an organoid to complete this step."))
+
+/datum/surgery_step/attach_mod/can_use(mob/living/user, obj/item/organ/internal/organ, obj/item/mod)
+	var/datum/component/modification/organ/C
+	var/obj/item/organ/external/limb = organ.get_limb()
+
+	if(istype(mod, /obj/item/modification/organ/internal))
+		C = mod.GetComponent(/datum/component/modification/organ)
+	else
+		return FALSE
+
+	if(limb && C)
+		var/organ_size_delta = (organ.specific_organ_size * (1 - C.specific_organ_size_multiplier) + C.specific_organ_size_mod) - organ.specific_organ_size
+		if(limb.get_total_occupied_volume() + organ_size_delta > limb.max_volume)
+			to_chat(user, SPAN_WARNING("There isn't enough space in \the [limb] to apply \the [mod]."))
+			return FALSE
+
+	return organ.is_open()
+
+/datum/surgery_step/attach_mod/begin_step(mob/living/user, obj/item/organ/internal/organ, obj/item/mod)
+	var/obj/item/organ/external/limb = organ.get_limb()
+	if(limb)
+		organ.owner_custom_pain("Someone is digging into into your [limb.name]!", 1)
+
+/datum/surgery_step/attach_mod/end_step(mob/living/user, obj/item/organ/internal/organ, obj/item/mod)
+	SEND_SIGNAL(mod, COMSIG_IATTACK, organ, user)
+
+/datum/surgery_step/attach_mod/fail_step(mob/living/user, obj/item/organ/internal/organ, obj/item/mod)
+	user.visible_message(
+		SPAN_WARNING("[user]'s hand slips, damaging [organ.get_surgery_name()] with \the [mod]!"),
+		SPAN_WARNING("Your hand slips, damaging [organ.get_surgery_name()] with \the [mod]!")
+	)
+	organ.take_damage(5, 0)
+
+/datum/surgery_step/remove_mod
+	required_tool_quality = QUALITY_LASER_CUTTING
+	target_organ_type = /obj/item/organ/internal
+	duration = 0
+	blood_level = 1
+
+/datum/surgery_step/remove_mod/can_use(mob/living/user, obj/item/organ/internal/organ, obj/item/tool)
+	return organ.is_open()
+
+/datum/surgery_step/remove_mod/begin_step(mob/living/user, obj/item/organ/internal/organ, obj/item/tool)
+	var/obj/item/organ/external/limb = organ.get_limb()
+	if(limb)
+		organ.owner_custom_pain("Someone is cutting into into your [limb.name]!", 1)
+
+/datum/surgery_step/remove_mod/end_step(mob/living/user, obj/item/organ/internal/organ, obj/item/tool)
+	SEND_SIGNAL(organ, COMSIG_ATTACKBY, tool, user)
+
+/datum/surgery_step/remove_mod/fail_step(mob/living/user, obj/item/organ/internal/organ, obj/item/tool)
+	user.visible_message(
+		SPAN_WARNING("[user]'s hand slips, damaging [organ.get_surgery_name()] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, damaging [organ.get_surgery_name()] with \the [tool]!")
+	)
+	organ.take_damage(5, 0)
+
+/datum/surgery_step/examine
+	required_tool_quality = null
+	target_organ_type = /obj/item/organ/internal
+	duration = 0
+	difficulty = 0
+
+/datum/surgery_step/examine/tool_quality(obj/item/tool)
+	return 100		// Don't need no tool
+
+/datum/surgery_step/examine/can_use(mob/living/user, obj/item/organ/organ, obj/item/tool, target)
+	return TRUE
+
+/datum/surgery_step/examine/can_use(mob/living/user, obj/item/organ/internal/organ, obj/item/tool)
+	return organ.is_open()
+
+/datum/surgery_step/examine/end_step(mob/living/user, obj/item/organ/internal/organ, obj/item/tool)
+	organ.examine(user)
+
+/datum/surgery_step/examine/fail_step(mob/living/user, obj/item/organ/internal/organ, obj/item/tool)
+	to_chat(user, SPAN_WARNING("You couldn't get a good look at \the [organ.get_surgery_name()]."))

--- a/nano/templates/surgery_organ.tmpl
+++ b/nano/templates/surgery_organ.tmpl
@@ -44,7 +44,8 @@
 					</section>
 					{{/for}}
 				{{/if}}
-
+			</article>
+			<article>
 				{{if organ.actions.length}}
 					{{for organ.actions :action:action_i}}
 					<section>
@@ -52,8 +53,6 @@
 					</section>
 					{{/for}}
 				{{/if}}
-				
-
 			</article>
 		</div>
 		{{/for}}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Organs can be modded without removing them. Basically, brains and bones are now moddable.

![image](https://user-images.githubusercontent.com/95178278/188351770-8d557b46-0dea-4b8b-a8df-f267684d5e57.png)

## Why It's Good For The Game

QoL and RNG reduction.

## Changelog
:cl:
add: Added mod attach/remove buttons to organs in the surgery window
add: Added examine button to aberrant organs in the surgery window
tweak: Reagent-based teratomas are separated by their reagent pool
fix: Fixes regurgitator substrate value going negative
fix: Adds stomach to the organ fab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
