### PR TITLE
Paramedic Style Fix

### DIFF
--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -604,7 +604,7 @@
 		rad = 50)
 	up = TRUE
 	spawn_blacklisted = TRUE
-	style = STYLE_HIGH
+	style = STYLE_NEG_HIGH
 	tint_down = TINT_NONE
 	obscuration_down = LIGHT_OBSCURATION
 	var/speaker_enabled = TRUE

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -634,7 +634,7 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	style_coverage = COVERS_TORSO|COVERS_UPPER_ARMS|COVERS_UPPER_LEGS
 	spawn_blacklisted = TRUE
-	style = STYLE_HIGH
+	style = STYLE_NEG_HIGH
 	action_button_name = "Toggle Acceleration"
 	var/speed_boost_ready = TRUE
 	var/speed_boost_active = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes paramedic armour from having 2 style to -2 style.

## Why It's Good For The Game

I cannot fathom that this wasn't a mistake. Paramedic armour has decent armour and a speed boost. -2 style is a must.

## Changelog
:cl:
tweak: Paramedic armour (both suit and helmet) now have style values of -2 instead of 2.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
