### PR TITLE
Implements winded intervention attack

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -397,7 +397,7 @@ meteor_act
 							break_all_grabs(M) //See about breaking grips or pulls
 							playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 							return TRUE
-						if(item_in_active_hand.wielded && !recoil >= 80)
+						if(item_in_active_hand.wielded && recoil < 80)
 							playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 							return TRUE
 						unEquip(item_in_active_hand)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -391,17 +391,16 @@ meteor_act
 					confused = max(confused, 2)
 					external_recoil(40)
 					var/obj/item/item_in_active_hand = get_active_hand()
-					var/mob/living/carbon/M = user
 					if(recoil >= 60 && item_in_active_hand)
 						if(istype(item_in_active_hand, /obj/item/grab))
-							break_all_grabs(M) //See about breaking grips or pulls
+							break_all_grabs(user) //See about breaking grips or pulls
 							playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 							return TRUE
 						if(item_in_active_hand.wielded && recoil < 80)
 							playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 							return TRUE
 						unEquip(item_in_active_hand)
-						visible_message(SPAN_DANGER("[M] has disarmed [src]!"))
+						visible_message(SPAN_DANGER("[user] has disarmed [src]!"))
 						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 						return TRUE
 	return TRUE

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -390,17 +390,17 @@ meteor_act
 					visible_message(SPAN_WARNING("[src] is winded!"), SPAN_DANGER("You feel disoriented!"))
 					confused = max(confused, 2)
 					external_recoil(40)
-					var/obj/item/I = get_active_hand()
+					var/obj/item/item_in_active_hand = get_active_hand()
 					var/mob/living/carbon/M = user
-					if(recoil >= 60 && I)
-						if(istype(I, /obj/item/grab))
+					if(recoil >= 60 && item_in_active_hand)
+						if(istype(item_in_active_hand, /obj/item/grab))
 							break_all_grabs(M) //See about breaking grips or pulls
 							playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 							return TRUE
-						if(I.wielded && !recoil >= 80)
+						if(item_in_active_hand.wielded && !recoil >= 80)
 							playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 							return TRUE
-						unEquip(I)
+						unEquip(item_in_active_hand)
 						visible_message(SPAN_DANGER("[M] has disarmed [src]!"))
 						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 						return TRUE

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -398,8 +398,8 @@ meteor_act
 							playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 							return TRUE
 						if(I.wielded && !recoil >= 80)
-								playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-								return TRUE
+							playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+							return TRUE
 						unEquip(I)
 						visible_message(SPAN_DANGER("[M] has disarmed [src]!"))
 						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -354,7 +354,7 @@ meteor_act
 					W.Fire(target_location, src)
 					return TRUE
 			//else do other types of intervention attacks
-			var/intervention_type = pick("out of breath", "bloodstains")
+			var/intervention_type = pick("out of breath", "bloodstains", "winded")
 			switch(intervention_type)
 				if("bloodstains")
 					var/turf/location = loc
@@ -386,7 +386,24 @@ meteor_act
 					adjustOxyLoss(10)
 					adjustHalLoss(5)
 
-
+				if("winded")
+					visible_message(SPAN_WARNING("[src] is winded!"), SPAN_DANGER("You feel disoriented!"))
+					confused = max(src.confused, 2)
+					external_recoil(40)
+					var/obj/item/I = get_active_hand()
+					mob/living/carbon/M = user
+					if(recoil >= 60 && I)
+						if(istype(I, /obj/item/grab))
+							break_all_grabs(M) //See about breaking grips or pulls
+							playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+							return TRUE
+						if(I.wielded && !recoil >= 80)
+								playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+								return TRUE
+						unEquip(I)
+						visible_message(SPAN_DANGER("[M] has disarmed [src]!"))
+						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+						return TRUE
 	return TRUE
 
 /mob/living/carbon/human/proc/attack_joint(var/obj/item/organ/external/organ, var/obj/item/W)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -388,7 +388,7 @@ meteor_act
 
 				if("winded")
 					visible_message(SPAN_WARNING("[src] is winded!"), SPAN_DANGER("You feel disoriented!"))
-					confused = max(src.confused, 2)
+					confused = max(confused, 2)
 					external_recoil(40)
 					var/obj/item/I = get_active_hand()
 					var/mob/living/carbon/M = user

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -391,7 +391,7 @@ meteor_act
 					confused = max(src.confused, 2)
 					external_recoil(40)
 					var/obj/item/I = get_active_hand()
-					mob/living/carbon/M = user
+					var/mob/living/carbon/M = user
 					if(recoil >= 60 && I)
 						if(istype(I, /obj/item/grab))
 							break_all_grabs(M) //See about breaking grips or pulls


### PR DESCRIPTION
## About The Pull Request

New intervention: Winded

This will confuse the target (walking in random directions) for two lifeticks, and add 40 recoil to them. If 60 recoil is reached, they are disarmed, similarly to disarm intent.

## Why It's Good For The Game

Actually impactful intervention attack against gun users.

## Changelog
:cl:
add: "Winded" intervention attack
/:cl: