### PR TITLE
Increase force and throwforce of intact bottles, bottles guaranteed to break on impact

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -5,6 +5,7 @@
 /obj/item/reagent_containers/food/drinks/bottle
 	amount_per_transfer_from_this = 10
 	volume = 100
+	description_info = "Thrown bottles don't break when you throw them while being on help intent."
 	item_state = "broken_beer" //Generic held-item sprite until unique ones are made.
 	force = 20
 	throwforce = 20
@@ -36,13 +37,21 @@
 	rag = null
 	return ..()
 
+/obj/item/reagent_containers/food/drinks/bottle/throw_at(atom/target, range, speed, thrower)
+	var/mob/H = thrower
+	if(istype(H))
+		bottle_thrower_intent = H.a_intent
+	..()
+	bottle_thrower_intent = null
+
 //when thrown on impact, bottles smash and spill their contents
 /obj/item/reagent_containers/food/drinks/bottle/throw_impact(atom/hit_atom, speed)
 	..()
-	if(reagents)
-		hit_atom.visible_message(SPAN_NOTICE("The contents of \the [src] splash all over [hit_atom]!"))
-		reagents.splash(hit_atom, reagents.total_volume)
-	src.smash(loc, hit_atom)
+	if(bottle_thrower_intent != I_HELP)
+		if(reagents)
+			hit_atom.visible_message(SPAN_NOTICE("The contents of \the [src] splash all over [hit_atom]!"))
+			reagents.splash(hit_atom, reagents.total_volume)
+		src.smash(loc, hit_atom)
 
 /obj/item/reagent_containers/food/drinks/bottle/proc/smash_check(distance)
 	if(!isGlass || !smash_duration)

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -7,8 +7,8 @@
 	volume = 100
 	description_info = "Thrown bottles don't break when you throw them while being on help intent."
 	item_state = "broken_beer" //Generic held-item sprite until unique ones are made.
-	force = 20
-	throwforce = 20
+	force = WEAPON_FORCE_WEAK
+	throwforce = WEAPON_FORCE_WEAK
 	rarity_value = 14
 	bad_type = /obj/item/reagent_containers/food/drinks/bottle
 	var/smash_duration = 5 //Directly relates to the 'weaken' duration. Lowered by armor (i.e. helmets)

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -6,7 +6,8 @@
 	amount_per_transfer_from_this = 10
 	volume = 100
 	item_state = "broken_beer" //Generic held-item sprite until unique ones are made.
-	force = 5
+	force = 20
+	throwforce = 20
 	rarity_value = 14
 	bad_type = /obj/item/reagent_containers/food/drinks/bottle
 	var/smash_duration = 5 //Directly relates to the 'weaken' duration. Lowered by armor (i.e. helmets)
@@ -35,24 +36,13 @@
 	rag = null
 	return ..()
 
-/obj/item/reagent_containers/food/drinks/bottle/throw_at(atom/target, range, speed, thrower)
-	var/mob/H = thrower
-	if(istype(H))
-		bottle_thrower_intent = H.a_intent
-	..()
-	bottle_thrower_intent = null
-
 //when thrown on impact, bottles smash and spill their contents
 /obj/item/reagent_containers/food/drinks/bottle/throw_impact(atom/hit_atom, speed)
 	..()
-
-	if(bottle_thrower_intent == I_HURT)
-		var/throw_dist = get_dist(throw_source, loc)
-		if(speed >= throw_speed && smash_check(throw_dist)) //not as reliable as smashing directly
-			if(reagents)
-				hit_atom.visible_message(SPAN_NOTICE("The contents of \the [src] splash all over [hit_atom]!"))
-				reagents.splash(hit_atom, reagents.total_volume)
-			src.smash(loc, hit_atom)
+	if(reagents)
+		hit_atom.visible_message(SPAN_NOTICE("The contents of \the [src] splash all over [hit_atom]!"))
+		reagents.splash(hit_atom, reagents.total_volume)
+	src.smash(loc, hit_atom)
 
 /obj/item/reagent_containers/food/drinks/bottle/proc/smash_check(distance)
 	if(!isGlass || !smash_duration)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

force from 5 to 7
throwforce from 1(__!!!__) to 7
tweaked intent check on throwing bottles
## Why It's Good For The Game
first off, now molotovs ACTUALLY WORK
second, hitting someone with a bottle is far stronger than a *fucking punch* now
third, throwing a bottle at someone is now ~~an alternative to throwing knives~~ *actually useful*
## Changelog
:cl:
add: increase force and throwforce of intact bottles
tweak: bottles guaranteed to break on impact when not in help mode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
