### PR TITLE
Backstabbing

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -138,10 +138,19 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		target.IgniteMob()
 
 	var/power = force
+	var/backstabbed = FALSE
+	if(can_backstab && backstab_multiplier)
+		var/attack_dir = 0
+		var/vulnerable_dirs = target.dir
+		attack_dir = get_dir(get_turf(user), get_turf(target))
+		if((attack_dir && (attack_dir & vulnerable_dirs))||target.lying)
+			power*= backstab_multiplier
+			backstabbed = TRUE
+
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		power *= H.damage_multiplier
 //	if(HULK in user.mutations)
 //		power *= 2
-	target.hit_with_weapon(src, user, power, hit_zone)
+	target.hit_with_weapon(src, user, power, hit_zone, backstabbed)
 	return

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -78,6 +78,8 @@
 
 	//Damage vars
 	var/force = 0	//How much damage the weapon deals
+	var/can_backstab = FALSE //Whether or not this item can backstab
+	var/backstab_multiplier = 2 //force multiplier for backstabbing
 	var/embed_mult = 0.5 //Multiplier for the chance of embedding in mobs. Set to zero to completely disable embedding
 	var/structure_damage_factor = STRUCTURE_DAMAGE_NORMAL	//Multiplier applied to the damage when attacking structures and machinery
 	//Does not affect damage dealt to mobs

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -88,7 +88,7 @@
 
 /obj/item/tool/sword/nt/scourge
 	name = "NT Scourge"
-	desc = "A saintly-looking whip that can be extended for more pain."
+	desc = "A saintly-looking whip that can be extended to cause more pain at the cost of damage."
 	icon_state = "nt_scourge"
 	item_state = "nt_scourge"
 	force = WEAPON_FORCE_ROBUST

--- a/code/game/objects/items/weapons/tools/knives.dm
+++ b/code/game/objects/items/weapons/tools/knives.dm
@@ -20,16 +20,11 @@
 	hitsound = 'sound/weapons/melee/lightstab.ogg'
 	slot_flags = SLOT_BELT
 	structure_damage_factor = STRUCTURE_DAMAGE_BLADE
+	can_backstab = TRUE
 
 	//spawn values
 	rarity_value = 10
 	spawn_tags = SPAWN_TAG_KNIFE
-
-/proc/check_backstab(mob/user, mob/victim)
-	var/attack_dir = 0
-	var/bad_arc = reverse_direction(victim.dir)
-	attack_dir = get_dir(get_turf(user), get_turf(victim))
-	if(attack_dir && (attack_dir & bad_arc))
 
 /obj/item/tool/knife/boot
 	name = "boot knife"
@@ -72,6 +67,7 @@
 	matter = list(MATERIAL_STEEL = 5, MATERIAL_PLASTIC = 1)
 	tool_qualities = list(QUALITY_CUTTING = 20,  QUALITY_WIRE_CUTTING = 15)
 	rarity_value = 5
+	can_backstab = FALSE
 
 /obj/item/tool/knife/neotritual
 	name = "NeoTheology ritual knife"
@@ -126,6 +122,7 @@
 	force = WEAPON_FORCE_NORMAL * 1.3
 	armor_divisor = ARMOR_PEN_MASSIVE
 	rarity_value = 15
+	backstab_multiplier = 2.5
 
 /obj/item/tool/knife/dagger/ceremonial
 	name = "ceremonial dagger"

--- a/code/game/objects/items/weapons/tools/knives.dm
+++ b/code/game/objects/items/weapons/tools/knives.dm
@@ -5,6 +5,7 @@
 	desc = "A general purpose Chef's Knife made by Asters Merchant Guild. Guaranteed to stay sharp for years to come."
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "knife"
+	description_info = "Attacking targets from behind or who are prone deals extra damage."
 	flags = CONDUCT
 	sharp = TRUE
 	edge = TRUE
@@ -47,6 +48,7 @@
 	armor_divisor = ARMOR_PEN_HALF //Should be countered be embedding
 	embed_mult = 1.5 //This is designed for embedding
 	rarity_value = 5
+	can_backstab = FALSE
 
 /obj/item/tool/knife/ritual
 	name = "ritual knife"

--- a/code/game/objects/items/weapons/tools/knives.dm
+++ b/code/game/objects/items/weapons/tools/knives.dm
@@ -25,6 +25,12 @@
 	rarity_value = 10
 	spawn_tags = SPAWN_TAG_KNIFE
 
+/proc/check_backstab(mob/user, mob/victim)
+	var/attack_dir = 0
+	var/bad_arc = reverse_direction(victim.dir)
+	attack_dir = get_dir(get_turf(user), get_turf(victim))
+	if(attack_dir && (attack_dir & bad_arc))
+
 /obj/item/tool/knife/boot
 	name = "boot knife"
 	desc = "A small fixed-blade knife for putting inside a boot."

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -267,12 +267,18 @@ meteor_act
 
 	return hit_zone
 
-/mob/living/carbon/human/hit_with_weapon(obj/item/I, mob/living/user, var/effective_force, var/hit_zone)
+/mob/living/carbon/human/hit_with_weapon(obj/item/I, mob/living/user, var/effective_force, var/hit_zone, backstabbing)
 	var/obj/item/organ/external/affecting = get_organ(hit_zone)
 	if(!affecting)
 		return FALSE//should be prevented by attacked_with_item() but for sanity.
-
-	visible_message("<span class='danger'>[src] has been [I.attack_verb.len? pick(I.attack_verb) : "attacked"] in the [affecting.name] with [I.name] by [user]!</span>")
+//	var/attack_verb_used
+//	if(!backstabbing)
+//		attack_verb_used = I.attack_verb.len? pick(I.attack_verb) : "attacked"
+//	else
+//		attack_verb_used = "backstabbed"
+	visible_message("<span class='danger'>[src] has been [I.attack_verb.len? pick(I.attack_verb) : backstabbing? "backstabbed" : "attacked"] in the [affecting.name] with [I.name] by [user]!</span>")
+	if(backstabbing)
+		visible_message("<span class='warning'>[src] has been [I.attack_verb.len? pick(I.attack_verb) : backstabbing? "backstabbed" : "attacked"] in the [affecting.name] with [I.name] by [user]!</span>")	
 
 	standard_weapon_hit_effects(I, user, effective_force, hit_zone)
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -271,15 +271,9 @@ meteor_act
 	var/obj/item/organ/external/affecting = get_organ(hit_zone)
 	if(!affecting)
 		return FALSE//should be prevented by attacked_with_item() but for sanity.
-//	var/attack_verb_used
-//	if(!backstabbing)
-//		attack_verb_used = I.attack_verb.len? pick(I.attack_verb) : "attacked"
-//	else
-//		attack_verb_used = "backstabbed"
-	visible_message("<span class='danger'>[src] has been [I.attack_verb.len? pick(I.attack_verb) : backstabbing? "backstabbed" : "attacked"] in the [affecting.name] with [I.name] by [user]!</span>")
-	if(backstabbing)
-		visible_message("<span class='warning'>[src] has been [I.attack_verb.len? pick(I.attack_verb) : backstabbing? "backstabbed" : "attacked"] in the [affecting.name] with [I.name] by [user]!</span>")	
 
+	visible_message("<span class='danger'>[src] has been [backstabbing? "backstabbed" : I.attack_verb.len? pick(I.attack_verb) : "attacked"] in the [affecting.name] with [I.name] by [user]!</span>")
+	
 	standard_weapon_hit_effects(I, user, effective_force, hit_zone)
 
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds backstabbing. Backstabbing happens when you stab someone in the back or stab someone who is prone. Backstabbing deals extra damage.
When attacking from the 3 tiles behind a person that are adjacent to them, a backstab happens.

The reason for why prone people are always backstabbed is mostly just that you can't really see which side someone's "back" is if you haven't memorized it, and having to move "behind" someone who is on the ground to backstab is kinda weird.

All knives except for the cleaver and the meathook can backstab (cleaver and meathook would deal too much damage if they could)
Regular knives deal double damage when backstabbing, daggers deal 2,5x damage, to create some distinction of daggers and knives, and to compensate for the lower damage of daggers.

damage values are of course up to discussion. If deemed necessary, damage values for stabbing in the back and stabbing while prone could be turned into different values.

also tweaks the description of the NT scourge to be more informative.

## Why It's Good For The Game

More reason to use knives good backstabbing cool. 

## Changelog
:cl:
add: knives can now perform backstab attacks. prone people are always backstabbed.
/:cl:


