### PR TITLE
Aberrant organ fixes and balancing

### DIFF
--- a/code/modules/aberrants/organs/_defines.dm
+++ b/code/modules/aberrants/organs/_defines.dm
@@ -76,7 +76,9 @@
 							/datum/reagent/metal/mercury, /datum/reagent/metal/potassium, /datum/reagent/metal/radium, /datum/reagent/metal/sodium,\
 							/datum/reagent/metal/tungsten)
 
-#define REAGENTS_EDIBLE list(/datum/reagent/organic/nutriment, /datum/reagent/organic/frostoil, /datum/reagent/organic/capsaicin, /datum/reagent/drink/milk)
+#define REAGENTS_EDIBLE list(/datum/reagent/organic/nutriment, /datum/reagent/organic/frostoil, /datum/reagent/organic/capsaicin, /datum/reagent/drink/milk,\
+							/datum/reagent/other/lipozine, /datum/reagent/drink/limejuice, /datum/reagent/drink/orangejuice, /datum/reagent/drink/tomatojuice,\
+							/datum/reagent/drink/tea, /datum/reagent/drink/tea/icetea)
 
 #define REAGENTS_ALCOHOL list(/datum/reagent/alcohol/ale, /datum/reagent/alcohol/beer, /datum/reagent/alcohol/mead,\
 								/datum/reagent/alcohol/gin, /datum/reagent/alcohol/rum, /datum/reagent/alcohol/tequilla, /datum/reagent/alcohol/vermouth,\

--- a/code/modules/aberrants/organs/holders.dm
+++ b/code/modules/aberrants/organs/holders.dm
@@ -47,15 +47,17 @@
 	var/using_sci_goggles = FALSE
 	var/details_unlocked = FALSE
 
-	// Goggles check
 	if(ishuman(user))
+		// Goggles check
 		var/mob/living/carbon/human/H = user
 		if(istype(H.glasses, /obj/item/clothing/glasses/powered/science))
 			var/obj/item/clothing/glasses/powered/G = H.glasses
 			using_sci_goggles = G.active	// Meat vision
 
-	// Stat check
-	details_unlocked = (user.stats.getStat(STAT_BIO) >= STAT_LEVEL_EXPERT - 5 && user.stats.getStat(STAT_COG) >= STAT_LEVEL_BASIC - 5) ? TRUE : FALSE
+		// Stat check
+		details_unlocked = (user.stats.getStat(STAT_BIO) >= STAT_LEVEL_EXPERT - 5 && user.stats.getStat(STAT_COG) >= STAT_LEVEL_BASIC - 5) ? TRUE : FALSE
+	else if(istype(user, /mob/observer/ghost))
+		details_unlocked = TRUE
 
 	if(item_upgrades.len)
 		to_chat(user, SPAN_NOTICE("Organoid grafts present ([item_upgrades.len]/[max_upgrades]). Use a laser cutting tool to remove."))

--- a/code/modules/aberrants/organs/internal/teratoma.dm
+++ b/code/modules/aberrants/organs/internal/teratoma.dm
@@ -135,7 +135,7 @@
 
 /obj/item/organ/internal/scaffold/aberrant/teratoma/input/reagents
 	name = "metabolic teratoma"
-	description_info = "A teratoma that houses a metabolic organoid. Use a laser cutting tool to remove the organoid (50 BIO recommended).\n\n\
+	description_info = "A teratoma that houses a metabolic organoid. Use a laser cutting tool to remove the organoid. 35 BIO and 15 COG recommended.\n\n\
 						Organoid information:\n\
 						Requires the specified reagent(s) to be present in one of the three metabolism holders: bloodstream, ingested, or touch. \
 						When the correct reagent is in the correct holder, the reagent will be removed at a rate equal to its metabolism times \
@@ -173,7 +173,7 @@
 
 /obj/item/organ/internal/scaffold/aberrant/teratoma/input/damage
 	name = "nociceptive teratoma"
-	description_info = "A teratoma that houses a nociceptive organoid. Use a laser cutting tool to remove the organoid (50 BIO recommended).\n\n\
+	description_info = "A teratoma that houses a nociceptive organoid. Use a laser cutting tool to remove the organoid. 35 BIO and 15 COG recommended.\n\n\
 						Organoid information:\n\
 						Requires the specified damage type(s) to be present. The process is triggered when at least one point of damage is taken \
 						(can be inflicted before attaching the organ), but no damage is healed."
@@ -181,7 +181,7 @@
 
 /obj/item/organ/internal/scaffold/aberrant/teratoma/input/power_source
 	name = "bioelectric teratoma"
-	description_info = "A teratoma that houses a bioelectric organoid. Use a laser cutting tool to remove the organoid (50 BIO recommended).\n\n\
+	description_info = "A teratoma that houses a bioelectric organoid. Use a laser cutting tool to remove the organoid. 35 BIO and 15 COG recommended.\n\n\
 						Organoid information:\n\
 						Requries the specified power source to be held in the bare hand of the organ's owner. Any amount of charge in a cell or sheets \
 						in a stack will trigger the process, but larger cells and rarer materials will provide a slight cognition and sanity boost."
@@ -277,21 +277,21 @@
 
 /obj/item/organ/internal/scaffold/aberrant/teratoma/process/map
 	name = "tubular teratoma"
-	description_info = "A teratoma that houses a tubular organoid. Use a laser cutting tool to remove the organoid (50 BIO recommended).\n\n\
+	description_info = "A teratoma that houses a tubular organoid. Use a laser cutting tool to remove the organoid. 35 BIO and 15 COG recommended.\n\n\
 						Organoid information:\n\
 						Maps inputs to outputs. Works for any number of inputs and outputs."
 	process_mod_path = /obj/item/modification/organ/internal/process/map
 
 /obj/item/organ/internal/scaffold/aberrant/teratoma/process/condense
 	name = "sphincter teratoma"
-	description_info = "A teratoma that houses a sphincter organoid. Use a laser cutting tool to remove the organoid (50 BIO recommended).\n\n\
+	description_info = "A teratoma that houses a sphincter organoid. Use a laser cutting tool to remove the organoid. 35 BIO and 15 COG recommended.\n\n\
 						Organoid information:\n\
 						Maps inputs to a single output. If there are multiple outputs, it only uses the first."
 	process_mod_path = /obj/item/modification/organ/internal/process/condense
 
 /obj/item/organ/internal/scaffold/aberrant/teratoma/process/boost
 	name = "enzymal teratoma"
-	description_info = "A teratoma that houses an enzymal organoid. Use a laser cutting tool to remove the organoid (50 BIO recommended).\n\n\
+	description_info = "A teratoma that houses an enzymal organoid. Use a laser cutting tool to remove the organoid. 35 BIO and 15 COG recommended.\n\n\
 						Organoid information:\n\
 						Maps inputs to outputs. Increases output magnitude."
 	process_mod_path = /obj/item/modification/organ/internal/process/boost
@@ -312,7 +312,7 @@
 
 /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_blood
 	name = "hepatic teratoma"
-	description_info = "A teratoma that houses an hepatic organoid. Use a laser cutting tool to remove the organoid (50 BIO recommended).\n\n\
+	description_info = "A teratoma that houses an hepatic organoid. Use a laser cutting tool to remove the organoid. 35 BIO and 15 COG recommended.\n\n\
 						Organoid information:\n\
 						Produces reagents in the bloodstream when triggered."
 	req_num_outputs = 1
@@ -336,7 +336,7 @@
 
 /obj/item/organ/internal/scaffold/aberrant/teratoma/output/reagents_ingest
 	name = "gastric teratoma"
-	description_info = "A teratoma that houses a gastric organoid. Use a laser cutting tool to remove the organoid (50 BIO recommended).\n\n\
+	description_info = "A teratoma that houses a gastric organoid. Use a laser cutting tool to remove the organoid. 35 BIO and 15 COG recommended.\n\n\
 						Organoid information:\n\
 						Produces reagents in the stomach when triggered."
 	req_num_outputs = 1
@@ -352,7 +352,7 @@
 
 /obj/item/organ/internal/scaffold/aberrant/teratoma/output/chemical_effects
 	name = "endocrinal teratoma"
-	description_info = "A teratoma that houses an endocrinal organoid. Use a laser cutting tool to remove the organoid (50 BIO recommended).\n\n\
+	description_info = "A teratoma that houses an endocrinal organoid. Use a laser cutting tool to remove the organoid. 35 BIO and 15 COG recommended.\n\n\
 						Organoid information:\n\
 						Produces hormones in the bloodstream when triggered."
 	req_num_outputs = 1
@@ -368,7 +368,7 @@
 
 /obj/item/organ/internal/scaffold/aberrant/teratoma/output/stat_boost
 	name = "intracrinal teratoma"
-	description_info = "A teratoma that houses an intracrinal organoid. Use a laser cutting tool to remove the organoid (50 BIO recommended).\n\n\
+	description_info = "A teratoma that houses an intracrinal organoid. Use a laser cutting tool to remove the organoid. 35 BIO and 15 COG recommended.\n\n\
 						Organoid information:\n\
 						Slightly increase stats when triggered."
 	req_num_outputs = 1
@@ -480,14 +480,14 @@
 
 /obj/item/organ/internal/scaffold/aberrant/teratoma/special/chemical_effect
 	name = "pygmy endocrinal teratoma"
-	description_info = "A teratoma that houses a pygmy endocrinal membrane. Use a laser cutting tool to remove the organoid (50 BIO recommended).\n\n\
+	description_info = "A teratoma that houses a pygmy endocrinal membrane. Use a laser cutting tool to remove the organoid. 35 BIO and 15 COG recommended.\n\n\
 						Membrane information:\n\
 						Produces a hormone when the primary function triggers."
 	special_mod_path = /obj/item/modification/organ/internal/special/on_cooldown/chemical_effect
 
 /obj/item/organ/internal/scaffold/aberrant/teratoma/special/stat_boost
 	name = "pygmy intracrinal teratoma"
-	description_info = "A teratoma that houses a pygmy intracrinal membrane. Use a laser cutting tool to remove the organoid (50 BIO recommended).\n\n\
+	description_info = "A teratoma that houses a pygmy intracrinal membrane. Use a laser cutting tool to remove the organoid. 35 BIO and 15 COG recommended.\n\n\
 						Membrane information:\n\
 						Slightly increases a stat when the primary function triggers."
 	special_mod_path = /obj/item/modification/organ/internal/special/on_cooldown/stat_boost

--- a/code/modules/aberrants/organs/internal/teratoma.dm
+++ b/code/modules/aberrants/organs/internal/teratoma.dm
@@ -69,7 +69,7 @@
 				output_pool = pick(possible_reagent_classes)
 			if(!output_info?.len)
 				for(var/i in 1 to req_num_outputs)
-					output_info += pick(VERY_LOW_OUTPUT)
+					output_info += pick(LOW_OUTPUT)
 
 		if(/obj/item/modification/organ/internal/output/reagents_ingest)
 			if(!output_pool?.len)
@@ -78,7 +78,7 @@
 				output_pool = pick(possible_reagent_classes)
 			if(!output_info?.len)
 				for(var/i in 1 to req_num_outputs)
-					output_info += pick(VERY_LOW_OUTPUT)
+					output_info += pick(LOW_OUTPUT)
 
 		if(/obj/item/modification/organ/internal/output/chemical_effects)
 			if(!output_pool?.len)

--- a/code/modules/aberrants/organs/machinery/disgorger.dm
+++ b/code/modules/aberrants/organs/machinery/disgorger.dm
@@ -82,7 +82,7 @@
 
 	if(blacklisted)
 		blacklisted = copytext(blacklisted, 1, length(blacklisted) - 1)
-		to_chat(user, SPAN_WARNING("Rejects [blacklisted]."))
+		to_chat(user, SPAN_WARNING("Rejects objects with the following reagents: [blacklisted]."))
 
 /obj/machinery/reagentgrinder/industrial/disgorger/proc/check_reagents(obj/item/I, mob/user)
 	if(!I.reagents || !I.reagents.total_volume)

--- a/code/modules/aberrants/organs/machinery/disgorger.dm
+++ b/code/modules/aberrants/organs/machinery/disgorger.dm
@@ -298,10 +298,10 @@
 
 /obj/item/electronics/circuitboard/disgorger
 	name = T_BOARD("disgorger")
+	spawn_blacklisted = TRUE
 	board_type = "machine"
 	build_path = /obj/machinery/reagentgrinder/industrial/disgorger
 	origin_tech = list(TECH_BIO = 3)
-	rarity_value = 20
 	req_components = list(
 		/obj/item/organ/internal = 4			// Build with any organ, but certain efficiencies will have different effects.
 	)

--- a/code/modules/aberrants/organs/machinery/disgorger.dm
+++ b/code/modules/aberrants/organs/machinery/disgorger.dm
@@ -248,7 +248,7 @@
 			/datum/reagent/toxin/blattedin = 0.5
 		)
 	if(liver_eff > 149)
-		accepted_reagents = list(
+		accepted_reagents |= list(
 			/datum/reagent/toxin/fuhrerole = 1,
 			/datum/reagent/toxin/kaiseraurum = 10
 		)

--- a/code/modules/aberrants/organs/machinery/organ_fabricator.dm
+++ b/code/modules/aberrants/organs/machinery/organ_fabricator.dm
@@ -88,9 +88,11 @@
 	return design_files
 
 /obj/machinery/autolathe/organ_fabricator/ui_interact()
-	if(!categories?.len)
+	if(!islist(categories))		// Runtime occured when the categories var was 0, but the null check wasn't catching it. 
+		categories = list()		
+	if(!categories.len)
 		categories = files.design_categories_organfab
-	if(!disk && !show_category && length(categories))
+	if(!disk && !show_category && categories.len)
 		show_category = categories[1]
 	..()
 

--- a/code/modules/aberrants/organs/machinery/organ_fabricator.dm
+++ b/code/modules/aberrants/organs/machinery/organ_fabricator.dm
@@ -170,6 +170,7 @@
 
 /obj/item/electronics/circuitboard/organ_fabricator
 	name = T_BOARD("organ fabricator")
+	spawn_blacklisted = TRUE
 	build_path = /obj/machinery/autolathe/organ_fabricator
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2, TECH_BIO = 2)

--- a/code/modules/aberrants/organs/mods/component/_component.dm
+++ b/code/modules/aberrants/organs/mods/component/_component.dm
@@ -150,17 +150,19 @@
 	var/using_sci_goggles = FALSE
 	var/details_unlocked = FALSE
 
-	// Goggles check
 	if(ishuman(user))
+		// Goggles check
 		var/mob/living/carbon/human/H = user
 		if(istype(H.glasses, /obj/item/clothing/glasses/powered/science))
 			var/obj/item/clothing/glasses/powered/G = H.glasses
 			using_sci_goggles = G.active	// Meat vision
 
-	// Stat check
-	details_unlocked = (user.stats.getStat(examine_stat) >= examine_difficulty) ? TRUE : FALSE
-	if(examine_stat_secondary && details_unlocked)
-		details_unlocked = (user.stats.getStat(examine_stat_secondary) >= examine_difficulty_secondary) ? TRUE : FALSE
+		// Stat check
+		details_unlocked = (user.stats.getStat(examine_stat) >= examine_difficulty) ? TRUE : FALSE
+		if(examine_stat_secondary && details_unlocked)
+			details_unlocked = (user.stats.getStat(examine_stat_secondary) >= examine_difficulty_secondary) ? TRUE : FALSE
+	else if(istype(user, /mob/observer/ghost))
+		details_unlocked = TRUE
 
 	if(examine_msg)
 		to_chat(user, SPAN_WARNING(examine_msg))

--- a/code/modules/aberrants/organs/mods/component/special.dm
+++ b/code/modules/aberrants/organs/mods/component/special.dm
@@ -65,7 +65,7 @@
 		if(H.getarmor_organ(active_hand, ARMOR_MELEE) < 3 && active_hand.get_total_occupied_volume() < active_hand.max_volume)
 			if(istype(holder, /obj/item/organ/internal))
 				var/obj/item/organ/internal/I = holder
-				owner.drop_item(I)
+				H.drop_item()
 				I.replaced(active_hand)
 				H.apply_damage(10, HALLOSS, active_hand)
 				H.apply_damage(10, BRUTE, active_hand)

--- a/code/modules/aberrants/organs/reagents/hormones.dm
+++ b/code/modules/aberrants/organs/reagents/hormones.dm
@@ -29,7 +29,7 @@
 /datum/reagent/hormone/bloodclot
 	name = "thrombopoietin"		// Increases platelet (clotting stuff) production
 	id = "thrombopoietin"
-	effects = list(CE_BLOODCLOT = 0.2)
+	effects = list(CE_BLOODCLOT = 0.25)
 
 /datum/reagent/hormone/bloodclot/alt
 	name = "thromboxane"		// Produced by platelets to encourage stronger clots
@@ -40,7 +40,7 @@
 /datum/reagent/hormone/bloodrestore
 	name = "aldosterone"		// Increases blood volume as a result of its IRL effects
 	id = "aldosterone"
-	effects = list(CE_BLOODRESTORE = 0.1)
+	effects = list(CE_BLOODRESTORE = 0.4)
 
 /datum/reagent/hormone/bloodrestore/alt
 	name = "erythropoietin"		// Stimulates red blood cell production
@@ -51,7 +51,7 @@
 /datum/reagent/hormone/painkiller
 	name = "enkephalin"			// Regulates nociception (pain response)
 	id = "enkephalin"
-	effects = list(CE_PAINKILLER = 10)
+	effects = list(CE_PAINKILLER = 20)
 
 /datum/reagent/hormone/painkiller/alt
 	name = "endomorphin"		// Regulates nociception (pain response)
@@ -62,7 +62,7 @@
 /datum/reagent/hormone/speedboost
 	name = "osteocalcin"		// Increases energy availability in muscles among other things, probably close enough
 	id = "osteocalcin"
-	effects = list(CE_SPEEDBOOST = 0.15)
+	effects = list(CE_SPEEDBOOST = 0.25)
 
 /datum/reagent/hormone/speedboost/alt
 	name = "noradrenaline"		// Fight or flight hormone


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Not sure where the organ fab runtime was coming from, but I added a check to prevent it.

A comment about 2u reagent outputs: Using the reagent outputs with an input that constantly triggered caused a lot of ODs in early tests. For example, brute damage input with a space drug output was a good way to remove yourself from the round if you weren't healing.

## Why It's Good For The Game

Fixes and balancing

## Changelog
:cl:
fix: Teratoma stat recommendation fixed
fix: Added check to prevent an organ fab runtime
fix: Disgorger description fix
fix: Fixes disgorger losing acceptable reagents
fix: Removed organ fab and disgorger circuits from junk spawns
tweak: Allows ghosts to see organoid info, fixes a runtime
balance: Added lipzoine, lime juice, orange juice, tomato juice, tea, and iced tea to teratoma (edible) pool
balance: Standard reagent outputs increased to 2u
balance: Hormone blood-clotting effect increased to 0.25
balance: Hormone blood regen effect increased to 0.4
balance: Hormone painkiller effect increased to 20
balance: Hormone speed boost effect increased to 0.25
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
