### PR TITLE
Technomancer QoL Update

### DIFF
--- a/code/datums/outfits/jobs/engineering.dm
+++ b/code/datums/outfits/jobs/engineering.dm
@@ -1,9 +1,9 @@
 /decl/hierarchy/outfit/job/engineering
 	hierarchy_type = /decl/hierarchy/outfit/job/engineering
-	belt = /obj/item/storage/belt/utility/full
+	belt = /obj/item/storage/belt/utility/technomancer
 	l_ear = /obj/item/device/radio/headset/headset_eng
 	shoes = /obj/item/clothing/shoes/workboots
-	gloves = /obj/item/clothing/gloves/thick
+	gloves = /obj/item/clothing/gloves/insulated
 	pda_slot = slot_l_store
 	r_pocket = /obj/item/device/t_scanner
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL

--- a/code/datums/outfits/jobs/engineering.dm
+++ b/code/datums/outfits/jobs/engineering.dm
@@ -3,7 +3,7 @@
 	belt = /obj/item/storage/belt/utility/technomancer
 	l_ear = /obj/item/device/radio/headset/headset_eng
 	shoes = /obj/item/clothing/shoes/workboots
-	gloves = /obj/item/clothing/gloves/insulated
+	gloves = /obj/item/clothing/gloves/thick
 	pda_slot = slot_l_store
 	r_pocket = /obj/item/device/t_scanner
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -81,10 +81,7 @@
 	new /obj/item/stack/cable_coil/random(src)
 
 /obj/item/storage/belt/utility/technomancer 
-	name = "technomancy tool belt"
-	desc = "Advanced tools provided by the clan."
-	icon_state = "utility"
-	spawn_blacklisted= TRUE
+	spawn_blacklisted = TRUE
 
 /obj/item/storage/belt/utility/technomancer/populate_contents()
 	new /obj/item/tool/screwdriver/electric(src)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -80,6 +80,21 @@
 	new /obj/item/tool/wirecutters(src)
 	new /obj/item/stack/cable_coil/random(src)
 
+/obj/item/storage/belt/utility/technomancer 
+	name = "technomancy tool belt"
+	desc = "Advanced tools provided by the clan."
+	icon_state = "utility"
+	spawn_blacklisted= TRUE
+
+/obj/item/storage/belt/utility/technomancer/populate_contents()
+	new /obj/item/tool/screwdriver/electric(src)
+	new /obj/item/tool/wrench/big_wrench(src)
+	new /obj/item/tool/weldingtool/advanced(src)
+	new /obj/item/tool/crowbar/pneumatic(src)
+	new /obj/item/tool/wirecutters/armature(src)
+	new /obj/item/tool/shovel/power(src)
+	new /obj/item/stack/cable_coil/random(src)
+	
 /obj/item/storage/belt/utility/neotheology
 	name = "neotheologian utility belt"
 	desc = "Waist-held holy items."

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -89,3 +89,4 @@
 	new /obj/item/clothing/head/armor/helmet/technomancer(src)
 	new /obj/item/clothing/suit/storage/vest/insulated(src)
 	new /obj/item/clothing/head/armor/helmet/technomancer_old(src)
+	new /obj/item/storage/pouch/engineering_tools (src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Much like the doctors and paramedics spawn with trauma kits and gloves, because they are required to perform their job efficiently. I believe technomancers should spawn in with tools of the trade

This PR
- Replaces the technomancer thick gloves with insulated gloves 
- Replaces the standard toolbelt with one full of advanced tools (electric screwdriver, big wrench, advanced welding tool, pneumatic crowbar, armature wirecutter, a power shovel and cable coils)
- Adds a technomancer tool pouch to each of the technomancer lockers (there are 4)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As someone who plays Technomancer constantly, these are items which I end up getting round after round just to be able to do my job properly, and it's honestly a slog to do.

Adding this to the profession and profession lockers from the get go seems like a huge QoL upgrade to me.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Technomancers spawn with insuls
add: Technomancer locker spawns with a tools pouch
add: Technomancer toolbelt spawns with (electric screwdriver, big wrench, advanced welding tool, pneumatic crowbar, armature wirecutter, a power shovel and cable coils)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
