### PR TITLE
fix knuckle dusters oversights

### DIFF
--- a/code/datums/craft/recipes/clothing.dm
+++ b/code/datums/craft/recipes/clothing.dm
@@ -35,7 +35,7 @@
 	result = /obj/item/clothing/gloves/dusters/gold
 	steps = list(
 		list(CRAFT_MATERIAL, 3, MATERIAL_GOLD), //Grab some gold
-		list(CRAFT_MATERIAL, 3, MATERIAL_PLATINUM), //Grab some platinum as well
+		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTEEL), //Grab some plasteel as well
 		list(QUALITY_WELDING, 10, "time" = 30), //Weld it into basic form
 		list(QUALITY_HAMMERING, 15, 10) //Harden into shape
 	)
@@ -54,7 +54,7 @@
 	name = "weighted knuckle gloves"
 	result = /obj/item/clothing/gloves/dusters/gloves
 	steps = list(
-		list(/obj/item/clothing/gloves/dusters, 1, "time" = 5), //Tear up the gloves
+		list(/obj/item/clothing/gloves/knuckles, 1, "time" = 5), //Tear up the gloves
 		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTEEL), //Grab some plasteel
 		list(QUALITY_HAMMERING, 15, 10), //Harden into powder
 		list(QUALITY_HAMMERING, 15, 10), //Harden into FINE powder

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -198,6 +198,7 @@
 	item_state = "dusters"
 	var/punch_increase = 5
 	price_tag = 20
+	spawn_blacklisted = TRUE
 
 /obj/item/clothing/gloves/dusters/silver
 	name = "silver knuckle dusters"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

golden dusters are made out of plasteel now, not platinum

all dusters are spawn blacklisted

weighted gloves now actually need knuckle gloves and not dusters...

## Why It's Good For The Game

fix oversights

## Changelog
:cl: Kegdo
fix: golden dusters are made out of plasteel now, not platinum
fix: all dusters are spawn blacklisted
fix: weighted gloves now actually need knuckle gloves and not dusters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
