### PR TITLE
Remove spiders toxin addiction chance

### DIFF
--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -555,6 +555,7 @@
 	color = "#a37d9c"
 	metabolism = REM * 2
 	overdose = REAGENTS_OVERDOSE/3
+	addiction_chance = 0
 	nerve_system_accumulations = 10
 	strength = 0.01
 	sanityloss = 1
@@ -568,7 +569,7 @@
 	M.stats.addTempStat(STAT_COG, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "pararein")
 	sanity_gain = 1.2
 	if(prob(10))
-		to_chat(M, SPAN_WARNING ("you feel like your mind is boiling and the blood in your veins is coming alive!"))
+		to_chat(M, SPAN_WARNING ("You feel like your mind is boiling and the blood in your veins is coming alive!"))
 
 /datum/reagent/toxin/aranecolmin
 	name = "Aranecolmin"
@@ -580,7 +581,7 @@
 	overdose = REAGENTS_OVERDOSE
 	strength = 0.1
 	metabolism = REM * 2
-	addiction_chance = 10
+	addiction_chance = 0
 	nerve_system_accumulations = 5
 
 /datum/reagent/toxin/aranecolmin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR sets `addiction_chance` to 0 for Pararein and Aranecolmin. It also fixed a lowercase.


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
These toxins already destroy your sanity and getting *addicted* to spider bites is something really stupid.

## Changelog
:cl:
balance: You cannot get addicted to spider toxins (Pararein and Aranecolmin) anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
