### PR TITLE
IH OP related stuff in loadout available to other IH jobs

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/headwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/headwear.dm
@@ -28,7 +28,7 @@
 /datum/gear/head/beret/bsec
 	display_name = "beret, Operative"
 	path = /obj/item/clothing/head/beret/sec/navy/officer
-	allowed_roles = list("Ironhammer Operative","Ironhammer Commander","Gunnery Sergeant","Ironhammer Medical Specialist")
+	allowed_roles = list(JOBS_SECURITY)
 
 /datum/gear/head/beret/bsec_warden
 	display_name = "beret, Sergeant"
@@ -128,7 +128,7 @@
 /datum/gear/head/cap/secfield
 	display_name = "cap, IH field"
 	path = /obj/item/clothing/head/soft/sec2soft
-	allowed_roles = list("Ironhammer Operative","Ironhammer Commander","Ironhammer Gunnery Sergeant", "Inspector")
+	allowed_roles = list(JOBS_SECURITY)
 
 /datum/gear/head/cap/sarge
 	display_name = "cap, IH sergeant"

--- a/code/modules/client/preference_setup/loadout/lists/uniforms.dm
+++ b/code/modules/client/preference_setup/loadout/lists/uniforms.dm
@@ -168,7 +168,7 @@
 /datum/gear/uniform/security_formal
 	display_name = "formal security outfit"
 	path = /obj/item/clothing/under/security_formal
-	allowed_roles = list("Ironhammer Operative","Ironhammer Commander","Gunnery Sergeant","Ironhammer Medical Specialist")
+	allowed_roles = list(JOBS_SECURITY)
 	cost = 2
 
 /datum/gear/uniform/assistantformal


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

OP beret, OP cap and formal sec outfit are now available to JOBS_SECURITY(every IH OP job)

## Why It's Good For The Game

more drip for other ironhammer gamers (for farya)

## Changelog
:cl: Kegdo
tweak: IH OP related stuff in loadout available to other IH jobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
