### PR TITLE
fix carrion spiders not displaying wearer properly

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
@@ -13,9 +13,9 @@
 	..()
 	if(wearer)
 		wearer.apply_damage(10, BRUTE, part)
-		src.uninstall()
 		to_chat(wearer, SPAN_WARNING("You feel something moving within [part]!"))
 		visible_message(SPAN_DANGER("[src] crawls out of [wearer] and flashes brightly!"))
+		src.uninstall()
 	else
 		visible_message(SPAN_DANGER("[src] flashes brightly!"))
 	playsound(src, 'sound/voice/insect_battle_screeching.ogg', 80, 1, 5)

--- a/code/game/objects/items/weapons/implant/implants/carrion/flashbang_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/flashbang_spider.dm
@@ -9,9 +9,9 @@
 	..()
 	if(wearer)
 		wearer.apply_damage(15, BURN, part)
-		src.uninstall()
 		to_chat(wearer, SPAN_WARNING("You feel an uncomfortable heat build up within [part]!"))
 		visible_message(SPAN_DANGER("[src] crawls out of [wearer] and flashes brightly!"))
+		src.uninstall()
 	else
 		visible_message(SPAN_DANGER("[src] flashes brightly!"))
 	playsound(src, 'sound/voice/insect_battle_screeching.ogg', 80, 1, 5)

--- a/code/game/objects/items/weapons/implant/implants/carrion/toxic_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/toxic_spider.dm
@@ -10,9 +10,9 @@
 	..()
 	if(wearer)
 		wearer.apply_damage(10, BRUTE, part)
-		src.uninstall()
 		to_chat(wearer, SPAN_WARNING("You feel something moving within [part]!"))
 		visible_message(SPAN_DANGER("[src] crawls out of [wearer] and flashes brightly!"))
+		src.uninstall()
 	else
 		visible_message(SPAN_DANGER("[src] flashes brightly!"))
 	playsound(src, 'sound/voice/insect_battle_screeching.ogg', 80, 1, 5)

--- a/html/changelogs/AutoChangeLog-pr-7375.yml
+++ b/html/changelogs/AutoChangeLog-pr-7375.yml
@@ -1,0 +1,4 @@
+author: MLGTASTICa
+delete-after: true
+changes:
+  - balance: Guns may no longer go below 1.1 ms firerate


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
swaps lines, fixes things
had a friend find and help with this one but they don't want to be mentioned

## Why It's Good For The Game

turns this
![изображение](https://user-images.githubusercontent.com/57810301/189862782-00f2a289-c132-49bf-afb7-fed6023378ee.png)
(notice 'crawls out of' and no target)
into this
https://user-images.githubusercontent.com/57810301/189864937-2599daf6-8d5c-48f3-abb4-398fb52397e2.mp4
(can't make preview show but it works trust me)




## Changelog
:cl:
fix: fixed explosive/flashbang/toxic spiders saying "crawls out of and flashes brightly!", now they actually crawl out of someone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
