### PR TITLE
voice changer bandaid fix and hud shitcode removal

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -57,7 +57,7 @@ GLOBAL_LIST_INIT(chameleon_key_to_path, list(
 
 
 /obj/item/proc/pick_disguise(mob/user)
-	var/list/options = generate_chameleon_choices(isgun(src) ? /obj/item/gun : parent_type)
+	var/list/options = generate_chameleon_choices(isgun(src) ? /obj/item/gun : istype(src, /obj/item/clothing/mask/chameleon/voice) ? /obj/item/clothing/mask : parent_type)
 	var/obj/item/I = input(user, "Available options", "Set appearance") as anything in options
 	if(I)
 		disguise(options[I], usr)

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -304,16 +304,8 @@
 /obj/item/clothing/glasses/hud/make_old(low_quality_oldification)
 	GET_COMPONENT(oldified, /datum/component/oldficator)
 	if(!oldified && prob(75) && !istype(src, /obj/item/clothing/glasses/hud/broken))
-		var/obj/item/clothing/glasses/hud/broken/brokenhud = new /obj/item/clothing/glasses/hud/broken(loc)
-		brokenhud.name = src.name
-		brokenhud.desc = src.desc
-		brokenhud.icon = src.icon
-		brokenhud.icon_state = src.icon_state
-		brokenhud.item_state = src.item_state
-		brokenhud.make_old(low_quality_oldification)
-		QDEL_NULL(src)
-	else
-		.=..()
+		malfunctioning = TRUE
+	.=..()
 
 /obj/item/clothing/glasses/make_old(low_quality_oldification)
 	.=..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can now manually change the appearance of the voice changer mask, which was bugged previously . this fix is not very elegant, but it will do for now.

Also replaces some shitcode that turned oldified huds into the broken hud subtype with the sprite of the original hud.

## Why It's Good For The Game



## Changelog
:cl:
fix: you can now manually change the appearance of the voice changer again.
fix: broken huds are now actually what they appear to be (no actual changes in-game)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
