### PR TITLE
Conveyor and lever removal

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -93995,12 +93995,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck1central)
-"erN" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel,
-/area/eris/quartermaster/hangarsupply)
 "erO" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -131116,7 +131110,7 @@ lGH
 vdS
 fjl
 xwS
-erN
+ato
 fFd
 atx
 fFd

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -8337,9 +8337,6 @@
 	pixel_x = -24;
 	pixel_y = -8
 	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "QMLoad2"
-	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/hangarsupply)
 "aty" = (
@@ -57536,10 +57533,7 @@
 	id = "QMLoaddoor2";
 	name = "Supply Dock Loading Door"
 	},
-/obj/machinery/conveyor/east{
-	id = "QMLoad"
-	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/hangarsupply)
 "cIl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -58180,12 +58174,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/storage/primary)
-"cJZ" = (
-/obj/machinery/conveyor/east{
-	id = "QMLoad"
-	},
-/turf/simulated/floor/plating/under,
-/area/eris/quartermaster/hangarsupply)
 "cKa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/closet/firecloset,
@@ -94011,10 +93999,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/conveyor/east{
-	id = "QMLoad"
-	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/hangarsupply)
 "erO" = (
 /obj/structure/cable/green{
@@ -96707,23 +96692,11 @@
 	id = "QMLoaddoor";
 	name = "Supply Dock Loading Door"
 	},
-/obj/machinery/conveyor/west{
-	id = "QMLoad2"
-	},
-/turf/simulated/floor/plating/under,
-/area/eris/quartermaster/hangarsupply)
-"exL" = (
-/obj/machinery/conveyor/west{
-	id = "QMLoad2"
-	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/hangarsupply)
 "exM" = (
 /obj/machinery/light/small,
-/obj/machinery/conveyor/west{
-	id = "QMLoad2"
-	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/hangarsupply)
 "exN" = (
 /obj/structure/catwalk,
@@ -107704,9 +107677,6 @@
 "xwS" = (
 /obj/machinery/status_display/supply_display{
 	pixel_x = -32
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "QMLoad"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/hangarsupply)
@@ -130742,11 +130712,11 @@ aBv
 aBv
 aBv
 auV
-cJZ
+ato
 fFd
 amn
 fFd
-exL
+ato
 auV
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes 2 levers and 4 conveyors in guild considering shuttle is gone now.
Before:
![before](https://user-images.githubusercontent.com/61051786/190484737-98e72892-61d7-437b-8246-691aa007c3b5.png)
After:
![Screenshot_1](https://user-images.githubusercontent.com/61051786/190706208-ede57f4b-2841-46f0-9eab-69281fbc34ca.png)



## Why It's Good For The Game

Map looks cleaner now that shuttle is gone.

## Changelog
:cl:
tweak: no more conveyors and levers in lower guild
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
