### PR TITLE
Aberrant Organs - balance PR

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -1326,7 +1326,7 @@
 #include "code\modules\aberrants\organs\mods\component\output.dm"
 #include "code\modules\aberrants\organs\mods\component\process.dm"
 #include "code\modules\aberrants\organs\mods\component\special.dm"
-#include "code\modules\aberrants\organs\mods\component\stromal.dm"
+#include "code\modules\aberrants\organs\mods\component\upgrades.dm"
 #include "code\modules\aberrants\organs\reagents\hormones.dm"
 #include "code\modules\acting\acting_items.dm"
 #include "code\modules\admin\admin.dm"

--- a/code/modules/aberrants/_modification.dm
+++ b/code/modules/aberrants/_modification.dm
@@ -229,7 +229,7 @@ COMSIG_ABERRANT_SECONDARY
 				return TRUE
 		var/datum/component/modification/M = toremove.GetComponent(/datum/component/modification)
 		if(M.removable == FALSE)
-			to_chat(user, SPAN_DANGER("\the [toremove] seems to be permanently attached to the [upgrade_loc]"))
+			to_chat(user, SPAN_DANGER("\The [toremove] seems to be permanently attached to the [upgrade_loc]"))
 		else
 			if(C.use_tool(user = user, target =  upgrade_loc, base_time = M.removal_time, required_quality = removal_tool_quality, fail_chance = M.removal_difficulty, required_stat = M.removal_stat))
 				// If you pass the check, then you manage to remove the upgrade intact

--- a/code/modules/aberrants/organs/_defines.dm
+++ b/code/modules/aberrants/organs/_defines.dm
@@ -14,7 +14,7 @@
 		OP_HEART		= list(100,   2,   0,   0,   10,  10,  list("he", "ar", "t"), list()),\
 		OP_LUNGS		= list(100,   2,   50,	10,  10,  0,   list("l", "un", "gs"), list()),\
 		OP_LIVER		= list(100,   1,   25,	5,   5,   7,   list("l", "iv", "er"), list()),\
-		OP_KIDNEYS		= list(50,    1,   7.5, 1.5, 2,   2.5, list("k", "idn", "ey"), list()),\
+		OP_KIDNEYS		= list(100,   2,   15,  3,   4,   5,   list("k", "idn", "ey"), list()),\
 		OP_APPENDIX		= list(100,   0,   0,	0,   0,   0,   list("app", "end", "ix"), list()),\
 		OP_STOMACH		= list(100,   1,   25,	5,   0,   5,   list("st", "om", "ach"), list()),\
 		OP_BONE			= list(100,   1,   0,	0,   0,   0,   list("b", "on", "e"), list()),\

--- a/code/modules/aberrants/organs/holders.dm
+++ b/code/modules/aberrants/organs/holders.dm
@@ -59,20 +59,12 @@
 	else if(istype(user, /mob/observer/ghost))
 		details_unlocked = TRUE
 
-	if(item_upgrades.len)
-		to_chat(user, SPAN_NOTICE("Organoid grafts present ([item_upgrades.len]/[max_upgrades]). Use a laser cutting tool to remove."))
 	if(using_sci_goggles || details_unlocked)
-		var/organs
-	
 		var/function_info
 		var/input_info
 		var/process_info
 		var/output_info
 		var/secondary_info
-
-		for(var/organ in organ_efficiency)
-			organs += organ + " ([organ_efficiency[organ]]), "
-		organs = copytext(organs, 1, length(organs) - 1)
 
 		for(var/mod in contents)
 			var/obj/item/modification/organ/internal/holder = mod
@@ -93,8 +85,6 @@
 
 		if(aberrant_cooldown_time > 0)
 			to_chat(user, SPAN_NOTICE("Average organ process duration: [aberrant_cooldown_time / (1 SECOND)] seconds"))
-
-		to_chat(user, SPAN_NOTICE("Organ tissues present (efficiency): <span style='color:pink'>[organs ? organs : "none"]</span>"))
 
 		if(function_info)
 			to_chat(user, SPAN_NOTICE(function_info))

--- a/code/modules/aberrants/organs/internal/dependent.dm
+++ b/code/modules/aberrants/organs/internal/dependent.dm
@@ -1,6 +1,6 @@
 /obj/item/organ/internal/scaffold/aberrant/dependent
 	max_upgrades = 4
-	price_tag = 350
+	price_tag = 400		// High value due to 4 slots + long cooldown
 	spawn_tags = SPAWN_TAG_ABERRANT_ORGAN_RARE		// Rare because 4 upgrade slots
 	spawn_blacklisted = TRUE	// More of a novel thing to find in the deep maint vendors
 	bad_type = /obj/item/organ/internal/scaffold/aberrant/dependent
@@ -12,7 +12,7 @@
 	should_process_have_organ_stats = FALSE
 	output_pool = ALL_STANDARD_ORGAN_EFFICIENCIES
 	output_info = list(1)
-	special_info = list(STAT_ROB, 3)
+	special_info = list(STAT_ROB, 10)
 
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/wifebeater
@@ -21,7 +21,7 @@
 		/datum/reagent/alcohol/beer, /datum/reagent/alcohol/ale, /datum/reagent/alcohol/roachbeer
 	)
 	input_mode = CHEM_INGEST
-	special_info = list(STAT_ROB, 3)		// specfic organs will have better buffs
+	special_info = list(STAT_ROB, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/wifebeater/New()
 	..()
@@ -40,17 +40,17 @@
 /obj/item/organ/internal/scaffold/aberrant/dependent/wifebeater/liver
 	name = "wifebeater's liver"
 	output_pool = list(OP_LIVER)
-	special_info = list(STAT_ROB, 6)
+	special_info = list(STAT_ROB, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/wifebeater/stomach
 	name = "wifebeater's stomach"
 	output_pool = list(OP_STOMACH)
-	special_info = list(STAT_ROB, 6)
+	special_info = list(STAT_ROB, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/wifebeater/kidney
 	name = "wifebeater's kidney"
 	output_pool = list(OP_KIDNEYS)
-	special_info = list(STAT_ROB, 6)
+	special_info = list(STAT_ROB, 10)
 
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/functional_alcoholic
@@ -60,7 +60,7 @@
 		/datum/reagent/alcohol/vodka, /datum/reagent/alcohol/whiskey, /datum/reagent/alcohol/wine
 	)
 	input_mode = CHEM_INGEST
-	special_info = list(STAT_MEC, 3)
+	special_info = list(STAT_MEC, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/functional_alcoholic/New()
 	..()
@@ -79,17 +79,17 @@
 /obj/item/organ/internal/scaffold/aberrant/dependent/functional_alcoholic/liver
 	name = "functional alcoholic's liver"
 	output_pool = list(OP_LIVER)
-	special_info = list(STAT_MEC, 6)
+	special_info = list(STAT_MEC, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/functional_alcoholic/stomach
 	name = "functional alcoholic's stomach"
 	output_pool = list(OP_STOMACH)
-	special_info = list(STAT_MEC, 6)
+	special_info = list(STAT_MEC, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/functional_alcoholic/kidney
 	name = "functional alcoholic's kidney"
 	output_pool = list(OP_KIDNEYS)
-	special_info = list(STAT_MEC, 6)
+	special_info = list(STAT_MEC, 10)
 
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/classy
@@ -98,7 +98,7 @@
 		/datum/reagent/alcohol/martini, /datum/reagent/alcohol/coffee/b52, /datum/reagent/alcohol/black_russian, /datum/reagent/alcohol/gintonic
 	)
 	input_mode = CHEM_INGEST
-	special_info = list(STAT_COG, 3)
+	special_info = list(STAT_COG, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/classy/New()
 	..()
@@ -117,17 +117,17 @@
 /obj/item/organ/internal/scaffold/aberrant/dependent/classy/liver
 	name = "aristocrat's liver"
 	output_pool = list(OP_LIVER)
-	special_info = list(STAT_COG, 6)
+	special_info = list(STAT_COG, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/classy/stomach
 	name = "aristocrat's stomach"
 	output_pool = list(OP_STOMACH)
-	special_info = list(STAT_COG, 6)
+	special_info = list(STAT_COG, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/classy/kidney
 	name = "aristocrat's kidney"
 	output_pool = list(OP_KIDNEYS)
-	special_info = list(STAT_COG, 6)
+	special_info = list(STAT_COG, 10)
 
 	
 /obj/item/organ/internal/scaffold/aberrant/dependent/exmercenary
@@ -136,7 +136,7 @@
 		/datum/reagent/stim/bouncer, /datum/reagent/stim/steady, /datum/reagent/stim/violence
 	)
 	input_mode = CHEM_BLOOD
-	special_info = list(STAT_VIG, 3)
+	special_info = list(STAT_VIG, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/exmercenary/New()
 	..()
@@ -155,17 +155,17 @@
 /obj/item/organ/internal/scaffold/aberrant/dependent/exmercenary/blood_vessel
 	name = "ex-mercenary's blood vessel"
 	output_pool = list(OP_BLOOD_VESSEL)
-	special_info = list(STAT_VIG, 3)
+	special_info = list(STAT_VIG, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/exmercenary/liver
 	name = "ex-mercenary's liver"
 	output_pool = list(OP_LIVER)
-	special_info = list(STAT_VIG, 6)
+	special_info = list(STAT_VIG, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/exmercenary/muscle
 	name = "ex-mercenary's muscle"
 	output_pool = list(OP_MUSCLE)
-	special_info = list(STAT_VIG, 3)
+	special_info = list(STAT_VIG, 10)
 
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/mobster
@@ -174,7 +174,7 @@
 		/datum/reagent/drug/space_drugs, /datum/reagent/drug/psilocybin
 	)
 	input_mode = CHEM_BLOOD
-	special_info = list(STAT_TGH, 3)
+	special_info = list(STAT_TGH, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/mobster/New()
 	..()
@@ -193,17 +193,17 @@
 /obj/item/organ/internal/scaffold/aberrant/dependent/mobster/blood_vessel
 	name = "mobster's blood vessel"
 	output_pool = list(OP_BLOOD_VESSEL)
-	special_info = list(STAT_TGH, 3)
+	special_info = list(STAT_TGH, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/mobster/liver
 	name = "mobster's liver"
 	output_pool = list(OP_LIVER)
-	special_info = list(STAT_TGH, 6)
+	special_info = list(STAT_TGH, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/mobster/muscle
 	name = "mobster's muscle"
 	output_pool = list(OP_MUSCLE)
-	special_info = list(STAT_TGH, 3)
+	special_info = list(STAT_TGH, 10)
 
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/chemist
@@ -212,7 +212,7 @@
 		/datum/reagent/stim/pro_surgeon, /datum/reagent/medicine/aminazine, /datum/reagent/medicine/citalopram
 	)
 	input_mode = CHEM_BLOOD
-	special_info = list(STAT_BIO, 3)
+	special_info = list(STAT_BIO, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/chemist/New()
 	..()
@@ -231,16 +231,14 @@
 /obj/item/organ/internal/scaffold/aberrant/dependent/chemist/blood_vessel
 	name = "chemist's blood vessel"
 	output_pool = list(OP_BLOOD_VESSEL)
-	special_info = list(STAT_BIO, 3)
+	special_info = list(STAT_BIO, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/chemist/liver
 	name = "chemist's liver"
 	output_pool = list(OP_LIVER)
-	special_info = list(STAT_BIO, 6)
+	special_info = list(STAT_BIO, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/chemist/kidney
 	name = "chemist's kidney"
 	output_pool = list(OP_KIDNEYS)
-	special_info = list(STAT_BIO, 6)
-
-// Soj uses Viv (NSA stat, "addict") and Anatomy (health stat, "bodybuilder")
+	special_info = list(STAT_BIO, 10)

--- a/code/modules/aberrants/organs/internal/simple.dm
+++ b/code/modules/aberrants/organs/internal/simple.dm
@@ -1,13 +1,12 @@
 /obj/item/organ/internal/scaffold/aberrant/scrub_toxin
 	rarity_value = 40
-	price_tag = 200
 	bad_type = /obj/item/organ/internal/scaffold/aberrant/scrub_toxin
 	use_generated_name = FALSE
 	input_mod_path = /obj/item/modification/organ/internal/input/reagents
 	process_mod_path = /obj/item/modification/organ/internal/process/boost
 	output_mod_path = /obj/item/modification/organ/internal/output/chemical_effects
 	specific_input_type_pool = list(/datum/reagent/toxin)	// This should let it scrub ANY toxin
-	output_pool = TYPE_1_HORMONES
+	output_pool = TYPE_2_HORMONES
 	output_info = list(NOT_USED)
 
 /obj/item/organ/internal/scaffold/aberrant/scrub_toxin/New()
@@ -51,7 +50,7 @@
 									/datum/reagent/toxin/amatoxin, /datum/reagent/toxin/carpotoxin, /datum/reagent/toxin/fertilizer, /datum/reagent/toxin/mold)
 	input_mode = CHEM_INGEST
 	output_pool = list(/datum/reagent/organic/nutriment)
-	output_info = list(VERY_LOW_OUTPUT)
+	output_info = list(LOW_OUTPUT)
 
 /obj/item/organ/internal/scaffold/aberrant/gastric/New()
 	..()
@@ -77,7 +76,7 @@
 	specific_input_type_pool = DAMAGE_TYPES_BASIC
 	input_mode = NOT_USED
 	output_pool = list(/datum/reagent/medicine/tricordrazine, /datum/reagent/medicine/polystem, /datum/reagent/medicine/dylovene)
-	output_info = list(VERY_LOW_OUTPUT)
+	output_info = list(LOW_OUTPUT)
 
 /obj/item/organ/internal/scaffold/aberrant/damage_response/New()
 	..()

--- a/code/modules/aberrants/organs/internal/teratoma.dm
+++ b/code/modules/aberrants/organs/internal/teratoma.dm
@@ -8,7 +8,6 @@
 	ruined_description_info = "Useless organ tissue. Recycle this in a disgorger."
 	ruined_color = "#696969"
 	icon_state = "teratoma"
-	price_tag = 200
 
 	max_upgrades = 1
 	use_generated_name = FALSE
@@ -94,7 +93,7 @@
 				output_pool = ALL_STATS
 			if(!output_info?.len)
 				for(var/i in 1 to req_num_outputs)
-					output_info += 3
+					output_info += MID_OUTPUT
 
 		if(/obj/item/modification/organ/internal/output/damaging_insight_gain)
 			if(!output_pool?.len)
@@ -114,7 +113,7 @@
 	..()
 	use_generated_name = FALSE
 	max_upgrades = 0
-	price_tag = 50
+	price_tag = 25
 	matter = list(MATERIAL_BIOMATTER = 5)
 	STOP_PROCESSING(SSobj, src)
 

--- a/code/modules/aberrants/organs/machinery/disgorger.dm
+++ b/code/modules/aberrants/organs/machinery/disgorger.dm
@@ -15,7 +15,7 @@
 	var/biomatter_counter = 0				// We don't want this to actually produce biomatter
 	var/list/accepted_reagents = list(
 		/datum/reagent/drink/milk = 0.13,				// Internet said milk is 13% solids, 87% water
-		/datum/reagent/organic/nutriment/protein = 1
+		/datum/reagent/organic/nutriment = 1
 	)
 	var/list/blacklisted_reagents = list(
 		/datum/reagent/drink/milk/soymilk
@@ -140,8 +140,10 @@
 		holdingitems -= I
 		for(var/reagent in I.reagents.reagent_list)
 			var/datum/reagent/R = reagent
-			if(!is_type_in_list(R, blacklisted_reagents) && is_type_in_list(R, accepted_reagents))
-				biomatter_counter += round(R.volume * accepted_reagents[R.type], 0.01)
+			if(!is_type_in_list(R, blacklisted_reagents))
+				for(var/reagent_type in accepted_reagents)
+					if(istype(R, reagent_type))
+						biomatter_counter += round(R.volume * accepted_reagents[reagent_type], 0.01)
 		qdel(I)
 
 /obj/machinery/reagentgrinder/industrial/disgorger/grind()
@@ -174,7 +176,6 @@
 	flick("[initial(icon_state)]_spit", src)
 	var/obj/item/fleshcube/new_cube = new(get_turf(src))
 	new_cube.throw_at(spit_target, 3, 1)
-
 
 /obj/machinery/reagentgrinder/industrial/disgorger/default_deconstruction(obj/item/I, mob/user)
 	var/qualities = list(QUALITY_RETRACTING)
@@ -263,18 +264,24 @@
 			/datum/reagent/toxin/pararein = 1,
 			/datum/reagent/toxin/aranecolmin = 2
 		)
+		for(var/reagent in accepted_reagents)
+			accepted_reagents[reagent] = round(accepted_reagents[reagent] * 2, 0.01)
 
 	if(stomach_eff > 99)
 		capacity_mod += 5
+		for(var/reagent in accepted_reagents)
+			accepted_reagents[reagent] = round(accepted_reagents[reagent] * 2, 0.01)
 	if(stomach_eff > 124)
 		capacity_mod += 5
+		for(var/reagent in accepted_reagents)
+			accepted_reagents[reagent] = round(accepted_reagents[reagent] * 2, 0.01)
 
 	if(muscle_eff > 99)
-		tick_reduction += 1
-	if(muscle_eff > 124)
-		tick_reduction += 1
-	if(muscle_eff > 149)
 		tick_reduction += 2
+	if(muscle_eff > 124)
+		tick_reduction += 2
+	if(muscle_eff > 149)
+		tick_reduction += 3
 
 	limit = initial(limit) + capacity_mod
 	grind_rate = initial(grind_rate) - tick_reduction

--- a/code/modules/aberrants/organs/machinery/disgorger.dm
+++ b/code/modules/aberrants/organs/machinery/disgorger.dm
@@ -222,6 +222,11 @@
 
 	has_brain = FALSE
 
+	// Initial doesn't work right with lists. Not an issue at the moment since it must be deconstructed to be upgraded.
+	//accepted_reagents = initial(accepted_reagents)
+	//blacklisted_reagents = initial(blacklisted_reagents)
+	//accepted_objects = initial(accepted_objects)
+
 	for(var/component in component_parts)
 		if(!istype(component, /obj/item/organ/internal))
 			continue

--- a/code/modules/aberrants/organs/machinery/organ_fabricator.dm
+++ b/code/modules/aberrants/organs/machinery/organ_fabricator.dm
@@ -14,7 +14,7 @@
 	circuit = /obj/item/electronics/circuitboard/organ_fabricator
 	build_type = ORGAN_GROWER			// Should not be able to use church disks
 	unsuitable_materials = list()		// Allows biomatter to be used (reskinned as "biotic substrate")
-	storage_capacity = 360
+	storage_capacity = 480
 	have_disk = TRUE
 	have_reagents = TRUE
 	have_recycling = FALSE
@@ -32,7 +32,7 @@
 	var/list/ripped_categories = list()		// For sanitizing categories
 
 /obj/machinery/autolathe/organ_fabricator/loaded
-	stored_material = list(MATERIAL_BIOMATTER = 360)
+	stored_material = list(MATERIAL_BIOMATTER = 480)
 
 /obj/machinery/autolathe/organ_fabricator/Initialize()
 	. = ..()

--- a/code/modules/aberrants/organs/mods/0_mods.dm
+++ b/code/modules/aberrants/organs/mods/0_mods.dm
@@ -3,6 +3,7 @@
 	bad_type = /obj/item/modification/organ
 	matter = list(MATERIAL_BIOMATTER = 5)
 	origin_tech = list(TECH_BIO = 3)	// One level higher than regular organs
+	price_tag = 25		// Biomatter is 5 credits per unit
 
 /obj/item/modification/organ/internal
 	icon = 'icons/obj/organ_mods.dmi'
@@ -11,7 +12,6 @@
 	spawn_tags = SPAWN_TAG_ORGAN_MOD
 	spawn_blacklisted = TRUE	// These should never spawn without a parent organ/teratoma.
 	bad_type = /obj/item/modification/organ/internal
-	price_tag = 200
 
 /obj/item/modification/organ/internal/New(loc, generate_organ_stats = FALSE, predefined_modifier = null)
 	..()

--- a/code/modules/aberrants/organs/mods/0_mods.dm
+++ b/code/modules/aberrants/organs/mods/0_mods.dm
@@ -50,4 +50,7 @@
 			O.nutriment_req_mod 			+= round(organ_stats[5] * modifier * (1 + (1 * is_parasitic)), 0.01)
 			O.oxygen_req_mod 				+= round(organ_stats[6] * modifier * (1 + (1 * is_parasitic)), 0.01)
 
+			if(predefined_modifier)
+				break
+
 			probability = probability / 8

--- a/code/modules/aberrants/organs/mods/4_special.dm
+++ b/code/modules/aberrants/organs/mods/4_special.dm
@@ -128,7 +128,7 @@
 	var/datum/component/modification/organ/on_cooldown/stat_boost/S = AddComponent(/datum/component/modification/organ/on_cooldown/stat_boost)
 
 	S.stat = STAT_MEC
-	S.boost = 3
+	S.boost = 10
 	..()
 
 /obj/item/modification/organ/internal/special/on_cooldown/stat_boost/cognition
@@ -136,7 +136,7 @@
 	var/datum/component/modification/organ/on_cooldown/stat_boost/S = AddComponent(/datum/component/modification/organ/on_cooldown/stat_boost)
 
 	S.stat = STAT_COG
-	S.boost = 3
+	S.boost = 10
 	..()
 
 /obj/item/modification/organ/internal/special/on_cooldown/stat_boost/biology
@@ -144,7 +144,7 @@
 	var/datum/component/modification/organ/on_cooldown/stat_boost/S = AddComponent(/datum/component/modification/organ/on_cooldown/stat_boost)
 
 	S.stat = STAT_BIO
-	S.boost = 3
+	S.boost = 10
 	..()
 
 /obj/item/modification/organ/internal/special/on_cooldown/stat_boost/robustness
@@ -152,7 +152,7 @@
 	var/datum/component/modification/organ/on_cooldown/stat_boost/S = AddComponent(/datum/component/modification/organ/on_cooldown/stat_boost)
 
 	S.stat = STAT_ROB
-	S.boost = 3
+	S.boost = 10
 	..()
 
 /obj/item/modification/organ/internal/special/on_cooldown/stat_boost/toughness
@@ -160,7 +160,7 @@
 	var/datum/component/modification/organ/on_cooldown/stat_boost/S = AddComponent(/datum/component/modification/organ/on_cooldown/stat_boost)
 
 	S.stat = STAT_TGH
-	S.boost = 3
+	S.boost = 10
 	..()
 
 /obj/item/modification/organ/internal/special/on_cooldown/stat_boost/vigilance_5
@@ -168,5 +168,5 @@
 	var/datum/component/modification/organ/on_cooldown/stat_boost/S = AddComponent(/datum/component/modification/organ/on_cooldown/stat_boost)
 
 	S.stat = STAT_VIG
-	S.boost = 3
+	S.boost = 10
 	..()

--- a/code/modules/aberrants/organs/mods/5_upgrades.dm
+++ b/code/modules/aberrants/organs/mods/5_upgrades.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/obj/organ_mods.dmi'
 	spawn_blacklisted = FALSE	// No RNG stats, no teratoma needed. Helps illustrate the gradual increase of weirdness from regular organs to the more bizarre aberrant organs.
 	bad_type = /obj/item/modification/organ/internal/stromal
-	price_tag = 200
 
 /obj/item/modification/organ/internal/stromal/update_icon()
 	return

--- a/code/modules/aberrants/organs/mods/5_upgrades.dm
+++ b/code/modules/aberrants/organs/mods/5_upgrades.dm
@@ -122,17 +122,14 @@
 	desc = "A graftable membrane for organ tissues. Contains functional tissue from one or more organs."
 	description_info = "Adds/increases organ efficiencies. Size, blood, oxygen, and nutrition requirements are based on the added efficiencies."
 	icon_state = "membrane"
-	var/organ_eff_mod = 0.1
+	var/organ_eff_mod = 0.2
 
 /obj/item/modification/organ/internal/parenchymal/New(loc, generate_organ_stats = TRUE, predefined_modifier = organ_eff_mod)
-	var/datum/component/modification/organ/M = AddComponent(/datum/component/modification/organ)
+	var/datum/component/modification/organ/parenchymal/M = AddComponent(/datum/component/modification/organ/parenchymal)
 
-	M.apply_to_types = list(/obj/item/organ/internal)
-	M.examine_msg = "Can be attached to internal organs."
-	M.examine_difficulty = STAT_LEVEL_BASIC
 	M.prefix = "multi-functional"
 	..()
 
 /obj/item/modification/organ/internal/parenchymal/large
 	name = "parenchymal membrane"
-	organ_eff_mod = 0.2
+	organ_eff_mod = 0.4

--- a/code/modules/aberrants/organs/mods/component/_component.dm
+++ b/code/modules/aberrants/organs/mods/component/_component.dm
@@ -1,7 +1,7 @@
 /datum/component/modification/organ
 	install_time = WORKTIME_FAST
 	//install_tool_quality = null
-	install_difficulty = FAILCHANCE_HARD
+	install_difficulty = 35
 	install_stat = STAT_BIO
 	install_sound = 'sound/effects/squelch1.ogg'
 

--- a/code/modules/aberrants/organs/mods/component/_component.dm
+++ b/code/modules/aberrants/organs/mods/component/_component.dm
@@ -97,6 +97,13 @@
 				holder.organ_efficiency.Add(organ)
 				holder.organ_efficiency[organ] = round(added_efficiency, 1)
 
+		if(holder.owner && istype(holder.owner, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = holder.owner
+			for(var/process in organ_efficiency_mod)
+				if(!islist(H.internal_organs_by_efficiency[process]))
+					H.internal_organs_by_efficiency[process] = list()
+				H.internal_organs_by_efficiency[process] |= holder
+
 	if(organ_efficiency_multiplier)
 		for(var/organ in holder.organ_efficiency)
 			holder.organ_efficiency[organ] = round(holder.organ_efficiency[organ] * (1 + organ_efficiency_multiplier), 1)

--- a/code/modules/aberrants/organs/mods/component/special.dm
+++ b/code/modules/aberrants/organs/mods/component/special.dm
@@ -2,9 +2,6 @@
 	exclusive_type = /obj/item/modification/organ/internal/special/on_item_examine
 	trigger_signal = COMSIG_EXAMINE
 
-/datum/component/modification/organ/on_item_examine/try_modify()
-	return
-
 /datum/component/modification/organ/on_item_examine/brainloss
 	var/damage = 1
 
@@ -30,9 +27,6 @@
 
 /datum/component/modification/organ/on_pickup/shock
 	var/damage = 5
-
-/datum/component/modification/organ/on_pickup/shock/try_modify()
-	return
 
 /datum/component/modification/organ/on_pickup/shock/get_function_info()
 	var/description = "<span style='color:purple'>Functional information (secondary):</span> electrocutes when touched"
@@ -75,9 +69,6 @@
 /datum/component/modification/organ/on_cooldown
 	exclusive_type = /obj/item/modification/organ/internal/special/on_cooldown
 	trigger_signal = COMSIG_ABERRANT_SECONDARY
-
-/datum/component/modification/organ/on_cooldown/try_modify()
-	return
 
 /datum/component/modification/organ/on_cooldown/chemical_effect
 	var/effect

--- a/code/modules/aberrants/organs/mods/component/upgrades.dm
+++ b/code/modules/aberrants/organs/mods/component/upgrades.dm
@@ -3,9 +3,6 @@
 	examine_msg = "Can be attached to internal organs."
 	examine_difficulty = STAT_LEVEL_BASIC
 
-/datum/component/modification/organ/stromal/try_modify()
-	return
-
 /datum/component/modification/organ/stromal/on_examine(mob/user)
 	var/function_info = get_function_info()
 	if(function_info)
@@ -74,3 +71,40 @@
 	function_info += "</i>"
 
 	return function_info
+
+/datum/component/modification/organ/parenchymal
+	apply_to_types = list(/obj/item/organ/internal)
+	examine_msg = "Can be attached to internal organs."
+	examine_difficulty = STAT_LEVEL_BASIC
+	adjustable = TRUE
+
+/datum/component/modification/organ/parenchymal/modify(obj/item/I, mob/living/user)
+	specific_organ_size_mod = 0
+	max_blood_storage_mod = 0
+	blood_req_mod = 0
+	nutriment_req_mod = 0
+	oxygen_req_mod = 0
+
+	var/list/possibilities = ALL_STANDARD_ORGAN_EFFICIENCIES
+
+	for(var/organ in organ_efficiency_mod)
+		if(organ_efficiency_mod.len > 1)
+			for(var/organ_eff in possibilities)
+				if(organ != organ_eff && organ_efficiency_mod.Find(organ_eff))
+					possibilities.Remove(organ_eff)
+
+		var/decision = input("Choose an organ type (current: [organ])","Adjusting Organoid") as null|anything in possibilities
+		if(!decision)
+			decision = organ
+
+		var/list/organ_stats = ALL_ORGAN_STATS[decision]
+		var/modifier = round(organ_efficiency_mod[organ] / 100, 0.01)
+
+		organ_efficiency_mod.Remove(organ)
+		organ_efficiency_mod.Add(decision)
+		organ_efficiency_mod[decision] 	= round(organ_stats[1] * modifier, 1)
+		specific_organ_size_mod 		+= round(organ_stats[2] * modifier, 0.01)
+		max_blood_storage_mod			+= round(organ_stats[3] * modifier, 1)
+		blood_req_mod 					+= round(organ_stats[4] * modifier, 0.01)
+		nutriment_req_mod 				+= round(organ_stats[5] * modifier, 0.01)
+		oxygen_req_mod 					+= round(organ_stats[6] * modifier, 0.01)

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -106,7 +106,16 @@
 	if(user.stats?.getStat(STAT_BIO) > STAT_LEVEL_BASIC)
 		to_chat(user, SPAN_NOTICE("Organ size: [specific_organ_size]"))
 	if(user.stats?.getStat(STAT_BIO) > STAT_LEVEL_EXPERT - 5)
+		var/organs
+		for(var/organ in organ_efficiency)
+			organs += organ + " ([organ_efficiency[organ]]), "
+		organs = copytext(organs, 1, length(organs) - 1)
+
 		to_chat(user, SPAN_NOTICE("Requirements: <span style='color:red'>[blood_req]</span>/<span style='color:blue'>[oxygen_req]</span>/<span style='color:orange'>[nutriment_req]</span>"))
+		to_chat(user, SPAN_NOTICE("Organ tissues present (efficiency): <span style='color:pink'>[organs ? organs : "none"]</span>"))
+
+		if(item_upgrades.len)
+			to_chat(user, SPAN_NOTICE("Organ grafts present ([item_upgrades.len]/[max_upgrades]). Use a laser cutting tool to remove."))
 
 /obj/item/organ/internal/is_usable()
 	return ..() && !is_broken()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes:
- Organ mod install difficulty reduced. 35 BIO (base bio-engineer level) has 100% success rate to attach.
- Stat-boosts from intracrinal organoids and membranes increased to 5 and 10, respectively.
- Disgorger buffed. Stomach, liver, and kidney efficiency affects conversion ratios for reagents, muscle efficiency increases consumption speed more than prior, and accepts any nutriment (includes child types like animal protein, corn oil). Fixed bug with handling child reagent types. Items will have their reagents checked before their biomatter content is checked.
- Pygmy and regular parenchymal membranes only come with a single organ tissue, but their base efficiency modifier is increased to 20 and 40, respectively. The organ type can be adjusted using a laser cutting tool on the membrane. 
- Aberrant organ and mod price tags adjusted. Scaffolds reduced to 100, mods reduced to 25.
- Certain vendor aberrant organs now produce type 2 hormones and output 2u reagents from their relevent organoids.
- Organ fabricator base and starting biotic substrate increased to 480.
- Regular internal organs will show their organ efficiencies and occupied mod slots at 35 BIO.
- Kidney efficiency mods are no longer halved.
- Fixed an issue where organs with new efficiencies weren't being added correctly when modded during surgery.

## Why It's Good For The Game

Makes the visceral research mechanics more forgiving. Stats were too low for the effort and it wasn’t fun to consistently produce the disgorger resources.

## Changelog
:cl:
balance: Organ mod installation has 100% success rate at 35 BIO
balance: intracrinal organoids increase a given stat by 5, intracrinal membranes increase it by 10
balance: Disgorger stomach, liver, kidney efficiency affects reagent-to-substrate conversion ratio, muscle efficiency better improves process speed, accepts nutriment, checks reagents before biomatter content
fix: Disgorger can handle child reagent types
balance: Parenchymal mods can be adjusted
balance: Parenchymal membranes have double base efficiency, but only one organ type
balance: Organ scaffold price reduced to 100, organ mod price reduced to 25
balance: Vendor aberrant organs tweaked to have type 2 hormones and 2u reagent output
balance: Organ fab base and starting biotic substrate increased to 480
tweak: Internal organs show efficiencies and mods at 35 BIO
fix: Kidney efficiency mods are no longer halved
fix: Fixed an issue where organs with new efficiencies weren't being added correctly when modded during surgery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
