### PR TITLE
Added head and torso prosthesis to tech and fabricator

### DIFF
--- a/code/modules/research/designs/prosthesis_implants.dm
+++ b/code/modules/research/designs/prosthesis_implants.dm
@@ -20,7 +20,7 @@
 	build_path = /obj/item/organ/external/robotic/moebius/groin
 
 /datum/design/research/item/mechfab/prosthesis/torso
-	build_path = /obj/item/organ/external/robotic/moebius/chest
+	build_path = /obj/item/organ/external/robotic/moebius/torso
 
 /datum/design/research/item/mechfab/prosthesis/head
 	build_path = /obj/item/organ/external/robotic/moebius/head
@@ -45,7 +45,7 @@
 	build_path = /obj/item/organ/external/robotic/moebius/reinforced/groin
 
 /datum/design/research/item/mechfab/prosthesis_moebius/torso
-	build_path = /obj/item/organ/external/robotic/moebius/reinforced/chest
+	build_path = /obj/item/organ/external/robotic/moebius/reinforced/torso
 
 /datum/design/research/item/mechfab/prosthesis_moebius/head
 	build_path = /obj/item/organ/external/robotic/moebius/reinforced/head

--- a/code/modules/research/designs/prosthesis_implants.dm
+++ b/code/modules/research/designs/prosthesis_implants.dm
@@ -5,19 +5,25 @@
 	starts_unlocked = TRUE
 
 /datum/design/research/item/mechfab/prosthesis/r_arm
-	build_path = /obj/item/organ/external/robotic/r_arm
+	build_path = /obj/item/organ/external/robotic/moebius/r_arm
 
 /datum/design/research/item/mechfab/prosthesis/l_arm
-	build_path = /obj/item/organ/external/robotic/l_arm
+	build_path = /obj/item/organ/external/robotic/moebius/l_arm
 
 /datum/design/research/item/mechfab/prosthesis/r_leg
-	build_path = /obj/item/organ/external/robotic/r_leg
+	build_path = /obj/item/organ/external/robotic/moebius/r_leg
 
 /datum/design/research/item/mechfab/prosthesis/l_leg
-	build_path = /obj/item/organ/external/robotic/l_leg
+	build_path = /obj/item/organ/external/robotic/moebius/l_leg
 
 /datum/design/research/item/mechfab/prosthesis/groin
-	build_path = /obj/item/organ/external/robotic/groin
+	build_path = /obj/item/organ/external/robotic/moebius/groin
+
+/datum/design/research/item/mechfab/prosthesis/torso
+	build_path = /obj/item/organ/external/robotic/moebius/chest
+
+/datum/design/research/item/mechfab/prosthesis/head
+	build_path = /obj/item/organ/external/robotic/moebius/head
 
 //Upgraded prosthesis ========================
 /datum/design/research/item/mechfab/prosthesis_moebius
@@ -37,6 +43,9 @@
 
 /datum/design/research/item/mechfab/prosthesis_moebius/groin
 	build_path = /obj/item/organ/external/robotic/moebius/reinforced/groin
+
+/datum/design/research/item/mechfab/prosthesis_moebius/torso
+	build_path = /obj/item/organ/external/robotic/moebius/reinforced/chest
 
 /datum/design/research/item/mechfab/prosthesis_moebius/head
 	build_path = /obj/item/organ/external/robotic/moebius/reinforced/head

--- a/code/modules/research/nodes/biotech.dm
+++ b/code/modules/research/nodes/biotech.dm
@@ -288,7 +288,9 @@
 							/datum/design/research/item/mechfab/prosthesis_moebius/l_arm,
 							/datum/design/research/item/mechfab/prosthesis_moebius/r_leg,
 							/datum/design/research/item/mechfab/prosthesis_moebius/l_leg,
-							/datum/design/research/item/mechfab/prosthesis_moebius/groin
+							/datum/design/research/item/mechfab/prosthesis_moebius/groin,
+							/datum/design/research/item/mechfab/prosthesis_moebius/torso,
+							/datum/design/research/item/mechfab/prosthesis_moebius/head
 							)
 
 /datum/technology/mind_biotech


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Added regular and advanced head and torso prosthesis to known designs. Changed prosthesis to moebius type instead of unbranded for aesthetics.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

You can now make any body part as a prosthesis. It also makes sense that moebius makes their own branded prosthesis.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: added torso and head to basic biotech
add: added reinforced torso to augmentations biotech
change: changed basic prosthesis type to moebius instead of unbranded
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
