### PR TITLE
Punch damage: ROB stat damage increase capped, formula changed

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -169,7 +169,7 @@
 				attack_generic(H,rand(1,3),"punched")
 				return
 
-			var/stat_damage = 3 + max(0, (H.stats.getStat(STAT_ROB) / 10))
+			var/stat_damage = max(0, min(15, (H.stats.getStat(STAT_ROB) / 4)))
 			var/limb_efficiency_multiplier = 1
 			var/block = 0
 			var/accurate = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

From 3 + ROB/10 to (0 + ) ROB/4, but the damage is hardcapped at 15.

## Why It's Good For The Game

The punch damage increase from ROB stat was ridicilously low. At 200(!!!) ROB, your damage was 5+3+20 = 28 damage, with no armor penetration whatsoever. This PR makes the ROB hustle much easier, but prevents people from achieving instakill levels of punching(1000+ ROB - instakill)

The formula, ROB/4, stops increasing after 60 robustness is reached, which is an increase to 15 damage.

With PLATINUM knuckle dusters and 60 rob, the MAXIMUM damage a punch can deal is 5 + 15 + 15 = 35. Again, no armor penetration. Fair and balanced!

## Changelog
:cl: Kegdo
balance: ROB stat damage increase capped, formula changed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
