### PR TITLE
Slug Buff (rework?)

### DIFF
--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -243,13 +243,13 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/shotgun
 	name = "slug"
 	icon_state = "slug"
-	damage_types = list(BRUTE = 25)
+	damage_types = list(BRUTE = 37.5)
 	armor_divisor = 1
 	knockback = 1
 	step_delay = 1.1
 	style_damage = 25
 	recoil = 8
-	wounding_mult = WOUNDING_EXTREME
+	wounding_mult = WOUNDING_WIDE
 
 /obj/item/projectile/bullet/shotgun/scrap
 	armor_divisor = 0.8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reworks slugs to have lower wound value, but higher base damage.

## Why It's Good For The Game

This makes slugs better against armour than buckshot. As they currently exist, slugs, despite their somewhat superior armour penetration, still lose out against buckshot save for fringe cases due their damage not being enough. These reworked slugs will now handily outdamage buckshot against 15 armour, slightly win over them at 10 armour, and drastically fall behind against unarmoured targets.

## Changelog
:cl:
balance: Slugs now have lower wound value and higher base damage,
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
