### PR TITLE
Timer roundstart runtime fix

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -96,7 +96,7 @@
 /obj/item/device/radio/intercom/proc/loop_area_check()
 	var/area/target_area = get_area(src)
 	if(!target_area?.apc)
-		addtimer(CALLBACK(src, .proc/loop_area_check), 30 SECONDS) // We don't proces if there is no APC , no point in doing so is there ?
+		addtimer(CALLBACK(src, .proc/loop_area_check), 30 SECONDS, TIMER_STOPPABLE) // We don't proces if there is no APC , no point in doing so is there ?
 		return FALSE
 	linked_area = target_area
 	RegisterSignal(target_area, COMSIG_AREA_APC_DELETED, .proc/on_apc_removal)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Another CI failure cause and generally annoying runtime. Intercoms were creating a timer with a negative ID.

## Why It's Good For The Game

Bug fix

## Changelog
:cl:
fix: Added a flag to intercom timer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
