### PR TITLE
Armament and EOTP Tweaks

### DIFF
--- a/code/datums/autolathe/biomatter.dm
+++ b/code/datums/autolathe/biomatter.dm
@@ -359,8 +359,8 @@
 	build_path = /obj/item/tool/sword/nt/spear
 
 /datum/design/autolathe/nt/sword/nt_verutum
-	name = "NT Javelin"
-	build_path = /obj/item/stack/thrown/nt/verutum
+	name = "NT Javelins (3)"
+	build_path = /obj/item/stack/thrown/nt/verutum/full
 
 /datum/design/autolathe/nt/tool_upgrade/sanctifier
 	name = "sanctifier"

--- a/code/game/objects/items/weapons/design_disks/NeoTheology.dm
+++ b/code/game/objects/items/weapons/design_disks/NeoTheology.dm
@@ -51,7 +51,7 @@
 // Javelins & bucklers, speed upgrade TODO: light armor
 /obj/item/computer_hardware/hard_drive/portable/design/nt/velite
 	disk_name = "NeoTheology Armory - \"Velite Arms\""
-	license = -1
+	license = 12
 	designs = list(
 		/datum/design/autolathe/nt/sword/nt_verutum,
 		/datum/design/autolathe/nt/shield/nt_buckler,
@@ -63,28 +63,28 @@
 	disk_name = "NeoTheology Armory - NT GL \"Protector\""
 	spawn_tags = SPAWN_TAG_DESIGN_ADVANCED
 	rarity_value = 90
-	license = -1
+	license = 12
 	designs = list(
-		/datum/design/autolathe/gun/grenade_launcher, // "NT GL \"Protector\""
+		/datum/design/autolathe/gun/grenade_launcher = 6, // "NT GL \"Protector\""
 		/datum/design/autolathe/ammo/nt_stinger
 	)
 
 // Greatshields & greatswords, space-worthy armor, protection upgrade
 /obj/item/computer_hardware/hard_drive/portable/design/nt/principes
 	disk_name = "NeoTheology Armory - \"Principes Arms\""
-	license = -1
+	license = 16
 	designs = list(
-		/datum/design/bioprinter/leather/holster/sheath,
+		/datum/design/bioprinter/leather/holster/sheath = 0,
 		/datum/design/autolathe/nt/sword/nt_longsword,
 		/datum/design/autolathe/nt/shield/nt_shield,
-		/datum/design/autolathe/clothing/NTvoid,
+		/datum/design/autolathe/clothing/NTvoid = 2,
 		/datum/design/autolathe/cruciform_upgrade/faiths_shield
 	)
 
 // First aid kits, TODO: proximity healing/stabilizing cruciform upgrade
 /obj/item/computer_hardware/hard_drive/portable/design/nt/medicii
 	disk_name = "NeoTheology Armory - \"Medicii Supplies\""
-	license = -1
+	license = 12
 	designs = list(
 		/datum/design/autolathe/firstaid/nt,
 		/datum/design/autolathe/cruciform_upgrade/natures_blessing
@@ -95,36 +95,37 @@
 	disk_name = "NeoTheology Armory - NT PR \"Dominion\""
 	spawn_tags = SPAWN_TAG_DESIGN_ADVANCED
 	rarity_value = 50
-	license = -1
+	license = 6
 	spawn_blacklisted = FALSE
 	designs = list(
-		/datum/design/autolathe/gun/plasma/dominion, //"NT PR \"Dominion\""
+		/datum/design/autolathe/gun/plasma/dominion = 3, //"NT PR \"Dominion\""
 		/datum/design/bioprinter/nt_cells/medium
 	)
 
 // Heavy weapons, heavy armor
 /obj/item/computer_hardware/hard_drive/portable/design/nt/triarii
 	disk_name = "NeoTheology Armory - \"Triarii Arms\""
-	license = -1
+	license = 24 // Chonky disk, chonky prices
 	designs = list(
 		/datum/design/bioprinter/leather/holster/sheath,
 		/datum/design/autolathe/nt/sword/nt_scourge,
-		/datum/design/autolathe/nt/sword/nt_halberd,
+		/datum/design/autolathe/nt/sword/nt_halberd = 2,
 		/datum/design/autolathe/nt/sword/nt_spear,
 		/datum/design/autolathe/nt/helmet/crusader,
-		/datum/design/autolathe/nt/armor/crusader,
+		/datum/design/autolathe/nt/armor/crusader = 2,
 		/datum/design/autolathe/cruciform_upgrade/wrath_of_god
 	)
 
 // Grenades - includes heatwave for launchers
 /obj/item/computer_hardware/hard_drive/portable/design/nt/grenades
 	disk_name = "NeoTheology Armory - Grenades Pack"
-	license = 12
+	license = 24
 	designs = list(
-		/datum/design/autolathe/nt/grenade/nt_heatwave,
+		/datum/design/autolathe/nt/grenade/nt_heatwave = 2,
 		/datum/design/autolathe/nt/grenade/nt_flashbang,
 		/datum/design/autolathe/nt/grenade/nt_smokebomb,
-		/datum/design/autolathe/nt/grenade/nt_heatwave
+		/datum/design/autolathe/ammo/shell_heatwave,
+		/datum/design/autolathe/ammo/nt_stinger
 	)
 
 // Laser rifle
@@ -133,7 +134,7 @@
 	spawn_tags = SPAWN_TAG_DESIGN_ADVANCED
 	license = 12
 	designs = list(
-		/datum/design/autolathe/gun/laser, // "NT LG \"Lightfall\""
+		/datum/design/autolathe/gun/laser = 3, // "NT LG \"Lightfall\""
 		/datum/design/bioprinter/nt_cells/medium
 	)
 
@@ -141,7 +142,7 @@
 /obj/item/computer_hardware/hard_drive/portable/design/nt/excruciator
 	disk_name = "NeoTheology Armory - NT \"EXCRUCIATOR\" giga lens"
 	spawn_tags = SPAWN_TAG_DESIGN_ADVANCED
-	license = -1
+	license = 12
 	designs = list(
 		/datum/design/autolathe/excruciator
 	)

--- a/code/game/objects/items/weapons/design_disks/NeoTheology.dm
+++ b/code/game/objects/items/weapons/design_disks/NeoTheology.dm
@@ -107,7 +107,7 @@
 	disk_name = "NeoTheology Armory - \"Triarii Arms\""
 	license = 24 // Chonky disk, chonky prices
 	designs = list(
-		/datum/design/bioprinter/leather/holster/sheath,
+		/datum/design/bioprinter/leather/holster/sheath = 0,
 		/datum/design/autolathe/nt/sword/nt_scourge,
 		/datum/design/autolathe/nt/sword/nt_halberd = 2,
 		/datum/design/autolathe/nt/sword/nt_spear,

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -365,3 +365,6 @@
 /obj/item/stack/thrown/nt/verutum/launchAt()
 	embed_mult = 300
 	..()
+
+/obj/item/stack/thrown/nt/verutum/full
+	amount = 3

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -30,7 +30,7 @@ var/global/obj/machinery/power/eotp/eotp
 
 
 	var/list/mob/living/carbon/human/scanned = list()
-	var/max_power = 120
+	var/max_power = 100
 	var/power = 0
 	var/power_gaine = 2
 	var/max_observation = 1800
@@ -45,8 +45,8 @@ var/global/obj/machinery/power/eotp/eotp
 	var/last_rescan = 0
 	var/list/armaments = list()
 	var/armaments_points = 0
-	var/max_armaments_points = 100
-	var/armaments_rate = 100
+	var/max_armaments_points = 150
+	var/armaments_rate = 125
 	var/static/list/unneeded_armaments = list(/datum/armament/item/gun, /datum/armament/item, /datum/armament/item/disk)
 
 /obj/machinery/power/eotp/New()

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -30,7 +30,7 @@ var/global/obj/machinery/power/eotp/eotp
 
 
 	var/list/mob/living/carbon/human/scanned = list()
-	var/max_power = 100
+	var/max_power = 120
 	var/power = 0
 	var/power_gaine = 2
 	var/max_observation = 1800


### PR DESCRIPTION
## About The Pull Request

Increases the amount of armament points rewarded by the EOTP (100->125), as well as the starting maximum (100->150)

Readds license points to most disks

## Why It's Good For The Game

EOTP design disks were troublesome as they required lots of points and were then limited by license. This did not solve the issue with lategame options simply not being worth the points before the three hour mark, such as the lightfall or the holy grenade.
The solution isn't to remove the license, but to provide more energy to the EOTP, helping NT reach their high tier disks faster.

## Changelog
:cl:
balance: NT disks have license points
balance: EOTP generates more armaments and starts at a higher tech
/:cl: