### PR TITLE
Numbered Sanity UI

### DIFF
--- a/nano/templates/sanity.tmpl
+++ b/nano/templates/sanity.tmpl
@@ -99,7 +99,7 @@
 				<div style="padding: 1px; overflow:auto;">
 					<h3>Rest progress:</h3>
 				</div>
-				{{:helper.displayBar(data.insight_rest, 0, 100, data.insight_rest < 33 ? 'bad' : data.insight_rest > 66 ? 'good': 'average', data.insight_rest)}}
+				{{:helper.displayBar(data.insight_rest, 0, 100, data.insight_rest < 33 ? 'bad' : data.insight_rest > 66 ? 'good': 'average', data.insight_rest ? data.insight_rest : "0")}}
 				<br>
 			{{else}}
 				Currently you don't have desires

--- a/nano/templates/sanity.tmpl
+++ b/nano/templates/sanity.tmpl
@@ -68,7 +68,7 @@
 			<div style="padding: 1px; overflow:auto;">
 				<h3>Current style:</h3>
 			</div>
-			{{:helper.displayBar(data.style, data.min_style, data.max_style, data.style < 0 ? 'bad' : data.style > 10 ? 'good': 'average', data.style)}}
+			{{:helper.displayBar(data.style, data.min_style, data.max_style, data.style < 4 ? 'bad' : data.style > 9 ? 'good': 'average', data.style ? data.style : "0")}}
 		</div>
 	</div>
 </div>

--- a/nano/templates/sanity.tmpl
+++ b/nano/templates/sanity.tmpl
@@ -19,7 +19,7 @@
 			<div style="padding: 1px; overflow:auto;">
 					<h3> Sanity level:</h3>
 			</div>
-			{{:helper.displayBar(data.sanity, 0, data.sanity_max_level, data.sanity < 33 ? 'bad' : data.sanity > 66 ? 'good': 'average')}}
+			{{:helper.displayBar(data.sanity, data.sanity, 0, data.sanity_max_level, data.sanity < 33 ? 'bad' : data.sanity > 66 ? 'good': 'average')}}
 		</div>
 	</div>
 </div>
@@ -44,7 +44,7 @@
 			<div style="padding: 1px; overflow:auto;">
 					<h3>Insight progress:</h3>
 			</div>
-			{{:helper.displayBar(data.insight, 0, 100, data.insight < 33 ? 'bad' : data.insight > 66 ? 'good': 'average')}}
+			{{:helper.displayBar(data.insight, data.insight, 0, 100, data.insight < 33 ? 'bad' : data.insight > 66 ? 'good': 'average')}}
 		</div>
 	</div>
 </div>
@@ -68,7 +68,7 @@
 			<div style="padding: 1px; overflow:auto;">
 				<h3>Current style:</h3>
 			</div>
-			{{:helper.displayBar(data.style, data.min_style, data.max_style, data.style < 0 ? 'bad' : data.style > 10 ? 'good': 'average')}}
+			{{:helper.displayBar(data.style, data.style, data.min_style, data.max_style, data.style < 0 ? 'bad' : data.style > 10 ? 'good': 'average')}}
 		</div>
 	</div>
 </div>
@@ -99,7 +99,7 @@
 				<div style="padding: 1px; overflow:auto;">
 					<h3>Rest progress:</h3>
 				</div>
-				{{:helper.displayBar(data.insight_rest, 0, 100, data.insight_rest < 33 ? 'bad' : data.insight_rest > 66 ? 'good': 'average')}}
+				{{:helper.displayBar(data.insight_rest, data.insight_rest, 0, 100, data.insight_rest < 33 ? 'bad' : data.insight_rest > 66 ? 'good': 'average')}}
 				<br>
 			{{else}}
 				Currently you don't have desires
@@ -130,7 +130,7 @@
 			<div style="padding: 1px; overflow:auto;">
 				<h3>holiness:</h3>
 			</div>
-			{{:helper.displayBar(data.righteous_life, 0, 100, data.righteous_life < 33 ? 'bad' : data.righteous_life > 66 ? 'good': 'average')}}
+			{{:helper.displayBar(data.righteous_life, data.righteous_life, 0, 100, data.righteous_life < 33 ? 'bad' : data.righteous_life > 66 ? 'good': 'average')}}
 			<br>
 		</div>
 	</div>

--- a/nano/templates/sanity.tmpl
+++ b/nano/templates/sanity.tmpl
@@ -19,7 +19,7 @@
 			<div style="padding: 1px; overflow:auto;">
 					<h3> Sanity level:</h3>
 			</div>
-			{{:helper.displayBar(data.sanity, 0, data.sanity_max_level, data.sanity < 33 ? 'bad' : data.sanity > 66 ? 'good': 'average', data.sanity)}}
+			{{:helper.displayBar(data.sanity, 0, data.sanity_max_level, data.sanity < 33 ? 'bad' : data.sanity > 66 ? 'good': 'average', data.sanity ? data.sanity : "0")}}
 		</div>
 	</div>
 </div>

--- a/nano/templates/sanity.tmpl
+++ b/nano/templates/sanity.tmpl
@@ -68,7 +68,7 @@
 			<div style="padding: 1px; overflow:auto;">
 				<h3>Current style:</h3>
 			</div>
-			{{:helper.displayBar(data.style, data.min_style, data.max_style, data.style < 4 ? 'bad' : data.style > 9 ? 'good': 'average', data.style ? data.style : "0")}}
+			{{:helper.displayBar(data.style, 0, data.max_style, data.style < 4 ? 'bad' : data.style > 9 ? 'good': 'average', data.style ? data.style : "0")}}
 		</div>
 	</div>
 </div>

--- a/nano/templates/sanity.tmpl
+++ b/nano/templates/sanity.tmpl
@@ -19,7 +19,7 @@
 			<div style="padding: 1px; overflow:auto;">
 					<h3> Sanity level:</h3>
 			</div>
-			{{:helper.displayBar(data.sanity, data.sanity, 0, data.sanity_max_level, data.sanity < 33 ? 'bad' : data.sanity > 66 ? 'good': 'average')}}
+			{{:helper.displayBar(data.sanity, 0, data.sanity_max_level, data.sanity < 33 ? 'bad' : data.sanity > 66 ? 'good': 'average', data.sanity)}}
 		</div>
 	</div>
 </div>
@@ -44,7 +44,7 @@
 			<div style="padding: 1px; overflow:auto;">
 					<h3>Insight progress:</h3>
 			</div>
-			{{:helper.displayBar(data.insight, data.insight, 0, 100, data.insight < 33 ? 'bad' : data.insight > 66 ? 'good': 'average')}}
+			{{:helper.displayBar(data.insight, 0, 100, data.insight < 33 ? 'bad' : data.insight > 66 ? 'good': 'average', data.insight)}}
 		</div>
 	</div>
 </div>
@@ -68,7 +68,7 @@
 			<div style="padding: 1px; overflow:auto;">
 				<h3>Current style:</h3>
 			</div>
-			{{:helper.displayBar(data.style, data.style, data.min_style, data.max_style, data.style < 0 ? 'bad' : data.style > 10 ? 'good': 'average')}}
+			{{:helper.displayBar(data.style, data.min_style, data.max_style, data.style < 0 ? 'bad' : data.style > 10 ? 'good': 'average', data.style)}}
 		</div>
 	</div>
 </div>
@@ -99,7 +99,7 @@
 				<div style="padding: 1px; overflow:auto;">
 					<h3>Rest progress:</h3>
 				</div>
-				{{:helper.displayBar(data.insight_rest, data.insight_rest, 0, 100, data.insight_rest < 33 ? 'bad' : data.insight_rest > 66 ? 'good': 'average')}}
+				{{:helper.displayBar(data.insight_rest, 0, 100, data.insight_rest < 33 ? 'bad' : data.insight_rest > 66 ? 'good': 'average', data.insight_rest)}}
 				<br>
 			{{else}}
 				Currently you don't have desires
@@ -130,7 +130,7 @@
 			<div style="padding: 1px; overflow:auto;">
 				<h3>holiness:</h3>
 			</div>
-			{{:helper.displayBar(data.righteous_life, data.righteous_life, 0, 100, data.righteous_life < 33 ? 'bad' : data.righteous_life > 66 ? 'good': 'average')}}
+			{{:helper.displayBar(data.righteous_life, 0, 100, data.righteous_life < 33 ? 'bad' : data.righteous_life > 66 ? 'good': 'average', data.righteous_life)}}
 			<br>
 		</div>
 	</div>

--- a/nano/templates/sanity.tmpl
+++ b/nano/templates/sanity.tmpl
@@ -130,7 +130,7 @@
 			<div style="padding: 1px; overflow:auto;">
 				<h3>holiness:</h3>
 			</div>
-			{{:helper.displayBar(data.righteous_life, 0, 100, data.righteous_life < 33 ? 'bad' : data.righteous_life > 66 ? 'good': 'average', data.righteous_life)}}
+			{{:helper.displayBar(data.righteous_life, 0, 100, data.righteous_life < 33 ? 'bad' : data.righteous_life > 66 ? 'good': 'average', data.righteous_life ? data.righteous_life : "0")}}
 			<br>
 		</div>
 	</div>

--- a/nano/templates/sanity.tmpl
+++ b/nano/templates/sanity.tmpl
@@ -44,7 +44,7 @@
 			<div style="padding: 1px; overflow:auto;">
 					<h3>Insight progress:</h3>
 			</div>
-			{{:helper.displayBar(data.insight, 0, 100, data.insight < 33 ? 'bad' : data.insight > 66 ? 'good': 'average', data.insight)}}
+			{{:helper.displayBar(data.insight, 0, 100, data.insight < 33 ? 'bad' : data.insight > 66 ? 'good': 'average', data.insight ? data.insight : "0")}}
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The values in the sanity UI (sanity, insight, style, rest progress, holiness) are now visible.

## Why It's Good For The Game

Vague bar bad, accurate number good

## Changelog
:cl:
add: Sanity UI now shows exact values
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
