### PR TITLE
Small Tweak to .20 damage

### DIFF
--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -51,7 +51,7 @@ There are important things regarding this file:
 
 /obj/item/projectile/bullet/srifle
 	name = ".20 caliber bullet"
-	damage_types = list(BRUTE = 36)
+	damage_types = list(BRUTE = 32)
 	armor_divisor = 1.5
 	penetrating = 2
 	can_ricochet = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lowers .20 raw damage by 4, which becomes 2 when you take the wounding multiplier into account.
 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Humon requested slightly lower damage, though the caliber still works fine against armor it is meant to defeat. .20 guns lose 3-2 damage vs the highest armor tier, without being as good as the non-AP calibers vs light armor (still inferior vs flesh or coats).

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: reduced .20 raw damage 36 -> 32
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
