### PR TITLE
Makes coolant cool

### DIFF
--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -389,17 +389,20 @@
 	..()
 	M.add_chemical_effect(CE_PULSE, 2)
 
-#define COOLANT_LATENT_HEAT 19000 //Twice as good at cooling than water is, but may cool below 20c. It'll cause freezing that atmos will have to deal with..
 /datum/reagent/other/coolant
 	name = "Coolant"
 	id = "coolant"
-	description = "Industrial cooling substance."
+	description = "Industrial coolant. Used to lower the freezing point and raises the boiling point of liquid in a system."
 	taste_description = "sourness"
 	taste_mult = 1.1
 	reagent_state = LIQUID
 	color = "#C8A5DC"
+	var/reagent_property_coeff = 2796	// 0.7857 * 3559, the density (kg/L) and specific heat (J/(kg K)) of 50:50 propylene glycol water
+	var/latent_heat = 600			// Arbitrarily chosen amount. Just needs to be worse than refrigerant.
 
-/datum/reagent/coolant/touch_turf(var/turf/simulated/T)
+/*		Proc was removed because of griefing
+#define COOLANT_LATENT_HEAT 19000
+/datum/reagent/other/coolant/touch_turf(var/turf/simulated/T)
 	if(!istype(T))
 		return
 
@@ -418,7 +421,43 @@
 		var/removed_heat = between(0, volume * COOLANT_LATENT_HEAT, -environment.get_thermal_energy_change(min_temperature))
 		environment.add_thermal_energy(-removed_heat)
 		if (prob(5) && environment && environment.temperature > T100C)
-			T.visible_message("<span class='warning'>The water sizzles as it lands on \the [T]!</span>")
+			T.visible_message("<span class='warning'>\The [src] sizzles as it lands on \the [T]!</span>")
+*/
+
+/datum/reagent/other/coolant/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	M.adjustToxLoss(1)
+	M.add_chemical_effect(CE_TOXIN, 1)
+
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/organ_process = pick(OP_LIVER, OP_LUNGS, OP_KIDNEYS, OP_BLOOD_VESSEL, OP_STOMACH)
+		var/obj/item/organ/internal/I = H.random_organ_by_process(organ_process)
+		if(istype(I))
+			I.take_damage(1, TRUE)
+
+// This was created to give people a way to cool reagents without needing a chem heater. Use it in a sprayer.
+/datum/reagent/other/coolant/touch_obj(obj/O, amount)
+	if(!istype(O, /obj/item/reagent_containers))	// Remove this check if we want to apply this to all objects.
+		return
+
+	// Q = mc(del_T);	Realistically, we'd look at the properties of the reagent being cooled and the removed heat (Q) of the coolant/refrigerant.
+	// temp change = Q / mc
+	var/removed_heat = amount * latent_heat								// Ignoring surrounding temp for simplicity
+	var/volume_in_liters = amount / 30									// L, Water latent heat comment in core.dm says 30u is 1 L
+	var/reagent_property_divisor = volume_in_liters * reagent_property_coeff
+	var/temperature_change = removed_heat / reagent_property_divisor	// K
+
+	O.reagents.chem_temp -= temperature_change
+
+// Not even close to how refrigerant is used IRL, but it's just a game.
+/datum/reagent/other/coolant/refrigerant
+	name = "Refrigerant"
+	id = "refrigerant"
+	description = "Industrial refrigerant R13. Used to remove heat."
+	taste_description = "fresh grass"
+	color = "#b6dca5"
+	reagent_property_coeff = 1496	// 1.21 * 1236, denstiy and specific heat of R22 refrigerant.
+	latent_heat = 1900				// Roughly a tenth of water's latent heat from core.dm
 
 /datum/reagent/other/ultraglue
 	name = "Ultra Glue"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows coolant to cool reagent containers when sprayed. Adds a refrigerant subtype that is better at cooling. Also, this makes them both somewhat toxic. Coolant will cool a container by about 5.5 K per 5 unit squirt and refrigerant will cool it by about 38 K.

## Why It's Good For The Game

Will be used in a future PR.

## Changelog
:cl:
tweak: Allows coolant to cool reagent containers
add: Added refrigerant as a coolant subtype
code: Commented out unused coolant proc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
