### PR TITLE
Vagabonds can Loadout a toolbelt with makeshift tools

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -91,7 +91,19 @@
 	new /obj/item/tool/wirecutters/armature(src)
 	new /obj/item/tool/shovel/power(src)
 	new /obj/item/stack/cable_coil/random(src)
-	
+
+/obj/item/storage/belt/utility/vagabond 
+	spawn_blacklisted = TRUE
+
+/obj/item/storage/belt/utility/vagabond/populate_contents()
+	new /obj/item/tool/screwdriver/improvised(src)
+	new /obj/item/tool/wrench/improvised(src)
+	new /obj/item/tool/weldingtool/improvised(src)
+	new /obj/item/tool/crowbar/improvised(src)
+	new /obj/item/tool/wirecutters/improvised(src)
+	new /obj/item/tool/shovel/improvised(src)
+	new /obj/item/tool/saw/improvised(src)
+
 /obj/item/storage/belt/utility/neotheology
 	name = "neotheology utility belt"
 	desc = "Waist-held holy items."

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -65,3 +65,9 @@
 	display_name = "duct tape"
 	path = /obj/item/tool/tape_roll
 	cost = 3
+
+/datum/gear/utility/ducttape
+	display_name = "makeshift tools toolbelt"
+	path = /obj/item/storage/belt/utility/vagabond 
+	cost = 3
+	allowed_roles = list(ASSISTANT_TITLE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a toolbelt option to the loadout
- Gives a toolbelt full of six makeshift tools
- Costs 3 points
- Is restricted to vagabonds

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makeshift tools are rarely made outside of gimmicks because they are worse than normal tools, and the makeshift omnitool is made even less because you have to craft about six different makeshift tools and then craft it.
Makeshift tools are also rarely made because there is zero tool scarcity in the game. Anyone can walk up to the public lathe and print out a full set of tool within 5 minutes.
The toolbelt costs 150 credits. Personally I always buy one, and I've never been in a round where I couldn't find one. 
Still it's useful, so I've given the option a 3 point cost.

It's my hope that people will pick this option as an alternative to printing tools, or to use the tools inside to make a makeshift omnitool.
It's likely they might also just pick it for the free toolbelt but, toolbelts were never scarce in the first place.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds a toolbelt full of makeshift tools to the loadout under utility
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
