### PR TITLE
Set default recoil for /obj/item/arrow

### DIFF
--- a/code/modules/projectiles/guns/matter/launcher/nt_sprayer.dm
+++ b/code/modules/projectiles/guns/matter/launcher/nt_sprayer.dm
@@ -15,6 +15,8 @@
 	projectile_type = /obj/item/arrow/neotheo/cleansing
 	spawn_blacklisted = TRUE
 
+/obj/item/arrow
+	var/recoil = 2  // Light recoil, it's just some cleaning stuff
 
 /obj/item/arrow/neotheo
 	icon = 'icons/obj/projectiles.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When you set the `projectile_type` of a gun to something that is not a projectile, shit happens (runtimes).

Used for the cleaning guns of NT and Excelsior.

Recoil of 2 is equivalent to light plasma bolt.

```
[21:30:25] Runtime in gun.dm,535: undefined variable /obj/item/arrow/neotheo/cleansing/var/recoil 
   proc name: kickback (/obj/item/gun/proc/kickback)
```

## Changelog
:cl: Hyperio
add: Set default recoil for /obj/item/arrow
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
