### PR TITLE
Fix takeshi disk having wrong ammo

### DIFF
--- a/code/datums/autolathe/ammo.dm
+++ b/code/datums/autolathe/ammo.dm
@@ -262,6 +262,10 @@
 	name = "box magazine (.25 Caseless)"
 	build_path = /obj/item/ammo_magazine/c10x24
 
+/datum/design/autolathe/ammo/ihclmg
+	name = "LMG munition box (.25 rifle)"
+	build_path = /obj/item/ammo_magazine/ihclmg
+
 // .25 rifle, but wide
 
 /datum/design/autolathe/ammo/cspistol
@@ -379,15 +383,15 @@
 /datum/design/autolathe/ammo/fs_stinger
 	name = "FS sting shell"
 	build_path = /obj/item/ammo_casing/grenade
-	
+
 /datum/design/autolathe/ammo/nt_stinger
 	name = "NT sting shell"
 	build_path = /obj/item/ammo_casing/grenade/weak
-		
+
 /datum/design/autolathe/ammo/shell_frag
 	name = "frag shell"
 	build_path = /obj/item/ammo_casing/grenade/frag
-		
+
 /datum/design/autolathe/ammo/shell_emp
 	name = "emp shell"
 	build_path = /obj/item/ammo_casing/grenade/emp

--- a/code/datums/autolathe/guns.dm
+++ b/code/datums/autolathe/guns.dm
@@ -194,7 +194,7 @@
 	build_path = /obj/item/gun/projectile/automatic/lmg/pk
 
 /datum/design/autolathe/gun/lmg_tk
-	name = "FS LMG .30 \"Takeshi\""
+	name = "FS LMG .25 \"Takeshi\""
 	build_path = /obj/item/gun/projectile/automatic/lmg/tk
 
 /datum/design/autolathe/gun/grenade_launcher

--- a/code/game/objects/items/weapons/design_disks/frozen_star.dm
+++ b/code/game/objects/items/weapons/design_disks/frozen_star.dm
@@ -406,12 +406,12 @@
 	)
 
 /obj/item/computer_hardware/hard_drive/portable/design/guns/fs_tk
-	disk_name = "Frozen Star - .30 Takeshi LMG"
+	disk_name = "Frozen Star - .25 Takeshi LMG"
 	icon_state = "frozenstar"
 	spawn_tags = SPAWN_TAG_DESIGN_ADVANCED
 	rarity_value = 90
 	license = 12
 	designs = list(
-		/datum/design/autolathe/gun/lmg_tk = 3, // "FS LMG .30 \"Takeshi\""
-		/datum/design/autolathe/ammo/lrifle_pk,
+		/datum/design/autolathe/gun/lmg_tk = 3, // "FS LMG .25 \"Takeshi\""
+		/datum/design/autolathe/ammo/ihclmg
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
It's .25 now, not .30
Also fixes its autolathe name


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I got eally pissed off when I got takeshi disk and realized this
how it is now:
![takeshi](https://user-images.githubusercontent.com/57810301/195130685-6ce601c0-f216-41fc-84ae-f9bf9ab3e139.png)



## Changelog
:cl:
fix: Takeshi disk is now properly named
fix: Takeshi disk now comes with .25 LMG box (its new caliber) instead of .30 LMG box
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
