### PR TITLE
Oldificator GC fix

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
+++ b/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
@@ -91,7 +91,7 @@
 				new /obj/item/stack/material/plasteel/random(src.loc)
 				new /obj/item/stack/cable_coil(src.loc)
 				for(var/i = 1, i <= 2 + rand(0,2), i++)
-					var/list/os_components_reward = pick(list(
+					var/os_components_reward = pick(list(
 						/obj/item/stock_parts/capacitor/one_star,
 						/obj/item/stock_parts/scanning_module/one_star,
 						/obj/item/stock_parts/manipulator/one_star,

--- a/code/modules/mob/living/simple_animal/hostile/doomba.dm
+++ b/code/modules/mob/living/simple_animal/hostile/doomba.dm
@@ -38,7 +38,7 @@
 	s.set_up(3, 1, src)
 	s.start()
 	if(prob(20))
-		var/list/os_components_reward = pick(list(
+		var/os_components_reward = pick(list(
 			/obj/item/stock_parts/capacitor/one_star,
 			/obj/item/stock_parts/scanning_module/one_star,
 			/obj/item/stock_parts/manipulator/one_star,

--- a/code/modules/mob/living/simple_animal/hostile/onestar_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/onestar_drone.dm
@@ -62,7 +62,7 @@
 	s.set_up(3, 1, src)
 	s.start()
 	if(prob(20))
-		var/list/os_components_reward = pick(list(
+		var/os_components_reward = pick(list(
 			/obj/item/stock_parts/capacitor/one_star,
 			/obj/item/stock_parts/scanning_module/one_star,
 			/obj/item/stock_parts/manipulator/one_star,

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -11,6 +11,12 @@
 		var/obj/item/I = parent
 		armor = I.armor.getList()
 
+/datum/component/oldficator/Destroy()
+	old_obj = null
+	LAZYCLEARLIST(armor)
+	LAZYCLEARLIST(all_vars)
+	return ..()
+
 /datum/component/oldficator/proc/make_young()
 	for(var/V in all_vars)
 		if(istype(parent.vars[V], /datum) || ismob(parent.vars[V]) || isHUDobj(parent.vars[V]) || isobj(parent.vars[V]))

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -187,6 +187,8 @@
 /obj/item/reagent_containers/food/snacks/liquidfood/make_old(low_quality_oldification)
 	return
 
+// This was causing roundstart hard dels
+/*
 /obj/item/ammo_magazine/make_old(low_quality_oldification)
 	var/del_count = rand(0, stored_ammo.len)
 	if(low_quality_oldification)
@@ -197,6 +199,7 @@
 		stored_ammo -= removed_item
 		QDEL_NULL(removed_item)
 	..()
+*/
 
 /obj/item/cell/make_old(low_quality_oldification)
 	.=..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stops oldification from removing bullets from a magazine due to the missing bullets being hard deleted. The oldficator (sic) component hold a reference to all variables on its parent object, which is bad. The component should be reworked at a later date.

## Why It's Good For The Game

Performance. This should take care of the bulk of roundstart lag.

## Changelog
:cl:
tweak: Oldified guns, magazines, and bullets clean up their oldification components on Destroy()
tweak: Oldification no longer removes bullets from magazines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
