### PR TITLE
OS dungeon generated only when teleporter is triggered

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -138,6 +138,10 @@
 #define COMSIG_ABERRANT_SECONDARY "aberrant_secondary"
 #define COMSIG_ABERRANT_COOLDOWN "aberrant_cooldown"
 
+// Overmap and expeditions signals
+#define COMSIG_GENERATE_DUNGEON "generate_dungeon"
+#define COMSIG_DUNGEON_GENERATED "dungeon_generated"
+
 /*******Component Specific Signals*******/
 //Janitor
 

--- a/code/modules/dungeons/crawler/dungeon_gen.dm
+++ b/code/modules/dungeons/crawler/dungeon_gen.dm
@@ -88,6 +88,7 @@
 	RegisterSignal(src, COMSIG_GENERATE_DUNGEON, .proc/trigger_generation)
 
 /obj/crawler/map_maker/proc/trigger_generation(obj/rogue/teleporter/O)
+	UnregisterSignal(src, COMSIG_GENERATE_DUNGEON)
 	generate_controllers()
 	populate_starting_lane()
 	sleep(100)

--- a/code/modules/dungeons/crawler/dungeon_gen.dm
+++ b/code/modules/dungeons/crawler/dungeon_gen.dm
@@ -82,10 +82,18 @@
 			lane3 += RC
 		else if(RC.roomnum <= 16)
 			lane4 += RC*/
+
+	// Listen to signal to trigger dungeon generation only when needed
+	// i.e only when teleporter to dungeon is activated
+	RegisterSignal(src, COMSIG_GENERATE_DUNGEON, .proc/trigger_generation)
+
+/obj/crawler/map_maker/proc/trigger_generation(obj/rogue/teleporter/O)
 	generate_controllers()
 	populate_starting_lane()
 	sleep(100)
 	generate_dungeon()
+	// Dungeon has been generated, send signal to teleporter
+	SEND_SIGNAL(O, COMSIG_DUNGEON_GENERATED)
 
 /obj/crawler/map_maker/proc/generate_controllers()
 	var/roomnumber = 0

--- a/code/modules/dungeons/teleporter.dm
+++ b/code/modules/dungeons/teleporter.dm
@@ -21,6 +21,8 @@
 	var/turfs_around = list()
 	var/victims_to_teleport = list()
 	var/obj/crawler/spawnpoint/target
+	var/obj/crawler/map_maker/dungeon_generator
+	var/dungeon_is_generated = FALSE
 	anchored = TRUE
 	unacidable = 1
 	density = TRUE
@@ -31,9 +33,13 @@
 
 /obj/rogue/teleporter/attack_hand(mob/user)
 	if(!charge)
-		target = locate(/obj/crawler/spawnpoint)
-		if(target)
+		dungeon_generator = locate(/obj/crawler/map_maker)
+		if(dungeon_generator)
 			to_chat(user, "You activate the teleporter. A strange rumbling fills the area around you.")
+			// Listen to signal for when the generation will be finished
+			RegisterSignal(src, COMSIG_DUNGEON_GENERATED, .proc/dungeon_generated)
+			// Generate the dungeon while mobs are spawning to attack the teleporter
+			SEND_SIGNAL(dungeon_generator, COMSIG_GENERATE_DUNGEON, src)
 			start_teleporter_event()
 		else
 			to_chat(user, "Nothing seems to happen.")
@@ -42,6 +48,9 @@
 			to_chat(user, "The portal looks too unstable to pass through!")
 		else
 			to_chat(user, "The teleporter needs time to charge.")
+
+/obj/rogue/teleporter/proc/dungeon_generated()
+	dungeon_is_generated = TRUE
 
 /obj/rogue/teleporter/proc/start_teleporter_event()
 	charging = TRUE
@@ -58,7 +67,18 @@
 			summon_mobs()
 		sleep(5)
 
-	end_teleporter_event()
+	var/start_waiting = world.time
+	while(!dungeon_is_generated && (world.time - start_waiting < 3 MINUTES))
+		sleep(10 SECONDS)
+
+	target = locate(/obj/crawler/spawnpoint)
+	if(!dungeon_is_generated || !target)
+		// Something wrong happened and dungeon was not properly generated
+		admin_notice("Failed to generate the OneStar dungeon - Warn coders.")
+		visible_message(SPAN_WARNING("The teleporter malfunctions and explodes in a shower of sparks!"))
+		destroy_teleporter()
+	else
+		end_teleporter_event()
 
 /obj/rogue/teleporter/proc/summon_mobs()
 	var/max_mobs = 3
@@ -118,6 +138,9 @@
 	for(var/mob/living/M in victims_to_teleport)
 		go_to_bluespace(get_turf(src), 3, FALSE, M, get_turf(target))
 
+	destroy_teleporter()
+
+/obj/rogue/teleporter/proc/destroy_teleporter()
 	new /obj/structure/scrap_spawner/science/large(src.loc)
 
 	sleep(2)

--- a/code/modules/dungeons/teleporter.dm
+++ b/code/modules/dungeons/teleporter.dm
@@ -51,6 +51,7 @@
 
 /obj/rogue/teleporter/proc/dungeon_generated()
 	dungeon_is_generated = TRUE
+	UnregisterSignal(src, COMSIG_DUNGEON_GENERATED)
 
 /obj/rogue/teleporter/proc/start_teleporter_event()
 	charging = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The OS dungeon is now generated only when the teleporter in space ruins is triggered to avoid unecessary server load with all the OS mobs and stuff.

## Changelog
:cl: Hyperio
server: OS dungeon generated only when teleporter is triggered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
