### PR TITLE
Mannequin runtime fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1271,6 +1271,8 @@ var/list/rank_prefix = list(\
 	update_client_colour(0)
 
 	spawn(0)
+		if(QDELETED(src))	// Needed because mannequins will continue this proc and runtime after being qdel'd
+			return
 		regenerate_icons()
 		if(vessel.total_volume < species.blood_volume)
 			vessel.maximum_volume = species.blood_volume

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -46,6 +46,8 @@
 
 //Resets blood data
 /mob/living/carbon/human/proc/fixblood()
+	if(QDELETED(src))	// Needed because mannequins will continue this proc and runtime after being qdel'd
+		return
 	for(var/datum/reagent/organic/blood/B in vessel.reagent_list)
 		if(B.id == "blood")
 			var/data = list("donor"=src,"viruses"=null,"species"=species.name,"blood_DNA"=dna_trace,"blood_colour"= species.blood_color,"blood_type"=b_type,	\


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds some qdel checks in human code since mannequins will qdel after being created, which causes problems with two instances of spawn() in human New().

## Why It's Good For The Game

Bug fix and should be one fewer item ruining CI checks.

## Changelog
:cl:
fix: Added qdel check in set_species()
fix: Added qdel check in fixblood()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
