### PR TITLE
Tweak construction prices and times.

### DIFF
--- a/code/datums/craft/recipes/furniture.dm
+++ b/code/datums/craft/recipes/furniture.dm
@@ -9,14 +9,14 @@
 	name = "railing"
 	result = /obj/structure/railing
 	steps = list(
-		list(CRAFT_MATERIAL, 4, MATERIAL_STEEL),
+		list(CRAFT_MATERIAL, 2, MATERIAL_STEEL),
 	)
 
 /datum/craft_recipe/furniture/railing_grey
 	name = "grey railing"
 	result = /obj/structure/railing/grey
 	steps = list(
-		list(CRAFT_MATERIAL, 4, MATERIAL_STEEL),
+		list(CRAFT_MATERIAL, 2, MATERIAL_STEEL),
 	)
 
 /datum/craft_recipe/furniture/table

--- a/code/datums/craft/recipes/machinery.dm
+++ b/code/datums/craft/recipes/machinery.dm
@@ -87,6 +87,7 @@
 	steps = list(
 		list(CRAFT_MATERIAL, 2, MATERIAL_STEEL),
 	)
+	time = WORKTIME_FAST
 	flags = null
 
 /datum/craft_recipe/machinery/wall/lightfixture

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -11,7 +11,7 @@
 	anchored = TRUE
 	flags = ON_BORDER
 	icon_state = "railing0"
-	matter = list(MATERIAL_STEEL = 4)
+	matter = list(MATERIAL_STEEL = 2)
 	var/broken = 0
 	var/health=70
 	var/maxhealth=70

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -224,12 +224,12 @@ var/list/flooring_types
 	if (istype(I, /obj/item/stack/rods))
 		.=TRUE
 		var/obj/item/stack/rods/R = I
-		if(R.amount <= 3)
+		if(R.amount <= 2)
 			return
 		else
-			R.use(3)
-			to_chat(user, SPAN_NOTICE("You start connecting [R.name]s to [src.name], creating catwalk ..."))
-			if(do_after(user,60))
+			R.use(2)
+			to_chat(user, SPAN_NOTICE("You start connecting [R.name]s to [src.name], creating catwalk..."))
+			if(do_after(user, (20 * user.stats.getMult(STAT_MEC, STAT_LEVEL_EXPERT))))
 				T.alpha = 0
 				var/obj/structure/catwalk/CT = new /obj/structure/catwalk(T)
 				T.contents += CT

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -4,8 +4,8 @@
 		return 0
 
 	if(istype(src, /turf/simulated/floor/plating/under) && (istype(I, /obj/item/stack/material/cyborg/steel) || istype(I, /obj/item/stack/material/steel)))
-		if(do_after(user, 5, src))
-			if(I:use(2))
+		if(do_after(user, (30 * user.stats.getMult(STAT_MEC, STAT_LEVEL_EXPERT, src))))
+			if(I:use(1))
 				ChangeTurf(/turf/simulated/floor/plating)
 
 	var/obj/effect/shield/turf_shield = getEffectShield()

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -64,12 +64,11 @@
 
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		if(L)
-			var/obj/item/stack/tile/floor/S = C
 			to_chat(user, SPAN_NOTICE("You start constructing underplating on the lattice."))
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 			if(do_after(user, (40 * user.stats.getMult(STAT_MEC, STAT_LEVEL_EXPERT, src))))
 				qdel(L)
-				S.use(1)
+				M.use(1)
 				ChangeTurf(/turf/simulated/floor/plating/under)
 			return
 		else

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -45,7 +45,6 @@
 		set_light(0)
 
 /turf/space/attackby(obj/item/C as obj, mob/user as mob)
-
 	if (istype(C, /obj/item/stack/rods))
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		if(L)
@@ -57,39 +56,24 @@
 			ReplaceWithLattice()
 		return
 
-	if (istype(C, /obj/item/stack/tile/floor))
-		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
-		if(L)
-			var/obj/item/stack/tile/floor/S = C
-			if (S.get_amount() < 1)
-				return
-			qdel(L)
-			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
-			S.use(1)
-			ChangeTurf(/turf/simulated/floor/airless)
-			return
-		else
-			to_chat(user, SPAN_WARNING("The plating is going to need some support."))
-			return
 	if (istype(C, /obj/item/stack/material))
 		var/obj/item/stack/material/M = C
 		var/material/mat = M.get_material()
 		if (!mat.name == MATERIAL_STEEL)
 			return
+
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		if(L)
-			var/obj/item/stack/tile/S = C
-			if (S.get_amount() < 1)
-				return
-			qdel(L)
+			var/obj/item/stack/tile/floor/S = C
+			to_chat(user, SPAN_NOTICE("You start constructing underplating on the lattice."))
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
-			S.use(1)
-			ChangeTurf(/turf/simulated/floor/plating/under)
+			if(do_after(user, (40 * user.stats.getMult(STAT_MEC, STAT_LEVEL_EXPERT, src))))
+				qdel(L)
+				S.use(1)
+				ChangeTurf(/turf/simulated/floor/plating/under)
 			return
 		else
 			to_chat(user, SPAN_WARNING("The plating is going to need some support."))
-	return
-
 
 // Ported from unstable r355
 

--- a/code/modules/aberrants/organs/mods/component/output.dm
+++ b/code/modules/aberrants/organs/mods/component/output.dm
@@ -11,7 +11,7 @@
 
 /datum/component/modification/organ/output/reagents/get_function_info()
 	var/metabolism = mode == CHEM_BLOOD ? "bloodstream" : "stomach"
-	
+
 	var/outputs
 	for(var/output in possible_outputs)
 		var/datum/reagent/R = output
@@ -102,7 +102,7 @@
 				var/amount_to_add = possible_outputs[output] * organ_multiplier * input_multiplier
 				RM.add_reagent(initial(output.id), amount_to_add)
 				triggered = TRUE
-	
+
 	if(triggered)
 		SEND_SIGNAL(holder, COMSIG_ABERRANT_COOLDOWN, TRUE)
 		SEND_SIGNAL(holder, COMSIG_ABERRANT_SECONDARY, holder, owner)
@@ -187,7 +187,7 @@
 				var/amount_to_add = initial(output.metabolism) * organ_multiplier * input_multiplier
 				RM.add_reagent(initial(output.id), amount_to_add)
 				triggered = TRUE
-	
+
 	if(triggered)
 		SEND_SIGNAL(holder, COMSIG_ABERRANT_COOLDOWN, TRUE)
 		SEND_SIGNAL(holder, COMSIG_ABERRANT_SECONDARY, holder, owner)
@@ -248,7 +248,7 @@
 				var/magnitude = possible_outputs[stat] * organ_multiplier * input_multiplier
 				owner.stats.addTempStat(stat, magnitude, delay, "\ref[parent]")
 				triggered = TRUE
-	
+
 	if(triggered)
 		SEND_SIGNAL(holder, COMSIG_ABERRANT_COOLDOWN, TRUE)
 		SEND_SIGNAL(holder, COMSIG_ABERRANT_SECONDARY, holder, owner)
@@ -282,8 +282,8 @@
 				H.adjustBrainLoss(damage_amount)		// Added brainloss because we're gaining insight and most damage is trivial anyway
 				H.sanity.give_insight(damage_amount)
 				triggered = TRUE
-				
-	if(triggered)			
+
+	if(triggered)
 		SEND_SIGNAL(holder, COMSIG_ABERRANT_COOLDOWN, TRUE)
 		SEND_SIGNAL(holder, COMSIG_ABERRANT_SECONDARY, holder, owner)
 
@@ -361,7 +361,7 @@
 				SEND_SIGNAL(holder, COMSIG_ABERRANT_COOLDOWN, TRUE)
 				SEND_SIGNAL(holder, COMSIG_ABERRANT_SECONDARY, holder, owner)
 				return TRUE
-	
+
 	organ_efficiency_mod = old_organ_efficiency_mod
 	blood_req_mod = old_blood_req_mod
 	nutriment_req_mod = old_nutriment_req_mod

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -176,7 +176,7 @@ see multiz/movement.dm for some info.
 
 		for(var/mob/living/M in below)
 			var/fall_damage = mover.get_fall_damage()
-			
+
 			if(ishuman(mover))
 				var/mob/living/carbon/human/H = mover
 				if(H.a_intent == I_HURT)
@@ -219,24 +219,18 @@ see multiz/movement.dm for some info.
 
 	if (istype(C, /obj/item/stack/material))
 		var/obj/item/stack/material/M = C
-
 		var/material/mat = M.get_material()
 		if (!mat.name == MATERIAL_STEEL)
-
 			return
 
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
-
 		if(L)
 			var/obj/item/stack/tile/floor/S = C
-			if (S.get_amount() < 4)
-				return
-
 			to_chat(user, SPAN_NOTICE("You start constructing underplating on the lattice."))
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
-			if(do_after(user,80, src))
+			if(do_after(user, (40 * user.stats.getMult(STAT_MEC, STAT_LEVEL_EXPERT, src))))
 				qdel(L)
-				S.use(4)
+				S.use(1)
 				ChangeTurf(/turf/simulated/floor/plating/under)
 			return
 		else

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -225,12 +225,11 @@ see multiz/movement.dm for some info.
 
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		if(L)
-			var/obj/item/stack/tile/floor/S = C
 			to_chat(user, SPAN_NOTICE("You start constructing underplating on the lattice."))
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 			if(do_after(user, (40 * user.stats.getMult(STAT_MEC, STAT_LEVEL_EXPERT, src))))
 				qdel(L)
-				S.use(1)
+				M.use(1)
 				ChangeTurf(/turf/simulated/floor/plating/under)
 			return
 		else

--- a/code/modules/overmap/exoplanets/turfs.dm
+++ b/code/modules/overmap/exoplanets/turfs.dm
@@ -185,24 +185,18 @@
 
 	if (istype(C, /obj/item/stack/material))
 		var/obj/item/stack/material/M = C
-
 		var/material/mat = M.get_material()
 		if (!mat.name == MATERIAL_STEEL)
-
 			return
 
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
-
 		if(L)
 			var/obj/item/stack/tile/floor/S = C
-			if (S.get_amount() < 4)
-				return
-
 			to_chat(user, SPAN_NOTICE("You start constructing underplating on the lattice."))
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
-			if(do_after(user,80, src))
+			if(do_after(user, (40 * user.stats.getMult(STAT_MEC, STAT_LEVEL_EXPERT, src))))
 				qdel(L)
-				S.use(4)
+				S.use(1)
 				ChangeTurf(/turf/simulated/floor/plating/under)
 			return
 		else

--- a/code/modules/overmap/exoplanets/turfs.dm
+++ b/code/modules/overmap/exoplanets/turfs.dm
@@ -191,12 +191,11 @@
 
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		if(L)
-			var/obj/item/stack/tile/floor/S = C
 			to_chat(user, SPAN_NOTICE("You start constructing underplating on the lattice."))
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 			if(do_after(user, (40 * user.stats.getMult(STAT_MEC, STAT_LEVEL_EXPERT, src))))
 				qdel(L)
-				S.use(1)
+				M.use(1)
 				ChangeTurf(/turf/simulated/floor/plating/under)
 			return
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Railings cost  4 → 2 sheets of metal
Catwalk cost 3 → 2 steel rods, speed adjusted from *six* seconds to 2 at 0 MEC and instant at 40 MEC
Underplating→Plating cost 2 → 1 sheet of metal, speed adjusted from 0.5 seconds to 3 at 0 MEC and instant at 40 MEC
Lattice→Underplating cost 4 → 1 sheet of metal, speed adjusted from 8 seconds to 4 at 0 MEC and instant at 40 MEC
Standartized (kinda?) construction on exoplanets/open space/space tiles
Most stuff that goes onto walls (air/fire alarms, light fixtures) craft time lowered from 9 to 6 seconds default (it is affected by MEC and other things too)

There are unrelated changes in this PR (indentation fixes) because compiler wouldn't shut up about them otherwise


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

it's no longer CBT

## Changelog
:cl:
balance: Railings cost 4 -> 2 sheets of metal
balance: Catwalk cost 3 -> 2 steel rods, speed adjusted from six seconds to 2 at 0 MEC and instant at 40 MEC
balance:  Underplating -> Plating cost 2 -> 1 sheet of metal, speed adjusted from 0.5 seconds to 3 at 0 MEC and instant at 40 MEC
balance:  Lattice -> Underplating cost 4 ->1 sheet of metal, speed adjusted from 8 seconds to 4 at 0 MEC and instant at 40 MEC
balance: most wall frame recipes default construction time is 6 seconds instead 9 seconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
