### PR TITLE
Fixed Sol Burst

### DIFF
--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -66,7 +66,7 @@
 
 #define BURST_2_ROUND			list(mode_name="2-round bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, move_delay=2, icon="burst")
 #define BURST_3_ROUND			list(mode_name="3-round bursts", mode_desc = "Short, controlled bursts", burst=3, fire_delay=null, move_delay=4, icon="burst")
-#define BURST_3_ROUND_RAPID		list(mode_name=" High-delay Rapid 3-round bursts", mode_desc = "Short, fast bursts with a higher delay between bursts", burst=3, fire_delay=15, move_delay=4, icon="auto", burst_delay = 2)
+#define BURST_3_ROUND_RAPID		list(mode_name=" High-delay Rapid 3-round bursts", mode_desc = "Short, fast bursts with a higher delay between bursts", burst=3, fire_delay=15, move_delay=4, icon="auto", burst_delay = 0.5)
 #define BURST_3_ROUND_DAMAGE	list(mode_name="3-round bursts", mode_desc = "Short, controlled bursts", burst=3, fire_delay=null, move_delay=4, icon="burst")
 #define BURST_5_ROUND			list(mode_name="5-round bursts", mode_desc = "Short, controlled bursts", burst=5, fire_delay=null, move_delay=6, icon="burst")
 #define BURST_8_ROUND			list(mode_name="8-round bursts", mode_desc = "Short, uncontrolled bursts", burst=8, fire_delay=null, move_delay=8, icon="burst")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Sol's high-delay rapid 3-round burst is now actually rapid.

## Why It's Good For The Game

Gun work. This is my second time writing this and I can't be assed to write a whole bible

## Changelog
:cl:
tweak: Reduced the burst delay on the high-delay rapid three round burst from 2 to 0.5
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
