### PR TITLE
Fix double overlays on sheaths

### DIFF
--- a/code/game/objects/items/weapons/storage/holster.dm
+++ b/code/game/objects/items/weapons/storage/holster.dm
@@ -355,13 +355,13 @@
 		overlays += image('icons/inventory/pockets/icon.dmi', "revolver_layer[contents.len]")
 
 /obj/item/storage/pouch/holster/belt/sheath/update_icon()
+	..()
 	cut_overlays()
 	var/icon_to_set
 	for(var/obj/item/SW in contents)
 		icon_to_set = SW.icon_state
 	icon_state = "sheath_[contents.len ? icon_to_set :"0"]"
 	item_state = "sheath_[contents.len ? icon_to_set :"0"]"
-	..()
 
 /obj/item/storage/pouch/holster/belt/knife/update_icon()
 	..()

--- a/code/game/objects/items/weapons/storage/holster.dm
+++ b/code/game/objects/items/weapons/storage/holster.dm
@@ -355,6 +355,7 @@
 		overlays += image('icons/inventory/pockets/icon.dmi', "revolver_layer[contents.len]")
 
 /obj/item/storage/pouch/holster/belt/sheath/update_icon()
+	cut_overlays()
 	var/icon_to_set
 	for(var/obj/item/SW in contents)
 		icon_to_set = SW.icon_state


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

gunsheath no more(this must be a feature)
@SirRichardFrancis localtest lied to us apparently
## Why It's Good For The Game

~~it's not~~ fix

## Changelog
:cl:
fix: no more gun overlay on sheaths
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
