### PR TITLE
NT obelisk uses LoS

### DIFF
--- a/code/modules/core_implant/cruciform/machinery/obelisk.dm
+++ b/code/modules/core_implant/cruciform/machinery/obelisk.dm
@@ -48,7 +48,7 @@ GLOBAL_LIST_EMPTY(all_obelisk)
 		return
 	var/list/affected = list()
 	for(var/mob/living/carbon/human/H in GLOB.human_mob_list)
-		if (H.z == src.z && get_dist(src, H) <= area_radius)
+		if(H.z == z && get_dist(src, H) <= area_radius && inLineOfSight(x, y, H.x, H.y, z))
 			affected.Add(H)
 	var/list/currently_copied = currently_affected.Copy()
 	for(var/mob/living/carbon/human/H in affected)

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -78570,7 +78570,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/power/nt_obelisk,
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
 "dGo" = (
@@ -106120,6 +106119,13 @@
 	dir = 8
 	},
 /area/eris/hallway/main/section2)
+"sNS" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/power/nt_obelisk,
+/turf/simulated/floor/tiled/dark/golden,
+/area/eris/neotheology/chapel)
 "sNY" = (
 /obj/structure/closet/acolyte,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -205709,7 +205715,7 @@ jDi
 bmx
 aaa
 cmE
-ewb
+sNS
 dFy
 mKQ
 dGn


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

NT obelisks use LoS. Returns chapel obelisk to original spot.

![image](https://user-images.githubusercontent.com/95178278/197093428-ef785e5b-3bd1-4000-b326-52201b67072e.png)

## Why It's Good For The Game

Makes sense

## Changelog
:cl:
tweak: NT obelisks use line of sight for checking affected mobs
tweak: Moved chapel obelisk back to original spot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
