### PR TITLE
Buffs OR Bullet Blender

### DIFF
--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -80,11 +80,11 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_PEN_MULT = -0.5,
+		GUN_UPGRADE_PEN_MULT = -0.2,
 		GUN_UPGRADE_PIERC_MULT = 3,
 		GUN_UPGRADE_RICO_MULT = 5,
 		GUN_UPGRADE_STEPDELAY_MULT = 0.6,
-		GUN_UPGRADE_RECOIL = 1.4
+		GUN_UPGRADE_RECOIL = 1.2
 		)
 	I.gun_loc_tag = GUN_BARREL
 	I.req_gun_tags = list(GUN_PROJECTILE)


### PR DESCRIPTION
## About The Pull Request
Buffs Oberth Bullet Blender by reducing its recoil increase and penetration decrease. 

## Why It's Good For The Game
Although this is the most balls to the wall insane gun modification, people are scared of using it since it'll nuke their gun damage. 

## Changelog
:cl:
balance: Oberth's bullet blender barrels have been buffed, and no longer nuke your armor penetration and recoil.
/:cl:
