### PR TITLE
Adds placeholder aberrant organ research

### DIFF
--- a/code/modules/aberrants/organs/machinery/disgorger.dm
+++ b/code/modules/aberrants/organs/machinery/disgorger.dm
@@ -31,6 +31,7 @@
 
 	// Lazy research placeholder
 	var/spits_until_unlock = 3
+	var/datum/research/knowledge
 	var/list/designs_to_unlock = list(
 		/datum/design/organ/organ_mod/parenchymal_large,
 		/datum/design/organ/teratoma/special/chemical_effect,
@@ -80,6 +81,8 @@
 /obj/machinery/reagentgrinder/industrial/disgorger/Initialize()
 	. = ..()
 	spit_target = get_ranged_target_turf(src, dir, spit_range)
+	knowledge = new /datum/research(src)
+	knowledge.known_designs = list()
 
 /obj/machinery/reagentgrinder/industrial/disgorger/InitCircuit()
 	if(!circuit)
@@ -236,6 +239,7 @@
 	spits_until_unlock = initial(spits_until_unlock)
 	var/datum/design/D = SSresearch.get_design(designs_to_unlock[1])
 	designs_to_unlock.Remove(D.type)
+	knowledge.AddDesign2Known(D)
 
 	var/message = pickweight(list(
 		"When you study and object from a distance, only its principle may be seen." = 1,									// Children of Dune

--- a/code/modules/aberrants/organs/machinery/organ_fabricator.dm
+++ b/code/modules/aberrants/organs/machinery/organ_fabricator.dm
@@ -38,6 +38,13 @@
 	. = ..()
 	files = new /datum/research(src)
 
+	// Remove when actual organ research is made
+	for(var/disgorger in get_area_all_atoms(get_area(src)))
+		if(istype(disgorger, /obj/machinery/reagentgrinder/industrial/disgorger))
+			var/obj/machinery/reagentgrinder/industrial/disgorger/D = disgorger
+			for(var/design in D.knowledge.known_designs)
+				files.AddDesign2Known(design)
+
 /obj/machinery/autolathe/organ_fabricator/res_load()
 	if(working || paused || error)
 		flick("[initial(icon_state)]_load_working", image_load)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

After every 3rd flesh cube, the disgorger will say a line and unlock a new design in the organ fabricators. This only works if the organ fabricators are in the area. When constructed organ fabricators will check for a disgorger in the area and copy its researched designs.

## Why It's Good For The Game

More self-sufficient progression, more gooder.

## Changelog
:cl:
add: Added placeholder aberrant organ research
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
