### PR TITLE
Switch stalker position in armory dungeon room

### DIFF
--- a/maps/submaps/dungeon_rooms/rooms/armory.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/armory.dmm
@@ -149,7 +149,7 @@
 /area/crawler)
 "U" = (
 /mob/living/carbon/superior_animal/stalker,
-/turf/simulated/floor/tiled/derelict/red_white_edges,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/crawler)
 
 (1,1,1) = {"
@@ -181,7 +181,7 @@ f
 k
 a
 x
-f
+U
 A
 a
 "}
@@ -225,7 +225,7 @@ o
 b
 a
 t
-U
+b
 a
 s
 "}
@@ -269,7 +269,7 @@ f
 k
 a
 y
-f
+U
 B
 a
 "}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Move the position of a stalker in the "armory" dungeon room. It was causing runtime at roundstart due to airflow trying to move the mob too soon, before its movement variables were all properly initialized

![image](https://user-images.githubusercontent.com/64754494/193448711-0c34bea5-147d-449a-99a0-e549666de1f2.png)


## Changelog
:cl: Hyperio
tweak: Switch stalker position in armory dungeon room
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
