### PR TITLE
Mob living qdel fix

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -890,6 +890,8 @@ default behaviour is:
 		update_z(T.z)
 
 /mob/living/Destroy()
+	if(registered_z)
+		SSmobs.mob_living_by_zlevel[registered_z] -= src	// STOP_PROCESSING() doesn't remove the mob from this list
 	qdel(stats)
 	stats = null
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Living mobs will remove themselves from the mob_living_by_zlevel list in SSmob when Destroy() is called. Doesn't seem to stop the carp hard dels, but mice and hivemind mobs stopped showing up in the GC failures after this.

## Why It's Good For The Game

Performance

## Changelog
:cl:
fix: Living mobs remove themselves from mob_living_by_zlevel in SSmob
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
