### PR TITLE
Nerf shrapnel removal damage, again

### DIFF
--- a/code/modules/surgery/organic.dm
+++ b/code/modules/surgery/organic.dm
@@ -414,7 +414,7 @@
 	)
 	var/obj/item/shrapnel = locate(/obj/item/material/shard/shrapnel) in organ.implants
 	organ.remove_item(shrapnel, user, FALSE)
-	organ.take_damage(tool.force / 0.1, 0, sharp=TRUE) //So it's a bad idea to remove shrapnel with a chainsaw
+	organ.take_damage(tool.force * 0.1, 0, sharp=TRUE) //So it's a bad idea to remove shrapnel with a chainsaw
 
 /datum/surgery_step/remove_shrapnel/fail_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
 	user.visible_message(
@@ -423,7 +423,7 @@
 	)
 	var/obj/item/shrapnel = locate(/obj/item/material/shard/shrapnel) in organ.implants //will succeed regardless
 	organ.remove_item(shrapnel, user, FALSE)
-	organ.take_damage(tool.force / 0.3, sharp=TRUE)
+	organ.take_damage(tool.force * 0.3, sharp=TRUE)
 
 //Cauterizing a wound to stop bleeding
 /datum/surgery_step/close_wounds
@@ -448,7 +448,7 @@
 		SPAN_NOTICE("You close the wounds on [organ.get_surgery_name()] with \the [tool].")
 	)
 	organ.stopBleeding()
-	organ.take_damage(0, tool.force / 0.3)
+	organ.take_damage(0, tool.force * 0.3)
 
 /datum/surgery_step/close_wounds/fail_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
 	user.visible_message(

--- a/code/modules/surgery/organic.dm
+++ b/code/modules/surgery/organic.dm
@@ -414,7 +414,7 @@
 	)
 	var/obj/item/shrapnel = locate(/obj/item/material/shard/shrapnel) in organ.implants
 	organ.remove_item(shrapnel, user, FALSE)
-	organ.take_damage(tool.force / 0.3, 0, sharp=TRUE, edge=TRUE) //So it's a bad idea to remove shrapnel with a chainsaw
+	organ.take_damage(tool.force / 0.1, 0, sharp=TRUE) //So it's a bad idea to remove shrapnel with a chainsaw
 
 /datum/surgery_step/remove_shrapnel/fail_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
 	user.visible_message(
@@ -423,7 +423,7 @@
 	)
 	var/obj/item/shrapnel = locate(/obj/item/material/shard/shrapnel) in organ.implants //will succeed regardless
 	organ.remove_item(shrapnel, user, FALSE)
-	organ.take_damage(tool.force, sharp=TRUE, edge=TRUE)
+	organ.take_damage(tool.force / 0.3, sharp=TRUE)
 
 //Cauterizing a wound to stop bleeding
 /datum/surgery_step/close_wounds


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

on success, the organ takes 0.1 of the tool's force instead of 0.3
on failure, the organ takes 0.3 of the tool's force instead of 1
both damage flags now lack EDGE, which means they cannot send limbs flying off
## Why It's Good For The Game
no more shall we experience this
![image](https://user-images.githubusercontent.com/112724221/189892365-a1a5dc1d-65c3-4c4d-a01a-e9408a0f0421.png)
glory to my salt prs
## Changelog
:cl:
balance: nerfed shrapnel removal damage, again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
