### PR TITLE
fix nerve strike not working(how)

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -693,7 +693,7 @@ var/list/rank_prefix = list(\
 			sleep(150)	//15 seconds until second warning
 			to_chat(src, SPAN_WARNING("You feel like you are about to throw up!"))
 			sleep(100)	//and you have 10 more for mad dash to the bucket
-		Stun(2)
+		Stun(3)
 
 		src.visible_message(SPAN_WARNING("[src] throws up!"),SPAN_WARNING("You throw up!"))
 		playsound(loc, 'sound/effects/splat.ogg', 50, 1)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -693,7 +693,7 @@ var/list/rank_prefix = list(\
 			sleep(150)	//15 seconds until second warning
 			to_chat(src, SPAN_WARNING("You feel like you are about to throw up!"))
 			sleep(100)	//and you have 10 more for mad dash to the bucket
-		Stun(3)
+		Stun(2)
 
 		src.visible_message(SPAN_WARNING("[src] throws up!"),SPAN_WARNING("You throw up!"))
 		playsound(loc, 'sound/effects/splat.ogg', 50, 1)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -127,7 +127,7 @@
 			continue
 
 		if(E.mob_can_unequip(src))
-			if(E.is_broken() || E.is_nerve_struck() || E.limb_efficiency <= 50)
+			if(E.is_broken() || E.limb_efficiency <= 50)
 				
 				drop_from_inventory(E)
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -345,11 +345,11 @@
 	. += tally
 
 /obj/item/organ/external/proc/is_nerve_struck()
-	if(nerve_struck > 0)
-		return 1
+	if(nerve_struck == 2)
+		return TRUE
 	if(parent)
 		return parent.is_nerve_struck()
-	return 0
+	return FALSE
 
 /obj/item/organ/external/proc/nerve_strike_add(var/primary)
 	if(nerve_struck != -1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title
also made it not drop items so that it wouldn't be instant disarm, being unable to use your hand is already tuff

## Why It's Good For The Game
fix

## Changelog
:cl: Kegdo
fix: nerve strike not working
balance: nerve strike doesn't make you drop items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
