### PR TITLE
Cleanbots don't always say stuff when cleaning

### DIFF
--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -170,9 +170,9 @@
 
 	cleaning = 1
 	visible_message("[src] begins to clean up \the [D]")
-	var/message = pick(possible_phrases)
-	say(message)
-	playsound(loc, "robot_talk_light", 100, 0, 0)
+	if(prob(10))
+		say(pick(possible_phrases))
+		playsound(loc, "robot_talk_light", 100, 0, 0)
 	update_icons()
 	var/cleantime = istype(D, /obj/effect/decal/cleanable/dirt) ? 10 : 50
 	if(do_after(src, cleantime, progress = 0))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

it's a 10% chance now

## Why It's Good For The Game
Massive QoL, huge even, one could even say hugongous

## Changelog
:cl: Kegdo
tweak: Cleanbots don't always say stuff when cleaning (10% chance)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
