### PR TITLE
Adds 15 armour to UI calculations

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -953,7 +953,8 @@
 	data["projectile_AP"] = P.armor_divisor + penetration_multiplier
 	data["projectile_WOUND"] = P.wounding_mult
 	data["unarmoured_damage"] = ((P.get_total_damage() * damage_multiplier) + get_total_damage_adjust()) * P.wounding_mult
-	data["armoured_damage"] = (((P.get_total_damage() * damage_multiplier) + get_total_damage_adjust()) - (10 / (P.armor_divisor + penetration_multiplier))) * P.wounding_mult
+	data["armoured_damage_10"] = (((P.get_total_damage() * damage_multiplier) + get_total_damage_adjust()) - (10 / (P.armor_divisor + penetration_multiplier))) * P.wounding_mult
+	data["armoured_damage_15"] = (((P.get_total_damage() * damage_multiplier) + get_total_damage_adjust()) - (15 / (P.armor_divisor + penetration_multiplier))) * P.wounding_mult
 	data["projectile_recoil"] = P.recoil
 	qdel(P)
 	return data

--- a/nano/templates/weapon_stats.tmpl
+++ b/nano/templates/weapon_stats.tmpl
@@ -171,7 +171,14 @@
 				Armoured (10) Damage:
 			</div>
 				<div class="itemContent">
-					{{:data.armoured_damage}}
+					{{:data.armoured_damage_10}}
+				</div>
+
+			<div class="itemLabel">
+				Armoured (15) Damage:
+			</div>
+				<div class="itemContent">
+					{{:data.armoured_damage_15}}
 				</div>
 
 			<div class="itemLabel">


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new autocalc value to the gun UI. In addition to damage against 0 and 10 armour, damage against 15 armour will also be displayed.

## Why It's Good For The Game

More info, yay. Making the actual effectiveness of weapons clear from even the most surface-level look should help massively with perception of my beloved armour rework. That being said, I won't deny that this could be seen as taking it too far. Fortunately for me, this was piss easy to code and I can just toss this shit out there! Merge it if you want.

## Changelog
:cl:
add: Added damage against 15 armour to the gun UI.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
