### PR TITLE
System override timer reduction

### DIFF
--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
@@ -32,7 +32,7 @@
 
 /datum/malf_research_ability/networking/system_override
 	ability = new/datum/game_mode/malfunction/verb/system_override()
-	price = 2750
+	price = 2000
 	name = "System Override"
 
 // END RESEARCH DATUMS
@@ -138,7 +138,7 @@
 	set desc = "500 CPU - Begins hacking into the ship's primary firewall, quickly overtaking remaining APC systems. When completed grants access to the ship's self-destruct mechanism. Network administrators will probably notice this."
 	var/price = 500
 	var/mob/living/silicon/ai/user = usr
-	if (alert(user, "Begin system override? This cannot be stopped once started. The network administrators will probably notice this.", "System Override:", "Yes", "No") != "Yes")
+	if (alert(user, "Begin system override? This cannot be stopped once started, and the network monitor will announce this action.", "System Override:", "Yes", "No") != "Yes")
 		return
 	if (!ability_prechecks(user, price) || !ability_pay(user, price) || user.system_override)
 		if(user.system_override)
@@ -152,34 +152,26 @@
 			continue
 		remaining_apcs += A
 
-	var/duration = (remaining_apcs.len * 100)	// Calculates duration for announcing system
+	var/duration = (remaining_apcs.len * 30)	// Calculates duration for announcing system
 	if(duration > 3000)							// Two types of announcements. Short hacks trigger immediate warnings. Long hacks are more "progressive".
 		spawn(0)
-			sleep(duration/5)
+			sleep(duration/3)
 			if(!user || user.stat == DEAD)
 				return
-			command_announcement.Announce("Caution, [station_name]. We have detected abnormal behaviour in your network. It seems someone is trying to hack your electronic systems. We will update you when we have more information.", "Network Monitoring")
-			sleep(duration/5)
+			command_announcement.Announce("Caution, [station_short]. Abnormal behaviour detected in network, initiating troubleshoot for more information.", "Network Monitoring")
+			sleep(duration/3)
 			if(!user || user.stat == DEAD)
 				return
-			command_announcement.Announce("We started tracing the intruder. Whoever is doing this, they seem to be on the ship itself. We suggest checking all network control terminals. We will keep you updated on the situation.", "Network Monitoring")
-			sleep(duration/5)
-			if(!user || user.stat == DEAD)
-				return
-			command_announcement.Announce("This is highly abnormal and somewhat concerning. The intruder is too fast, he is evading our traces. No man could be this fast...", "Network Monitoring")
-			sleep(duration/5)
-			if(!user || user.stat == DEAD)
-				return
-			command_announcement.Announce("We have traced the intrude#, it seem& t( e yo3r AI s7stem, it &# *#ck@ng th$ sel$ destru$t mechani&m, stop i# bef*@!)$#&&@@  <CONNECTION LOST>", "Network Monitoring")
+			command_announcement.Announce("Troubleshoot complet#, it seem& t( e yo3r AI s7stem, it &# *#ck@ng th$ sel$ destru$t mechani&m, unplug i# bef*@!)$#&&@@", "Network Monitoring")
 	else
-		command_announcement.Announce("We have detected a strong brute-force attack on your firewall which seems to be originating from your AI system. It already controls almost the whole network, and the only thing that's preventing it from accessing the self-destruct is this firewall. You don't have much time before it succeeds.", "Network Monitoring")
+		command_announcement.Announce("Detected brute-force attack on network firewall originating from AI system. Control over majority of whole network compromised, firewall for Self-Destruct Control in threat. Success of hostile intrusion likely, eliminate origin immediately.", "Network Monitoring")
 	to_chat(user, "## BEGINNING SYSTEM OVERRIDE.")
 	to_chat(user, "## ESTIMATED DURATION: [round((duration+300)/600)] MINUTES")
 	user.hacking = 1
 	user.system_override = 1
-	// Now actually begin the hack. Each APC takes 10 seconds.
+	// Now actually begin the hack. Each APC takes 3 seconds.
 	for(var/obj/machinery/power/apc/A in shuffle(remaining_apcs))
-		sleep(100)
+		sleep(30)
 		if(!user || user.stat == DEAD)
 			return
 		if(!A || !istype(A) || A.aidisabled)
@@ -197,7 +189,7 @@
 
 
 	to_chat(user, "## PRIMARY FIREWALL BYPASSED. YOU NOW HAVE FULL SYSTEM CONTROL.")
-	command_announcement.Announce("Our system administrators just reported that we've been locked out from your control network. Whoever did this now has full access to the ship's systems.", "Network Administration Center")
+	command_announcement.Announce("System administrator is no longer able to access control network, control of ship's systems has been unilaterally compromised. Unidentified user now expressing kernel access to the ship's systems.", "Network Monitoring")
 	user.hack_can_fail = 0
 	user.hacking = 0
 	user.system_override = 2

--- a/code/game/gamemodes/roleset/simple.dm
+++ b/code/game/gamemodes/roleset/simple.dm
@@ -89,7 +89,7 @@
 	role_id = ROLE_MALFUNCTION
 	req_crew = 20
 	ocurrences_max = 1
-
+	tags = list(TAG_DESTRUCTIVE, TAG_NEGATIVE)
 
 /datum/storyevent/roleset/marshal
 	id = "marshal"

--- a/code/game/gamemodes/roleset/simple.dm
+++ b/code/game/gamemodes/roleset/simple.dm
@@ -87,7 +87,8 @@
 	id = "malf"
 	name = "malfunctioning AI"
 	role_id = ROLE_MALFUNCTION
-	req_crew = 15
+	req_crew = 20
+	ocurrences_max = 1
 
 
 /datum/storyevent/roleset/marshal


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the Malf AI's System Override reasonably achievable. It should no longer be expected to take ~2 hours to self-destruct the ship.

Cost for system override reduced to help mid-round Malf AIs.

Adjusted when command announcements trigger for both lore, and the fact there's no real metagame rules.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The AI blowing up the ship finally has the needed closure of the round. The AI spends the time murdering people, only for it to sputter out into a "glorious death" scenario. Even on low-pop of ~5 players as Malf AI, in a 4 hour round, I was still unable to successfully perform override. That was years ago, and was when I realized this role was dead end garbage with little ground to explore as it currently stood. This isn't exploring anything, it's just one step to getting to the best part of a Malf AI round, it ending. This time, hopefully with an attempt at closure.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Malfunctioning AIs may now get closer to their goal of destroying the ship with a faster system override command, one which doesn't take two hours to complete.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
