### PR TITLE
Armor Divisor Code Change, Shield Integrity Buff

### DIFF
--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -211,7 +211,7 @@
 	base_block_chance = 45
 	shield_difficulty = 40
 	item_flags = DRAG_AND_DROP_UNEQUIP
-	shield_integrity = 130
+	shield_integrity = 200
 	var/obj/item/storage/internal/container
 	var/storage_slots = 3
 	var/max_w_class = ITEM_SIZE_HUGE
@@ -272,7 +272,7 @@
 	base_block_chance = 35
 	shield_difficulty = 70
 	item_flags = DRAG_AND_DROP_UNEQUIP
-	shield_integrity = 110
+	shield_integrity = 180
 	var/obj/item/storage/internal/container
 	var/storage_slots = 1
 	var/max_w_class = ITEM_SIZE_HUGE

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -149,7 +149,7 @@
 	matter = list(MATERIAL_GLASS = 5, MATERIAL_STEEL = 5, MATERIAL_PLASTEEL = 12)
 	price_tag = 500
 	attack_verb = list("shoved", "bashed")
-	shield_integrity = 125
+	shield_integrity = 195
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 	var/picked_by_human = FALSE
 	var/mob/living/carbon/human/picking_human
@@ -207,7 +207,7 @@
 	base_block_chance = 45
 	shield_difficulty = 35
 	attack_verb = list("shoved", "bashed")
-	shield_integrity = 135
+	shield_integrity = 205
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 	var/picked_by_human = FALSE
 	var/mob/living/carbon/human/picking_human
@@ -307,7 +307,7 @@
 	price_tag = 200
 	base_block_chance = 55
 	shield_difficulty = 10
-	shield_integrity = 160
+	shield_integrity = 230
 	slowdown_hold = 1
 
 /obj/item/shield/riot/dozershield/attackby(obj/item/W as obj, mob/user as mob)
@@ -335,7 +335,7 @@
 	base_block_chance = 60
 	shield_difficulty = 10
 	attack_verb = list("smashed", "bashed")
-	shield_integrity = 180
+	shield_integrity = 250
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 	var/picked_by_human = FALSE
 	var/mob/living/carbon/human/picking_human
@@ -413,7 +413,7 @@
 	matter = list(MATERIAL_STEEL = 6)
 	base_block_chance = 35
 	shield_difficulty = 65
-	shield_integrity = 100
+	shield_integrity = 170
 
 /obj/item/shield/buckler/handmade/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/extinguisher) || istype(W, /obj/item/storage/toolbox) || istype(W, /obj/item/melee))
@@ -432,7 +432,7 @@
 	matter = list(MATERIAL_STEEL = 4)
 	base_block_chance = 40
 	shield_difficulty = 30
-	shield_integrity = 85
+	shield_integrity = 155
 
 /obj/item/shield/riot/tray/get_protected_area(mob/user)
 	var/list/p_area = list(BP_CHEST, BP_HEAD, BP_L_ARM, BP_R_ARM, BP_GROIN)
@@ -467,7 +467,7 @@
 	var/active = 0
 	base_block_chance = 35
 	shield_difficulty = 70
-	shield_integrity = 130
+	shield_integrity = 200
 
 /obj/item/shield/buckler/energy/handle_shield(mob/user)
 	if(!active)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -41,26 +41,29 @@
 		return 1 //exosuits have their own penetration handling
 
 	var/blocked_damage = 0
+	var/adjusted_armor_divisor = armor_divisor - rand(0,4)
+    if(!adjusted_armor_divisor)
+        adjusted_armor_divisor = 1
 	if(istype(A, /turf/simulated/wall)) // TODO: refactor this from functional into OOP
 		var/turf/simulated/wall/W = A
-		blocked_damage = round(W.material.integrity / (armor_divisor - rand(0,4)/8)) / 8
+		blocked_damage = round(W.material.integrity / (adjusted_armor_divisor / 8)) / 8
 	else if(istype(A, /obj/item/shield))
 		var/obj/item/shield/S = A
-		blocked_damage = round(S.shield_integrity / (armor_divisor - rand(0,4)/8)) / 8
+		blocked_damage = round(S.shield_integrity / (adjusted_armor_divisor / 8)) / 8
 	else if(istype(A, /obj/machinery/door))
 		var/obj/machinery/door/D = A
-		blocked_damage = round(D.maxhealth / (armor_divisor - rand(0,4)/8)) / 8
+		blocked_damage = round(D.maxhealth / (adjusted_armor_divisor / 8)) / 8
 		if(D.glass) blocked_damage /= 2
 	else if(istype(A, /obj/structure/girder))
 		return TRUE
 	else if(istype(A, /obj/structure/low_wall))
-		blocked_damage = round(20 / (armor_divisor - rand(0,4)/8)) / 8 // hardcoded, value is same as steel wall, will have to be changed once low walls have integrity
+		blocked_damage = round(20 / (adjusted_armor_divisor / 8)) / 8 // hardcoded, value is same as steel wall, will have to be changed once low walls have integrity
 	else if(istype(A, /obj/structure/table))
 		var/obj/structure/table/T = A
-		blocked_damage = round(T.maxhealth / (armor_divisor - rand(0,4)/8)) / 8
+		blocked_damage = round(T.maxhealth / (adjusted_armor_divisor / 8)) / 8
 	else if(istype(A, /obj/structure/barricade))
 		var/obj/structure/barricade/B = A
-		blocked_damage = round(B.material.integrity / (armor_divisor - rand(0,4)/8)) / 8
+		blocked_damage = round(B.material.integrity / (adjusted_armor_divisor / 8)) / 8
 	else if(istype(A, /obj/machinery) || istype(A, /obj/structure))
 		blocked_damage = round(20 / armor_divisor)
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -43,24 +43,24 @@
 	var/blocked_damage = 0
 	if(istype(A, /turf/simulated/wall)) // TODO: refactor this from functional into OOP
 		var/turf/simulated/wall/W = A
-		blocked_damage = round(W.material.integrity / armor_divisor / 8)
+		blocked_damage = round(W.material.integrity / (armor_divisor - rand(0,4)/8)) / 8
 	else if(istype(A, /obj/item/shield))
 		var/obj/item/shield/S = A
-		blocked_damage = round(S.shield_integrity / armor_divisor / 8)
+		blocked_damage = round(S.shield_integrity / (armor_divisor - rand(0,4)/8)) / 8
 	else if(istype(A, /obj/machinery/door))
 		var/obj/machinery/door/D = A
-		blocked_damage = round(D.maxhealth / armor_divisor / 8)
+		blocked_damage = round(D.maxhealth / (armor_divisor - rand(0,4)/8)) / 8
 		if(D.glass) blocked_damage /= 2
 	else if(istype(A, /obj/structure/girder))
 		return TRUE
 	else if(istype(A, /obj/structure/low_wall))
-		blocked_damage = round(20 / armor_divisor) // hardcoded, value is same as steel wall, will have to be changed once low walls have integrity
+		blocked_damage = round(20 / (armor_divisor - rand(0,4)/8)) / 8 // hardcoded, value is same as steel wall, will have to be changed once low walls have integrity
 	else if(istype(A, /obj/structure/table))
 		var/obj/structure/table/T = A
-		blocked_damage = round(T.maxhealth / armor_divisor / 8)
+		blocked_damage = round(T.maxhealth / (armor_divisor - rand(0,4)/8)) / 8
 	else if(istype(A, /obj/structure/barricade))
 		var/obj/structure/barricade/B = A
-		blocked_damage = round(B.material.integrity / armor_divisor / 8)
+		blocked_damage = round(B.material.integrity / (armor_divisor - rand(0,4)/8)) / 8
 	else if(istype(A, /obj/machinery) || istype(A, /obj/structure))
 		blocked_damage = round(20 / armor_divisor)
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -42,8 +42,8 @@
 
 	var/blocked_damage = 0
 	var/adjusted_armor_divisor = armor_divisor - rand(0,4)
-    if(!adjusted_armor_divisor)
-        adjusted_armor_divisor = 1
+	if(!adjusted_armor_divisor)
+		adjusted_armor_divisor = 1
 	if(istype(A, /turf/simulated/wall)) // TODO: refactor this from functional into OOP
 		var/turf/simulated/wall/W = A
 		blocked_damage = round(W.material.integrity / (adjusted_armor_divisor / 8)) / 8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Previous PRs made shields able to be penetrated but leaned too hard on it, making it difficult to block even shrapnel properly and having it embed in the body.
This buffs the integrity of shields to near wall levels/above wall levels, and makes it so even when bullets penetrate their damage is reduced enough that it's worth using a shield.

Buckler Tac 125 > 195
Ballistic 135 > 205
Bulldozer 160 > 230
Hardsuit 180 > 250
Buckler Wooden 100 > 170
Tray 85 > 155
Energy 130 > 200 
NT 130 > 200

Divisor code is Humons, I just got annoyed enough to bug him on how to edit it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You're able to tank smaller calibers as intended but still not immortal to larger ones meant to penetrate
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: All shields have gotten an integrity buff of 70 points
code: Armor divisor code now has a minor rng element to it (Humons idea)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
