### PR TITLE
OS robots drop OS components

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
+++ b/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
@@ -61,6 +61,12 @@
 	acceptableTargetDistance = 6
 	kept_distance = 3
 
+	var/list/components = list(/obj/item/stock_parts/capacitor/one_star,
+								/obj/item/stock_parts/scanning_module/one_star,
+								/obj/item/stock_parts/manipulator/one_star,
+								/obj/item/stock_parts/micro_laser/one_star,
+								/obj/item/stock_parts/matter_bin/one_star)
+
 /mob/living/carbon/superior_animal/stalker/dual
 	name = "OneStar Stalker Mk2"
 	desc = "A ruthless patrol borg that defends OneStar facilities. This one is an upgraded version with a dual minigun, don\'t stand in front of it for too long."
@@ -75,3 +81,23 @@
 	..()
 	pixel_x = 0
 	pixel_y = 0
+
+/mob/living/carbon/superior_animal/stalker/attackby(var/obj/item/O, var/mob/user)
+	if(istype(O, /obj/item/gripper))
+		return ..(O, user)
+
+	else if(istype(O, /obj/item/reagent_containers) || istype(O, /obj/item/stack/medical))
+		..()
+
+	else if(stat == DEAD)
+		if(QUALITY_PRYING in O.tool_qualities)
+			if(O.use_tool(user, src, WORKTIME_NORMAL, QUALITY_PRYING, FAILCHANCE_HARD, required_stat = STAT_MEC))
+				new /obj/item/stack/material/steel/random(src.loc)
+				new /obj/item/stack/material/plasteel/random(src.loc)
+				new /obj/item/stack/cable_coil(src.loc)
+				for(var/i = 1, i <= 2 + rand(0,2), i++)
+					var/components_reward = pick(components)
+					new components_reward(get_turf(src))
+				qdel(src)
+	else
+		O.attack(src, user, user.targeted_organ)

--- a/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
+++ b/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
@@ -91,7 +91,13 @@
 				new /obj/item/stack/material/plasteel/random(src.loc)
 				new /obj/item/stack/cable_coil(src.loc)
 				for(var/i = 1, i <= 2 + rand(0,2), i++)
-					var/list/os_components_reward = pick(os_components)
+					var/list/os_components_reward = pick(list(
+						/obj/item/stock_parts/capacitor/one_star,
+						/obj/item/stock_parts/scanning_module/one_star,
+						/obj/item/stock_parts/manipulator/one_star,
+						/obj/item/stock_parts/micro_laser/one_star,
+						/obj/item/stock_parts/matter_bin/one_star
+					))
 					new os_components_reward(get_turf(src))
 				qdel(src)
 	else

--- a/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
+++ b/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
@@ -61,11 +61,6 @@
 	acceptableTargetDistance = 6
 	kept_distance = 3
 
-	var/list/components = list(/obj/item/stock_parts/capacitor/one_star,
-								/obj/item/stock_parts/scanning_module/one_star,
-								/obj/item/stock_parts/manipulator/one_star,
-								/obj/item/stock_parts/micro_laser/one_star,
-								/obj/item/stock_parts/matter_bin/one_star)
 
 /mob/living/carbon/superior_animal/stalker/dual
 	name = "OneStar Stalker Mk2"
@@ -96,8 +91,8 @@
 				new /obj/item/stack/material/plasteel/random(src.loc)
 				new /obj/item/stack/cable_coil(src.loc)
 				for(var/i = 1, i <= 2 + rand(0,2), i++)
-					var/components_reward = pick(components)
-					new components_reward(get_turf(src))
+					var/list/os_components_reward = pick(os_components)
+					new os_components_reward(get_turf(src))
 				qdel(src)
 	else
 		O.attack(src, user, user.targeted_organ)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -84,3 +84,9 @@
 
 	spawn_frequency = 10
 	bad_type = /mob/living
+
+	var/list/os_components = list(/obj/item/stock_parts/capacitor/one_star,
+								/obj/item/stock_parts/scanning_module/one_star,
+								/obj/item/stock_parts/manipulator/one_star,
+								/obj/item/stock_parts/micro_laser/one_star,
+								/obj/item/stock_parts/matter_bin/one_star) //One Star Robot Drop

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -84,9 +84,3 @@
 
 	spawn_frequency = 10
 	bad_type = /mob/living
-
-	var/list/os_components = list(/obj/item/stock_parts/capacitor/one_star,
-								/obj/item/stock_parts/scanning_module/one_star,
-								/obj/item/stock_parts/manipulator/one_star,
-								/obj/item/stock_parts/micro_laser/one_star,
-								/obj/item/stock_parts/matter_bin/one_star) //One Star Robot Drop

--- a/code/modules/mob/living/simple_animal/hostile/doomba.dm
+++ b/code/modules/mob/living/simple_animal/hostile/doomba.dm
@@ -28,11 +28,6 @@
 	melee_damage_upper = 10
 	rarity_value = 36
 	spawn_tags = SPAWN_TAG_MOB_ROOMBA
-	var/list/components = list(/obj/item/stock_parts/capacitor/one_star,
-								/obj/item/stock_parts/scanning_module/one_star,
-								/obj/item/stock_parts/manipulator/one_star,
-								/obj/item/stock_parts/micro_laser/one_star,
-								/obj/item/stock_parts/matter_bin/one_star)
 
 
 /mob/living/simple_animal/hostile/roomba/death()
@@ -43,8 +38,8 @@
 	s.set_up(3, 1, src)
 	s.start()
 	if(prob(20))
-		var/components_reward = pick(components)
-		new components_reward(get_turf(src))
+		var/list/os_components_reward = pick(os_components)
+		new os_components_reward(get_turf(src))
 	qdel(src)
 	return
 

--- a/code/modules/mob/living/simple_animal/hostile/doomba.dm
+++ b/code/modules/mob/living/simple_animal/hostile/doomba.dm
@@ -38,7 +38,13 @@
 	s.set_up(3, 1, src)
 	s.start()
 	if(prob(20))
-		var/list/os_components_reward = pick(os_components)
+		var/list/os_components_reward = pick(list(
+			/obj/item/stock_parts/capacitor/one_star,
+			/obj/item/stock_parts/scanning_module/one_star,
+			/obj/item/stock_parts/manipulator/one_star,
+			/obj/item/stock_parts/micro_laser/one_star,
+			/obj/item/stock_parts/matter_bin/one_star
+		))
 		new os_components_reward(get_turf(src))
 	qdel(src)
 	return

--- a/code/modules/mob/living/simple_animal/hostile/doomba.dm
+++ b/code/modules/mob/living/simple_animal/hostile/doomba.dm
@@ -28,6 +28,12 @@
 	melee_damage_upper = 10
 	rarity_value = 36
 	spawn_tags = SPAWN_TAG_MOB_ROOMBA
+	var/list/components = list(/obj/item/stock_parts/capacitor/one_star,
+								/obj/item/stock_parts/scanning_module/one_star,
+								/obj/item/stock_parts/manipulator/one_star,
+								/obj/item/stock_parts/micro_laser/one_star,
+								/obj/item/stock_parts/matter_bin/one_star)
+
 
 /mob/living/simple_animal/hostile/roomba/death()
 	..()
@@ -36,6 +42,9 @@
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	s.set_up(3, 1, src)
 	s.start()
+	if(prob(20))
+		var/components_reward = pick(components)
+		new components_reward(get_turf(src))
 	qdel(src)
 	return
 

--- a/code/modules/mob/living/simple_animal/hostile/onestar_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/onestar_drone.dm
@@ -62,7 +62,13 @@
 	s.set_up(3, 1, src)
 	s.start()
 	if(prob(20))
-		var/list/os_components_reward = pick(os_components)
+		var/list/os_components_reward = pick(list(
+			/obj/item/stock_parts/capacitor/one_star,
+			/obj/item/stock_parts/scanning_module/one_star,
+			/obj/item/stock_parts/manipulator/one_star,
+			/obj/item/stock_parts/micro_laser/one_star,
+			/obj/item/stock_parts/matter_bin/one_star
+		))
 		new os_components_reward(get_turf(src))
 	qdel(src)
 	return

--- a/code/modules/mob/living/simple_animal/hostile/onestar_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/onestar_drone.dm
@@ -30,6 +30,11 @@
 	var/screen_type = "os" //if someone decides to make the drones for something aside from OS and have different desgins
 	var/tool = "laser"
 	var/tooltype = "os"
+	var/list/components = list(/obj/item/stock_parts/capacitor/one_star,
+								/obj/item/stock_parts/scanning_module/one_star,
+								/obj/item/stock_parts/manipulator/one_star,
+								/obj/item/stock_parts/micro_laser/one_star,
+								/obj/item/stock_parts/matter_bin/one_star)
 
 /mob/living/simple_animal/hostile/onestar_custodian/New()
 	. = ..()
@@ -61,6 +66,9 @@
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	s.set_up(3, 1, src)
 	s.start()
+	if(prob(20))
+		var/components_reward = pick(components)
+		new components_reward(get_turf(src))
 	qdel(src)
 	return
 

--- a/code/modules/mob/living/simple_animal/hostile/onestar_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/onestar_drone.dm
@@ -30,11 +30,6 @@
 	var/screen_type = "os" //if someone decides to make the drones for something aside from OS and have different desgins
 	var/tool = "laser"
 	var/tooltype = "os"
-	var/list/components = list(/obj/item/stock_parts/capacitor/one_star,
-								/obj/item/stock_parts/scanning_module/one_star,
-								/obj/item/stock_parts/manipulator/one_star,
-								/obj/item/stock_parts/micro_laser/one_star,
-								/obj/item/stock_parts/matter_bin/one_star)
 
 /mob/living/simple_animal/hostile/onestar_custodian/New()
 	. = ..()
@@ -67,8 +62,8 @@
 	s.set_up(3, 1, src)
 	s.start()
 	if(prob(20))
-		var/components_reward = pick(components)
-		new components_reward(get_turf(src))
+		var/list/os_components_reward = pick(os_components)
+		new os_components_reward(get_turf(src))
 	qdel(src)
 	return
 


### PR DESCRIPTION
## About The Pull Request
One Star roombas and drones have a 1/5 chance to drop a random One Star component. Dead One Star Stalkers can be pried apart to reveal 2-4 One Star Components, along with cable coil and random quantities of steel and plasteel.

## Why It's Good For The Game
Valo is doing One Star ruins/blacksites, and asked for it. Outside of the One Star Trash Beacon, you need some hell of good luck to get OS components other than capacitors.

## Changelog
:cl:
tweak: One Star Roombas and Drones drop One Star Components.
tweak: One Star Stalkers can be broken down with the prying quality, yields: 2-4 One Star Components, Steel, Plasteel, Wires
/:cl:
