### PR TITLE
Various map fixes

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1814,7 +1814,7 @@
     name = "emergency companion cube"
 
 /obj/item/reagent_containers/food/snacks/monkeycube/punpun/Expand()
-    src.visible_message(SPAN_NOTICE("\The [src] expands!"))
+    visible_message(SPAN_NOTICE("\The [src] expands!"))
     var/turf/T = get_turf(src)
     if(istype(T))
         new /mob/living/carbon/human/monkey/punpun(T)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1810,6 +1810,17 @@
 	preloaded_reagents = list("protein" = 10)
 	taste_tag = list(MEAT_FOOD,SALTY_FOOD)
 
+/obj/item/reagent_containers/food/snacks/monkeycube/punpun
+    name = "emergency companion cube"
+
+/obj/item/reagent_containers/food/snacks/monkeycube/punpun/Expand()
+    src.visible_message(SPAN_NOTICE("\The [src] expands!"))
+    var/turf/T = get_turf(src)
+    if(istype(T))
+        new /mob/living/carbon/human/monkey/punpun(T)
+    qdel(src)
+    return TRUE
+
 /obj/item/reagent_containers/food/snacks/monkeycube/attack_self(mob/user as mob)
 	if(wrapped)
 		Unwrap(user)

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -103327,19 +103327,6 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
-"lrq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/camera/network/medbay,
-/turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/iso)
 "lsH" = (
 /obj/machinery/autolathe/loaded,
 /turf/simulated/floor/tiled/techmaint,
@@ -245092,7 +245079,7 @@ cmt
 cnX
 dnE
 dlL
-lrq
+dpS
 dre
 duD
 dvk

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -19996,7 +19996,7 @@
 /turf/simulated/wall/r_wall,
 /area/eris/maintenance/substation/section1)
 "aXi" = (
-/mob/living/carbon/human/monkey,
+/obj/item/reagent_containers/food/snacks/monkeycube/wrapped,
 /turf/simulated/floor/reinforced,
 /area/eris/medical/virology)
 "aXj" = (
@@ -20158,7 +20158,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/mob/living/carbon/human/monkey,
+/obj/item/reagent_containers/food/snacks/monkeycube/wrapped,
 /turf/simulated/floor/reinforced,
 /area/eris/medical/virology)
 "aXD" = (
@@ -20295,7 +20295,7 @@
 /obj/machinery/camera/network/medbay{
 	dir = 4
 	},
-/mob/living/carbon/human/monkey,
+/obj/item/reagent_containers/food/snacks/monkeycube/wrapped,
 /turf/simulated/floor/reinforced,
 /area/eris/medical/virology)
 "aXR" = (
@@ -20326,7 +20326,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/mob/living/carbon/human/monkey,
+/obj/item/reagent_containers/food/snacks/monkeycube/wrapped,
 /turf/simulated/floor/reinforced,
 /area/eris/medical/virology)
 "aXU" = (
@@ -103392,7 +103392,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/mob/living/carbon/human/monkey,
+/obj/item/reagent_containers/food/snacks/monkeycube/wrapped,
 /turf/simulated/floor/reinforced,
 /area/eris/medical/chemstor)
 "lwW" = (
@@ -104045,7 +104045,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/mob/living/carbon/human/monkey,
+/obj/item/reagent_containers/food/snacks/monkeycube/wrapped,
 /turf/simulated/floor/reinforced,
 /area/eris/medical/chemstor)
 "nha" = (
@@ -106080,7 +106080,7 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/section3starboard)
 "sJL" = (
-/mob/living/carbon/human/monkey,
+/obj/item/reagent_containers/food/snacks/monkeycube/wrapped,
 /turf/simulated/floor/reinforced,
 /area/eris/medical/chemstor)
 "sMn" = (

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -101257,7 +101257,7 @@
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
 "fHF" = (
-/mob/living/carbon/human/monkey/punpun,
+/obj/item/reagent_containers/food/snacks/monkeycube/punpun,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/barbackroom)
 "fIs" = (

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -51695,6 +51695,7 @@
 	pixel_x = -24;
 	req_access = null
 	},
+/obj/landmark/join/start/artist,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/quartermaster/artistoffice)
 "ctY" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes all roundstart monkeys to monkey cubes.
Punpun is in his own special cube which specifically spawns him.
Also puts one more artist landmark on map so that instead of when having two artists ready roundstart one spawns in office and one in in cryo now both spawn in the office.
Also deletes a floating camera in medbay isolation.

## Why It's Good For The Game

Dev del approval.

## Changelog
:cl:
tweak: roundstart monkeys changed to monkey cubes, artists now spawn in office always instead of only when there is one artist and floating camera in medbay isolation deleted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
