### PR TITLE
Make golden knuckles use plasteel instead of platinum

### DIFF
--- a/code/datums/craft/recipes/clothing.dm
+++ b/code/datums/craft/recipes/clothing.dm
@@ -35,7 +35,7 @@
 	result = /obj/item/clothing/gloves/dusters/gold
 	steps = list(
 		list(CRAFT_MATERIAL, 3, MATERIAL_GOLD), //Grab some gold
-		list(CRAFT_MATERIAL, 3, MATERIAL_PLATINUM), //Grab some platinum as well
+		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTEEL), //Grab some plasteel as well
 		list(QUALITY_WELDING, 10, "time" = 30), //Weld it into basic form
 		list(QUALITY_HAMMERING, 15, 10) //Harden into shape
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
#7602 desc mentions that they are made out of plasteel and gold
besides you can make vastly better knuckle dusters with just platinum
![изображение](https://user-images.githubusercontent.com/57810301/194886485-ff7a2c6b-3932-483f-a29c-19d4083d7bdd.png)
![изображение](https://user-images.githubusercontent.com/57810301/194886595-72bf2e56-9786-45e6-b081-d7e814ff6869.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
bugfix

## Changelog
:cl:
balance: Golden knuckle dusters now require plasteel+gold instead of platinum+gold
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
