### PR TITLE
Remove COCO_FOOD from morale bar

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -2533,7 +2533,7 @@
 	trash = /obj/item/trash/mre_candy
 	preloaded_reagents = list("sugar" = 3, "serotrotium" = 2)
 	open = FALSE
-	taste_tag = list(COCO_FOOD, SWEET_FOOD)
+	taste_tag = list(SWEET_FOOD)
 
 /obj/item/reagent_containers/food/snacks/proc/open(mob/user)
 	open = TRUE

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -397,7 +397,7 @@
 
 /obj/item/reagent_containers/food/snacks/shokoloud
 	name = "shokolad bar"
-	desc = "A bar of dark chocolate. Strangely polarizing."
+	desc = "A bar of some waxy looking candy. Tastes like it too."
 	icon_state = "shokoloud"
 	trash = /obj/item/trash/shokoloud
 	open = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removed tag COCO_FOOD from the ration morale bar since it contains no cocoa. Makes it similar to Shokolad bar in effect of fulfilling COCOA desires (it doesn't).
Changed Shokolad description to better identify that it is NOT FUCKING CHOCOLATE TASTING DESPITE THE NAME.

## Why It's Good For The Game

Brings the morale bar in line with other foods that  are not produced by cooking

## Changelog
:cl:
tweak: Changed Shokolad description to try and identify that it is not valid for Chocolate desires
balance: Removed COCO_FOOD taste tag from the ration Morale bar since it does not have cocoa in the preloaded reagents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
