### PR TITLE
Adding deprivation lithany to all NT roles

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -344,3 +344,39 @@
 	set_personal_cooldown(user)
 
 	return TRUE
+
+/datum/ritual/cruciform/base/ejection
+	name = "Deprivation"
+	phrase = "Et revertatur pulvis in terram suam unde erat et spiritus redeat ad Deum qui dedit illum"
+	desc = "This litany will command cruciform to detach from bearer, if the one bearing it is dead. You will be able to use it in scanner for Resurrection."
+
+/datum/ritual/cruciform/base/ejection/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/C)
+	var/obj/item/implant/core_implant/cruciform/CI = get_implant_from_victim(user, /obj/item/implant/core_implant/cruciform, FALSE)
+
+	if(!CI)
+		fail("There is no cruciform on this one", user, C)
+		return FALSE
+
+	if(!CI.wearer)
+		fail("Cruciform is not installed.", user, C)
+		return FALSE
+
+	var/mob/M = CI.wearer
+
+	if(ishuman(M) && M.is_dead())
+		var/mob/living/carbon/human/H = M
+		var/obj/item/organ/external/E = H.organs_by_name[BP_CHEST]
+		E.take_damage(15)
+		H.custom_pain("You feel the cruciform ripping out of your chest!",1)
+		CI.name = "[M]'s Cruciform"
+		CI.uninstall()
+		return TRUE
+
+	else if(ismob(M) && M.is_dead()) //Cruciforms can't normally be placed on non-humans, but this is still here for sanity purposes.
+		CI.name = "[M]'s Cruciform"
+		CI.uninstall()
+		return TRUE
+
+	else
+		fail("Deprivation does not work upon the living.", user, C)
+		return FALSE

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -65,43 +65,6 @@
 	phrase = "Et ne inducas nos in tentationem, sed libera nos a malo"
 */
 
-/datum/ritual/cruciform/priest/acolyte/ejection
-	name = "Deprivation"
-	phrase = "Et revertatur pulvis in terram suam unde erat et spiritus redeat ad Deum qui dedit illum"
-	desc = "This litany will command cruciform to detach from bearer, if the one bearing it is dead. You will be able to use it in scanner for Resurrection."
-
-/datum/ritual/cruciform/priest/acolyte/ejection/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/C)
-	var/obj/item/implant/core_implant/cruciform/CI = get_implant_from_victim(user, /obj/item/implant/core_implant/cruciform, FALSE)
-
-	if(!CI)
-		fail("There is no cruciform on this one", user, C)
-		return FALSE
-
-	if(!CI.wearer)
-		fail("Cruciform is not installed.", user, C)
-		return FALSE
-
-	var/mob/M = CI.wearer
-
-	if(ishuman(M) && M.is_dead())
-		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/external/E = H.organs_by_name[BP_CHEST]
-		E.take_damage(15)
-		H.custom_pain("You feel the cruciform ripping out of your chest!",1)
-		CI.name = "[M]'s Cruciform"
-		CI.uninstall()
-		return TRUE
-
-	else if(ismob(M) && M.is_dead()) //Cruciforms can't normally be placed on non-humans, but this is still here for sanity purposes.
-		CI.name = "[M]'s Cruciform"
-		CI.uninstall()
-		return TRUE
-
-	else
-		fail("Deprivation does not work upon the living.", user, C)
-		return FALSE
-
-
 /datum/ritual/cruciform/priest/acolyte/unupgrade
 	name = "Asacris"
 	phrase = "A caelo usque ad centrum"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

All of the NT occupations are able to clone, but none of them except the preacher were able to do the deprivation lithany (ejecting the cruciform). This PR adds it to all occupations.

## Why It's Good For The Game

Quality of life for all Neotheology, so they don't have to perform surgery every time.

## Changelog
:cl:
balance: adds deprivation lithany to all NT occupations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
