### PR TITLE
Make holsters hold EVERY subtype of /gun

### DIFF
--- a/code/game/objects/items/weapons/storage/holster.dm
+++ b/code/game/objects/items/weapons/storage/holster.dm
@@ -16,32 +16,7 @@
 	var/sound_out = 'sound/effects/holsterout.ogg'
 
 	can_hold = list(
-		/obj/item/gun/projectile/selfload,
-		/obj/item/gun/projectile/colt,
-		/obj/item/gun/projectile/avasarala,
-		/obj/item/gun/projectile/giskard,
-		/obj/item/gun/projectile/gyropistol,
-		/obj/item/gun/projectile/handmade_pistol,
-		/obj/item/gun/projectile/flare_gun,
-		/obj/item/gun/projectile/lamia,
-		/obj/item/gun/projectile/mk58,
-		/obj/item/gun/projectile/olivaw,
-		/obj/item/gun/projectile/mandella,
-		/obj/item/gun/energy/gun,
-		/obj/item/gun/energy/chameleon,
-		/obj/item/gun/energy/captain,
-		/obj/item/gun/energy/stunrevolver,
-		/obj/item/gun/projectile/revolver,
-		/obj/item/gun/projectile/automatic/molly,
-		/obj/item/gun/projectile/paco,
-		/obj/item/gun/projectile/shotgun/doublebarrel/sawn, //short enough to fit in
-		/obj/item/gun/launcher/syringe,
-		/obj/item/gun/energy/plasma/brigador,
-		/obj/item/gun/projectile/shotgun/pump/sawn,
-		/obj/item/gun/projectile/boltgun/obrez,
-		/obj/item/gun/energy/retro/sawn,
-		/obj/item/gun/projectile/automatic/luty,
-		/obj/item/gun/projectile/revolver/hornet
+		/obj/item/gun
 		)
 
 	sliding_behavior = TRUE
@@ -153,32 +128,7 @@
 
 	var/obj/item/storage/internal/holster
 	var/list/can_hold = list(
-		/obj/item/gun/projectile/selfload,
-		/obj/item/gun/projectile/colt,
-		/obj/item/gun/projectile/avasarala,
-		/obj/item/gun/projectile/giskard,
-		/obj/item/gun/projectile/gyropistol,
-		/obj/item/gun/projectile/handmade_pistol,
-		/obj/item/gun/projectile/flare_gun,
-		/obj/item/gun/projectile/lamia,
-		/obj/item/gun/projectile/mk58,
-		/obj/item/gun/projectile/olivaw,
-		/obj/item/gun/projectile/mandella,
-		/obj/item/gun/energy/gun,
-		/obj/item/gun/energy/chameleon,
-		/obj/item/gun/energy/captain,
-		/obj/item/gun/energy/stunrevolver,
-		/obj/item/gun/projectile/revolver,
-		/obj/item/gun/projectile/automatic/molly,
-		/obj/item/gun/projectile/paco,
-		/obj/item/gun/projectile/shotgun/doublebarrel/sawn, //short enough to fit in
-		/obj/item/gun/launcher/syringe,
-		/obj/item/gun/energy/plasma/brigador,
-		/obj/item/gun/projectile/shotgun/pump/sawn,
-		/obj/item/gun/projectile/boltgun/obrez,
-		/obj/item/gun/energy/retro/sawn,
-		/obj/item/gun/projectile/automatic/luty,
-		/obj/item/gun/projectile/revolver/hornet,
+		/obj/item/gun,
 		/obj/item/reagent_containers/food/snacks/mushroompizzaslice,
 		/obj/item/reagent_containers/food/snacks/meatpizzaslice,
 		/obj/item/reagent_containers/food/snacks/vegetablepizzaslice,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

...as long as it is ITEM_SIZE_NORMAL or less, which shouldn't mean anything, as those are only light SMGs, pistols and et cetera.
If holsters suddenly start holding boltguns and anything like that, that's a problem, since ITEM_SIZE_NORMAL items also fit in regular pockets.

## Why It's Good For The Game
No need to add your own gun to the holster list anymore. Slaught-o-matics, svallin and other guns don't have to be added to holster list as well.
Also fixes #7645(save for type 21 size)

## Changelog
:cl: Kegdo
tweak: holsters hold EVERY subtype of /gun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
