### PR TITLE
Nanite timer fix

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/roach/types/nanites.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/nanites.dm
@@ -97,12 +97,13 @@
 	..()
 	parent = nuparent
 
-/mob/living/simple_animal/hostile/naniteswarm/death()
+/mob/living/simple_animal/hostile/naniteswarm/death(gibbed)
 	..()
 	if(parent)
 		parent.nanite_swarms.Remove(src)
 	new /obj/effect/decal/cleanable/blood/oil(get_turf(src))
-	qdel(src)
+	if(!gibbed)		// Parent roach gibs all child nanites on death, which qdels the nanites.
+		qdel(src)
 
 /mob/living/simple_animal/hostile/naniteswarm/Destroy()
 	if(parent)

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/nanites.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/nanites.dm
@@ -54,13 +54,13 @@
 /mob/living/carbon/superior_animal/roach/nanite/death()
 	for(var/mob/living/simple_animal/hostile/naniteswarm/NS in nanite_swarms)
 		nanite_swarms.Remove(NS)
-		NS.gib()
+		NS.death()
 	..()
 
 /mob/living/carbon/superior_animal/roach/nanite/Destroy()
 	for(var/mob/living/simple_animal/hostile/naniteswarm/NS in nanite_swarms)
 		nanite_swarms.Remove(NS)
-		NS.gib()
+		NS.death()
 	.=..()
 
 
@@ -97,13 +97,12 @@
 	..()
 	parent = nuparent
 
-/mob/living/simple_animal/hostile/naniteswarm/death(gibbed)
+/mob/living/simple_animal/hostile/naniteswarm/death()
 	..()
 	if(parent)
 		parent.nanite_swarms.Remove(src)
 	new /obj/effect/decal/cleanable/blood/oil(get_turf(src))
-	if(!gibbed)		// Parent roach gibs all child nanites on death, which qdels the nanites.
-		qdel(src)
+	qdel(src)
 
 /mob/living/simple_animal/hostile/naniteswarm/Destroy()
 	if(parent)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nanites would gib when their parent Kraftwerk roach would die, but they would be qdel'd before the gib() proc finishes. I changed it to death() since it already leaves behind an oil spill. Plus, the gib() proc only makes blood splatters.

## Why It's Good For The Game

Bug fix

## Changelog
:cl:
fix: Fixed nanite death via parent roach death
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
