### PR TITLE
Gun UI Changes

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -931,9 +931,11 @@
 		return list()
 	var/list/data = list()
 	data["projectile_name"] = P.name
-	data["projectile_damage"] = ((P.get_total_damage() * damage_multiplier) * P.wounding_mult) + get_total_damage_adjust()
+	data["projectile_damage"] = (P.get_total_damage() * damage_multiplier) + get_total_damage_adjust()
 	data["projectile_AP"] = P.armor_divisor + penetration_multiplier
 	data["projectile_WOUND"] = P.wounding_mult
+	data["unarmoured_damage"] = ((P.get_total_damage() * damage_multiplier) + get_total_damage_adjust())*P.wounding_mult
+	data["armoured_damage"] = (((P.get_total_damage() * damage_multiplier) + get_total_damage_adjust())-(10/(P.armor_divisor + penetration_multiplier))*P.wounding_mult)
 	data["projectile_recoil"] = P.recoil
 	qdel(P)
 	return data

--- a/nano/templates/weapon_stats.tmpl
+++ b/nano/templates/weapon_stats.tmpl
@@ -154,6 +154,27 @@
 				</div>
 
 			<div class="itemLabel">
+				Wound scale:
+			</div>
+				<div class="itemContent">
+					{{:data.projectile_WOUND}}
+				</div>
+
+			<div class="itemLabel">
+				Unarmoured Damage:
+			</div>
+				<div class="itemContent">
+					{{:data.unarmoured_damage}}
+				</div>
+
+			<div class="itemLabel">
+				Armoured (10) Damage:
+			</div>
+				<div class="itemContent">
+					{{:data.armoured_damage}}
+				</div>
+
+			<div class="itemLabel">
 				Recoil multiplier:
 			</div>
 				<div class="itemContent">


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Wound Value is visible again, and damage against unarmoured and armoured targets (10 armour) is displayed as a weapon stat.

## Why It's Good For The Game

People who understand the calculations get all the info they need, and people who don't understand the calculations no longer have to. Also, the removal of visible wound value was broken and didn't factor into AP, meaning that it was highly inaccurate and would show many guns as having better or worse damage against armour than they actually do.

## Changelog
:cl:
add: Weapon stats now include damage against targets with 0 and 10 armour.
add: Readded Wound Value to visible weapon stats
tweak: Wound Value is no longer factored into overall damage

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
