### PR TITLE
Nerf flashes, again

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -94,15 +94,9 @@
 		if(C)
 			stat("Cruciform", "[C.power]/[C.max_power]")
 
-/mob/living/carbon/human/flash(duration = 0, drop_items = FALSE, doblind = FALSE, doblurry = FALSE, eye_damage = 0)
+/mob/living/carbon/human/flash(duration = 0, drop_items = FALSE, doblind = FALSE, doblurry = FALSE)
 	if(blinded)
 		return
-	if(eye_damage)
-		eye_damage *= species.flash_mod // increase based on how susceptible they are
-		var/obj/item/organ/internal/eyes/E = src.random_organ_by_process(OP_EYES)
-		E.take_damage(eye_damage, FALSE)
-		if (E && E.damage >= E.min_bruised_damage)
-			to_chat(src, SPAN_DANGER("Your eyes start to burn badly!"))
 	..(duration, drop_items, doblind, doblurry)
 
 /mob/living/carbon/human/ex_act(severity, epicenter)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -14,6 +14,8 @@
 	if (HUDtech.Find("flash"))
 		flick("e_flash", HUDtech["flash"])
 	if(duration)
+		if(!ishuman)
+			Weaken(duration)
 		if(doblind)
 			eye_blind += duration
 		if(doblurry)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -14,7 +14,6 @@
 	if (HUDtech.Find("flash"))
 		flick("e_flash", HUDtech["flash"])
 	if(duration)
-		Weaken(duration, drop_items)
 		if(doblind)
 			eye_blind += duration
 		if(doblurry)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -14,7 +14,7 @@
 	if (HUDtech.Find("flash"))
 		flick("e_flash", HUDtech["flash"])
 	if(duration)
-		if(!ishuman)
+		if(!ishuman(src))
 			Weaken(duration)
 		if(doblind)
 			eye_blind += duration


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

flashes don't weaken humans
flashes don't deal eye damage
## Why It's Good For The Game
muh salt pr
flash is no longer an autowin button
flashbangs still are though, because that stumble is really strong and is not related to flashes themselves
flash already fucks you over by dealing eye damage not to the mob, but to you, the player, as well as obstructing your entire screen for a very long time.

if someone is standing and shooting, and then suddenly gets flashed, they shouldn't go and say "aw jeez, my eyes hurtie so I have to lay down for a while and rest", no, they keep shooting, but since they can't see where they click, they miss.

personally I wanted the flash to also give a temporary vision obstruction like welding helmets/goggles do, but HUDOverlay code countered my grab, irish-whipped me on a table, gut-punched and suplexed me in just a span of 2 seconds, so I can't do that :(
## Changelog
:cl:
balance: flashes don't deal eye damage
balance: flashes no longer weaken humans
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
