### PR TITLE
Small .20 Tweak to Small Tweak to .20 Damage

### DIFF
--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -51,7 +51,7 @@ There are important things regarding this file:
 
 /obj/item/projectile/bullet/srifle
 	name = ".20 caliber bullet"
-	damage_types = list(BRUTE = 32)
+	damage_types = list(BRUTE = 34)
 	armor_divisor = 1.5
 	penetrating = 2
 	can_ricochet = TRUE


### PR DESCRIPTION
## About The Pull Request

Increases .20 damage from 32 to 34.

## Why It's Good For The Game

The previous nerf to .20s went a bit too far, reducing damage from 36 to 32, causing a lot of .20 guns to become less than viable and a bit anemic. My goal with this minor adjustment is to hopefully approach if not reach that sweet spot between intended balance and viability.

## Changelog
:cl:
Increased .20 damage from 32 to 34.
/:cl: