### PR TITLE
Armour Protec (Armour reduces pain more.)

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -1,4 +1,4 @@
-#define ARMOR_HALLOS_COEFFICIENT 0.175
+#define ARMOR_HALLOS_COEFFICIENT 0.2
 
 
 //This calculation replaces old run_armor_check in favor of more complex and better system

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -1,4 +1,4 @@
-#define ARMOR_HALLOS_COEFFICIENT 0.2
+#define ARMOR_HALLOS_COEFFICIENT 0.25
 
 
 //This calculation replaces old run_armor_check in favor of more complex and better system

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -1,4 +1,4 @@
-#define ARMOR_HALLOS_COEFFICIENT 0.4
+#define ARMOR_HALLOS_COEFFICIENT 0.2
 
 
 //This calculation replaces old run_armor_check in favor of more complex and better system

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -1,4 +1,4 @@
-#define ARMOR_HALLOS_COEFFICIENT 0.15
+#define ARMOR_HALLOS_COEFFICIENT 0.175
 
 
 //This calculation replaces old run_armor_check in favor of more complex and better system

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -1,4 +1,4 @@
-#define ARMOR_HALLOS_COEFFICIENT 0.2
+#define ARMOR_HALLOS_COEFFICIENT 0.15
 
 
 //This calculation replaces old run_armor_check in favor of more complex and better system


### PR DESCRIPTION
## About The Pull Request

Raised pain resistance given by armour from 60% to 75%. (No more near paincrits from a single .40 rubber against bulletproof armour.)

## Why It's Good For The Game

Currently, the balance between Style and Armour is in a poor state leaning towards Style, this change should hopefully lessen the power difference as it will be harder to paincrit people wearing high amounts of armour.

(Free to discuss in comments if 80% is too high or too low, I personally feel like 85% is too high and 75% is too low. However regardless, I think this is a necessary change to make armour a more solid choice when considering your defensive options.)

## Changelog
:cl:
Changed pain block from 60% to 75%
/:cl: