### PR TITLE
Mannequin litany bug fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -12,7 +12,6 @@
 	. = ..()
 	STOP_PROCESSING(SSmobs, src)
 	GLOB.human_mob_list -= src
-	disciples -= src	// Should stop mannequins from showing up in litany lists
 	delete_inventory()
 
 /mob/living/carbon/human/dummy/mannequin/fully_replace_character_name(var/oldname, var/newname)

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -12,6 +12,7 @@
 	. = ..()
 	STOP_PROCESSING(SSmobs, src)
 	GLOB.human_mob_list -= src
+	disciples -= src	// Should stop mannequins from showing up in litany lists
 	delete_inventory()
 
 /mob/living/carbon/human/dummy/mannequin/fully_replace_character_name(var/oldname, var/newname)

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -240,6 +240,7 @@
 					if(G.slot && G.slot != slot_accessory_buffer && !(G.slot in loadout_taken_slots) && G.spawn_on_mob(mannequin, gear_list[gear_slot][G.display_name]))
 						loadout_taken_slots.Add(G.slot)
 						update_icon = TRUE
+			disciples -= src	// Should stop mannequins from showing up in litany lists
 
 	if(update_icon)
 		mannequin.update_icons()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This should prevent mannequins from showing up in NT lists.

## Why It's Good For The Game

Unintended stuff bad.

## Changelog
:cl:
fix: Removes mannequins from disciple global list during preview
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
