### PR TITLE
Stasis Bag design on Moebius Medical Disk

### DIFF
--- a/code/datums/autolathe/containers.dm
+++ b/code/datums/autolathe/containers.dm
@@ -83,3 +83,7 @@
 /datum/design/autolathe/container/hcase_engi
 	name = "Parts Hardcase"
 	build_path = /obj/item/storage/hcases/engi
+
+/datum/design/autolathe/bodybag/cryobag
+	name = "Stasis Bag"
+	build_path = /obj/item/bodybag/cryobag

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -107,6 +107,8 @@
 	icon = 'icons/obj/cryobag.dmi'
 	icon_state = "bodybag_folded"
 	origin_tech = list(TECH_BIO = 4)
+	matter = list(MATERIAL_STEEL = 10, MATERIAL_PLASTIC = 5, , MATERIAL_URANIUM = 0.5)
+	matter_reagents = list("coolant" = 40)
 	price_tag = 250
 
 /obj/item/bodybag/cryobag/attack_self(mob/user)

--- a/code/game/objects/items/weapons/design_disks/moebius.dm
+++ b/code/game/objects/items/weapons/design_disks/moebius.dm
@@ -25,7 +25,9 @@
 		/datum/design/autolathe/device/implanter,
 		/datum/design/autolathe/container/syringegun_ammo,
 		/datum/design/autolathe/container/syringe/large,
-		/datum/design/autolathe/container/hcase_med
+		/datum/design/autolathe/container/hcase_med,
+		/datum/design/autolathe/bodybag/cryobag
+
 
 	)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I placed the Stasis Bag on the Moebius Medical Disk so people can print more of them.

The recipe is 10x Steel, 5x Plastic, 0.5x Uranium, and 40u of Coolant

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

QoL, Stasis Bags are pretty useful, but you couldn't craft them to get more (I know because they didnt have a material composition until now). So figured since it was very useful, might as well give somewhat an easy way to get more.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Put stasis bag on disk
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
