### PR TITLE
Uplink renames

### DIFF
--- a/code/datums/autolathe/guns.dm
+++ b/code/datums/autolathe/guns.dm
@@ -180,7 +180,7 @@
 	build_path = /obj/item/gun/projectile/automatic/ak47/sa
 
 /datum/design/autolathe/gun/sts35
-	name = "OR SDF .30 \"STS-35\""
+	name = "OR BR .30 \"STS-35\""
 	build_path = /obj/item/gun/projectile/automatic/sts35
 
 // Heavy

--- a/code/datums/uplink/highly visible and dangerous weapons.dm
+++ b/code/datums/uplink/highly visible and dangerous weapons.dm
@@ -5,7 +5,7 @@
 	category = /datum/uplink_category/visible_weapons
 
 /datum/uplink_item/item/visible_weapons/dartgun
-	name = "Dart Gun"
+	name = "Z-H P \"Artemis\" Dart Gun"
 	item_cost = 4
 	path = /obj/item/storage/box/syndie_kit/dartgun
 
@@ -20,7 +20,7 @@
 	path = /obj/item/melee/energy/sword
 
 /datum/uplink_item/item/visible_weapons/pistol
-	name = "Silenced .25 Caseless Handgun"
+	name = "OR HG .25 CS \"Mandella\" Silenced Handgun"
 	item_cost = 6
 	path = /obj/item/storage/box/syndie_kit/pistol
 
@@ -31,24 +31,24 @@
 
 
 /datum/uplink_item/item/visible_weapons/revolver
-	name = "Revolver"
+	name = "FS REV .40 Magnum \"Miller\" Revolver"
 	item_cost = 7
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/storage/box/syndie_kit/revolver
 
 /datum/uplink_item/item/visible_weapons/hornet
-	name = "Revolver"
+	name = "OR REV .20 \"LBR-8 Hornet\" Revolver"
 	item_cost = 7
 	antag_roles = list(ROLE_MARSHAL)
 	path = /obj/item/storage/box/syndie_kit/hornet
 
 /datum/uplink_item/item/visible_weapons/submachinegun
-	name = "Submachine Gun"
+	name = "S SMG .35 \"C-20r\" Submachinegun"
 	item_cost = 8
 	path = /obj/item/storage/box/syndie_kit/c20r
 
 /datum/uplink_item/item/visible_weapons/assaultrifle
-	name = "Assault Rifle"
+	name = "OR BR \"STS-35\" Battle Rifle"
 	item_cost = 10
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/storage/box/syndie_kit/sts35
@@ -66,13 +66,13 @@
 	path = /obj/item/storage/box/syndie_kit/lshotgun
 
 /datum/uplink_item/item/visible_weapons/pug
-	name = "Pug Shotgun"
+	name = "SA SG \"Bojevic\" Pug Shotgun"
 	item_cost = 8
 	antag_roles = list(ROLE_CONTRACTOR,ROLE_INQUISITOR,ROLE_MERCENARY,ROLE_CARRION)
 	path = /obj/item/storage/box/syndie_kit/pug
 
 /datum/uplink_item/item/visible_weapons/heavysniper
-	name = "Anti-material Rifle"
+	name = "SA AMR .60 \"Hristov\" Anti-material Rifle"
 	item_cost = 20
 	path = /obj/item/storage/briefcase/antimaterial_rifle
 

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/shrapnel
-	name = "OR SDF \"Shellshock\" energy shotgun"
+	name = "OR ESG \"Shellshock\" energy shotgun"
 	desc = "An Oberth Republic Self Defence Force design, this mat-fab shotgun tends to burn through cells with use. The matter contained in empty cells can be converted directly into ammunition as well, if the safety bolts are loosened."
 	icon = 'icons/obj/guns/energy/shrapnel.dmi'
 	icon_state = "eshotgun"

--- a/code/modules/projectiles/guns/projectile/automatic/sts35.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts35.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/sts35
-	name = "OR SDF \"STS-35\""
+	name = "OR BR \"STS-35\""
 	desc = "The rugged STS-35 is a durable automatic weapon, made by Oberth Republic Self Defence Force. \
 			Extremely efficient rifle design that was put in service right before collapse of the Republic, this weapon can be found almost anywhere in the galaxy by now. \
 			Uses .30 Rifle rounds."

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -42,7 +42,7 @@
 	ammo_states = list(1, 2, 3, 4, 5)
 
 /obj/item/gun/projectile/dartgun
-	name = "Z-H P Artemis"
+	name = "Z-H P \"Artemis\""
 	desc = "Zeng-Hu Pharmaceutical's entry into the arms market, the Z-H P Artemis is a gas-powered dart gun capable of delivering chemical cocktails swiftly across short distances."
 	icon = 'icons/obj/guns/projectile/dartgun.dmi'
 	icon_state = "dartgun-empty"


### PR DESCRIPTION
## About The Pull Request

Renames the gun boxes in uplink to clarify them, renames Oberth guns to follow convention.

## Why It's Good For The Game

No more misunderstanding good

## Changelog
:cl:
tweak: name of uplink gun boxes clarified
spellcheck: Oberth gun names adjusted to follow convention
/:cl: