### PR TITLE
Bladeruiner - slightly buff armblade's damage, prevent embed tools from being dropped

### DIFF
--- a/code/game/objects/items/devices/organ_module/active/armblades.dm
+++ b/code/game/objects/items/devices/organ_module/active/armblades.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "armblade"
 	worksound = WORKSOUND_HARD_SLASH
-	force = WEAPON_FORCE_DANGEROUS
+	force = WEAPON_FORCE_BRUTAL
 	throwforce = WEAPON_FORCE_WEAK
 	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("stabbed", "chopped", "cut")

--- a/code/game/objects/items/devices/organ_module/simple.dm
+++ b/code/game/objects/items/devices/organ_module/simple.dm
@@ -29,7 +29,7 @@
 		var/mob/M = holding.loc
 		M.drop_from_inventory(holding)
 		M.visible_message(
-			SPAN_WARNING("[M] retract \his [holding.name] into [E]."),
+			SPAN_WARNING("[M] retracts \his [holding.name] into [E]."),
 			SPAN_NOTICE("You retract your [holding.name] into [E].")
 		)
 	holding.forceMove(src)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -109,7 +109,7 @@ meteor_act
 
 	switch (def_zone)
 		if(BP_L_ARM, BP_R_ARM)
-			var/obj/item/organ/external/hand = src.get_organ(def_zone)
+			var/obj/item/organ/external/hand = get_organ(def_zone)
 
 			if(hand && hand.mob_can_unequip(src) && (stun_amount || agony_amount > 10))
 				msg_admin_attack("[src.name] ([src.ckey]) was disarmed by a stun effect")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -109,16 +109,12 @@ meteor_act
 
 	switch (def_zone)
 		if(BP_L_ARM, BP_R_ARM)
-			var/c_hand
-			if (def_zone == BP_L_ARM)
-				c_hand = l_hand
-			else
-				c_hand = r_hand
+			var/obj/item/organ/external/hand = src.get_organ(def_zone)
 
-			if(c_hand && (stun_amount || agony_amount > 10))
+			if(hand && hand.mob_can_unequip(src) && (stun_amount || agony_amount > 10))
 				msg_admin_attack("[src.name] ([src.ckey]) was disarmed by a stun effect")
 
-				drop_from_inventory(c_hand)
+				drop_from_inventory(hand)
 				if (BP_IS_ROBOTIC(affected))
 					emote("pain", 1, "drops what they were holding, their [affected.name] malfunctioning!")
 				else

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -132,17 +132,12 @@
 				drop_from_inventory(E)
 
 				if(E.limb_efficiency <= 50)
-					emote("me", 1, "drops what they were holding in their [E.name], [pick("unable to grasp it", "unable to feel it", "too weak to hold it"]!")
+					emote("me", 1, "drops what they were holding in their [E.name], [pick("unable to grasp it", "unable to feel it", "too weak to hold it")]!")
 				else
 					emote("me", 1, "[(species.flags & NO_PAIN) ? "" : pick("screams in pain and ", "lets out a sharp cry and ", "cries out and ")]drops what they were holding in their [E.name]!")
 
 			else if(E.is_malfunctioning())
-				switch(E.body_part)
-					if(ARM_LEFT)
-						l_hand ? drop_from_inventory(l_hand) : continue
-					if(ARM_RIGHT)
-						r_hand ? drop_from_inventory(r_hand) : continue
-
+				drop_from_inventory(E)
 				emote("pain", 1, "drops what they were holding, their [E.name] malfunctioning!")
 
 				var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -142,13 +142,9 @@
 			else if(E.is_malfunctioning())
 				switch(E.body_part)
 					if(ARM_LEFT)
-						if(!l_hand)
-							continue
-						drop_from_inventory(l_hand)
+						l_hand ? drop_from_inventory(l_hand) : continue
 					if(ARM_RIGHT)
-						if(!r_hand)
-							continue
-						drop_from_inventory(r_hand)
+						r_hand ? drop_from_inventory(r_hand) : continue
 
 				emote("pain", 1, "drops what they were holding, their [E.name] malfunctioning!")
 

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -131,13 +131,10 @@
 				
 				drop_from_inventory(E)
 
-				var/emote_scream = pick("screams in pain and ", "lets out a sharp cry and ", "cries out and ")
 				if(E.limb_efficiency <= 50)
-					var/emote_2 = pick("unable to grasp it", "unable to feel it", "too weak to hold it")
-					emote("me", 1, "drops what they were holding in their [E.name], [emote_2]!")
-
+					emote("me", 1, "drops what they were holding in their [E.name], [pick("unable to grasp it", "unable to feel it", "too weak to hold it"]!")
 				else
-					emote("me", 1, "[(species.flags & NO_PAIN) ? "" : emote_scream ]drops what they were holding in their [E.name]!")
+					emote("me", 1, "[(species.flags & NO_PAIN) ? "" : pick("screams in pain and ", "lets out a sharp cry and ", "cries out and ")]drops what they were holding in their [E.name]!")
 
 			else if(E.is_malfunctioning())
 				switch(E.body_part)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -127,7 +127,7 @@
 			continue
 
 		if(E.mob_can_unequip(src))
-			if((E.is_broken() || E.is_nerve_struck() || E.limb_efficiency <= 50))
+			if(E.is_broken() || E.is_nerve_struck() || E.limb_efficiency <= 50)
 				
 				drop_from_inventory(E)
 

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -126,44 +126,38 @@
 		if(!E || !(E.functions & BODYPART_GRASP) || (E.status & ORGAN_SPLINTED))
 			continue
 
-		if(E.is_broken() || E.is_nerve_struck() || E.limb_efficiency <= 50)
-			switch(E.body_part)
-				if(ARM_LEFT)
-					if(!l_hand)
-						continue
-					drop_from_inventory(l_hand)
-				if(ARM_RIGHT)
-					if(!r_hand)
-						continue
-					drop_from_inventory(r_hand)
+		if(E.mob_can_unequip(src))
+			if((E.is_broken() || E.is_nerve_struck() || E.limb_efficiency <= 50))
+				
+				drop_from_inventory(E)
 
-			var/emote_scream = pick("screams in pain and ", "lets out a sharp cry and ", "cries out and ")
-			if(E.limb_efficiency <= 50)
-				var/emote_2 = pick("unable to grasp it", "unable to feel it", "too weak to hold it")
-				emote("me", 1, "drops what they were holding in their [E.name], [emote_2]!")
+				var/emote_scream = pick("screams in pain and ", "lets out a sharp cry and ", "cries out and ")
+				if(E.limb_efficiency <= 50)
+					var/emote_2 = pick("unable to grasp it", "unable to feel it", "too weak to hold it")
+					emote("me", 1, "drops what they were holding in their [E.name], [emote_2]!")
 
-			else
-				emote("me", 1, "[(species.flags & NO_PAIN) ? "" : emote_scream ]drops what they were holding in their [E.name]!")
+				else
+					emote("me", 1, "[(species.flags & NO_PAIN) ? "" : emote_scream ]drops what they were holding in their [E.name]!")
 
-		else if(E.is_malfunctioning())
-			switch(E.body_part)
-				if(ARM_LEFT)
-					if(!l_hand)
-						continue
-					drop_from_inventory(l_hand)
-				if(ARM_RIGHT)
-					if(!r_hand)
-						continue
-					drop_from_inventory(r_hand)
+			else if(E.is_malfunctioning())
+				switch(E.body_part)
+					if(ARM_LEFT)
+						if(!l_hand)
+							continue
+						drop_from_inventory(l_hand)
+					if(ARM_RIGHT)
+						if(!r_hand)
+							continue
+						drop_from_inventory(r_hand)
 
-			emote("pain", 1, "drops what they were holding, their [E.name] malfunctioning!")
+				emote("pain", 1, "drops what they were holding, their [E.name] malfunctioning!")
 
-			var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-			spark_system.set_up(5, 0, src)
-			spark_system.attach(src)
-			spark_system.start()
-			spawn(10)
-				qdel(spark_system)
+				var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
+				spark_system.set_up(5, 0, src)
+				spark_system.attach(src)
+				spark_system.start()
+				spawn(10)
+					qdel(spark_system)
 
 //Handles chem traces
 /mob/living/carbon/human/proc/handle_trace_chems()

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -156,8 +156,7 @@
 				spark_system.set_up(5, 0, src)
 				spark_system.attach(src)
 				spark_system.start()
-				spawn(10)
-					qdel(spark_system)
+				QDEL_IN(spark_system, 1 SECOND)
 
 //Handles chem traces
 /mob/living/carbon/human/proc/handle_trace_chems()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

increases armblade's force from dangerous(20) to brutal(33) to be on par with other swords.

finally prevents embedded tools and weapons(like surgery omnitool or armblade) to be dropped by pain and malfunctioning(etc.)

also very slightly refactored nanako/bay code(i genuinely have no idea whose it is), thanks to @SirRichardFrancis on that part

## Why It's Good For The Game

~~it's probably not~~

now a tool you have to research and have a surgery for is on par with something you can find in maint(it was worse than a junkblade)

FINALLY FIXING THIS DAMN BUG

## Changelog
:cl:
balance: armblade damage increased
fix: no more embed tools being dropped
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
