### PR TITLE
Removes Malfunctioning AI from Roleset

### DIFF
--- a/code/game/gamemodes/roleset/simple.dm
+++ b/code/game/gamemodes/roleset/simple.dm
@@ -82,13 +82,13 @@
 
 
 
-
+/*
 /datum/storyevent/roleset/malf
 	id = "malf"
 	name = "malfunctioning AI"
 	role_id = ROLE_MALFUNCTION
 	req_crew = 15
-
+*/
 
 /datum/storyevent/roleset/marshal
 	id = "marshal"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes Malfunctioning AI from the storyteller event pool.

The hardest part of this PR is perhaps this description. To describe to you, in detail, how this roleset is frankly not fun for either the player playing it or the many receiving it. There is no endgame for any AI playing it, besides just waiting for the siege to occur, some even try hiding, but I ask, "for what?" Why do they even attempt to delay? They aren't delaying so they can accomplish their goal or objective, just to remain alive. With this in mind recently the player base for AIs in general has taken a new meta regarding in how to play Malfunctioning AI, and it instead incorporates losing _as the goal._ Realizing that instead they can achieve gratification by killing as many players as possible by self-destructing once they're inevitably overwhelmed. This roleset has remained for years, not even functional, which I believe shows a general disinterest to support it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We no longer must interrupt our rounds for this fossilized relic to go full Jurassic Park on us _consistently_. If you have Malf AI enabled, and the roleset is called you are essentially guaranteed to be called for roleset. Many players have even, if unintentionally, memorized names and know OOCly that they are going to roll Malf within a specific timeframe of activating.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Malfunctioning AI has been removed from the storyteller event pool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
