### PR TITLE
Rewrites embed code to make more sense

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -78,7 +78,7 @@
 
 	//Damage vars
 	var/force = 0	//How much damage the weapon deals
-	var/embed_mult = 0.5 //Multiplier for the chance of embedding in mobs. Set to zero to completely disable embedding
+	var/embed_mult = 1 //Multiplier for the chance of embedding in mobs. Set to zero to completely disable embedding
 	var/structure_damage_factor = STRUCTURE_DAMAGE_NORMAL	//Multiplier applied to the damage when attacking structures and machinery
 	//Does not affect damage dealt to mobs
 	var/style = STYLE_NONE // how much using this item increases your style

--- a/code/game/objects/items/stacks/knife.dm
+++ b/code/game/objects/items/stacks/knife.dm
@@ -66,7 +66,7 @@
 	flags = CONDUCT
 	sharp = TRUE
 	edge = TRUE
-	embed_mult = 40 //MADE for embedding
+	embed_mult = 80 //MADE for embedding
 	tool_qualities = list(QUALITY_WIRE_CUTTING = 5, QUALITY_CUTTING = 5)
 	max_upgrades = 0
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")

--- a/code/game/objects/items/weapons/material/thrown.dm
+++ b/code/game/objects/items/weapons/material/thrown.dm
@@ -8,7 +8,7 @@
 	throw_range = 15
 	sharp = TRUE
 	edge = TRUE
-	embed_mult = 10 //We want these to embed
+	embed_mult = 20 //We want these to embed
 
 /obj/item/material/star/New()
 	..()

--- a/code/game/objects/items/weapons/material/thrown.dm
+++ b/code/game/objects/items/weapons/material/thrown.dm
@@ -8,7 +8,7 @@
 	throw_range = 15
 	sharp = TRUE
 	edge = TRUE
-	embed_mult = 5 //We want these to embed
+	embed_mult = 10 //We want these to embed
 
 /obj/item/material/star/New()
 	..()

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -66,7 +66,7 @@
 /obj/item/tool/knife/dagger/nt/equipped(mob/living/H)
 	..()
 	if(is_held() && is_neotheology_disciple(H))
-		embed_mult = 0.05
+		embed_mult = 0.2
 	else
 		embed_mult = initial(embed_mult)
 
@@ -168,7 +168,7 @@
 /obj/item/tool/sword/nt/spear/equipped(mob/living/W)
 	..()
 	if(is_held() && is_neotheology_disciple(W))
-		embed_mult = 0.05
+		embed_mult = 0.2
 	else
 		embed_mult = initial(embed_mult)
 
@@ -338,7 +338,7 @@
 /obj/item/stack/thrown/nt/equipped(mob/living/M)
 	..()
 	if(is_held() && is_neotheology_disciple(M))
-		embed_mult = 0.05
+		embed_mult = 0.2
 	else
 		embed_mult = initial(embed_mult)
 

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -17,7 +17,7 @@
 /obj/item/tool/sword/nt/equipped(mob/living/M)
 	..()
 	if(is_held() && is_neotheology_disciple(M))
-		embed_mult = 0.1
+		embed_mult = 0.05
 	else
 		embed_mult = initial(embed_mult)
 
@@ -66,7 +66,7 @@
 /obj/item/tool/knife/dagger/nt/equipped(mob/living/H)
 	..()
 	if(is_held() && is_neotheology_disciple(H))
-		embed_mult = 0.1
+		embed_mult = 0.05
 	else
 		embed_mult = initial(embed_mult)
 
@@ -168,12 +168,12 @@
 /obj/item/tool/sword/nt/spear/equipped(mob/living/W)
 	..()
 	if(is_held() && is_neotheology_disciple(W))
-		embed_mult = 0.1
+		embed_mult = 0.05
 	else
 		embed_mult = initial(embed_mult)
 
 /obj/item/tool/sword/nt/spear/dropped(mob/living/W)
-	embed_mult = 300
+	embed_mult = 600
 	..()
 
 /obj/item/tool/sword/nt/spear/throw_impact(atom/hit_atom, speed)
@@ -338,7 +338,7 @@
 /obj/item/stack/thrown/nt/equipped(mob/living/M)
 	..()
 	if(is_held() && is_neotheology_disciple(M))
-		embed_mult = 0.1
+		embed_mult = 0.05
 	else
 		embed_mult = initial(embed_mult)
 
@@ -364,5 +364,5 @@
 	style_damage = 30
 
 /obj/item/stack/thrown/nt/verutum/launchAt()
-	embed_mult = 300
+	embed_mult = 600
 	..()

--- a/code/game/objects/items/weapons/sword_of_truth.dm
+++ b/code/game/objects/items/weapons/sword_of_truth.dm
@@ -102,7 +102,7 @@
 /obj/item/tool/sword/nt_sword/equipped(mob/living/M)
 	. = ..()
 	if(is_held() && is_neotheology_disciple(M))
-		embed_mult = 0.01
+		embed_mult = 0.2
 	else
 		embed_mult = initial(embed_mult)
 

--- a/code/game/objects/items/weapons/sword_of_truth.dm
+++ b/code/game/objects/items/weapons/sword_of_truth.dm
@@ -102,7 +102,7 @@
 /obj/item/tool/sword/nt_sword/equipped(mob/living/M)
 	. = ..()
 	if(is_held() && is_neotheology_disciple(M))
-		embed_mult = 0.1
+		embed_mult = 0.01
 	else
 		embed_mult = initial(embed_mult)
 

--- a/code/game/objects/items/weapons/tools/knives.dm
+++ b/code/game/objects/items/weapons/tools/knives.dm
@@ -95,7 +95,7 @@
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 2)
 	force = WEAPON_FORCE_PAINFUL
 	armor_divisor = ARMOR_PEN_MODERATE
-	embed_mult = 0.15
+	embed_mult = 0.6
 	max_upgrades = 3
 
 /obj/item/tool/knife/tacknife/New()
@@ -128,7 +128,7 @@
 	item_state = "fancydagger"
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 2, MATERIAL_GOLD = 1, MATERIAL_SILVER = 1)
 	armor_divisor = ARMOR_PEN_MASSIVE
-	embed_mult = 0.15
+	embed_mult = 0.6
 	max_upgrades = 4
 	spawn_blacklisted = TRUE
 

--- a/code/game/objects/items/weapons/tools/knives.dm
+++ b/code/game/objects/items/weapons/tools/knives.dm
@@ -44,7 +44,7 @@
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_PLASTIC = 2)
 	force = WEAPON_FORCE_DANGEROUS
 	armor_divisor = ARMOR_PEN_HALF //Should be countered be embedding
-	embed_mult = 1.5 //This is designed for embedding
+	embed_mult = 3 //This is designed for embedding
 	rarity_value = 5
 
 /obj/item/tool/knife/ritual
@@ -75,14 +75,14 @@
 	item_state = "knife"
 	matter = list(MATERIAL_PLASTEEL = 4, MATERIAL_PLASTIC = 1)
 	force = WEAPON_FORCE_PAINFUL
-	embed_mult = 3
+	embed_mult = 6
 	max_upgrades = 3
 	spawn_blacklisted = TRUE
 
 /obj/item/tool/knife/neotritual/equipped(mob/living/H)
 	. = ..()
 	if(is_held() && is_neotheology_disciple(H))
-		embed_mult = 0.1
+		embed_mult = 0.05
 	else
 		embed_mult = initial(embed_mult)
 
@@ -95,7 +95,7 @@
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 2)
 	force = WEAPON_FORCE_PAINFUL
 	armor_divisor = ARMOR_PEN_MODERATE
-	embed_mult = 0.3
+	embed_mult = 0.15
 	max_upgrades = 3
 
 /obj/item/tool/knife/tacknife/New()
@@ -128,7 +128,7 @@
 	item_state = "fancydagger"
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 2, MATERIAL_GOLD = 1, MATERIAL_SILVER = 1)
 	armor_divisor = ARMOR_PEN_MASSIVE
-	embed_mult = 0.3
+	embed_mult = 0.15
 	max_upgrades = 4
 	spawn_blacklisted = TRUE
 
@@ -139,7 +139,7 @@
 	item_state = "bluespace_dagger"
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 10, MATERIAL_GOLD = 5, MATERIAL_PLASMA = 20)
 	force = WEAPON_FORCE_NORMAL+1
-	embed_mult = 25 //You WANT it to embed
+	embed_mult = 50 //You WANT it to embed
 	suitable_cell = /obj/item/cell/small
 	toggleable = TRUE
 	use_power_cost = 0.4

--- a/code/game/objects/items/weapons/tools/knives.dm
+++ b/code/game/objects/items/weapons/tools/knives.dm
@@ -44,7 +44,7 @@
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_PLASTIC = 2)
 	force = WEAPON_FORCE_DANGEROUS
 	armor_divisor = ARMOR_PEN_HALF //Should be countered be embedding
-	embed_mult = 3 //This is designed for embedding
+	embed_mult = 1.5 //This is designed for embedding
 	rarity_value = 5
 
 /obj/item/tool/knife/ritual

--- a/code/game/objects/items/weapons/tools/pickaxe.dm
+++ b/code/game/objects/items/weapons/tools/pickaxe.dm
@@ -20,7 +20,7 @@
 	sharp = TRUE
 	structure_damage_factor = STRUCTURE_DAMAGE_BORING //Drills and picks are made for getting through hard materials
 	//They are the best anti-structure melee weapons
-	embed_mult = 1.2 //Digs deep
+	embed_mult = 2.4 //Digs deep
 	mode = EXCAVATE //Mode should be whatever is the starting tool and off quality.
 	rarity_value = 24
 

--- a/code/game/objects/items/weapons/tools/pickaxe.dm
+++ b/code/game/objects/items/weapons/tools/pickaxe.dm
@@ -20,7 +20,7 @@
 	sharp = TRUE
 	structure_damage_factor = STRUCTURE_DAMAGE_BORING //Drills and picks are made for getting through hard materials
 	//They are the best anti-structure melee weapons
-	embed_mult = 1.6 //Digs deep
+	embed_mult = 1.2 //Digs deep
 	mode = EXCAVATE //Mode should be whatever is the starting tool and off quality.
 	rarity_value = 24
 

--- a/code/game/objects/items/weapons/tools/pickaxe.dm
+++ b/code/game/objects/items/weapons/tools/pickaxe.dm
@@ -20,7 +20,7 @@
 	sharp = TRUE
 	structure_damage_factor = STRUCTURE_DAMAGE_BORING //Drills and picks are made for getting through hard materials
 	//They are the best anti-structure melee weapons
-	embed_mult = 2.4 //Digs deep
+	embed_mult = 1.6 //Digs deep
 	mode = EXCAVATE //Mode should be whatever is the starting tool and off quality.
 	rarity_value = 24
 

--- a/code/game/objects/items/weapons/tools/saws.dm
+++ b/code/game/objects/items/weapons/tools/saws.dm
@@ -13,7 +13,7 @@
 	sharp = TRUE
 	edge = TRUE
 	tool_qualities = list(QUALITY_SAWING = 30, QUALITY_CUTTING = 20, QUALITY_WIRE_CUTTING = 20)
-	embed_mult = 1.5 //Serrated blades catch on bone more easily
+	embed_mult = 1.3 //Serrated blades catch on bone more easily
 
 /obj/item/tool/saw/improvised //tier 1
 	name = "choppa"

--- a/code/game/objects/items/weapons/tools/saws.dm
+++ b/code/game/objects/items/weapons/tools/saws.dm
@@ -13,7 +13,7 @@
 	sharp = TRUE
 	edge = TRUE
 	tool_qualities = list(QUALITY_SAWING = 30, QUALITY_CUTTING = 20, QUALITY_WIRE_CUTTING = 20)
-	embed_mult = 2 //Serrated blades catch on bone more easily
+	embed_mult = 1.5 //Serrated blades catch on bone more easily
 
 /obj/item/tool/saw/improvised //tier 1
 	name = "choppa"

--- a/code/game/objects/items/weapons/tools/saws.dm
+++ b/code/game/objects/items/weapons/tools/saws.dm
@@ -13,7 +13,7 @@
 	sharp = TRUE
 	edge = TRUE
 	tool_qualities = list(QUALITY_SAWING = 30, QUALITY_CUTTING = 20, QUALITY_WIRE_CUTTING = 20)
-	embed_mult = 1 //Serrated blades catch on bone more easily
+	embed_mult = 2 //Serrated blades catch on bone more easily
 
 /obj/item/tool/saw/improvised //tier 1
 	name = "choppa"

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -70,7 +70,7 @@
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
-	embed_mult = 2 //Axes cut deep, and their hooked shape catches on things
+	embed_mult = 1.5 //Axes cut deep, and their hooked shape catches on things
 	rarity_value = 48
 
 /obj/item/tool/fireaxe/afterattack(atom/A as mob|obj|turf|area, mob/user, proximity)

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -70,6 +70,7 @@
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
+	embed_mult = 1.2 //Axes cut deep, and their hooked shape catches on things
 	rarity_value = 48
 
 /obj/item/tool/fireaxe/afterattack(atom/A as mob|obj|turf|area, mob/user, proximity)

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -70,7 +70,6 @@
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
-	embed_mult = 1.5 //Axes cut deep, and their hooked shape catches on things
 	rarity_value = 48
 
 /obj/item/tool/fireaxe/afterattack(atom/A as mob|obj|turf|area, mob/user, proximity)

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -70,7 +70,7 @@
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
-	embed_mult = 1 //Axes cut deep, and their hooked shape catches on things
+	embed_mult = 2 //Axes cut deep, and their hooked shape catches on things
 	rarity_value = 48
 
 /obj/item/tool/fireaxe/afterattack(atom/A as mob|obj|turf|area, mob/user, proximity)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -43,8 +43,8 @@ true, and the mob is not yet deleted, so we need to check that as well*/
 
 		//The user's robustness stat adds to the threshold, allowing you to use more powerful weapons without embedding risk
 		embed_threshold += user.stats.getStat(STAT_ROB)
-		var/embed_chance = (damage - embed_threshold)*I.embed_mult
-		if (embed_chance > 0 && prob(embed_chance))
+		var/embed_chance = (damage*I.embed_mult - embed_threshold)/2
+		if(embed_chance > 0 && prob(embed_chance))
 			src.embed(I, hit_zone)
 
 	return TRUE

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -44,7 +44,6 @@ true, and the mob is not yet deleted, so we need to check that as well*/
 		//The user's robustness stat adds to the threshold, allowing you to use more powerful weapons without embedding risk
 		embed_threshold += user.stats.getStat(STAT_ROB)
 		var/embed_chance = (damage*I.embed_mult - embed_threshold)/2
-		to_chat(world, "[embed_chance]")
 		if(embed_chance > 0 && prob(embed_chance))
 			src.embed(I, hit_zone)
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -44,6 +44,7 @@ true, and the mob is not yet deleted, so we need to check that as well*/
 		//The user's robustness stat adds to the threshold, allowing you to use more powerful weapons without embedding risk
 		embed_threshold += user.stats.getStat(STAT_ROB)
 		var/embed_chance = (damage*I.embed_mult - embed_threshold)/2
+		to_chat(world, "[embed_chance]")
 		if(embed_chance > 0 && prob(embed_chance))
 			src.embed(I, hit_zone)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Items have an embed multiplier that makes it more/less likely than normal for that item to embed. Unfortunately, the way this was calculated caused to the problem that if a weapon used to have a negative base chance to embed (without the embed multiplier calculated in), then even having an insanely high embed multiplier would never cause the weapon to embed. This is now fixed, and for the majority of weapons, everything stays the same. Only weapons that had a non-standard embed mult now behave differently. 
Those weapons that are designed to embed such as throwing knives, the ritual dagger or the displacement dagger are now much more likely to embed. 
Weapons that had a higher embed multiplier before (saws including chainsaws, pickaxes including drills and jackhammers , the meat hook and the fire axe)  should have roughly the same chance of embedding now than they did before, but leaving the chances completely the same is impossible, as the embed chance also varies with damage and robustness.

Also, of the changes seem weird at first, keep in mind that the default embed mult has been changed from being 0.5 to being 1.

## Why It's Good For The Game

Items that were intended to embed by having high embed multipliers often could not. The embed chance calculation now works more intuitively.

## Changelog
:cl:
balance: changes to weapon embedding, so weapons that were designed to embed, but could not due to a bad formula now have a much higher chance of embedding.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
