### PR TITLE
Makes prosthetics examine text work properly

### DIFF
--- a/code/modules/organs/external/subtypes/robotic_types.dm
+++ b/code/modules/organs/external/subtypes/robotic_types.dm
@@ -26,19 +26,15 @@
 	bad_type = /obj/item/organ/external/robotic/frozen_star
 
 /obj/item/organ/external/robotic/frozen_star/l_arm
-	name = "\"Frozen Star\" Left Arm"
 	default_description = /datum/organ_description/arm/left
 
 /obj/item/organ/external/robotic/frozen_star/r_arm
-	name = "\"Frozen Star\" Right Arm"
 	default_description = /datum/organ_description/arm/right
 
 /obj/item/organ/external/robotic/frozen_star/l_leg
-	name = "\"Frozen Star\" Left Leg"
 	default_description = /datum/organ_description/leg/left
 
 /obj/item/organ/external/robotic/frozen_star/r_leg
-	name = "\"Frozen Star\" Right Leg"
 	default_description = /datum/organ_description/leg/right
 
 /obj/item/organ/external/robotic/technomancer
@@ -50,31 +46,24 @@
 	bad_type = /obj/item/organ/external/robotic/technomancer
 
 /obj/item/organ/external/robotic/technomancer/l_arm
-	name = "Technomancer \"Homebrew\" Left Arm"
 	default_description = /datum/organ_description/arm/left
 
 /obj/item/organ/external/robotic/technomancer/r_arm
-	name = "Technomancer \"Homebrew\" Right Arm"
 	default_description = /datum/organ_description/arm/right
 
 /obj/item/organ/external/robotic/technomancer/l_leg
-	name = "Technomancer \"Homebrew\" Left Leg"
 	default_description = /datum/organ_description/leg/left
 
 /obj/item/organ/external/robotic/technomancer/r_leg
-	name = "Technomancer \"Homebrew\" Right Leg"
 	default_description = /datum/organ_description/leg/right
 
 /obj/item/organ/external/robotic/technomancer/groin
-	name = "\"Technomancer\" Groin"
 	default_description = /datum/organ_description/groin
 
 /obj/item/organ/external/robotic/technomancer/torso
-	name = "\"Technomancer\" Torso"
 	default_description = /datum/organ_description/chest
 
 /obj/item/organ/external/robotic/technomancer/head
-	name = "\"Technomancer\" Head"
 	default_description = /datum/organ_description/head
 
 /obj/item/organ/external/robotic/moebius


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes prosthetics examine text work properly, instead of showing stuff two times.
No more this:
![17-Sep-22_21-59-00](https://user-images.githubusercontent.com/61051786/193026955-5cdd6706-04e8-425a-8bc4-5f6f3c6cb131.png)


## Why It's Good For The Game

Bug bad.

## Changelog
:cl:
fix: prosthetics examine text now works properly for all prosthetics
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
