### PR TITLE
More Relevant Salaries

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -2,8 +2,8 @@
 
 //Hourly wage defines
 #define WAGE_NONE			0	//Unpaid. Assistant, captain, and those who sell things
-#define WAGE_LABOUR_DUMB	450 //Dumb jobs anyone can do. Janitor, actor, cargotech, etc
-#define WAGE_LABOUR			600 //The standard wage that most people get
-#define WAGE_LABOUR_HAZARD	750	//Hazard pay. For miners and IHOperatives
-#define WAGE_PROFESSIONAL	900	//The wage for educated professionals. Doctors, scientists, etc
-#define WAGE_COMMAND		1200	//Wage paid to command staff, generally regardless of department
+#define WAGE_LABOUR_DUMB	225 //Dumb jobs anyone can do. Janitor, actor, cargotech, etc
+#define WAGE_LABOUR			300 //The standard wage that most people get
+#define WAGE_LABOUR_HAZARD	375	//Hazard pay. For miners and IHOperatives
+#define WAGE_PROFESSIONAL	450	//The wage for educated professionals. Doctors, scientists, etc
+#define WAGE_COMMAND		600	//Wage paid to command staff, generally regardless of department

--- a/code/controllers/subsystems/economy.dm
+++ b/code/controllers/subsystems/economy.dm
@@ -8,8 +8,8 @@ SUBSYSTEM_DEF(economy)
 	init_order = INIT_ORDER_LATELOAD
 
 	wait = 300 //Ticks once per 30 seconds
-	var/payday_interval = 1 HOURS
-	var/next_payday = 1 HOURS
+	var/payday_interval = 30 MINUTES
+	var/next_payday = 30 MINUTES
 
 /datum/controller/subsystem/economy/Initialize()
 	.=..()
@@ -61,7 +61,7 @@ SUBSYSTEM_DEF(economy)
 	for(var/datum/money_account/A in personal_accounts)
 		if(!A.employer)
 			continue
-		
+
 		var/amount_to_pay = A.debt + A.wage
 		if(amount_to_pay <= 0)
 			continue


### PR DESCRIPTION
## About The Pull Request

Reduces the time between salaries and reduces the salary amount themselves by half.

## Why It's Good For The Game

Makes salaries more relevant in gameplay for the average crewmember.

## Changelog
:cl:
Salaries paid at 30 minutes instead of 1 hour.
Salaries slashed in half.
/:cl: