### PR TITLE
fix melee attacks proccing when you click on atoms on yourself

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -165,7 +165,7 @@
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
 				var/resolved = (SEND_SIGNAL(W, COMSIG_IATTACK, A, src, params)) || (SEND_SIGNAL(A, COMSIG_ATTACKBY, W, src, params))
 				if(!resolved && A && W)
-					if(W.double_tact(src))
+					if(W.double_tact(src, A))
 						resolved = W.resolve_attackby(A, src, params)
 					if(!resolved)
 						W.afterattack(A, src, 1, params) // 1: clicking something Adjacent
@@ -176,7 +176,7 @@
 			return
 		else // non-adjacent click
 			if(W)
-				if(W.double_tact(src))
+				if(W.double_tact(src, A))
 					W.afterattack(A, src, 0, params) // 0: not Adjacent
 			else
 				setClickCooldown(DEFAULT_ATTACK_COOLDOWN) // no ranged spam

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -46,7 +46,9 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	return A.attackby(src, user, params)
 
 //Returns TRUE if attack is to be carried out, FALSE otherwise.
-/obj/item/proc/double_tact(mob/user)
+/obj/item/proc/double_tact(mob/user, atom/atom_target)//putting stuff in your backpack, or something else on your person?
+	if(atom_target.loc == user)
+		return TRUE
 	if(w_class >= ITEM_SIZE_BULKY && !abstract && !istype(src, /obj/item/gun))//grabs have colossal w_class. You can't raise something that does not exist.
 		if(!(ready))						//guns have the point blank privilege
 			user.visible_message(SPAN_DANGER("[user] raises \his [src]!"))

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -40,15 +40,15 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		var/mob/living/carbon/human/H = user
 		if(H.blocking)
 			H.stop_blocking()
-	if(ishuman(user) && !(user == A) && !(user.loc == A) && (w_class >=  ITEM_SIZE_NORMAL) && wielded && user.a_intent == I_HURT && !istype(src, /obj/item/gun) && !istype(A, /obj/structure) && !istype(A, /turf/simulated/wall))
+	if(ishuman(user) && !(user == A) && !(user.loc == A) && (w_class >=  ITEM_SIZE_NORMAL) && wielded && user.a_intent == I_HURT && !istype(src, /obj/item/gun) && !istype(A, /obj/structure) && !istype(A, /turf/simulated/wall) && A.loc != user)
 		swing_attack(src, user, params)
 		return 1 //Swinging calls its own attacks
 	return A.attackby(src, user, params)
 
 //Returns TRUE if attack is to be carried out, FALSE otherwise.
-/obj/item/proc/double_tact(mob/user, atom/atom_target)//putting stuff in your backpack, or something else on your person?
-	if(atom_target.loc == user)
-		return TRUE
+/obj/item/proc/double_tact(mob/user, atom/atom_target)
+	if(atom_target.loc == user)//putting stuff in your backpack, or something else on your person?
+		return TRUE //regular bags won't even be able to hold items this big, but who knows
 	if(w_class >= ITEM_SIZE_BULKY && !abstract && !istype(src, /obj/item/gun))//grabs have colossal w_class. You can't raise something that does not exist.
 		if(!(ready))						//guns have the point blank privilege
 			user.visible_message(SPAN_DANGER("[user] raises \his [src]!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title, fixes the issue of swinging when you click on your equipped bag when you are wielding the item on harm intent.
also fixes a possible issue of clicking on an atom on yourself requiring double tact

## Why It's Good For The Game

fixes

## Changelog
:cl: Kegdo
fix: fix melee attacks proccing when you click on atoms on yourself
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
