### PR TITLE
Makes melee less cringe

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -286,6 +286,8 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		power *= H.damage_multiplier
+		if(H.pulling_attacks)
+			power /= 2
 //	if(HULK in user.mutations)
 //		power *= 2
 	target.hit_with_weapon(src, user, power, hit_zone)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -286,7 +286,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		power *= H.damage_multiplier
-		if(H.pulling_attacks)
+		if(H.holding_back)
 			power /= 2
 //	if(HULK in user.mutations)
 //		power *= 2

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1572,13 +1572,13 @@ var/list/rank_prefix = list(\
 	return ..()
 
 /mob/living/carbon/human/verb/pull_punches()
-	set name = "Pull Attacks"
+	set name = "Hold your attacks back"
 	set desc = "Try not to hurt them."
 	set category = "IC"
 
 	if(stat) return
-	pulling_attacks = !pulling_attacks
-	to_chat(src, "<span class='notice'>You are now [pulling_attacks ? "pulling your attacks" : "not pulling your attacks"].</span>")
+	holding_back = !holding_back
+	to_chat(src, "<span class='notice'>You are now [holding_back ? "holding back your attacks" : "not holding back your attacks"].</span>")
 	return
 
 /mob/living/carbon/human/verb/toggle_dodging()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1578,7 +1578,7 @@ var/list/rank_prefix = list(\
 
 	if(stat) return
 	holding_back = !holding_back
-	to_chat(src, "<span class='notice'>You are now [holding_back ? "holding back your attacks" : "not holding back your attacks"].</span>")
+	to_chat(src, SPAN_NOTICE("You are now [holding_back ? "holding back your attacks" : "not holding back your attacks"]."))
 	return
 
 /mob/living/carbon/human/verb/toggle_dodging()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1572,13 +1572,13 @@ var/list/rank_prefix = list(\
 	return ..()
 
 /mob/living/carbon/human/verb/pull_punches()
-	set name = "Pull Punches"
+	set name = "Pull Attacks"
 	set desc = "Try not to hurt them."
 	set category = "IC"
 
 	if(stat) return
-	pulling_punches = !pulling_punches
-	to_chat(src, "<span class='notice'>You are now [pulling_punches ? "pulling your punches" : "not pulling your punches"].</span>")
+	pulling_attacks = !pulling_attacks
+	to_chat(src, "<span class='notice'>You are now [pulling_attacks ? "pulling your attacks" : "not pulling your attacks"].</span>")
 	return
 
 /mob/living/carbon/human/verb/toggle_dodging()

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/human/proc/get_unarmed_attack(var/mob/living/carbon/human/target, var/hit_zone)
 	for(var/datum/unarmed_attack/u_attack in species.unarmed_attacks)
 		if(u_attack.is_usable(src, target, hit_zone))
-			if(pulling_attacks)
+			if(holding_back)
 				var/datum/unarmed_attack/soft_variant = u_attack.get_sparring_variant()
 				if(soft_variant)
 					return soft_variant

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/human/proc/get_unarmed_attack(var/mob/living/carbon/human/target, var/hit_zone)
 	for(var/datum/unarmed_attack/u_attack in species.unarmed_attacks)
 		if(u_attack.is_usable(src, target, hit_zone))
-			if(pulling_punches)
+			if(pulling_attacks)
 				var/datum/unarmed_attack/soft_variant = u_attack.get_sparring_variant()
 				if(soft_variant)
 					return soft_variant

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -326,7 +326,6 @@ meteor_act
 
 	else if(!..())
 		return FALSE
-		
 	if(effective_force > 10 || effective_force >= 5 && prob(33))
 		forcesay(hit_appends)	//forcesay checks stat already
 		//Apply blood

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -305,7 +305,7 @@ meteor_act
 	//If not blocked, handle broad strike attacks
 	if(((I.sharp && I.edge && user.a_intent == I_DISARM) || I.forced_broad_strike) && (!istype(I, /obj/item/tool/sword/nt/spear) || !istype(I, /obj/item/tele_spear) || !istype(I, /obj/item/tool/spear)))
 		var/list/L[] = BP_ALL_LIMBS
-		effective_force /= 3
+		effective_force /= 2.7
 		L.Remove(hit_zone)
 		for(var/i in 1 to 2)
 			var/temp_zone = pick(L)
@@ -319,7 +319,6 @@ meteor_act
 
 	// Handle striking to cripple.
 	if(user.a_intent == I_HELP)
-		effective_force /= 2 //half the effective force
 		if(!..(I, user, effective_force, hit_zone))
 			return FALSE
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -305,7 +305,7 @@ meteor_act
 	//If not blocked, handle broad strike attacks
 	if(((I.sharp && I.edge && user.a_intent == I_DISARM) || I.forced_broad_strike) && (!istype(I, /obj/item/tool/sword/nt/spear) || !istype(I, /obj/item/tele_spear) || !istype(I, /obj/item/tool/spear)))
 		var/list/L[] = BP_ALL_LIMBS
-		effective_force /= 2.7
+		effective_force /= 3
 		L.Remove(hit_zone)
 		for(var/i in 1 to 2)
 			var/temp_zone = pick(L)
@@ -323,9 +323,10 @@ meteor_act
 			return FALSE
 
 		attack_joint(affecting, I) //but can dislocate(strike nerve) joints
+
 	else if(!..())
 		return FALSE
-
+		
 	if(effective_force > 10 || effective_force >= 5 && prob(33))
 		forcesay(hit_appends)	//forcesay checks stat already
 		//Apply blood

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -69,7 +69,7 @@
 	var/hand_blood_color
 
 	var/gunshot_residue
-	var/pulling_attacks // Are you trying not to hurt your opponent?
+	var/holding_back // Are you trying not to hurt your opponent?
 	var/blocking = FALSE //ready to block melee attacks?
 	var/dodging = TRUE // are you dodging those shots?
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -69,7 +69,7 @@
 	var/hand_blood_color
 
 	var/gunshot_residue
-	var/pulling_punches // Are you trying not to hurt your opponent?
+	var/pulling_attacks // Are you trying not to hurt your opponent?
 	var/blocking = FALSE //ready to block melee attacks?
 	var/dodging = TRUE // are you dodging those shots?
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request



Removes help intent halving the damage you deal, because that's just another noob trap. Instead, pulling punches will now also halve the melee damage you deal with weapons.


## Why It's Good For The Game

cringe removal.

## Changelog
:cl:
balance: attacking with help intent no longer halves your melee damage, but pulling attacks will.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
