### PR TITLE
/mob/living GC fix

### DIFF
--- a/code/datums/mob_stats.dm
+++ b/code/datums/mob_stats.dm
@@ -12,6 +12,8 @@
 
 /datum/stat_holder/Destroy()
 	holder = null
+	QDEL_LIST(perks)
+	QDEL_LIST(perk_stats)
 	return ..()
 
 /datum/stat_holder/proc/check_for_shared_perk(ability_bitflag)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -892,8 +892,8 @@ default behaviour is:
 /mob/living/Destroy()
 	if(registered_z)
 		SSmobs.mob_living_by_zlevel[registered_z] -= src	// STOP_PROCESSING() doesn't remove the mob from this list
-	qdel(stats)
-	stats = null
+	QDEL_NULL(stats)
+	QDEL_NULL(static_overlay)
 	return ..()
 
 /mob/living/proc/vomit()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stat holder datums clean up perks, which may be a cause of human hard dels. /mob/living objects clean up their static overlay, which may be the cause of image hard dels (unsure).

## Why It's Good For The Game

Performance

## Changelog
:cl:
fix: Stat holders clean up perks on Destroy()
fix: /mob/living objects clean up their static overlays on Destroy()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
