### PR TITLE
Tweak armor plates

### DIFF
--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -212,14 +212,14 @@
 		MATERIAL_STEEL = 8,
 		MATERIAL_PLASTEEL = 1,
 	)
-	slowdown = 0
+	slowdown = LIGHT_SLOWDOWN
 	stiffness = LIGHT_STIFFNESS
 
 /obj/item/clothing/accessory/armor/on_attached()
 	..()
 	has_suit.armor = armor
 	has_suit.style -= 2
-	has_suit.slowdown = slowdown
+	has_suit.slowdown += slowdown
 	has_suit.stiffness = stiffness
 	has_suit.body_parts_covered = UPPER_TORSO|LOWER_TORSO // Tears up the clothes
 

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -213,7 +213,6 @@
 		MATERIAL_PLASTEEL = 1
 	)
 	slowdown = LIGHT_SLOWDOWN
-	stiffness = 0
 
 /obj/item/clothing/accessory/armor/on_attached()
 	..()

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -210,10 +210,10 @@
 	)
 	matter = list(
 		MATERIAL_STEEL = 8,
-		MATERIAL_PLASTEEL = 1,
+		MATERIAL_PLASTEEL = 1
 	)
 	slowdown = LIGHT_SLOWDOWN
-	stiffness = LIGHT_STIFFNESS
+	stiffness = 0
 
 /obj/item/clothing/accessory/armor/on_attached()
 	..()
@@ -237,10 +237,10 @@
 	)
 	matter = list(
 		MATERIAL_STEEL = 10,
-		MATERIAL_PLASTEEL = 3,
+		MATERIAL_PLASTEEL = 3
 	)
 	slowdown = LIGHT_SLOWDOWN
-	stiffness = MEDIUM_STIFFNESS
+	stiffness = LIGHT_STIFFNESS
 
 /obj/item/clothing/accessory/armor/platecarrier
 	name = "platecarrier armor plates"
@@ -256,9 +256,8 @@
 	)
 	matter = list(
 		MATERIAL_STEEL = 10,
-		MATERIAL_PLASTEEL = 3,
+		MATERIAL_PLASTEEL = 3
 	)
-	slowdown = LIGHT_SLOWDOWN
 
 /obj/item/clothing/accessory/armor/riot
 	name = "padded armor plates"
@@ -287,7 +286,7 @@
 		bio = 0,
 		rad = 0
 	)
-	slowdown = LIGHT_SLOWDOWN
+	stiffness = LIGHT_STIFFNESS
 
 //Ponchos, Capes and Cloaks//
 

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -220,7 +220,7 @@
 	has_suit.armor = armor
 	has_suit.style -= 2
 	has_suit.slowdown += slowdown
-	has_suit.stiffness = stiffness
+	has_suit.stiffness += stiffness
 	has_suit.body_parts_covered = UPPER_TORSO|LOWER_TORSO // Tears up the clothes
 
 /obj/item/clothing/accessory/armor/bullet


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes armor plates possibly speeding you up and lowering your stiffnes, now instead of setting your slowdown/stiffness to set value (if you put it on a suit) they just add to it. 
Also tweaks some values:
added slowdown to basic armor plate, removed stiffnes from it, lowered slowdown on ballistic armor plate. I believe `LIGHT_STIFFNESS` is only used for full vests or something similar and those aren't even close to it. We'll keep it on more bulky ones, though
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
bugfix good, rebalance even better

## Changelog
:cl:
fix: armor plates (which is an accessory) now properly slows you down and increases your stiffness
balance: basic armor plate now gives 0.1 slowdown (very little)
balance: basic armor plate now doesn't gives any stiffness (gun accuracy penalty)
balance: ballistic armor plate now gives light stiffness (instead of medium)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
