### PR TITLE
Metabolism qdel fix

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -15,9 +15,11 @@
 		germ_level++
 
 /mob/living/carbon/Destroy()
-	qdel(ingested)
-	qdel(touching)
-	// We don't qdel(bloodstr) because it's the same as qdel(reagents)
+	QDEL_NULL(metabolism_effects)
+	reagents = null
+	QDEL_NULL(ingested)
+	QDEL_NULL(touching)
+	QDEL_NULL(bloodstr)
 	QDEL_LIST(internal_organs)
 	QDEL_LIST(stomach_contents)
 	QDEL_LIST(hallucinations)

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -66,6 +66,7 @@
 	reagent_list = null
 	if(my_atom && my_atom.reagents == src)
 		my_atom.reagents = null
+	my_atom = null
 
 /* Internal procs */
 

--- a/code/modules/reagents/metabolism.dm
+++ b/code/modules/reagents/metabolism.dm
@@ -11,7 +11,7 @@
 
 /datum/reagents/metabolism/Destroy()
 	parent = null
-	. = ..()
+	return ..()
 
 /datum/reagents/metabolism/proc/metabolize()
 	expose_temperature(parent.bodytemperature, 0.25)

--- a/code/modules/reagents/metabolism.dm
+++ b/code/modules/reagents/metabolism.dm
@@ -46,6 +46,13 @@
 	/// The final chance for an addiction to manifest is multiplied by this value before being passed to prob.
 	var/addiction_chance_multiplier = 1
 
+/datum/metabolism_effects/Destroy()
+	parent = null
+	withdrawal_list.Cut()
+	active_withdrawals.Cut()
+	addiction_list.Cut()
+	return ..()
+
 /datum/metabolism_effects/proc/adjust_nsa(value, tag)
 	if(!tag)
 		CRASH("no tag given to adjust_nsa()")

--- a/code/modules/reagents/metabolism.dm
+++ b/code/modules/reagents/metabolism.dm
@@ -9,6 +9,10 @@
 	if(istype(parent_mob))
 		parent = parent_mob
 
+/datum/reagents/metabolism/Destroy()
+	parent = null
+	. = ..()
+
 /datum/reagents/metabolism/proc/metabolize()
 	expose_temperature(parent.bodytemperature, 0.25)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cleans up some qdel stuff for reagent holders, metabolism, and metabolism effects in carbon mobs. This should reduce the amount of hard dels for roaches and other mobs.

## Why It's Good For The Game

Performance

## Changelog
:cl:
fix: Added Destroy() logic to metabolism and metabolism effects
fix: Cleaned up logic for qdels in reagent holders
fix: Cleaned up logic for metabolism qdels in carbon mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
