### PR TITLE
Add a check for area existence in Stranger code

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/stranger.dm
+++ b/code/modules/mob/living/simple_animal/hostile/stranger.dm
@@ -181,10 +181,12 @@
 	var/list/final_oddity = list()
 	var/stat = pick(stats)
 	final_oddity += stat
+	final_oddity[stat] = 6
 	var/area/my_area = get_area(src)
-	var/bluespacemodifier = round(my_area.bluespace_entropy/(my_area.bluespace_hazard_threshold/4))
-	final_oddity[stat] = 6 + bluespacemodifier
-	my_area.bluespace_entropy = max(0, my_area.bluespace_entropy - (6 + bluespacemodifier))
+	if(my_area)
+		var/bluespacemodifier = round(my_area.bluespace_entropy/(my_area.bluespace_hazard_threshold/4))
+		final_oddity[stat] += bluespacemodifier
+		my_area.bluespace_entropy = max(0, my_area.bluespace_entropy - (6 + bluespacemodifier))
 	var/datum/component/inspiration/odd = GetComponent(/datum/component/inspiration)
 	odd.stats = final_oddity
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix this runtime in chaos proc, called during initialization. I guess Stranger ends up in null space sometimes? So area is null.
```
[21:37:03] Runtime in stranger.dm,185: Cannot read null.bluespace_entropy
  proc name: chaos (/obj/item/gun/energy/plasma/stranger/proc/chaos)
  src: the unknown plasma gun (/obj/item/gun/energy/plasma/stranger)
  src.loc: null
  call stack:
  the unknown plasma gun (/obj/item/gun/energy/plasma/stranger): chaos()
  the unknown plasma gun (/obj/item/gun/energy/plasma/stranger): New()
  Random wave radio (/obj/item/device/radio/random_radio): Process(10, 0, Objs (/datum/controller/subsystem/processing/obj))
  Objs (/datum/controller/subsystem/processing/obj): fire(0)
  Objs (/datum/controller/subsystem/processing/obj): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing(0)
```

## Changelog
:cl: Hyperio
fix: Fixed runtime in Stranger initialization
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
