### PR TITLE
Certain scrap ammo is no longer superior to normal ammo

### DIFF
--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -265,7 +265,8 @@ There are important things regarding this file:
 	wounding_mult = WOUNDING_WIDE
 
 /obj/item/projectile/bullet/shotgun/beanbag/scrap
-	damage_types = list(BRUTE = 9, HALLOSS = 55)
+	damage_types = list(BRUTE = 9, HALLOSS = 20)
+	recoil = 10
 
 /obj/item/projectile/bullet/shotgun/practice
 	name = "practice slug"
@@ -304,7 +305,7 @@ There are important things regarding this file:
 	icon_state = "birdshot-[rand(1,4)]"
 
 /obj/item/projectile/bullet/pellet/shotgun/scrap
-	armor_divisor = 1.2
+	armor_divisor = 0.8
 	recoil = 5
 
 //Miscellaneous


### PR DESCRIPTION
## About The Pull Request

Fixes a error that was discussed weeks ago and then nobody got up to fix.

## Why It's Good For The Game
Scrap ammo is supposed to be worse than normal ammo, but easier to produce. No idea what happened here.

## Changelog
:cl:
balance: Fixed two cases where scrap ammo was superior to normal ammo.
/:cl: