### PR TITLE
Throwing knives now spawn in full stack

### DIFF
--- a/code/datums/craft/recipes/weapon.dm
+++ b/code/datums/craft/recipes/weapon.dm
@@ -68,7 +68,7 @@
 	)
 
 /datum/craft_recipe/weapon/throwing_knife
-	name = "throwing knife"
+	name = "throwing knives"
 	result = /obj/item/stack/thrown/throwing_knife
 	steps = list(
 		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTEEL),

--- a/code/datums/craft/recipes/weapon.dm
+++ b/code/datums/craft/recipes/weapon.dm
@@ -71,7 +71,7 @@
 	name = "throwing knives"
 	result = /obj/item/stack/thrown/throwing_knife
 	steps = list(
-		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTEEL),
+		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTEEL),
 		list(QUALITY_WELDING, 10, "time" = 30),
 		list(QUALITY_HAMMERING, 10, "time" = 20)
 	)

--- a/code/game/objects/items/stacks/knife.dm
+++ b/code/game/objects/items/stacks/knife.dm
@@ -72,8 +72,8 @@
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/melee/lightstab.ogg'
 	structure_damage_factor = STRUCTURE_DAMAGE_BLADE
-	matter = list(MATERIAL_PLASTEEL = 2)
-	amount = 1
+	matter = list(MATERIAL_PLASTEEL = 1)
+	amount = 3
 	max_amount = 3
 	w_class = ITEM_SIZE_SMALL
 	force = WEAPON_FORCE_NORMAL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
amount = 3
also changes  crafting recipe name from "knife" to "knives" to reflect on the change
deconstructing knives now gives 1 plasteel instead of 2

## Why It's Good For The Game

no need to waste 6 plasteel sheets for three knives anymore, now you get 3 for 3(the item is very tiny anyway)

## Changelog
:cl:
tweak: throwing knives now spawn in full stack
balance: deconstructing throwing knives now gives 1 plasteel instead of 2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
