### PR TITLE
Lasblender buff

### DIFF
--- a/code/datums/craft/recipes/guns.dm
+++ b/code/datums/craft/recipes/guns.dm
@@ -95,6 +95,20 @@
 		list(QUALITY_ADHESIVE, 15, 70)
 	)
 
+/datum/craft_recipe/gun/lasersmg
+	name = "Lasblender"
+	result = /obj/item/gun/energy/lasersmg
+	steps = list(
+		list(/obj/item/gun/projectile/automatic/atreides, 1),
+		list(QUALITY_WELDING, 10, "time" = 30),
+		list(CRAFT_MATERIAL, 6, MATERIAL_PLASTEEL, "time" = 10),
+		list(/obj/item/stock_parts/subspace/crystal, 1),
+		list(/obj/item/computer_hardware/led, 1),
+		list(/obj/item/stack/cable_coil, 5, "time" = 20),
+		list(/obj/item/stock_parts/capacitor, 1, "time" = 5),
+		list(CRAFT_MATERIAL, 2, MATERIAL_GLASS, "time" = 10),
+		list(QUALITY_ADHESIVE, 15, 70))
+
 /datum/craft_recipe/gun/kalash
 	name = "Makeshift AR .30 \"Kalash\""
 	result = /obj/item/part/gun/frame/kalash

--- a/code/datums/craft/recipes/weapon.dm
+++ b/code/datums/craft/recipes/weapon.dm
@@ -290,21 +290,6 @@
 		list(QUALITY_WIRE_CUTTING, 30, "time" = 50), //Fix the wires
 	)
 
-/datum/craft_recipe/weapon/lasersmg
-	name = "Lasblender"
-	result = /obj/item/gun/energy/lasersmg
-	steps = list(
-		list(/obj/item/gun/projectile/automatic/atreides, 1),
-		list(QUALITY_WELDING, 10, "time" = 30),
-		list(CRAFT_MATERIAL, 6, MATERIAL_PLASTEEL, "time" = 10),
-		list(/obj/item/stock_parts/subspace/crystal, 1),
-		list(/obj/item/computer_hardware/led, 1),
-		list(/obj/item/stack/cable_coil, 5, "time" = 20),
-		list(/obj/item/stock_parts/capacitor, 1, "time" = 5),
-		list(CRAFT_MATERIAL, 2, MATERIAL_GLASS, "time" = 10),
-		list(QUALITY_ADHESIVE, 15, 70)
-	)
-
 /datum/craft_recipe/weapon/gravcharger
 	name = "Makeshift bullet time generator"
 	result = /obj/item/gun_upgrade/mechanism/gravcharger

--- a/code/modules/projectiles/guns/energy/lasersmg.dm
+++ b/code/modules/projectiles/guns/energy/lasersmg.dm
@@ -1,7 +1,7 @@
 /obj/item/gun/energy/lasersmg
 	name = "Disco Vazer \"Lasblender\""
 	desc = "This conversion of the \"Atreides\" enables it to shoot lasers. Unlike in other laser weapons, the process of creating a laser is based on a chain reaction of localized micro-explosions.\
-			While this method is charge-effective, it worsens accuracy, and the chain-reaction makes the gun always fire in bursts. \
+			While this method is charge-effective, the chain-reaction makes the gun always fire in bursts. \
 			Sometimes jokingly called the \"Disco Vazer\"."
 	icon = 'icons/obj/guns/energy/lasersmg.dmi'
 	icon_state = "lasersmg"

--- a/code/modules/projectiles/guns/energy/lasersmg.dm
+++ b/code/modules/projectiles/guns/energy/lasersmg.dm
@@ -16,9 +16,9 @@
 	slot_flags = SLOT_BELT
 	matter = list(MATERIAL_PLASTEEL = 11, MATERIAL_STEEL = 13, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 1, MATERIAL_GLASS = 2)
 	price_tag = 1000
-	damage_multiplier = 0.28 //makeshift laser
+	damage_multiplier = 0.35 //makeshift laser
 	projectile_type = /obj/item/projectile/beam
-	init_offset = 7 // bad accuracy even on the first shot
+	init_offset = 0 
 	suitable_cell = /obj/item/cell/medium
 	charge_cost = 25 // 4 bursts with a 800m cell
 

--- a/code/modules/projectiles/guns/energy/lasersmg.dm
+++ b/code/modules/projectiles/guns/energy/lasersmg.dm
@@ -17,6 +17,7 @@
 	matter = list(MATERIAL_PLASTEEL = 11, MATERIAL_STEEL = 13, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 1, MATERIAL_GLASS = 2)
 	price_tag = 1000
 	damage_multiplier = 0.35 //makeshift laser
+	penetration_multiplier = 1
 	projectile_type = /obj/item/projectile/beam
 	init_offset = 0 
 	suitable_cell = /obj/item/cell/medium


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lasblender has slightly better damage, pen and no initial offset now.
Description changed to remove the accuracy malus mention.

Furher dies in 4 bursts.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
The gun was overnerfed the first time and now it's a waste of materials, it's still pretty bad now but not as bad.
Does 10.5 damage with 1 pen, so 84 if you get pegged with every shot from a full burst.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added Lasblender crafting recipe to the guns section
del: Removed Lasblender crafting recipe from the weapons section
tweak: Lasblenders description has been updated
balance: Lasblender does has a 0.35 damage mod and a 1 pen mod now, up from 0.28 and default
balance: Lasblenders initial offset is gone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
