### PR TITLE
Eye damage from any source is no longer doubled

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -98,7 +98,7 @@
 	if(blinded)
 		return
 	if(eye_damage)
-		eye_damage += eye_damage * species.flash_mod // increase based on how susceptible they are
+		eye_damage *= species.flash_mod // increase based on how susceptible they are
 		var/obj/item/organ/internal/eyes/E = src.random_organ_by_process(OP_EYES)
 		E.take_damage(eye_damage, FALSE)
 		if (E && E.damage >= E.min_bruised_damage)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

oops
## Why It's Good For The Game
Bugfix

## Changelog
:cl:
fix: Fixed the eye damage from flashes always being doubled/
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
