### PR TITLE
Fixes debug gun appearing when using weapon frame

### DIFF
--- a/code/datums/craft/gun_parts.dm
+++ b/code/datums/craft/gun_parts.dm
@@ -42,22 +42,14 @@
 				spawn_with_preinstalled_parts = TRUE
 
 	if(spawn_with_preinstalled_parts)
-		var/list/parts_list = list(pick(gripvars), mechanism, barrel)
+		var/list/parts_list = list(mechanism, barrel)
 
 		pick_n_take(parts_list)
 		if(prob(50))
 			pick_n_take(parts_list)
 
 		for(var/part in parts_list)
-			if(ispath(part, grip))
-				new part(src)
-				grip_attached = TRUE
-			else if(part in gripvars)
-				var/variantnum = gripvars.Find(part)
-				result = resultvars[variantnum]
-				new part(src)
-				grip_attached = TRUE
-			else if(ispath(part, barrel))
+			if(ispath(part, barrel))
 				new part(src)
 				barrel_attached = TRUE
 			else if(ispath(part, mechanism))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Debug guns were spawning because of problems with how grips were inserted in the trash. To fix the problem, I have removed the chance to add grips to frames in the trash

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Useless debug gun bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: removed grips spawning in frames
fix: fixed debug gun spawning when assembling frames
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
