### PR TITLE
Technomancer Rig Speed Buff

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -211,6 +211,7 @@ Technomancer RIG
 	)
 
 	spawn_blacklisted = TRUE
+	slowdown = LIGHT_SLOWDOWN
 
 /obj/item/rig/techno/equipped
 	initial_modules = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This gives the Technomancer Rig the same slowdown as the Technomancer Exhault Rig.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I feel like there's enough of a distinction between the TE and Techno rigs module and armor wise, that boosting the speed of the latter won't blur the lines between them.

Also it's weird that while all Clan are expected to be able to respond to trouble effectively, the majority of the clan is stuck lagging behind when it comes to simple movement.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Techno Rig has the Light_Slowdown Flag now, same as the TE Rig
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
