### PR TITLE
Armor Part Matter Tweak

### DIFF
--- a/code/datums/craft/crafting_items.dm
+++ b/code/datums/craft/crafting_items.dm
@@ -23,7 +23,7 @@
 	desc = "Spare part of armor."
 	icon_state = "armor_part"
 	spawn_tags = SPAWN_TAG_PART_ARMOR
-	matter = list(MATERIAL_PLASTIC = 5, MATERIAL_WOOD = 5, MATERIAL_CARDBOARD = 5, MATERIAL_STEEL = 5)
+	matter = list(MATERIAL_PLASTIC = 20, MATERIAL_STEEL = 20)
 
 /obj/item/part/armor/artwork
 	desc = "This is an artistically-made armor part."

--- a/code/datums/craft/crafting_items.dm
+++ b/code/datums/craft/crafting_items.dm
@@ -23,7 +23,7 @@
 	desc = "Spare part of armor."
 	icon_state = "armor_part"
 	spawn_tags = SPAWN_TAG_PART_ARMOR
-	matter = list(MATERIAL_PLASTIC = 20, MATERIAL_STEEL = 20)
+	matter = list(MATERIAL_PLASTIC = 10, MATERIAL_STEEL = 10)
 
 /obj/item/part/armor/artwork
 	desc = "This is an artistically-made armor part."

--- a/code/game/machinery/crafting_station.dm
+++ b/code/game/machinery/crafting_station.dm
@@ -14,7 +14,7 @@
 	var/list/materials_stored = list()
 	var/list/materials_compatible = list (MATERIAL_PLASTEEL, MATERIAL_STEEL, MATERIAL_PLASTIC, MATERIAL_WOOD, MATERIAL_CARDBOARD, MATERIAL_PLASMA)
 	var/list/materials_gunpart = list(MATERIAL_PLASTEEL = 5)
-	var/list/materials_armorpart = list(MATERIAL_STEEL = 20, MATERIAL_PLASTIC = 20)
+	var/list/materials_armorpart = list(MATERIAL_STEEL = 10, MATERIAL_PLASTIC = 10)
 	var/list/materials_ammo = list(MATERIAL_STEEL = 10, MATERIAL_CARDBOARD = 1)
 	var/list/materials_rocket = list(MATERIAL_PLASMA = 5, MATERIAL_PLASTIC = 5, MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 10)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Armor parts now recycle for 10 steel and 10 plastic
Armor parts are now made for 10 steel and 10 plastic
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The cost of printing them was changed awhile ago, Maik asked me to update the recycle gain to match
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Armor parts now recycle for 10 steel and 10 plastic, same as the cost to print them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
