### PR TITLE
Added reagents to Caduceus autoinjectors

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -190,40 +190,40 @@
 
 /obj/item/reagent_containers/hypospray/autoinjector/bloodclot
 	name = "autoinjector (blood clotting, type 1)"
-	preloaded_reagents = list("thrombopoietin")
+	preloaded_reagents = list("thrombopoietin" = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/bloodclot_alt
 	name = "autoinjector (blood clotting, type 2)"
-	preloaded_reagents = list("thromboxane")
+	preloaded_reagents = list("thromboxane" = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/bloodrestore
 	name = "autoinjector (blood restoration, type 1)"
-	preloaded_reagents = list("aldosterone")
+	preloaded_reagents = list("aldosterone" = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/bloodrestore_alt
 	name = "autoinjector (blood restoration, type 2)"
-	preloaded_reagents = list("erythropoietin")
+	preloaded_reagents = list("erythropoietin" = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/painkiller
 	name = "autoinjector (painkiller, type 1)"
-	preloaded_reagents = list("enkephalin")
+	preloaded_reagents = list("enkephalin" = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/painkiller_alt
 	name = "autoinjector (painkiller, type 2)"
-	preloaded_reagents = list("endomorphin")
+	preloaded_reagents = list("endomorphin" = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/speedboost
 	name = "autoinjector (agility, type 1)"
-	preloaded_reagents = list("osteocalcin")
+	preloaded_reagents = list("osteocalcin" = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/speedboost_alt
 	name = "autoinjector (agility, type 2)"
-	preloaded_reagents = list("noradrenaline")
+	preloaded_reagents = list("noradrenaline" = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/oxygenation
 	name = "autoinjector (oxygenation, type 1)"
-	preloaded_reagents = list("dexterone")
+	preloaded_reagents = list("dexterone" = 5)
 
 /obj/item/reagent_containers/hypospray/autoinjector/oxygenation_alt
 	name = "autoinjector (oxygenation, type 2)"
-	preloaded_reagents = list("vasotriene")
+	preloaded_reagents = list("vasotriene" = 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Autoinjectors sold in hidden Caduceus inventory are no longer empty.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

There's a point to buying Caduceus autoinjectors.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: added reagent values to bloodclot, bloodrestore, painkiller, speedboost and oxygenation autoinjectors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
