### PR TITLE
Help Those That Help Themselves

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1492,7 +1492,7 @@
 	
 		var/mob/living/carbon/human/H = user
 
-		if(scan_id == !1) //I have no idea why == 0 didn't work. It just wouldn't. But this did. I don't know why. Thanks Jeff Jefferson.
+		if(!scan_id)
 			bingo = TRUE
 
 		else if(is_neotheology_disciple(H))

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1492,7 +1492,7 @@
 	
 		var/mob/living/carbon/human/H = user
 
-		if(scan_id == !1)
+		if(scan_id == !1) //I have no idea why == 0 didn't work. It just wouldn't. But this did. I don't know why. Thanks Jeff Jefferson.
 			bingo = TRUE
 
 		else if(is_neotheology_disciple(H))

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1489,8 +1489,13 @@
 /obj/machinery/vending/theomat/proc/check_NT(mob/user)
 	var/bingo = FALSE
 	if(ishuman(user))
+	
 		var/mob/living/carbon/human/H = user
-		if(is_neotheology_disciple(H))
+
+		if(scan_id == !1)
+			bingo = TRUE
+
+		else if(is_neotheology_disciple(H))
 			bingo = TRUE
 
 		else if(istype(H.get_active_hand(), /obj/item/clothing/accessory/cross))


### PR DESCRIPTION
## About The Pull Request

Added check for id_scan flip before cruciform checks to the NeoTheology vendor.

## Why It's Good For The Game

The Guild has orders that require church items that are locked within the church, or behind the Theomat that checks for only the faithful. An aspiring techie can now try to hack the NT Vendor for the items stealthily.

This will also lead into future changes that I intend where ritual books need more availability to people outside the church.

## Changelog
:cl:
tweak: Added id_scan check to the NeoTheology vendor before it checks for cruciform.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
