### PR TITLE
Trade tweaks

### DIFF
--- a/code/__DEFINES/trade.dm
+++ b/code/__DEFINES/trade.dm
@@ -1,13 +1,11 @@
-// Beacon offer price caps
-#define SPECIAL_OFFER_MIN_PRICE 200
-#define SPECIAL_OFFER_MAX_PRICE 100000
-
 // Export price multipliers
 #define NONEXPORTABLE 0
 #define JUNK 0.5
 #define EXPORTABLE 1.0
 #define HOCKABLE 0.8		// Term for items being sold to a pawnbroker; means the item can be exported but is not a typical export, sold at 80% value
 #define REFUND 1
+
+#define EXPORT_COUNT_MAXIMUM 200	// To mitigate GC issues
 
 // Data packets - inventories and offers
 #define good_data(nam, randList, price) list("name" = nam, "amount_range" = randList, "price" = price)

--- a/code/modules/trade/datums/_trade_station.dm
+++ b/code/modules/trade/datums/_trade_station.dm
@@ -143,7 +143,7 @@
 		goods_tick()
 	else
 		initialized = TRUE
-	update_time = rand(8,12) MINUTES
+	update_time = rand(6,8) MINUTES
 	addtimer(CALLBACK(src, .proc/update_tick), update_time, TIMER_STOPPABLE)
 	update_timer_start = world.time
 
@@ -331,24 +331,15 @@
 			components = offer_content["attachments"]
 			component_count = offer_content["attach_count"]
 
-		var/min_amt = round(SPECIAL_OFFER_MIN_PRICE / max(1, base_price))
-		var/max_amt = round(SPECIAL_OFFER_MAX_PRICE / (max(1, base_price)))
-
-		if(min_amt < 1)
-			min_amt = 1
+		var/max_amt = 1
 
 		if(amount_cap > 0)
-			if(max_amt > amount_cap)
-				max_amt = amount_cap
+			max_amt = amount_cap
 		else if(offer_limit > 0)
-			if(max_amt > offer_limit)
-				max_amt = offer_limit
+			max_amt = offer_limit
 
-		var/new_amt = rand(min_amt, max_amt)
-
-		var/min_price = clamp(new_amt * max(1, base_price), SPECIAL_OFFER_MIN_PRICE, SPECIAL_OFFER_MAX_PRICE)
-		var/max_price = clamp(new_amt * max(1, base_price), min_price, SPECIAL_OFFER_MAX_PRICE)
-		var/new_price = rand(min_price, max_price)
+		var/new_amt = rand(1, max_amt)
+		var/new_price = new_amt * base_price
 
 		if(offer_content?.len >= 5)
 			offer_content = offer_data_mods(name, new_price, new_amt, components, component_count)

--- a/nano/templates/trade_offers.tmpl
+++ b/nano/templates/trade_offers.tmpl
@@ -5,9 +5,7 @@
 			<tr>
 				<th>Station
 				<th>Name
-				{{if data.prg_type != "ordering"}}
-					<th>Price
-				{{/if}}
+				<th>Price
 				<th>Amount
 				{{if data.prg_type != "ordering"}}
 					<th>Send
@@ -17,9 +15,7 @@
 				<tr>
 					<td>{{:value.station}}
 					<td>{{:value.name}}
-					{{if data.prg_type != "ordering"}}
-						<td>{{:value.price}}
-					{{/if}}
+					<td>{{:value.price}}
 					<td>{{:(isNaN(value.available) ? '' : +value.available + '/') + value.amount}}
 					{{if data.prg_type != "ordering"}}
 						<td style="width: 0">{{:helper.link("", 'check', {'PRG_offer_fulfill' : value.index, 'PRG_offer_fulfill_path' : value.path}, (value.available >= value.amount && value.amount > 0) ? null : 'disabled')}}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Exports are soft capped at 200 items per use. It'll suck when you have loaded ammo mags in the pile, but it's for the sake of server performance.
- Objects containing humans and monkeys will not export.
- Special offer tab on the ordering app shows offer credit value.
- Trade station offer update time range reduced to 6 to 8 minutes.
- Removed special offer limits. This shouldn't affect anything in-game.

## Why It's Good For The Game

Performance, bug fixes, and QoL

## Changelog
:cl:
fix: Humans and monkeys inside objects will prevent the object from being exported
code: Added export item soft cap of 200
tweak: Ordering app shows special offer value
tweak: Trade station offer update time reduced to 6 to 8 minutes
code: Removed special offer price limits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
