### PR TITLE
Firedoors are no longer instant , vents and scrubbers no longer use atmos signals and go back to processing.

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -51,49 +51,9 @@
 		assign_uid()
 		id_tag = num2text(uid)
 
-/obj/machinery/atmospherics/unary/vent_scrubber/Initialize(mapload)
-	if(mapload)
-		addtimer(CALLBACK(src, .proc/link_to_zas), 20 SECONDS)
-	else
-		link_to_zas()
-	..()
-
 /obj/machinery/atmospherics/unary/vent_scrubber/Destroy()
 	unregister_radio(src, frequency)
-	if(current_linked_zone)
-		UnregisterSignal(current_linked_zone, COMSIG_ZAS_TICK)
-		UnregisterSignal(current_linked_zone, COMSIG_ZAS_DELETE)
-		current_linked_zone = null
 	. = ..()
-
-/obj/machinery/atmospherics/unary/vent_scrubber/proc/link_to_zas()
-	SHOULD_NOT_SLEEP(TRUE)
-	if(current_linked_zone)
-		UnregisterSignal(current_linked_zone, COMSIG_ZAS_TICK)
-		UnregisterSignal(current_linked_zone, COMSIG_ZAS_DELETE)
-		current_linked_zone = null
-	var/turf/simulated/where_the_fuck_are_we = get_turf(src)
-	if(!istype(where_the_fuck_are_we))
-		. = FALSE
-		CRASH("[src] scrubber located in [loc] on a non-simulated turf.Delete this or make the turf it is on simulated.")
-	current_linked_zone = where_the_fuck_are_we.zone
-	RegisterSignal(current_linked_zone , COMSIG_ZAS_TICK, .proc/begin_processing)
-	RegisterSignal(current_linked_zone, COMSIG_ZAS_DELETE, .proc/relink_zas)
-
-/obj/machinery/atmospherics/unary/vent_scrubber/proc/relink_zas()
-	SHOULD_NOT_SLEEP(TRUE)
-	INVOKE_ASYNC(src , .proc/zas_relink_wrapper)
-
-/obj/machinery/atmospherics/unary/vent_scrubber/proc/zas_relink_wrapper()
-	addtimer(CALLBACK(src, .proc/link_to_zas), 2 SECONDS)
-
-/obj/machinery/atmospherics/unary/vent_scrubber/proc/begin_processing()
-	SHOULD_NOT_SLEEP(TRUE)
-	last_zas_update = world.time
-	if(!currently_processing)
-		START_PROCESSING(SSmachines, src)
-		return TRUE
-	return FALSE
 
 /obj/machinery/atmospherics/unary/vent_scrubber/update_icon(safety = 0)
 	if(!node1)
@@ -169,10 +129,6 @@
 		src.broadcast_status()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/Process()
-	if(last_zas_update + SLEEPOUT_TIME < world.time)
-		currently_processing = FALSE
-		return PROCESS_KILL
-
 	..()
 
 	if (!node1)

--- a/code/ZAS/Zone.dm
+++ b/code/ZAS/Zone.dm
@@ -124,7 +124,6 @@ Class Procs:
 /zone/proc/c_invalidate()
 	invalid = TRUE
 	SSair.remove_zone(src)
-	SEND_SIGNAL(src, COMSIG_ZAS_DELETE, TRUE)
 	#ifdef ZASDBG
 	for(var/turf/simulated/T in contents)
 		T.dbg(invalid_zone)
@@ -162,8 +161,6 @@ Class Procs:
 	for(var/connection_edge/E in edges)
 		if(E.sleeping)
 			E.recheck()
-
-	SEND_SIGNAL(src, COMSIG_ZAS_TICK, src)
 
 /zone/proc/dbg_data(mob/M)
 	to_chat(M, name)

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -33,11 +33,6 @@
 
 //////////////////////////////////////////////////////////////////
 
-// /zone signals
-
-#define COMSIG_ZAS_TICK "z_tick"
-#define COMSIG_ZAS_DELETE "z_del"
-
 // /datum signals
 #define COMSIG_COMPONENT_ADDED "component_added"				//when a component is added to a datum: (/datum/component)
 #define COMSIG_COMPONENT_REMOVING "component_removing"			//before a component is removed from a datum because of RemoveComponent: (/datum/component)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -46,16 +46,6 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 5
 
-	var/last_update = 0
-	var/delay_between_updates = 5 SECONDS
-	var/list/tile_info = list(F_NORTH = list(), F_SOUTH = list(), F_EAST = list(), F_WEST = list())
-	var/list/registered_zas_zones = list(F_NORTH = null , F_SOUTH = null , F_EAST = null , F_WEST = null)
-	// MUST be in same order as FIREDOOR_ALERT_*
-	var/list/ALERT_STATES=list(
-		"hot",
-		"cold"
-	)
-
 /obj/machinery/door/firedoor/New()
 	..()
 
@@ -74,168 +64,38 @@
 /obj/machinery/door/firedoor/Destroy()
 	for(var/area/A in areas_added)
 		A.all_doors.Remove(src)
-	for(var/our_cardinal in registered_zas_zones)
-		if(!registered_zas_zones[our_cardinal])
-			continue
-		var/target_zone = registered_zas_zones[our_cardinal]
-		UnregisterSignal(target_zone , COMSIG_ZAS_TICK)
-		UnregisterSignal(target_zone, COMSIG_ZAS_DELETE)
-	registered_zas_zones = null
-	tile_info = null
 	. = ..()
-
-
-/obj/machinery/door/firedoor/Initialize(mapload)
-	if(mapload)
-		addtimer(CALLBACK(src, .proc/link_to_zas), 30 SECONDS)
-	else
-		link_to_zas()
-	. = ..()
-
-/obj/machinery/door/firedoor/proc/link_to_zas_with_update()
-	SHOULD_NOT_SLEEP(TRUE)
-	link_to_zas()
-	update_firedoor_data()
-
-/obj/machinery/door/firedoor/proc/link_to_zas(do_delayed)
-	SHOULD_NOT_SLEEP(TRUE)
-	if(do_delayed && (world.time > last_time_since_link))
-		last_time_since_link = world.time + minimum_link_cooldown
-		spawn(20) link_to_zas_with_update()
-		return FALSE
-	for(var/our_cardinal in registered_zas_zones)
-		if(!registered_zas_zones[our_cardinal])
-			continue
-		var/target_zone = registered_zas_zones[our_cardinal]
-		UnregisterSignal(target_zone , COMSIG_ZAS_TICK)
-		UnregisterSignal(target_zone, COMSIG_ZAS_DELETE)
-
-	for(var/turf/neighbor in cardinal_turfs(src))
-		var/cardinal = get_dir(src, neighbor)
-		cardinal = direction_to_text(cardinal)
-		if(!neighbor.density && istype(neighbor, /turf/simulated))
-			var/turf/simulated/redefined_turf = neighbor
-			var/turf_zone = redefined_turf.zone
-			tile_info[cardinal] = list(
-				FIREDOOR_TURF = redefined_turf,
-				FIREDOOR_ATMOS = FALSE,
-				FIREDOOR_ALERT = FALSE
-			)
-			registered_zas_zones[cardinal] = turf_zone
-		else
-			tile_info[cardinal] =  list(
-				FIREDOOR_TURF = neighbor,
-				FIREDOOR_ATMOS = FALSE,
-				FIREDOOR_ALERT = FALSE
-			)
-			registered_zas_zones[cardinal] = null
-	handle_unique_zone_register()
-	return TRUE
-
-/obj/machinery/door/firedoor/proc/handle_unique_zone_register()
-	SHOULD_NOT_SLEEP(TRUE)
-	var/list/registered = list()
-	for(var/cardinal_inside in registered_zas_zones)
-		if(registered.Find(registered_zas_zones[cardinal_inside]))
-			registered_zas_zones[cardinal_inside] = null
-			continue
-		var/zone = registered_zas_zones[cardinal_inside]
-		registered += zone
-		RegisterSignal(zone, COMSIG_ZAS_TICK, .proc/update_firedoor_data)
-		RegisterSignal(zone, COMSIG_ZAS_DELETE, .proc/link_to_zas)
-
 
 /obj/machinery/door/firedoor/get_material()
 	return get_material_by_name(MATERIAL_STEEL)
-/*
-/obj/machinery/door/firedoor/proc/update_firedoor_data()
-	SHOULD_NOT_SLEEP(TRUE)
-	var/gotta_update_icon = FALSE
-	if(!density)
-		return FALSE
-
-	for(var/list/cardinal_target in tile_info)
-		var/list/data = tile_info[cardinal_target]
-		if(data[FIREDOOR_ATMOS] == FIREDOOR_DONT_UPDATE)
-			continue
-		data[FIREDOOR_ATMOS] = data[FIREDOOR_TURF].return_air() // yes it can return nothing in space.
-		var/alerts = 0
-		lockdown = FALSE
-		var/old_alerts = data[FIREDOOR_ALERT]
-		if(data[FIREDOOR_ATMOS])
-			var/datum/gas_mixture/gasses = data[FIREDOOR_ATMOS]
-			if(gasses.temperature >= FIREDOOR_MAX_TEMP)
-				alerts |= FIREDOOR_ALERT_HOT
-			if(gasses.temperature <= FIREDOOR_MIN_TIMP)
-				alerts |= FIREDOOR_ALERT_COLD
-			data[FIREDOOR_ALERT] = alerts
-			if(data[FIREDOOR_ALERT != old_alerts])
-				gotta_update_icon = TRUE
-
-	if(gotta_update_icon)
-		INVOKE_ASYNC(src , proc/update_icon)
-*/
 
 /obj/machinery/door/firedoor/examine(mob/user)
 	if(!density || !..(user, 1))
 		return FALSE
 
 	to_chat(user, "<b> EMERGENCY SENSOR READINGS </b>")
-	for(var/cardinal in tile_info)
-		var/list/data = tile_info[cardinal]
+	for(var/turf/simulated/card in cardinal_turfs(src))
 		var/text_to_say = "&nbsp;&nbsp" // Magic bullshit im not even gonna question from the old proc
-		text_to_say += SPAN_NOTICE("[cardinal] :/:")
-		if(data[FIREDOOR_ATMOS])
-			var/datum/gas_mixture/gasses = data[FIREDOOR_ATMOS]
-			text_to_say += " PKA : [gasses.return_pressure()] | "
-		if(!data[FIREDOOR_ALERT])
-			text_to_say += " ALERT : NO DATA |"
+		var/dangerous = FALSE
+		text_to_say += "[dir2text(get_dir(src, card))] : "
+		if(card.is_wall || !card.zone)
+			text_to_say += SPAN_NOTICE("NO DATA")
 			to_chat(user, text_to_say)
 			continue
-		if(data[FIREDOOR_ALERT] & FIREDOOR_ALERT_COLD)
-			text_to_say += SPAN_DANGER("ALERT : VACUMM / LOW TEMPERATURE DETECTED |")
-		if(data[FIREDOOR_ALERT] & FIREDOOR_ALERT_HOT)
-			text_to_say += SPAN_DANGER("ALERT : HIGH TEMPERATURE DETECTED |")
+		if(card.zone.return_pressure() < FIREDOOR_MIN_PRESSURE)
+			text_to_say += SPAN_DANGER("LOW PRESSURE ")
+			dangerous = TRUE
+		if(card.zone.temperature > FIREDOOR_MAX_TEMP)
+			text_to_say += SPAN_DANGER("HIGH TEMPERATURE ")
+			dangerous = TRUE
+		else if(card.zone.temperature < FIREDOOR_MIN_TEMP)
+			text_to_say += SPAN_DANGER("LOW TEMPERATURE ")
+			dangerous = TRUE
+		if(dangerous)
+			to_chat(user, text_to_say)
+			return
+		text_to_say += span_green("SAFE")
 		to_chat(user, text_to_say)
-
-	/*
-	if(!. || !density)
-		return FALSE
-
-	if(pdiff >= FIREDOOR_MAX_PRESSURE_DIFF)
-		to_chat(user, SPAN_WARNING("WARNING: Current pressure differential is [pdiff]kPa! Opening door may result in injury!"))
-
-	to_chat(user, "<b>Sensor readings:</b>")
-	for(var/index = 1; index <= tile_info.len; index++)
-		var/o = "&nbsp;&nbsp;"
-		switch(index)
-			if(1)
-				o += "NORTH: "
-			if(2)
-				o += "SOUTH: "
-			if(3)
-				o += "EAST: "
-			if(4)
-				o += "WEST: "
-		if(tile_info[index] == null)
-			o += SPAN_WARNING("DATA UNAVAILABLE")
-			to_chat(user, o)
-			continue
-		var/celsius = convert_k2c(tile_info[index][1])
-		var/pressure = tile_info[index][2]
-		o += "<span class='[(dir_alerts[index] & (FIREDOOR_ALERT_HOT|FIREDOOR_ALERT_COLD)) ? "warning" : "color:blue"]'>"
-		o += "[celsius]&deg;C</span> "
-		o += "<span style='color:blue'>"
-		o += "[pressure]kPa</span></li>"
-		to_chat(user, o)
-
-	if(islist(users_to_open) && users_to_open.len)
-		var/users_to_open_string = users_to_open[1]
-		if(users_to_open.len >= 2)
-			for(var/i = 2 to users_to_open.len)
-				users_to_open_string += ", [users_to_open[i]]"
-		to_chat(user, "These people have opened \the [src] during an alert: [users_to_open_string].")
-	*/
 
 /obj/machinery/door/firedoor/Bumped(atom/AM)
 	if(p_open || operating)
@@ -368,76 +228,6 @@
 
 	return ..()
 
-// CHECK PRESSURE
-/obj/machinery/door/firedoor/proc/update_firedoor_data()
-	SHOULD_NOT_SLEEP(TRUE)
-	if(!density)
-		return FALSE
-
-	if(world.time + delay_between_updates > last_update)
-		last_update = world.time
-	else
-		return FALSE
-
-	lockdown = FALSE
-	for(var/cardinal_target in tile_info)
-		var/alerts = 0
-		var/list/data = tile_info[cardinal_target]
-		var/turf/target_turf = data[FIREDOOR_TURF]
-		spawn(5) // we need this here else the air subsystem pauses whenever we do return_air
-			data[FIREDOOR_ATMOS] = target_turf.return_air() // problem?
-			if(!data[FIREDOOR_ATMOS])
-				alerts |= FIREDOOR_ALERT_COLD
-				lockdown = TRUE
-				continue
-			data[FIREDOOR_ALERT] = 0
-			if(data[FIREDOOR_ATMOS])
-				var/datum/gas_mixture/gasses = data[FIREDOOR_ATMOS]
-				if(gasses.temperature >= FIREDOOR_MAX_TEMP)
-					alerts |= FIREDOOR_ALERT_HOT
-					lockdown = TRUE
-				if(gasses.temperature <= FIREDOOR_MIN_TEMP)
-					alerts |= FIREDOOR_ALERT_COLD
-					lockdown = TRUE
-				if(gasses.return_pressure() <= FIREDOOR_MIN_PRESSURE)
-					alerts |= FIREDOOR_ALERT_COLD
-					lockdown = TRUE
-				data[FIREDOOR_ALERT] = alerts
-			tile_info[cardinal_target] = data
-	spawn(10) update_icon()
-	return TRUE
-
-	/*
-		var/changed = 0
-		lockdown = 0
-
-
-
-		tile_info = getCardinalAirInfo(src.loc,list("temperature","pressure"))
-		var/old_alerts = dir_alerts
-		for(var/index = 1; index <= 4; index++)
-			var/list/tileinfo=tile_info[index]
-			if(tileinfo==null)
-				continue // Bad data.
-			var/celsius = convert_k2c(tileinfo[1])
-
-			var/alerts=0
-
-			// Temperatures
-			if(celsius >= FIREDOOR_MAX_TEMP)
-				alerts |= FIREDOOR_ALERT_HOT
-				lockdown = 1
-			else if(celsius <= FIREDOOR_MIN_TEMP)
-				alerts |= FIREDOOR_ALERT_COLD
-				lockdown = 1
-
-			dir_alerts[index]=alerts
-
-		if(dir_alerts != old_alerts)
-			changed = 1
-		if(changed)
-			update_icon()
-		*/
 
 /obj/machinery/door/firedoor/close(var/forced = 0)
 	if (blocked) //welded

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -74,26 +74,28 @@
 		return FALSE
 
 	to_chat(user, "<b> EMERGENCY SENSOR READINGS </b>")
-	for(var/turf/simulated/card in cardinal_turfs(src))
+	for(var/possible_cardinal in cardinal)
+		var/turf/simulated/turf_sim = get_step(src, possible_cardinal)
 		var/text_to_say = "&nbsp;&nbsp" // Magic bullshit im not even gonna question from the old proc
-		var/dangerous = FALSE
-		text_to_say += "[dir2text(get_dir(src, card))] : "
-		if(card.is_wall || !card.zone)
+		text_to_say += "[uppertext(dir2text(possible_cardinal))] : "
+		if(!istype(turf_sim) || turf_sim.is_wall || !turf_sim.zone)
 			text_to_say += SPAN_NOTICE("NO DATA")
 			to_chat(user, text_to_say)
 			continue
-		if(card.zone.return_pressure() < FIREDOOR_MIN_PRESSURE)
+		var/dangerous = FALSE
+		var/datum/gas_mixture/air_data = turf_sim.zone.air
+		if(air_data.return_pressure() < FIREDOOR_MIN_PRESSURE)
 			text_to_say += SPAN_DANGER("LOW PRESSURE ")
 			dangerous = TRUE
-		if(card.zone.temperature > FIREDOOR_MAX_TEMP)
+		if(air_data.temperature > FIREDOOR_MAX_TEMP)
 			text_to_say += SPAN_DANGER("HIGH TEMPERATURE ")
 			dangerous = TRUE
-		else if(card.zone.temperature < FIREDOOR_MIN_TEMP)
+		else if(air_data.temperature < FIREDOOR_MIN_TEMP)
 			text_to_say += SPAN_DANGER("LOW TEMPERATURE ")
 			dangerous = TRUE
 		if(dangerous)
 			to_chat(user, text_to_say)
-			return
+			continue
 		text_to_say += span_green("SAFE")
 		to_chat(user, text_to_say)
 
@@ -286,21 +288,6 @@
 		if(blocked)
 			overlays += "welded"
 			do_set_light = TRUE
-		for(var/cardinals in tile_info)
-			var/target_card = text2dir(cardinals)
-			var/list/turf_data = tile_info[cardinals]
-			if(length(turf_data) && turf_data[FIREDOOR_ALERT])
-				var/our_alert_color = (turf_data[FIREDOOR_ALERT] & FIREDOOR_ALERT_HOT) ? 1 : 2
-				overlays += new/icon(icon,"alert_[ALERT_STATES[our_alert_color]]", dir=target_card)
-		/*
-		if(dir_alerts)
-			for(var/d=1;d<=4;d++)
-				var/cdir = cardinal[d]
-				for(var/i=1;i<=ALERT_STATES.len;i++)
-					if(dir_alerts[d] & (1<<(i-1)))
-						overlays += new/icon(icon,"alert_[ALERT_STATES[i]]", dir=cdir)
-						do_set_light = TRUE
-		*/
 	else
 		icon_state = "door_open"
 		if(blocked)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes all atmos signals from vent , scrubbers and firedoors
Firedoors now get triggered by firealarms
Vents and Scrubbers go back to constant-processing

## Why It's Good For The Game
It works with the new MC system changes , also firedoors are even less intensive , but vents and scrubbers are back to.. processing for now
## Changelog
:cl:
code: Made firedoors even less of a performance hit, and no longer update their icons.
code: Brought back processing for vents and scrubbers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
