### PR TITLE
New Rome now buffs the stats that NeoTheology members use.

### DIFF
--- a/code/datums/setup_option/backgrounds/origin.dm
+++ b/code/datums/setup_option/backgrounds/origin.dm
@@ -77,10 +77,10 @@
 	stat_modifiers = list(
 		STAT_ROB = 5,
 		STAT_TGH = 5,
-		STAT_BIO = 10,
-		STAT_MEC = 5,
+		STAT_BIO = 5,
+		STAT_MEC = -10,
 		STAT_VIG = -10,
-		STAT_COG = -10
+		STAT_COG = 10
 	)
 
 /datum/category_item/setup_option/background/origin/new_rome/apply(mob/living/carbon/human/character)


### PR DESCRIPTION
New stat spread:
ROB = 5
TGH = 5
BIO = 5
MEC = -10
VIG = -10
COG = 10
## Why It's Good For The Game
 
1. There is no background that gives high COG gain besides End Point, which mirrors Crozet and is supposed to be a location with all work stats.

2. Stat spread now corresponds to things NeoTheology members use. COG +10 for Cruciform recharge speed. 
-10 MEC because literally nobody there uses MEC. They don't even know how their miracle technology works. VIG -10 because they're melee fanatics.
BIO +5 because they have interest in both medicine and botany, but not all of them. ROB/TGH unchanged.

## Changelog

:cl: 
tweak: New Rome background updated, now increases COG and decreases MEC. 
/:cl: