### PR TITLE
Fixes hivemind mobs processing after death

### DIFF
--- a/code/modules/hivemind/mobs.dm
+++ b/code/modules/hivemind/mobs.dm
@@ -106,7 +106,7 @@
 
 /mob/living/simple_animal/hostile/hivemind/Life()
 	if(stat == DEAD)
-		return
+		return FALSE
 	. = ..()
 
 	speak()
@@ -129,6 +129,7 @@
 	if(!hive_mind_ai)
 		if(prob(5))
 			death()
+			return FALSE
 		else if(prob(15))
 			mulfunction()
 
@@ -384,7 +385,11 @@
 
 /mob/living/simple_animal/hostile/hivemind/lobber/Life()
 	. = ..()
-//checks if cooldown is over and is targeting mob, if so, activates special ability
+
+	if(!.)
+		return
+
+	//checks if cooldown is over and is targeting mob, if so, activates special ability
 	if(target_mob && world.time > special_ability_cooldown)
 		special_ability()
 
@@ -551,6 +556,9 @@
 
 /mob/living/simple_animal/hostile/hivemind/himan/Life()
 	. = ..()
+
+	if(!.)
+		return
 
 	//shriek
 	if(target_mob && !fake_dead && world.time > special_ability_cooldown)
@@ -720,6 +728,10 @@
 
 /mob/living/simple_animal/hostile/hivemind/mechiver/Life()
 	. = ..()
+
+	if(!.)
+		return
+
 	update_icon()
 
 	//when we have passenger, we torture him
@@ -921,6 +933,9 @@
 /mob/living/simple_animal/hostile/hivemind/treader/Life()
 	. = ..()
 
+	if(!.)
+		return
+
 	if(maxHealth > health && world.time > special_ability_cooldown)
 		special_ability()
 
@@ -973,7 +988,11 @@
 
 /mob/living/simple_animal/hostile/hivemind/phaser/Life()
 	stop_automated_movement = TRUE
+
 	. = ..()
+
+	if(!.)
+		return
 
 	//special ability using
 	if(world.time > special_ability_cooldown && can_use_special_ability)

--- a/code/modules/hivemind/mobs.dm
+++ b/code/modules/hivemind/mobs.dm
@@ -106,7 +106,7 @@
 
 /mob/living/simple_animal/hostile/hivemind/Life()
 	if(stat == DEAD)
-		return FALSE
+		return
 	. = ..()
 
 	speak()

--- a/code/modules/hivemind/mobs.dm
+++ b/code/modules/hivemind/mobs.dm
@@ -384,9 +384,7 @@
 
 
 /mob/living/simple_animal/hostile/hivemind/lobber/Life()
-	. = ..()
-
-	if(!.)
+	if(!..())
 		return
 
 	//checks if cooldown is over and is targeting mob, if so, activates special ability
@@ -555,9 +553,7 @@
 
 
 /mob/living/simple_animal/hostile/hivemind/himan/Life()
-	. = ..()
-
-	if(!.)
+	if(!..())
 		return
 
 	//shriek
@@ -727,9 +723,7 @@
 
 
 /mob/living/simple_animal/hostile/hivemind/mechiver/Life()
-	. = ..()
-
-	if(!.)
+	if(!..())
 		return
 
 	update_icon()
@@ -931,9 +925,7 @@
 	set_light(2, 1, COLOR_BLUE_LIGHT)
 
 /mob/living/simple_animal/hostile/hivemind/treader/Life()
-	. = ..()
-
-	if(!.)
+	if(!..())
 		return
 
 	if(maxHealth > health && world.time > special_ability_cooldown)
@@ -989,9 +981,7 @@
 /mob/living/simple_animal/hostile/hivemind/phaser/Life()
 	stop_automated_movement = TRUE
 
-	. = ..()
-
-	if(!.)
+	if(!..())
 		return
 
 	//special ability using


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hivemind mobs won't use their special abilities after dying. Should take care of a related timer bug, too.

## Why It's Good For The Game

Bug fix

## Changelog
:cl:
fix: Fixed hivemind mobs processing after death
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
