### PR TITLE
Adjusts Cyborg Module Languages

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -25,18 +25,13 @@ var/global/list/robot_modules = list(
 	var/channels = list()
 	var/networks = list()
 	var/languages = list(							//Any listed language will be understandable. Any set to 1 will be speakable
-					LANGUAGE_SOL_COMMON = 1,
-					LANGUAGE_TRADEBAND = 1,
-					LANGUAGE_UNATHI = 0,
-					LANGUAGE_SIIK_MAAS = 0,
-					LANGUAGE_SKRELLIAN = 0,
-					LANGUAGE_GUTTER = 1,
-					LANGUAGE_VAURCESE = 0,
-					LANGUAGE_ROOTSONG = 0,
-					LANGUAGE_SIGN = 0,
-					LANGUAGE_SIGN_TAJARA = 0,
-					LANGUAGE_SIIK_TAJR = 0,
-					LANGUAGE_AZAZIBA = 0
+					LANGUAGE_COMMON = 1,
+					LANGUAGE_GERMAN = 1,
+					LANGUAGE_CYRILLIC = 1,
+					LANGUAGE_SERBIAN = 1,
+					LANGUAGE_JIVE = 0,
+					LANGUAGE_NEOHONGO = 1,
+					LANGUAGE_LATIN = 0,
 					)
 	var/sprites = list()
 	var/can_be_pushed = 1
@@ -786,13 +781,14 @@ var/global/list/robot_modules = list(
 	name = "service robot module"
 	channels = list("Service" = 1)
 	languages = list(
-					LANGUAGE_SOL_COMMON = 1,
-					LANGUAGE_TRADEBAND = 1,
-					LANGUAGE_UNATHI = 1,
-					LANGUAGE_SIIK_MAAS = 1,
-					LANGUAGE_SKRELLIAN = 1,
-					LANGUAGE_GUTTER = 1,
-					LANGUAGE_ROOTSONG = 1
+					LANGUAGE_COMMON = 1,
+					LANGUAGE_GERMAN = 1,
+					LANGUAGE_CYRILLIC = 1,
+					LANGUAGE_SERBIAN = 1,
+					LANGUAGE_JIVE = 1,
+					LANGUAGE_NEOHONGO = 1,
+					LANGUAGE_LATIN = 1,
+					LANGUAGE_MONKEY = 1
 					)
 
 	sprites = list(	"Waitress" = "service",
@@ -979,13 +975,13 @@ var/global/list/robot_modules = list(
 	name = "syndicate robot module"
 	hide_on_manifest = TRUE
 	languages = list(
-					LANGUAGE_SOL_COMMON = 1,
-					LANGUAGE_TRADEBAND = 1,
-					LANGUAGE_UNATHI = 1,
-					LANGUAGE_SIIK_MAAS = 1,
-					LANGUAGE_SKRELLIAN = 1,
-					LANGUAGE_GUTTER = 1,
-					LANGUAGE_ROOTSONG = 1
+					LANGUAGE_COMMON = 1,
+					LANGUAGE_GERMAN = 1,
+					LANGUAGE_CYRILLIC = 1,
+					LANGUAGE_SERBIAN = 1,
+					LANGUAGE_JIVE = 1,
+					LANGUAGE_NEOHONGO = 1,
+					LANGUAGE_LATIN = 1
 					)
 
 	sprites = list(
@@ -1129,14 +1125,13 @@ var/global/list/robot_modules = list(
 /obj/item/robot_module/hunter_seeker
 	name = "hunter seeker robot module"
 	languages = list(
-					LANGUAGE_SOL_COMMON = 1,
-					LANGUAGE_TRADEBAND = 1,
-					LANGUAGE_UNATHI = 1,
-					LANGUAGE_SIIK_MAAS = 1,
-					LANGUAGE_SKRELLIAN = 1,
-					LANGUAGE_GUTTER = 1,
-					LANGUAGE_ROOTSONG = 1,
-					LANGUAGE_TERMINATOR = 1
+					LANGUAGE_COMMON = 1,
+					LANGUAGE_GERMAN = 1,
+					LANGUAGE_CYRILLIC = 1,
+					LANGUAGE_SERBIAN = 1,
+					LANGUAGE_JIVE = 1,
+					LANGUAGE_NEOHONGO = 1,
+					LANGUAGE_LATIN = 1
 					)
 
 	sprites = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cyborg modules use actual languages, instead of Bay remnants which no longer exist.

There's a discussion to be had whether or not Cyborgs should be able to understand Jive or not.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Another piece of support for a dead-end mob type.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Cyborgs can actually understand most station languages now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
