### PR TITLE
One star stalkers no longer make roach gibs

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
+++ b/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
@@ -62,7 +62,7 @@
 	kept_distance = 3
 
 /mob/living/carbon/superior_animal/stalker/death()
-	..()
+	. = ..()
 	visible_message("[src] blows apart!")
 	new /obj/effect/decal/cleanable/blood/gibs/robot(loc)
 	do_sparks(3, TRUE, src)

--- a/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
+++ b/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
@@ -64,10 +64,8 @@
 /mob/living/carbon/superior_animal/stalker/death()
 	..()
 	visible_message("<b>[src]</b> blows apart!")
-	new /obj/effect/decal/cleanable/blood/gibs/robot(src.loc)
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(3, 1, src)
-	s.start()
+	new /obj/effect/decal/cleanable/blood/gibs/robot(loc)
+	do_sparks(3, TRUE, src)
 	qdel(src)
 	return
 

--- a/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
+++ b/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
@@ -63,12 +63,10 @@
 
 /mob/living/carbon/superior_animal/stalker/death()
 	..()
-	visible_message("<b>[src]</b> blows apart!")
+	visible_message("[src] blows apart!")
 	new /obj/effect/decal/cleanable/blood/gibs/robot(loc)
 	do_sparks(3, TRUE, src)
 	qdel(src)
-	return
-
 
 /mob/living/carbon/superior_animal/stalker/dual
 	name = "OneStar Stalker Mk2"

--- a/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
+++ b/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
@@ -61,6 +61,16 @@
 	acceptableTargetDistance = 6
 	kept_distance = 3
 
+/mob/living/carbon/superior_animal/stalker/death()
+	..()
+	visible_message("<b>[src]</b> blows apart!")
+	new /obj/effect/decal/cleanable/blood/gibs/robot(src.loc)
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+	s.set_up(3, 1, src)
+	s.start()
+	qdel(src)
+	return
+
 
 /mob/living/carbon/superior_animal/stalker/dual
 	name = "OneStar Stalker Mk2"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

One star stalkers no longer make roach gibs upon death, they make black robotic gibs instead.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: one star stalkers are no longer roaches
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
