### PR TITLE
Happy Meal Change

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -761,10 +761,11 @@
 /obj/item/storage/box/happy_meal/New()
 	. = ..()
 	var/list/things2spawn = list(
-		/obj/item/reagent_containers/food/snacks/sliceable/plaincake,
-		/obj/item/reagent_containers/food/snacks/sliceable/chocolatecake,
+		/obj/item/reagent_containers/food/snacks/creamcheesebreadslice,
+		/obj/item/reagent_containers/food/snacks/applecakeslice,
 		/obj/item/reagent_containers/food/snacks/bigbiteburger,
-		/obj/item/reagent_containers/food/snacks/fishandchips
+		/obj/item/reagent_containers/food/snacks/fishandchips,
+		/obj/spawner/soda
 	)
 /*someday...
 	if(prob(1))

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -2105,6 +2105,7 @@
 /obj/item/reagent_containers/food/snacks/jelliedtoast/slime
 	preloaded_reagents = list("slimejelly" = 5)
 	taste_tag = list(UMAMI_FOOD)
+
 /obj/item/reagent_containers/food/snacks/jellyburger
 	name = "jelly burger"
 	desc = "Culinary curiousity or undiscovered delight?"
@@ -2114,6 +2115,7 @@
 	center_of_mass = list("x"=16, "y"=11)
 	nutriment_desc = list("buns" = 5)
 	nutriment_amt = 5
+	cooked = TRUE
 	taste_tag = list(UMAMI_FOOD)
 
 /obj/item/reagent_containers/food/snacks/jellyburger/slime
@@ -2122,6 +2124,7 @@
 /obj/item/reagent_containers/food/snacks/jellyburger/cherry
 	preloaded_reagents = list("cherryjelly" = 5)
 	taste_tag = list(UMAMI_FOOD)
+
 /obj/item/reagent_containers/food/snacks/milosoup
 	name = "milosoup"
 	desc = "The universe's best soup! Yum!"
@@ -2310,6 +2313,7 @@
 	center_of_mass = list("x"=16, "y"=8)
 	nutriment_desc = list("bread" = 2)
 	nutriment_amt = 2
+	cooked = TRUE
 	taste_tag = list(BLAND_FOOD,UMAMI_FOOD)
 
 /obj/item/reagent_containers/food/snacks/jellysandwich/slime
@@ -2617,6 +2621,7 @@
 	nutriment_amt = 2
 	nutriment_desc = list("bread" = 2)
 	preloaded_reagents = list("protein" = 4)
+	cooked = TRUE
 	taste_tag = list(MEAT_FOOD,FLOURY_FOOD)
 
 
@@ -2723,6 +2728,7 @@
 	bitesize = 2
 	center_of_mass = list("x"=16, "y"=12)
 	preloaded_reagents = list("protein" = 5, "nutriment" = 1, "alkysine" = 2)
+	cooked = TRUE
 	taste_tag = list(MEAT_FOOD,SWEET_FOOD)
 
 /obj/item/reagent_containers/food/snacks/sliceable/cheesecake
@@ -2917,6 +2923,7 @@
 	bitesize = 2
 	center_of_mass = list("x"=16, "y"=14)
 	preloaded_reagents = list("nutriment" = 4, "sprinkles" = 2)
+	cooked = TRUE
 	taste_tag = list(SWEET_FOOD)
 
 /obj/item/reagent_containers/food/snacks/sliceable/bread
@@ -2941,6 +2948,7 @@
 	nutriment_amt = 1
 	bitesize = 2
 	center_of_mass = list("x"=16, "y"=4)
+	cooked = FALSE
 	taste_tag = list(BLAND_FOOD,FLOURY_FOOD)
 
 /obj/item/reagent_containers/food/snacks/sliceable/creamcheesebread

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/McRonalds.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/McRonalds.dm
@@ -29,13 +29,12 @@
 			/obj/item/pizzabox/margherita = good_data("PizzeR: autoTomato", list(1, 3), 400)
 		),
 		"Cakes" = list(
-			/obj/item/reagent_containers/food/snacks/sliceable/plaincake = good_data("Vanilla", list(1, 3), 300),
-			/obj/item/reagent_containers/food/snacks/sliceable/chocolatecake = good_data("Chocola", list(1, 3), 300),
-			/obj/item/reagent_containers/food/snacks/sliceable/carrotcake = good_data("carrot cake", list(1, 3), 300),
-			/obj/item/reagent_containers/food/snacks/sliceable/cheesecake = good_data("cheese cake", list(1, 3), 300),
-			/obj/item/reagent_containers/food/snacks/sliceable/orangecake = good_data("orange cake", list(1, 3), 300),
-			/obj/item/reagent_containers/food/snacks/sliceable/limecake = good_data("lime cake", list(1, 3), 300),
-			/obj/item/reagent_containers/food/snacks/sliceable/lemoncake = good_data("lemon cake", list(1, 3), 300)
+			/obj/item/reagent_containers/food/snacks/plaincakeslice = good_data("Vanilla", list(3, 5), 300),
+			/obj/item/reagent_containers/food/snacks/chocolatecakeslice = good_data("Chocola", list(3, 5), 300),
+			/obj/item/reagent_containers/food/snacks/carrotcakeslice = good_data("carrot cake", list(3, 5), 300),
+			/obj/item/reagent_containers/food/snacks/cheesecakeslice = good_data("cheese cake", list(3, 5), 300),
+			/obj/item/reagent_containers/food/snacks/limecakeslice = good_data("lime cake", list(3, 5), 300),
+			/obj/item/reagent_containers/food/snacks/lemoncakeslice = good_data("lemon cake", list(3, 5), 300)
 		),
 		"Misc" = list(
 			/obj/item/reagent_containers/food/snacks/fishandchips = custom_good_name("Fishps"),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes some changes to the McRonalds trade station, to the benefit of kitchen workers primarily.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Thou shalt not ignore the kitchen... as much.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Changed the Happy Meal to include some different items, and a soda.
balance: You may no longer buy whole cakes from the McRonalds trade beacon, they instead come in smaller slices.
balance: A few cooked items such as jelly burgers and sandwiches now count as cooked for gathering insight.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
