### PR TITLE
Fixed the NT Cloning bug

### DIFF
--- a/code/modules/core_implant/cruciform/machinery/cloning.dm
+++ b/code/modules/core_implant/cruciform/machinery/cloning.dm
@@ -213,6 +213,15 @@
 			occupant.real_name = R.real_name
 			occupant.b_type = R.b_type
 			occupant.age = R.age
+			occupant.h_style = R.h_style
+			occupant.hair_color = R.hair_color
+			occupant.f_style = R.f_style
+			occupant.facial_color = R.facial_color
+			occupant.eyes_color = R.eyes_color
+			occupant.skin_color = R.skin_color
+			occupant.change_skin_tone(R.s_tone)
+			occupant.gender = R.gender
+			occupant.tts_seed = R.tts_seed
 			occupant.sync_organ_dna()
 			occupant.flavor_text = R.flavor
 			R.stats.copyTo(occupant.stats)

--- a/code/modules/core_implant/cruciform/modules.dm
+++ b/code/modules/core_implant/cruciform/modules.dm
@@ -64,6 +64,15 @@
 	var/list/dormant_mutations
 	var/list/active_mutations
 	var/b_type
+	var/h_style
+	var/hair_color
+	var/f_style
+	var/facial_color
+	var/eyes_color
+	var/skin_color
+	var/s_tone
+	var/gender
+	var/tts_seed
 	var/real_name
 	var/dna_trace = null
 	var/fingers_trace = null
@@ -74,6 +83,15 @@
 	dna_trace = H.dna_trace
 	real_name = H.real_name
 	b_type = H.b_type
+	h_style = H.h_style
+	hair_color = H.hair_color
+	f_style = H.f_style
+	facial_color = H.facial_color
+	eyes_color = H.eyes_color
+	skin_color = H.skin_color
+	s_tone = H.s_tone
+	gender = H.gender
+	tts_seed = H.tts_seed
 	dormant_mutations = H.dormant_mutations
 	active_mutations = H.active_mutations
 	if(H.ckey)


### PR DESCRIPTION
<!--_ Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Neotheology Cloning pumps out a generic potato man instead of your character's original appearance, which sort of sucked.

So I fixed that and now basically all of your character's apperance is copied over, code-wise technically so should the TTS seed (how your character sounds) as well, but I cant test it in local server so it has to be tested live.

Thanks to @Pink-Chink for helping with the skin tone part of the appearance code

## Why It's Good For The Game

A bug is fixed and people can keep their appearances as NT followers, not really life important, but it is a QoL imo

## Changelog
:cl:
fix: fixed the NT not being able to copy all of appearance bug
code: Did some new code on the cloning machine and cruciform module to allow for this
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
