### PR TITLE
Buffs NT Faith Shield cruciform upgrade

### DIFF
--- a/code/modules/core_implant/cruciform/upgrades.dm
+++ b/code/modules/core_implant/cruciform/upgrades.dm
@@ -106,7 +106,7 @@
 	desc = "This upgrade will slightly increase follower resistance to physical and burn injuries from any source."
 	icon_state = "faiths_shield"
 	matter = list(MATERIAL_BIOMATTER = 50, MATERIAL_GOLD = 5, MATERIAL_PLASTEEL = 10)
-	var/shield_mod = 0.1
+	var/shield_mod = 0.2
 
 /obj/item/cruciform_upgrade/faiths_shield/OnInstall(var/disciple, var/_cruciform)
 	..()


### PR DESCRIPTION
## About The Pull Request
Buffs Faith's Shield to 20% brute and burn protection.

## Why It's Good For The Game
The Cruciform IS competing with Moebius mutations and artificial organs, or robotic limbs. And that free bicardine mutation is really, really strong. 
I think free Bicardine+Tricord is still better than Faith's Shield actually, but this covers fully burn damage and the aforementioned combo only less-than-half-covers it, so lets call it even.

I could be wrong but it was really hard to feel the difference in-game, even at +100 TGH (And thus 200 HP instead of 100~)

## Changelog
:cl:
balance: NT Faith's Shield damage reduction just got stronger.
/:cl: