### PR TITLE
Makes two NT Cruciform Upgrades obtainable again.

### DIFF
--- a/code/game/objects/items/weapons/design_disks/NeoTheology.dm
+++ b/code/game/objects/items/weapons/design_disks/NeoTheology.dm
@@ -126,6 +126,7 @@
 		/datum/design/autolathe/nt/grenade/nt_smokebomb,
 		/datum/design/autolathe/ammo/shell_heatwave,
 		/datum/design/autolathe/ammo/nt_stinger
+		/datum/design/autolathe/cruciform_upgrade/martyr_gift
 	)
 
 // Laser rifle
@@ -176,6 +177,7 @@
 		/datum/design/autolathe/device/grenade/nt_weedkiller,
 
 		/datum/design/bioprinter/holyvacuum
+		/datum/design/autolathe/cruciform_upgrade/cleansing_presence
 
 	)
 

--- a/code/game/objects/items/weapons/design_disks/NeoTheology.dm
+++ b/code/game/objects/items/weapons/design_disks/NeoTheology.dm
@@ -125,7 +125,7 @@
 		/datum/design/autolathe/nt/grenade/nt_flashbang,
 		/datum/design/autolathe/nt/grenade/nt_smokebomb,
 		/datum/design/autolathe/ammo/shell_heatwave,
-		/datum/design/autolathe/ammo/nt_stinger
+		/datum/design/autolathe/ammo/nt_stinger,
 		/datum/design/autolathe/cruciform_upgrade/martyr_gift
 	)
 
@@ -175,8 +175,7 @@
 		/datum/design/autolathe/gun/nt_sprayer,
 		/datum/design/autolathe/device/grenade/nt_cleaner,
 		/datum/design/autolathe/device/grenade/nt_weedkiller,
-
-		/datum/design/bioprinter/holyvacuum
+		/datum/design/bioprinter/holyvacuum,
 		/datum/design/autolathe/cruciform_upgrade/cleansing_presence
 
 	)


### PR DESCRIPTION
## About The Pull Request
Adds Cleansing Presence and Martyr's Gift to existing NT disks.

## Why It's Good For The Game
Those cruciform upgrades are basically gone, unless NT manages to find a incredibly rare generic cruciform upgrade disk in maintenance.

## Changelog
:cl:
tweak: Martyr's Gift is now available on NT's Grenade disk, and Cleansing Presence is now available on Products and Utilities.
/:cl:
