### PR TITLE
Adds vipr to golden disk

### DIFF
--- a/code/game/objects/items/weapons/design_disks/autolathe_disks.dm
+++ b/code/game/objects/items/weapons/design_disks/autolathe_disks.dm
@@ -20,7 +20,8 @@
 		/datum/design/autolathe/sec/gold = 3,
 		/datum/design/autolathe/gun/colt = 3,
 		/datum/design/autolathe/gun/atreides = 6,
-		/datum/design/autolathe/gun/avasarala = 6
+		/datum/design/autolathe/gun/avasarala = 6,
+		/datum/design/autolathe/gun/ak47_fs = 6
 	)
 
 // ARMOR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds vipr to golden disk it already has a golden sprite, license  cost of 6 used like of similar guns on that disk.

## Why It's Good For The Game

Fixing a mistake I made with an earlier PR

## Changelog
:cl:
fix: vipr is not on gold paint disk
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
