### PR TITLE
Fix Jive comms

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -281,6 +281,9 @@ var/global/list/default_medbay_channels = list(
 	//  Fix for permacell radios, but kinda eh about actually fixing them.
 	if(!M || !message) return 0
 
+	if(speaking && (speaking.flags & (NONVERBAL|SIGNLANG))) // so we don't speak sign language over radio
+		return 0
+
 	//  Uncommenting this. To the above comment:
 	// 	The permacell radios aren't suppose to be able to transmit, this isn't a bug and this "fix" is just making radio wires useless. -Giacom
 	if(wires.IsIndexCut(WIRE_TRANSMIT)) // The device has to have all its wires and shit intact

--- a/code/modules/mob/language/jive.dm
+++ b/code/modules/mob/language/jive.dm
@@ -1,10 +1,10 @@
 /datum/language/jive
 	name = LANGUAGE_JIVE
-	desc = "A mostly nonverbal language made of hand gestures, popular among criminals, punks and mercenaries. Often used to conduct illicit trade away from prying ears."
+	desc = "Nonverbal language made of hand gestures, popular among criminals, punks and mercenaries. Often used to conduct illicit trade away from prying ears."
 	signlang_verb = list("gestures", "signs", "signals", "motions")
 	colour = "jive"
 	key = "s"
-	flags = SIGNLANG | NO_STUTTER | NONVERBAL
+	flags = SIGNLANG | NO_STUTTER
 	shorthand = "JI"
 
 //To maintain an air of informality, jive does not force capitalization

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -244,12 +244,9 @@ var/list/channel_to_radio_key = new
 
 	//handle nonverbal and sign languages here
 	if(speaking)
-		if(speaking.flags&NONVERBAL)
+		if(speaking.flags&(NONVERBAL|SIGNLANG))
 			if(prob(30))
 				src.custom_emote(1, "[pick(speaking.signlang_verb)].")
-
-		if(speaking.flags&SIGNLANG)
-			return say_signlang(message, pick(speaking.signlang_verb), speaking)
 
 	var/list/listening = list()
 	var/list/listening_obj = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes NONVERBAL flag from it. As much as I can say, those two flag (NONVERBAL and SIGNLANG) shouldn't be used together and Jive is more of subtle motions rather than moaning slightly and pointing fingers (which is kind of non-verbal)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes people talking on Jive through radio
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Removed NONVERBAL flag from Jive, in return it's much more like a sign language and people can't talk on it through comms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
