### PR TITLE
Removes modded gun offers

### DIFF
--- a/code/modules/trade/datums/trade_stations_presets/1-common/hellcat.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/hellcat.dm
@@ -91,7 +91,7 @@
 		/obj/item/part/armor = offer_data("armor part", 500, 8),
 		/obj/item/part/armor/artwork = offer_data("artistic armor part", 1000, 1),
 		/obj/item/part/gun/artwork = offer_data("artistic gun part", 1000, 1),
-		/obj/item/gun = offer_data_mods("modified gun (3 upgrades)", 3200, 2, OFFER_MODDED_GUN, 3),
+		//obj/item/gun = offer_data_mods("modified gun (3 upgrades)", 3200, 2, OFFER_MODDED_GUN, 3),	// Stops guns from exporting
 		/obj/item/part/gun/frame/ak47 = offer_data("AK frame", 800, 1),
 		/obj/item/part/gun/frame/boltgun  = offer_data("boltgun frame", 800, 1),
 		/obj/item/part/gun/frame/sol = offer_data("Sol frame", 2000, 1),

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/tb_cheapammofactorys.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/tb_cheapammofactorys.dm
@@ -85,7 +85,7 @@
 		)
 	)
 	offer_types = list(
-		/obj/item/gun = offer_data_mods("modified gun (3 upgrades)", 3200, 2, OFFER_MODDED_GUN, 3),
+		//obj/item/gun = offer_data_mods("modified gun (3 upgrades)", 3200, 2, OFFER_MODDED_GUN, 3),	// Stops guns from exporting
 		/obj/item/part/gun/frame/ak47 = offer_data("AK frame", 800, 1),
 		/obj/item/part/gun/frame/boltgun  = offer_data("boltgun frame", 800, 1),
 		/obj/item/part/gun/frame/sol = offer_data("Sol frame", 2000, 1),

--- a/code/modules/trade/datums/trade_stations_presets/3-rare/fs_experimental_factory.dm
+++ b/code/modules/trade/datums/trade_stations_presets/3-rare/fs_experimental_factory.dm
@@ -32,7 +32,7 @@
 		)
 	)
 	offer_types = list(
-		/obj/item/gun = offer_data_mods("modified gun (3 upgrades)", 3200, 2, OFFER_MODDED_GUN, 3),
+		//obj/item/gun = offer_data_mods("modified gun (3 upgrades)", 3200, 2, OFFER_MODDED_GUN, 3),	// Stops guns from exporting
 		/obj/item/part/gun/frame/ak47 = offer_data("AK frame", 800, 1),
 		/obj/item/part/gun/frame/boltgun  = offer_data("boltgun frame", 800, 1),
 		/obj/item/part/gun/frame/sol = offer_data("Sol frame", 2000, 1),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Since trade station special offers stop the requested items from exporting, these modded guns were preventing any guns from exporting.

## Why It's Good For The Game

Smoother trade gameplay

## Changelog
:cl:
fix: Removes modded gun offers from trade stations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
