### PR TITLE
Crossbows and Shellshock lose energy weapon privileges, Shellshock gets barrel mods

### DIFF
--- a/code/modules/projectiles/guns/energy/poweredcrossbow.dm
+++ b/code/modules/projectiles/guns/energy/poweredcrossbow.dm
@@ -52,3 +52,6 @@
 	if(bolt && cell.use(charge_cost))
 		. = new bolt.projectile_type
 		bolt = null
+
+/obj/item/gun/energy/poweredcrossbow/generate_guntags()
+	gun_tags = list()

--- a/code/modules/projectiles/guns/energy/rapidcrossbow.dm
+++ b/code/modules/projectiles/guns/energy/rapidcrossbow.dm
@@ -21,3 +21,6 @@
 
 /obj/item/gun/energy/rxd/update_icon()
 	icon_state = cell ? "rxb_drawn" : "rxb_empty"
+
+/obj/item/gun/energy/rxd/generate_guntags()
+	gun_tags = list()

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -57,7 +57,7 @@
 				to_chat(user, SPAN_NOTICE("You loosen the safety bolts, allowing the weapon to destroy empty cells for use as ammunition."))
 
 /obj/item/gun/energy/shrapnel/generate_guntags()
-	gun_tags = list()
+	gun_tags = list(GUN_PROJECTILE)
 
 /obj/item/gun/energy/shrapnel/mounted
 	name = "SDF SC \"Schrapnell\""

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -56,6 +56,9 @@
 				consume_cell = TRUE
 				to_chat(user, SPAN_NOTICE("You loosen the safety bolts, allowing the weapon to destroy empty cells for use as ammunition."))
 
+/obj/item/gun/energy/shrapnel/generate_guntags()
+	gun_tags = list()
+
 /obj/item/gun/energy/shrapnel/mounted
 	name = "SDF SC \"Schrapnell\""
 	desc = "An energy-based shotgun, employing a matter fabricator to pull shotgun rounds from thin air and energy."

--- a/code/modules/projectiles/guns/mods/research_mods.dm
+++ b/code/modules/projectiles/guns/mods/research_mods.dm
@@ -60,8 +60,8 @@
 	GUN_UPGRADE_RECOIL = 1.2,
 	GUN_UPGRADE_DAMAGE_MULT = 1.5,
 	GUN_UPGRADE_CHARGECOST = 3)
-	I.req_fuel_cell = REQ_CELL
 	I.gun_loc_tag = GUN_MECHANISM
+	I.req_gun_tags = list(GUN_ENERGY)
 
 // Greatly increase firerate at the cost of lower damage
 /obj/item/gun_upgrade/mechanism/overdrive
@@ -81,8 +81,8 @@
 	GUN_UPGRADE_CHARGECOST = 0.5,
 	GUN_UPGRADE_FIRE_DELAY_MULT = 0.33,
 	GUN_UPGRADE_FULLAUTO = TRUE)
-	I.req_fuel_cell = REQ_CELL
 	I.gun_loc_tag = GUN_MECHANISM
+	I.req_gun_tags = list(GUN_ENERGY)
 
 // Add toxin damage to your weapon
 /obj/item/gun_upgrade/barrel/toxin_coater


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes an oversight.

The RCD Crossbow, Rapid Crossbow and Shellshock have now been blacklisted from using the following gun mods.
- Excruciator Lens (More damage less charge)
- Battery Shunt (More damage less charge)
- Telsa overdrive (Less damage more fire rate and battery)

The Shellshock should now be able to use the following gun mods
- Moebius "Atomik" isotope diffuser
- Moebius "Mastermind" psionic catalyst
- Moebius "Black Mamba" toxin coater
- Moebius "Caster" magnetic overheat barrel
- Moebius "Penetrator" magnetic accelerator barrel
- Syndicate "Gauss Coil" barrel
- Makeshift bullet time generator

The main reason for this is the mentioned weapons being hybrid weapons rather than energy weapons.
The RCD Xbow and Shellshock are mat fab, and the Rapid Crossbow just uses a cell for extra firing power.

The other reason is that a Tesla overdrive would be ridiculous on the RCDXbow, which has an innate property that makes it always embed. So even with little to no damage on everyshot, you could simply stack upwards of 50 embedded bolts on someone, killing them instantly the moment they moved.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nips intended interactions in the bud before they can become issues, doesn't affect any actual energy guns.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The RXB, Powered Crossbow and Shellshock can no longer take the Giga Lens, Battery Shunt and Overdrive mods
tweak: The Shellshock has been given the projectile firing flag and can take mods reliant on that now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
