### PR TITLE
Remove twirling humans on help intent

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -449,9 +449,7 @@ var/global/list/items_blood_overlay_by_type = list()
 	if (istype(I, /obj/item/grab)) // a grab signifies that it's another mob that should be spun
 		var/obj/item/grab/inhand_grab = I
 		var/mob/living/grabbed = inhand_grab.throw_held()
-		if (a_intent == I_HELP && inhand_grab.affecting.a_intent == I_HELP) // this doesn't use grabbed to allow passive twirl
-			visible_message(SPAN_NOTICE("[src] twirls [inhand_grab.affecting]."), SPAN_NOTICE("You twirl [inhand_grab.affecting]."))
-		else if (grabbed)
+		if (grabbed)
 			if (grabbed.stats.getPerk(PERK_ASS_OF_CONCRETE))
 				visible_message(SPAN_WARNING("[src] tries to pick up [grabbed], and fails!"))
 				if (ishuman(src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
removed the twirling proc that happened when both the attacker and the victim have help intents

## Why It's Good For The Game

i have been told that people sometimes they keep twirling people around instead of irish whipping them. Haram!
Besides, this is obscure and bloat. ~~and this is also not written on wiki because I was unaware of this~~
## Changelog
:cl:
del: twirling instead of irish whipping on help intent
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
