### PR TITLE
Let me clean it!

### DIFF
--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -109,7 +109,7 @@
 		return
 
 	else if(src.dirty==100) // The microwave is all dirty so can't be used!
-		if(istype(I, /obj/item/reagent_containers/spray/cleaner)) // If they're trying to clean it then let them
+		if(istype(I, /obj/item/reagent_containers/spray/cleaner) || istype(I, /obj/item/soap) || istype(I, /obj/item/reagent_containers/glass/rag)) // If they're trying to clean it then let them
 			user.visible_message( \
 				SPAN_NOTICE("\The [user] starts to clean the [src]."), \
 				SPAN_NOTICE("You start to clean the [src].") \
@@ -126,6 +126,7 @@
 		else //Otherwise bad luck!!
 			to_chat(user, SPAN_WARNING("It's dirty!"))
 			return 1
+
 	else if(is_type_in_list(I,acceptable_items))
 		if(length(contents) >= max_n_of_items)
 			to_chat(user, SPAN_WARNING("This [src] is full of ingredients, you cannot put more."))
@@ -146,6 +147,7 @@
 				SPAN_NOTICE("\The [user] has added \the [I] to \the [src]."), \
 				SPAN_NOTICE("You add \the [I] to \the [src]."))
 			return
+
 	else if(istype(I,/obj/item/reagent_containers/glass) || \
 	        istype(I,/obj/item/reagent_containers/food/drinks) || \
 	        istype(I,/obj/item/reagent_containers/food/condiment) \
@@ -157,6 +159,7 @@
 				to_chat(user, SPAN_WARNING("Your [I] contains components unsuitable for cookery."))
 				return 1
 		return
+
 	if(QUALITY_BOLT_TURNING in I.tool_qualities)
 		user.visible_message( \
 		"<span class='notice'>\The [user] begins [src.anchored ? "unsecuring" : "securing"] the [src].</span>", \
@@ -168,8 +171,8 @@
 			"<span class='notice'>You [src.anchored ? "unsecure" : "secure"] the [src].</span>"
 			)
 			src.anchored = !src.anchored
-	else
 
+	else
 		to_chat(user, SPAN_WARNING("You have no idea what you can cook with this [I]."))
 	..()
 	src.updateUsrDialog()

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -109,7 +109,7 @@
 		return
 
 	else if(src.dirty==100) // The microwave is all dirty so can't be used!
-		if(istype(I, /obj/item/reagent_containers/spray/cleaner) || istype(I, /obj/item/soap) || istype(I, /obj/item/reagent_containers/glass/rag)) // If they're trying to clean it then let them
+		if(istype(I, /obj/item/soap) || istype(I, /obj/item/reagent_containers/glass/rag)) // If they're trying to clean it then let them
 			user.visible_message( \
 				SPAN_NOTICE("\The [user] starts to clean the [src]."), \
 				SPAN_NOTICE("You start to clean the [src].") \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Microwaves accepts more items for cleaning. That being soap bars, and the rag.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Too often a Club Worker will hit the microwave with a bar of soap only to be frustrated, they will then print a spray bottle, go through the effort of acquiring space cleaner to fill it, and also face that it _also_ doesn't work. There's still many issues and bugged behavior with this object, but this is at least one step.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: You may now clean microwaves if they get dirty with soap bars or a dry/damp rag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
