### PR TITLE
Make combat less lethal

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -3,7 +3,7 @@
 ****************************************************/
 
 //These control the damage thresholds for the various ways of removing limbs
-#define DROPLIMB_THRESHOLD_EDGE 0.75
+#define DROPLIMB_THRESHOLD_EDGE 1.15
 #define DROPLIMB_THRESHOLD_TEAROFF 1.35
 #define DROPLIMB_THRESHOLD_DESTROY 1.5
 

--- a/code/modules/organs/external/damage.dm
+++ b/code/modules/organs/external/damage.dm
@@ -103,7 +103,7 @@
 				droplimb(0, DROPLIMB_EDGE)
 			else if((burn + prev_burn) >= max_damage * DROPLIMB_THRESHOLD_DESTROY && prob(burn/3))
 				droplimb(0, DROPLIMB_BURN)
-			else if((brute + prev_brute) >= max_damage * DROPLIMB_THRESHOLD_DESTROY && prob(brute/2))
+			else if((brute + prev_brute) >= max_damage * DROPLIMB_THRESHOLD_DESTROY && prob(brute/3))
 				droplimb(0, DROPLIMB_BLUNT)
 			else if((brute + prev_brute) >= max_damage * DROPLIMB_THRESHOLD_TEAROFF && prob(brute/5))
 				droplimb(0, DROPLIMB_EDGE)

--- a/code/modules/organs/organ_description.dm
+++ b/code/modules/organs/organ_description.dm
@@ -79,7 +79,7 @@
 	default_type = /obj/item/organ/external/head
 	default_bone_type = /obj/item/organ/internal/bone/head
 
-	max_damage = 75
+	max_damage = 90
 	min_broken_damage = 60
 	vital = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
increases DROPLIMB_THRESHOLD_EDGE from 0.75 to 1.15

increases max_health from 75 to 90

lowers the droplimb proc's chance to dismember with a blunt weapon from brute/2 to brute/3

## Why It's Good For The Game

less funny funky rng instakills, call it a salt pr, but if I could I'd delete that proc's random chance to dismember completely and nothing of value would be lost

## Changelog
:cl:
balance: made combat less lethal (salt pr)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
