### PR TITLE
Fixes fragment damage values

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -95,6 +95,7 @@
 	var/base_spread = 90	//lower means the pellets spread more across body parts. If zero then this is considered a shrapnel explosion instead of a shrapnel cone
 	var/spread_step = 10	//higher means the pellets spread more across body parts with distance
 	var/pellet_to_knockback_ratio = 0
+	wounding_mult = WOUNDING_SMALL
 
 /obj/item/projectile/bullet/pellet/Bumped()
 	. = ..()

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -290,6 +290,7 @@ There are important things regarding this file:
 
 //Should do about 80 damage at 1 tile distance (adjacent), and 50 damage at 3 tiles distance.
 //Overall less damage than slugs in exchange for more damage at very close range and more embedding
+//Has a small wounding modifier due to /bullet/pellet
 /obj/item/projectile/bullet/pellet/shotgun
 	name = "shrapnel"
 	icon_state = "birdshot-1"
@@ -300,7 +301,6 @@ There are important things regarding this file:
 	spread_step = 10
 	pellet_to_knockback_ratio = 2
 	recoil = 8
-	wounding_mult = WOUNDING_SMALL
 
 /obj/item/projectile/bullet/pellet/shotgun/Initialize()
 	. = ..()

--- a/code/modules/projectiles/projectile/fragment.dm
+++ b/code/modules/projectiles/projectile/fragment.dm
@@ -1,5 +1,5 @@
 /obj/item/projectile/bullet/pellet/fragment
-	damage_types = list(BRUTE = 10)
+	damage_types = list(BRUTE = 15) // Blocked by heavy armor
 	range_step = 2
 
 	base_spread = 0 //causes it to be treated as a shrapnel explosion instead of cone
@@ -13,22 +13,22 @@
 	ricochet_ability = 10
 
 /obj/item/projectile/bullet/pellet/fragment/strong
-	damage_types = list(BRUTE = 15)
+	damage_types = list(BRUTE = 20)
 
 /obj/item/projectile/bullet/pellet/fragment/weak
-	damage_types = list(BRUTE = 5)
+	damage_types = list(BRUTE = 10) // Blocked by most armor
 
 /obj/item/projectile/bullet/pellet/fragment/rubber
 	icon_state = "rubber"
 	name = "stinger"
-	damage_types = list(BRUTE = 5, HALLOSS = 25)
+	damage_types = list(BRUTE = 8, HALLOSS = 12)
 	embed = FALSE
 	sharp = FALSE
 
 /obj/item/projectile/bullet/pellet/fragment/rubber/weak
 	icon_state = "rubber"
 	name = "stinger"
-	damage_types = list(BRUTE = 3, HALLOSS = 20)
+	damage_types = list(BRUTE = 8, HALLOSS = 10)
 	embed = FALSE
 	sharp = FALSE
 
@@ -36,5 +36,5 @@
 	name = "explosion"
 	icon_state = "invisible"
 	embed = 0
-	damage_types = list(BRUTE = 20)
+	damage_types = list(BRUTE = 30)
 	check_armour = ARMOR_BOMB


### PR DESCRIPTION
## About The Pull Request

Gives fragments a 0.5 wound modifier, but buffs base damage

As stinger rounds now use combined damage types, halloss was significantly cut on them

## Why It's Good For The Game

No more insta-KO from stinger rounds

## Changelog
:cl:
balance: fragment damage adjusted for new armor system
fix: fragment damage type fixed
/:cl:
