### PR TITLE
Reorders all common oddities in oddities.dm to make more sense

### DIFF
--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -53,15 +53,39 @@
 	bad_type = /obj/item/oddity/common
 	spawn_blacklisted = FALSE
 
-/obj/item/oddity/common/blueprint
-	name = "strange blueprint"
-	desc = "There's no telling what this design is supposed to be. Whatever could be built from this likely wouldn't work."
-	icon_state = "blueprint"
+/obj/item/oddity/common/lighter
+	name = "rusted lighter"
+	desc = "This zippo ligher has been rusted shut. It smells faintly of sulphur and blood."
+	icon_state = "syndicate_lighter"
 	oddity_stats = list(
-		STAT_COG = 5,
-		STAT_MEC = 7,
+		STAT_TGH = 9,
 	)
-	rarity_value = 15
+
+/obj/item/oddity/common/old_id
+	name = "old id"
+	desc = "There is a story behind this name. Untold, and cruel in fate."
+	icon_state = "old_id"
+	oddity_stats = list(
+		STAT_VIG = 9,
+	)
+
+/obj/item/oddity/common/disk
+	name = "broken design disk"
+	desc = "This disk is corrupted and completely unusable. It has a hand-drawn picture of some strange mechanism on it - looking at it for too long makes your head hurt."
+	icon_state = "disc"
+	oddity_stats = list(
+		STAT_MEC = 9,
+	)
+
+/obj/item/oddity/common/old_money
+	name = "old money"
+	desc = "It's not like the organization that issued this exists anymore."
+	icon_state = "old_money"
+	oddity_stats = list(
+		STAT_ROB = 4,
+		STAT_TGH = 4,
+	)
+	rarity_value = 8
 
 /obj/item/oddity/common/coin
 	name = "strange coin"
@@ -70,6 +94,25 @@
 	oddity_stats = list(
 		STAT_ROB = 5,
 		STAT_TGH = 5,
+	)
+
+/obj/item/oddity/common/towel
+	name = "trustworthy towel"
+	desc = "It's always good to have one with you."
+	icon_state = "towel"
+	oddity_stats = list(
+		STAT_ROB = 6,
+		STAT_TGH = 6,
+	)
+	rarity_value = 15
+
+/obj/item/oddity/common/book_bible
+	name = "old bible"
+	desc = "Oh, how quickly we forgot."
+	icon_state = "book_bible"
+	oddity_stats = list(
+		STAT_ROB = 5,
+		STAT_VIG = 5,
 	)
 
 /obj/item/oddity/common/photo_landscape
@@ -90,6 +133,108 @@
 		STAT_TGH = 5,
 	)
 
+/obj/item/oddity/common/mirror
+	name = "cracked mirror"
+	desc = "A thousand mirror images stare back at you as you examine the trinket. What if you're the reflection, staring back out at the real world? At the real you?"
+	icon_state = "mirror"
+	oddity_stats = list(
+		STAT_COG = 4,
+		STAT_VIG = 4,
+	)
+	rarity_value = 8
+
+/obj/item/oddity/common/photo_crime
+	name = "crime scene photo"
+	desc = "It is unclear whether this is a victim of suicide or murder. His face is frozen in a look of agony and terror, and you shudder to think at what his last moments might have been."
+	icon_state = "photo_crime"
+	oddity_stats = list(
+		STAT_COG = 7,
+		STAT_VIG = 7,
+	)
+	rarity_value = 23
+
+/obj/item/oddity/common/old_radio
+	name = "old radio"
+	desc = "Close your eyes, bring it closer and listen. You can almost hear it, in the edge of your consciousness. The World is ticking."
+	icon_state = "old_radio"
+	oddity_stats = list(
+		STAT_COG = 9,
+		STAT_VIG = 9,
+	)
+	rarity_value = 23
+
+/obj/item/oddity/common/old_pda
+	name = "broken pda"
+	desc = "An old Nanotrasen era PDA. These were issued to their employees all throughout the galaxy."
+	icon_state = "old_pda"
+	item_state = "electronic"
+	oddity_stats = list(
+		STAT_COG = 6,
+		STAT_MEC = 6,
+	)
+	rarity_value = 15
+
+/obj/item/oddity/common/blueprint
+	name = "strange blueprint"
+	desc = "There's no telling what this design is supposed to be. Whatever could be built from this likely wouldn't work."
+	icon_state = "blueprint"
+	oddity_stats = list(
+		STAT_COG = 5,
+		STAT_MEC = 7,
+	)
+	rarity_value = 15
+
+/obj/item/oddity/common/book_unholy
+	name = "unholy book"
+	desc = "The writings inside entail some strange ritual. Pages have been torn out or smudged to illegibility."
+	icon_state = "book_skull"
+	oddity_stats = list(
+		STAT_COG = 7,
+		STAT_MEC = 7,
+	)
+	rarity_value = 24
+
+/obj/item/oddity/common/device
+	name = "odd device"
+	desc = "Something about this gadget both disturbs and interests you. It's manufacturer's name has been mostly smudged away, but you can see a strange mechanism as their logo."
+	icon_state = "device"
+	oddity_stats = list(
+		STAT_COG = 8,
+		STAT_MEC = 8,
+	)
+	rarity_value = 19
+
+/obj/item/oddity/common/healthscanner
+	name = "odd health scanner"
+	desc = "It's broken and stuck on some really strange readings. Was this even human?"
+	icon_state = "healthscanner"
+	item_state = "electronic"
+	oddity_stats = list(
+		STAT_COG = 8,
+		STAT_BIO = 8,
+	)
+	rarity_value = 23
+
+/obj/item/oddity/common/old_knife
+	name = "old knife"
+	desc = "Is this blood older then you? You can't tell, and will never know."
+	icon_state = "old_knife"
+	item_state = "knife"
+	structure_damage_factor = STRUCTURE_DAMAGE_BLADE
+	tool_qualities = list(QUALITY_CUTTING = 20,  QUALITY_WIRE_CUTTING = 10, QUALITY_SCREW_DRIVING = 5)
+	force = WEAPON_FORCE_DANGEROUS
+	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	slot_flags = SLOT_BELT
+	sharp = TRUE
+	edge = TRUE
+	oddity_stats = list(
+		STAT_ROB = 5,
+		STAT_TGH = 5,
+		STAT_VIG = 5,
+	)
+	rarity_value = 22
+
 /obj/item/oddity/common/photo_eyes
 	name = "observer photo"
 	desc = "Just looking at this photo sparks a primal fear in your heart."
@@ -101,15 +246,38 @@
 	)
 	rarity_value = 18
 
-/obj/item/oddity/common/photo_crime
-	name = "crime scene photo"
-	desc = "It is unclear whether this is a victim of suicide or murder. His face is frozen in a look of agony and terror, and you shudder to think at what his last moments might have been."
-	icon_state = "photo_crime"
+/obj/item/oddity/common/book_omega
+	name = "occult book"
+	desc = "Most of the stories in this book seem to be the writings of madmen, but at least the stories are interesting."
+	icon_state = "book_omega"
 	oddity_stats = list(
-		STAT_COG = 7,
+		STAT_BIO = 6,
+		STAT_ROB = 6,
+		STAT_VIG = 6,
+	)
+	rarity_value = 18
+
+/obj/item/oddity/common/teddy
+	name = "teddy bear"
+	desc = "He will be there for you, even in tough times."
+	icon_state = "teddy"
+	oddity_stats = list(
+		STAT_ROB = 7,
+		STAT_TGH = 7,
 		STAT_VIG = 7,
 	)
-	rarity_value = 23
+	rarity_value = 20
+
+/obj/item/oddity/common/book_eyes
+	name = "observer book"
+	desc = "This book contains detailed information on unknown cyber creatures. Who did this, how is this even possible?"
+	icon_state = "book_eyes"
+	oddity_stats = list(
+		STAT_ROB = 9,
+		STAT_TGH = 9,
+		STAT_VIG = 9,
+	)
+	rarity_value = 30
 
 /obj/item/oddity/common/old_newspaper
 	name = "old newspaper"
@@ -136,185 +304,6 @@
 	)
 	rarity_value = 18
 
-/obj/item/oddity/common/paper_omega
-	name = "collection of obscure reports"
-	desc = "Even the authors seem to be rather skeptical about their findings. The reports are not connected to each other, but their results are similar."
-	icon_state = "folder-omega" //changed from "paper_omega"
-	oddity_stats = list(
-		STAT_MEC = 8,
-		STAT_COG = 8,
-		STAT_BIO = 8,
-	)
-	rarity_value = 27
-
-/obj/item/oddity/common/book_eyes
-	name = "observer book"
-	desc = "This book details information on some cyber creatures. Who did this, how this is even possible?"
-	icon_state = "book_eyes"
-	oddity_stats = list(
-		STAT_ROB = 9,
-		STAT_TGH = 9,
-		STAT_VIG = 9,
-	)
-	rarity_value = 30
-
-/obj/item/oddity/common/book_omega
-	name = "occult book"
-	desc = "Most of the stories in this book seem to be the writings of madmen, but at least the stories are interesting."
-	icon_state = "book_omega"
-	oddity_stats = list(
-		STAT_BIO = 6,
-		STAT_ROB = 6,
-		STAT_VIG = 6,
-	)
-	rarity_value = 18
-
-/obj/item/oddity/common/book_bible
-	name = "old bible"
-	desc = "Oh, how quickly we forgot."
-	icon_state = "book_bible"
-	oddity_stats = list(
-		STAT_ROB = 5,
-		STAT_VIG = 5,
-	)
-
-/obj/item/oddity/common/book_unholy
-	name = "unholy book"
-	desc = "The writings inside entail some strange ritual. Pages have been torn out or smudged to illegibility."
-	icon_state = "book_skull"
-	oddity_stats = list(
-		STAT_COG = 7,
-		STAT_MEC = 7,
-	)
-	rarity_value = 24
-
-/obj/item/oddity/common/old_money
-	name = "old money"
-	desc = "It's not like the organization that issued this exists anymore."
-	icon_state = "old_money"
-	oddity_stats = list(
-		STAT_ROB = 4,
-		STAT_TGH = 4,
-	)
-	rarity_value = 8
-
-/obj/item/oddity/common/healthscanner
-	name = "odd health scanner"
-	desc = "It's broken and stuck on some really strange readings. Was this even human?"
-	icon_state = "healthscanner"
-	item_state = "electronic"
-	oddity_stats = list(
-		STAT_COG = 8,
-		STAT_BIO = 8,
-	)
-	rarity_value = 23
-
-/obj/item/oddity/common/old_pda
-	name = "broken pda"
-	desc = "An old Nanotrasen era PDA. These were issued to their employees all throughout the galaxy."
-	icon_state = "old_pda"
-	item_state = "electronic"
-	oddity_stats = list(
-		STAT_COG = 6,
-		STAT_MEC = 6,
-	)
-	rarity_value = 15
-
-/obj/item/oddity/common/towel
-	name = "trustworthy towel"
-	desc = "It's always good to have one with you."
-	icon_state = "towel"
-	oddity_stats = list(
-		STAT_ROB = 6,
-		STAT_TGH = 6,
-	)
-	rarity_value = 15
-
-/obj/item/oddity/common/teddy
-	name = "teddy bear"
-	desc = "He will be there for you, even in tough times."
-	icon_state = "teddy"
-	oddity_stats = list(
-		STAT_ROB = 7,
-		STAT_TGH = 7,
-		STAT_VIG = 7,
-	)
-	rarity_value = 20
-
-/obj/item/oddity/common/old_knife
-	name = "old knife"
-	desc = "Is this blood older then you? You can't tell, and will never know."
-	icon_state = "old_knife"
-	item_state = "knife"
-	structure_damage_factor = STRUCTURE_DAMAGE_BLADE
-	tool_qualities = list(QUALITY_CUTTING = 20,  QUALITY_WIRE_CUTTING = 10, QUALITY_SCREW_DRIVING = 5)
-	force = WEAPON_FORCE_DANGEROUS
-	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	hitsound = 'sound/weapons/bladeslice.ogg'
-	slot_flags = SLOT_BELT
-	sharp = TRUE
-	edge = TRUE
-	oddity_stats = list(
-		STAT_ROB = 5,
-		STAT_TGH = 5,
-		STAT_VIG = 5,
-	)
-	rarity_value = 22
-
-/obj/item/oddity/common/old_id
-	name = "old id"
-	desc = "There is a story behind this name. Untold, and cruel in fate."
-	icon_state = "old_id"
-	oddity_stats = list(
-		STAT_VIG = 9,
-	)
-
-/obj/item/oddity/common/disk
-	name = "broken design disk"
-	desc = "This disk is corrupted and completely unusable. It has a hand-drawn picture of some strange mechanism on it - looking at it for too long makes your head hurt."
-	icon_state = "disc"
-	oddity_stats = list(
-		STAT_MEC = 9,
-	)
-
-/obj/item/oddity/common/mirror
-	name = "cracked mirror"
-	desc = "A thousand mirror images stare back at you as you examine the trinket. What if you're the reflection, staring back out at the real world? At the real you?"
-	icon_state = "mirror"
-	oddity_stats = list(
-		STAT_COG = 4,
-		STAT_VIG = 4,
-	)
-	rarity_value = 8
-
-/obj/item/oddity/common/lighter
-	name = "rusted lighter"
-	desc = "This zippo ligher has been rusted shut. It smells faintly of sulphur and blood."
-	icon_state = "syndicate_lighter"
-	oddity_stats = list(
-		STAT_TGH = 9,
-	)
-
-/obj/item/oddity/common/device
-	name = "odd device"
-	desc = "Something about this gadget both disturbs and interests you. It's manufacturer's name has been mostly smudged away, but you can see a strange mechanism as their logo."
-	icon_state = "device"
-	oddity_stats = list(
-		STAT_MEC = 8,
-		STAT_COG = 8,
-	)
-	rarity_value = 19
-
-/obj/item/oddity/common/old_radio
-	name = "old radio"
-	desc = "Close your eyes, bring it closer and listen. You can almost hear it, in the edge of your consciousness. The World is ticking."
-	icon_state = "old_radio"
-	oddity_stats = list(
-		STAT_COG = 9,
-		STAT_VIG = 9,
-	)
-	rarity_value = 23
-
 /obj/item/oddity/common/paper_bundle
 	name = "paper bundle"
 	desc = "Somewhere there is a truth, hidden under all of this scrap."
@@ -326,6 +315,18 @@
 	)
 	rarity_value = 16
 
+/obj/item/oddity/common/paper_omega
+	name = "collection of obscure reports"
+	desc = "Even the authors seem to be rather skeptical about their findings. The reports are not connected to each other, but their results are similar."
+	icon_state = "folder-omega" //changed from "paper_omega"
+	oddity_stats = list(
+		STAT_MEC = 8,
+		STAT_COG = 8,
+		STAT_BIO = 8,
+	)
+	rarity_value = 27
+
+//Technomancer artifact generated oddity
 /obj/item/oddity/techno
 	name = "Unknown technological part"
 	desc = "Technological part created by Techno-Tribalism Enforcer."
@@ -601,7 +602,7 @@
 		var/datum/perk/big_shot/perk = user.stats.getPerk(PERK_BIG_SHOT)
 		perk.my_mask = src
 
-
+//This exists.
 /obj/item/oddity/bearmath
 	name = "scrap of semi-semiotics research pamphlet"
 	desc = "A piece of paper with an unfinished mathematical equation."

--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -613,7 +613,7 @@
 		perk.my_mask = src
 
 //This exists.
-/obj/item/oddity/bearmath
+/obj/item/oddity/common/bearmath
 	name = "scrap of semi-semiotics research pamphlet"
 	desc = "A piece of paper with an unfinished mathematical equation."
 	icon = 'icons/obj/bureaucracy.dmi'

--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -53,6 +53,8 @@
 	bad_type = /obj/item/oddity/common
 	spawn_blacklisted = FALSE
 
+
+//Single stat oddities. Starting with combat stats (ROB, TGH, and VIG)
 /obj/item/oddity/common/lighter
 	name = "rusted lighter"
 	desc = "This zippo ligher has been rusted shut. It smells faintly of sulphur and blood."
@@ -69,6 +71,7 @@
 		STAT_VIG = 9,
 	)
 
+//Single stat, work stat (BIO, COG, and MEC)
 /obj/item/oddity/common/disk
 	name = "broken design disk"
 	desc = "This disk is corrupted and completely unusable. It has a hand-drawn picture of some strange mechanism on it - looking at it for too long makes your head hurt."
@@ -77,6 +80,7 @@
 		STAT_MEC = 9,
 	)
 
+//Double stat oddities, combat.
 /obj/item/oddity/common/old_money
 	name = "old money"
 	desc = "It's not like the organization that issued this exists anymore."
@@ -115,6 +119,7 @@
 		STAT_VIG = 5,
 	)
 
+//Double stat, mixed
 /obj/item/oddity/common/photo_landscape
 	name = "alien landscape photo"
 	desc = "There is some ire about the planet in this photograph."
@@ -163,6 +168,7 @@
 	)
 	rarity_value = 23
 
+//Double stat, work
 /obj/item/oddity/common/old_pda
 	name = "broken pda"
 	desc = "An old Nanotrasen era PDA. These were issued to their employees all throughout the galaxy."
@@ -215,6 +221,7 @@
 	)
 	rarity_value = 23
 
+//Triple stat, combat
 /obj/item/oddity/common/old_knife
 	name = "old knife"
 	desc = "Is this blood older then you? You can't tell, and will never know."
@@ -246,17 +253,6 @@
 	)
 	rarity_value = 18
 
-/obj/item/oddity/common/book_omega
-	name = "occult book"
-	desc = "Most of the stories in this book seem to be the writings of madmen, but at least the stories are interesting."
-	icon_state = "book_omega"
-	oddity_stats = list(
-		STAT_BIO = 6,
-		STAT_ROB = 6,
-		STAT_VIG = 6,
-	)
-	rarity_value = 18
-
 /obj/item/oddity/common/teddy
 	name = "teddy bear"
 	desc = "He will be there for you, even in tough times."
@@ -270,7 +266,7 @@
 
 /obj/item/oddity/common/book_eyes
 	name = "observer book"
-	desc = "This book contains detailed information on unknown cyber creatures. Who did this, how is this even possible?"
+	desc = "This book contains detailed information on otherwise unknown cyber creatures. Who did this, how is this even possible?"
 	icon_state = "book_eyes"
 	oddity_stats = list(
 		STAT_ROB = 9,
@@ -279,6 +275,30 @@
 	)
 	rarity_value = 30
 
+//Triple stat, mixed
+/obj/item/oddity/common/paper_bundle
+	name = "paper bundle"
+	desc = "Somewhere there is a truth, hidden under all of this scrap."
+	icon_state = "paper_bundle"
+	oddity_stats = list(
+		STAT_BIO = 6,
+		STAT_ROB = 6,
+		STAT_VIG = 6,
+	)
+	rarity_value = 16
+
+/obj/item/oddity/common/book_omega
+	name = "occult book"
+	desc = "Most of the stories in this book seem to be the writings of madmen, but at least the stories are interesting."
+	icon_state = "book_omega"
+	oddity_stats = list(
+		STAT_BIO = 6,
+		STAT_ROB = 6,
+		STAT_VIG = 6,
+	)
+	rarity_value = 18
+
+//Triple stat, work
 /obj/item/oddity/common/old_newspaper
 	name = "old newspaper"
 	desc = "It contains a report on some old and strange phenomenon. Maybe it's lies, maybe it's corporate experiments gone wrong. Wait, there are two comically obvious holes for peering through!"
@@ -304,17 +324,6 @@
 	)
 	rarity_value = 18
 
-/obj/item/oddity/common/paper_bundle
-	name = "paper bundle"
-	desc = "Somewhere there is a truth, hidden under all of this scrap."
-	icon_state = "paper_bundle"
-	oddity_stats = list(
-		STAT_BIO = 6,
-		STAT_ROB = 6,
-		STAT_VIG = 6,
-	)
-	rarity_value = 16
-
 /obj/item/oddity/common/paper_omega
 	name = "collection of obscure reports"
 	desc = "Even the authors seem to be rather skeptical about their findings. The reports are not connected to each other, but their results are similar."
@@ -326,7 +335,7 @@
 	)
 	rarity_value = 27
 
-//Technomancer artifact generated oddity
+//Oddity generated from Technomancer's Techno-Tribalism Enforcer
 /obj/item/oddity/techno
 	name = "Unknown technological part"
 	desc = "Technological part created by Techno-Tribalism Enforcer."
@@ -336,6 +345,7 @@
 	icon_state = "techno_part[rand(1,7)]"
 	.=..()
 
+//Rare bluespace oddity.
 /obj/item/oddity/broken_necklace
 	name = "Broken necklace"
 	desc = "A broken necklace that has a blue crystal as a trinket."


### PR DESCRIPTION
## About The Pull Request
Prepares this document for another PR I'm planning to make later down the line.
General order should be Singular Combat Stat > Singular Work Stat > Dual Combat Stat > Dual Mixed >, and so on.
Also fixes description on the observer book.

## Why It's Good For The Game
I tried to mess with this file earlier, but since everything was out of order and ended up constantly jumping towards different points.
I also believe the reorganized state of this file reveals some things about our current oddity design and layout.

## Changelog
:cl: 
tweak: The oddities.dm file has been reordered.
spellcheck: Observer book description changed.
fix: Bear math oddity is now a subtype of /obj/item/oddity/common/, which allows it to spawn in maintenance.
/ :cl: 
