### PR TITLE
RIG armor buff

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -30,9 +30,9 @@
 
 	// These values are passed on to all component pieces.
 	armor = list(
-		melee = 7,
-		bullet = 5,
-		energy = 5,
+		melee = 9,
+		bullet = 7,
+		energy = 7,
 		bomb = 25,
 		bio = 100,
 		rad = 50

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -8,9 +8,9 @@
 	icon_state = "security_rig"
 	suit_type = "combat hardsuit"
 	armor = list(
-		melee = 8,
-		bullet = 8,
-		energy = 8,
+		melee = 10,
+		bullet = 10,
+		energy = 10,
 		bomb = 50,
 		bio = 100,
 		rad = 50
@@ -69,9 +69,9 @@
 	desc = "A Security hardsuit designed for prolonged EVA in dangerous environments."
 	icon_state = "hazard_rig"
 	armor = list(
-		melee = 10,
-		bullet = 7,
-		energy = 7,
+		melee = 12,
+		bullet = 9,
+		energy = 9,
 		bomb = 90,
 		bio = 100,
 		rad = 100

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -5,9 +5,9 @@
 	icon_state = "ninja_rig"
 	suit_type = "light suit"
 	armor = list(
-		melee = 6,
-		bullet = 3,
-		energy = 3,
+		melee = 8,
+		bullet = 5,
+		energy = 5,
 		bomb = 20,
 		bio = 75,
 		rad = 25
@@ -87,8 +87,8 @@
 	desc = "A unique, vaccum-proof suit of nano-enhanced armor designed specifically for Spider Clan assassins."
 	icon_state = "ninja_rig"
 	armor = list(
-		melee = 5,
-		bullet = 2,
+		melee = 7,
+		bullet = 5,
 		energy = 0,
 		bomb = 25,
 		bio = 100,

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -9,9 +9,9 @@
 	icon_state = "merc_rig"
 	suit_type = "crimson hardsuit"
 	armor = list(
-		melee = 6,
-		bullet = 8,
-		energy = 3,
+		melee = 8,
+		bullet = 10,
+		energy = 5,
 		bomb = 75,
 		bio = 100,
 		rad = 50

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -32,8 +32,8 @@
 	icon_state = "engineering_rig"
 	price_tag = 350
 	armor = list(
-		melee = 8,
-		bullet = 8,
+		melee = 10,
+		bullet = 10,
 		energy = 0,
 		bomb = 25,
 		bio = 100,
@@ -79,9 +79,9 @@
 	desc = "A light rig for repairs and maintenance to the outside of habitats and vessels."
 	icon_state = "eva_rig"
 	armor = list(
-		melee = 7,
-		bullet = 2,
-		energy = 2,
+		melee = 9,
+		bullet = 3,
+		energy = 3,
 		bomb = 10,
 		bio = 100,
 		rad = 100
@@ -122,9 +122,9 @@ Advanced Voidsuit: Technomancer Exultant
 	icon_state = "ce_rig"
 	rarity_value = 20
 	armor = list(
-		melee = 6,
-		bullet = 6,
-		energy = 6,
+		melee = 8,
+		bullet = 8,
+		energy = 8,
 		bomb = 50,
 		bio = 100,
 		rad = 100
@@ -185,9 +185,9 @@ Technomancer RIG
 	icon_state = "techno_rig"
 	rarity_value = 20
 	armor = list(
-		melee = 6,
-		bullet = 6,
-		energy = 6,
+		melee = 8,
+		bullet = 8,
+		energy = 8,
 		bomb = 50,
 		bio = 100,
 		rad = 100
@@ -245,7 +245,7 @@ Technomancer RIG
 	armor = list(
 		melee = 0,
 		bullet = 0,
-		energy = 5,
+		energy = 8,
 		bomb = 90,
 		bio = 100,
 		rad = 100
@@ -297,8 +297,8 @@ Technomancer RIG
 	desc = "A relatively lightweight ceramic RIG suit designed for medical rescue in hazardous locations."
 	icon_state = "medical_rig"
 	armor = list(
-		melee = 2,
-		bullet = 0,
+		melee = 4,
+		bullet = 4,
 		energy = 0,
 		bomb = 50,
 		bio = 100,
@@ -316,7 +316,7 @@ Technomancer RIG
 		/obj/item/stack/medical,
 		/obj/item/roller
 	)
-	slowdown = HEAVY_SLOWDOWN * 0.5
+	slowdown = LIGHT_SLOWDOWN
 	stiffness = MEDIUM_STIFFNESS
 
 /obj/item/rig/medical/equipped


### PR DESCRIPTION
## About The Pull Request

Buffs all RIG armor across the board, rescue suit RIG has less slowdown

Further buffs might be necessary, but due to how overly effective we have made AP, it walks a fine line between being worthless against a Tosshin and being indestructible against an atreides.

## Why It's Good For The Game

Rework made RIGs not as effective as they should be, this alleviates it

## Changelog
:cl:
 balance: RIG armor values increased
 balance: Rescue Suit RIG slowdown decreased
/:cl: