### PR TITLE
Fixes guild radio and burrows taking out pipes roundstart

### DIFF
--- a/code/controllers/subsystems/migration.dm
+++ b/code/controllers/subsystems/migration.dm
@@ -71,6 +71,11 @@ This proc will attempt to create a burrow against a wall, within view of the tar
 		if (F.is_wall)
 			continue
 
+		// SPCR 2022 - added this to prevent them disconnecting pipes and cables , since , through magical means , it is impossible to find the code behind pipes being disconnected
+		// on turfs with burrows.
+		if(!turf_clear(F))
+			continue
+
 		//No stacking multiple burrows per tile
 		if (locate(/obj/structure/burrow) in F)
 			continue

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -813,7 +813,7 @@ var/global/list/default_medbay_channels = list(
 		var/obj/item/paper/stash_note = stash.spawn_note(get_turf(src))
 		visible_message(SPAN_NOTICE("[src] spits out a [stash_note]."))
 		last_produce = world.time
-	if(world.time > last_bluespace)
+	if(world.time > last_bluespace && bluespace_generating)
 		var/pathed = pickweight(bluespace_items, pick(5,10,25))
 		var/atom/movable/the_chosen = new pathed()
 		the_chosen.forceMove(get_turf(src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes guild radio spawning bluespace items without being upgraded
fixes burrows taking out pipes roundstart (with shitcode)

## Why It's Good For The Game
Fixes

## Changelog
:cl:
fix: Fixed guild radio spawning bluespace items with no upgrade
fix: Fixed burrows taking out pipes round-start
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
