### PR TITLE
Reworks throwing, window combat interactions , adds more upsides to ass of concrete

### DIFF
--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -31,6 +31,7 @@
 //Resistance value is also used on simple animals.
 //Reduces the damage they take by flat amounts
 #define RESISTANCE_NONE 				0
+#define RESISTANCE_FLIMSY				2
 #define RESISTANCE_FRAGILE 				4
 #define RESISTANCE_AVERAGE 				8
 #define RESISTANCE_IMPROVED 			12

--- a/code/datums/perks/oddity.dm
+++ b/code/datums/perks/oddity.dm
@@ -152,7 +152,8 @@
 	name = "Ass of Concrete"
 	desc = "Years of training your body made you a hulk of a person. No more pushing around. \
 			Nobody can move past you, even on help intent. You won\'t slip in gravity. \
-			You deal more damage to windows when you dive into them."
+			You deal more damage to windows when you dive into them and suffer less from being thrown \
+			or smashed into them"
 	icon_state = "muscular" // https://game-icons.net
 
 /datum/perk/oddity/ass_of_concrete/assign(mob/living/carbon/human/H)

--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -89,7 +89,7 @@
 	w_class = ITEM_SIZE_BULKY
 	force = 0
 	throwforce = 0
-	throw_speed = 1
+	throw_speed = 0.5
 	throw_range = 20
 	flags = CONDUCT
 

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -6,7 +6,7 @@
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_SMALL
 	item_state = "electronic"
-	throw_speed = 4
+	throw_speed = 2
 	throw_range = 20
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	//spawn_blacklisted = TRUE//antag_item_targets??

--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -8,7 +8,7 @@
 	w_class = ITEM_SIZE_SMALL
 	throwforce = WEAPON_FORCE_WEAK
 	throw_range = 15
-	throw_speed = 3
+	throw_speed = 0.3
 
 	matter = list(MATERIAL_PLASTIC = 3, MATERIAL_GLASS = 1)
 

--- a/code/game/objects/items/devices/biosyphon.dm
+++ b/code/game/objects/items/devices/biosyphon.dm
@@ -9,7 +9,7 @@
 	w_class = ITEM_SIZE_BULKY
 	flags = CONDUCT
 	throwforce = WEAPON_FORCE_PAINFUL
-	throw_speed = 1
+	throw_speed = 0.3
 	throw_range = 2
 	price_tag = 20000
 	origin_tech = list(TECH_MATERIAL = 4, TECH_BLUESPACE = 8, TECH_POWER = 7)

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -4,7 +4,7 @@
 	icon_state = "flash"
 	w_class = ITEM_SIZE_TINY
 	item_state = "electronic"
-	throw_speed = 4
+	throw_speed = 0.2
 	throw_range = 20
 
 /obj/item/camera_bug/attack_self(mob/user)

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -11,7 +11,7 @@ GLOBAL_LIST_INIT(champroj_whitelist, list())
 	slot_flags = SLOT_BELT
 	item_state = "electronic"
 	throwforce = WEAPON_FORCE_HARMLESS
-	throw_speed = 1
+	throw_speed = 0.3
 	throw_range = 5
 	w_class = ITEM_SIZE_SMALL
 	origin_tech = list(TECH_COVERT = 4, TECH_MAGNET = 4)

--- a/code/game/objects/items/devices/contractordevices.dm
+++ b/code/game/objects/items/devices/contractordevices.dm
@@ -20,7 +20,7 @@ effective or pretty fucking useless.
 	icon_state = "batterer"
 	throwforce = WEAPON_FORCE_HARMLESS
 	w_class = ITEM_SIZE_TINY
-	throw_speed = 4
+	throw_speed = 0.4
 	throw_range = 10
 	flags = CONDUCT
 	item_state = "electronic"

--- a/code/game/objects/items/devices/debugger.dm
+++ b/code/game/objects/items/devices/debugger.dm
@@ -14,7 +14,7 @@
 	w_class = ITEM_SIZE_SMALL
 	throwforce = WEAPON_FORCE_HARMLESS
 	throw_range = 15
-	throw_speed = 3
+	throw_speed = 0.3
 
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -6,7 +6,7 @@
 	item_state = "flashtool"
 	throwforce = WEAPON_FORCE_HARMLESS
 	w_class = ITEM_SIZE_SMALL
-	throw_speed = 4
+	throw_speed = 0.3
 	throw_range = 10
 	price_tag = 300
 	flags = CONDUCT

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -5,7 +5,7 @@
 	item_state = "holowarrant"
 	throwforce = 5
 	w_class = ITEM_SIZE_SMALL
-	throw_speed = 4
+	throw_speed = 0.2
 	throw_range = 10
 	slot_flags = SLOT_BELT
 	req_access = list(list(access_heads, access_security))

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -8,7 +8,7 @@
 	w_class = ITEM_SIZE_BULKY
 	flags = CONDUCT
 	throwforce = WEAPON_FORCE_PAINFUL
-	throw_speed = 1
+	throw_speed = 0.5
 	throw_range = 2
 	spawn_blacklisted = TRUE
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -32,7 +32,7 @@ var/global/list/default_medbay_channels = list(
 	item_state = "walkietalkie"
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
-	throw_speed = 2
+	throw_speed = 0.3
 	throw_range = 9
 	w_class = ITEM_SIZE_SMALL
 

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -4,7 +4,7 @@
 	desc = "A hand-held body scanner able to distinguish vital signs of the subject."
 	icon_state = "health"
 	item_state = "analyzer"
-	throw_speed = 5
+	throw_speed = 0.8
 	throw_range = 10
 
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)

--- a/code/game/objects/items/devices/scanners/scanners.dm
+++ b/code/game/objects/items/devices/scanners/scanners.dm
@@ -7,7 +7,7 @@
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_SMALL
 	throwforce = WEAPON_FORCE_HARMLESS
-	throw_speed = 3
+	throw_speed = 0.7
 	throw_range = 7
 
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)

--- a/code/game/objects/items/devices/scanners/xenobio.dm
+++ b/code/game/objects/items/devices/scanners/xenobio.dm
@@ -2,7 +2,7 @@
 	name = "slime scanner"
 	icon_state = "adv_spectrometer"
 	item_state = "analyzer"
-	throw_speed = 3
+	throw_speed = 0.7
 	throw_range = 7
 
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)

--- a/code/game/objects/items/devices/spy_bug.dm
+++ b/code/game/objects/items/devices/spy_bug.dm
@@ -12,7 +12,7 @@
 	slot_flags = SLOT_EARS
 	throwforce = WEAPON_FORCE_HARMLESS
 	throw_range = 15
-	throw_speed = 3
+	throw_speed = 0.5
 
 	origin_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1, TECH_COVERT = 3)
 	spawn_blacklisted = TRUE

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -11,7 +11,7 @@
 	flags = CONDUCT
 	force = WEAPON_FORCE_NORMAL
 	throwforce = WEAPON_FORCE_NORMAL
-	throw_speed = 1
+	throw_speed = 0.6
 	throw_range = 4
 
 	origin_tech = list(TECH_MAGNET = 2, TECH_MATERIAL = 2)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -8,7 +8,7 @@
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	flags = CONDUCT
 	throwforce = WEAPON_FORCE_HARMLESS
-	throw_speed = 4
+	throw_speed = 0.3
 	throw_range = 20
 
 	var/emagged = 0

--- a/code/game/objects/items/devices/von-krabin.dm
+++ b/code/game/objects/items/devices/von-krabin.dm
@@ -9,7 +9,7 @@
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	throwforce = WEAPON_FORCE_HARMLESS
-	throw_speed = 1
+	throw_speed = 0.6
 	throw_range = 5
 	price_tag = 20000
 	w_class = ITEM_SIZE_NORMAL

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -6,7 +6,7 @@
 	force = 0
 	throwforce = 0
 	w_class = ITEM_SIZE_SMALL
-	throw_speed = 1
+	throw_speed = 0.5
 	throw_range = 15
 	var/state
 	var/datum/gas_mixture/air_contents = null

--- a/code/game/objects/items/stacks/knife.dm
+++ b/code/game/objects/items/stacks/knife.dm
@@ -22,7 +22,9 @@
 	force = WEAPON_FORCE_NORMAL
 	throwforce = WEAPON_FORCE_WEAK
 	armor_divisor = ARMOR_PEN_SHALLOW
-	throw_speed = 3
+	// very fast
+	throw_speed = 0.1
+	throw_range = 10
 	slot_flags = SLOT_BELT
 	//spawn values
 	rarity_value = 8

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -5,7 +5,7 @@
 	amount = 5
 	max_amount = 5
 	w_class = ITEM_SIZE_SMALL
-	throw_speed = 4
+	throw_speed = 0.6
 	throw_range = 20
 	price_tag = 10
 	spawn_tags = SPAWN_TAG_MEDICINE

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -9,7 +9,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	force = WEAPON_FORCE_WEAK
 	throwforce = WEAPON_FORCE_WEAK
-	throw_speed = 5
+	throw_speed = 0.9
 	throw_range = 20
 	matter = list(MATERIAL_STEEL = 1)
 	max_amount = 60

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -16,7 +16,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	force = WEAPON_FORCE_HARMLESS
 	throwforce = WEAPON_FORCE_WEAK
-	throw_speed = 3
+	throw_speed = 0.5
 	throw_range = 7
 	max_amount = 60
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -18,7 +18,7 @@
 
 /obj/item/toy
 	throwforce = NONE
-	throw_speed = 4
+	throw_speed = 0.1
 	throw_range = 20
 	force = NONE
 

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -16,7 +16,7 @@ AI MODULES
 	force = WEAPON_FORCE_WEAK
 	w_class = ITEM_SIZE_SMALL
 	throwforce = WEAPON_FORCE_WEAK
-	throw_speed = 3
+	throw_speed = 0.6
 	throw_range = 15
 	origin_tech = list(TECH_DATA = 3)
 	matter = list(MATERIAL_GLASS = 2, MATERIAL_GOLD = 1)

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -10,7 +10,7 @@
 	flags = CONDUCT
 	force = WEAPON_FORCE_PAINFUL
 	throwforce = WEAPON_FORCE_PAINFUL
-	throw_speed = 1
+	throw_speed = 0.8
 	throw_range = 5
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 2)

--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -10,7 +10,7 @@
 	flags = CONDUCT
 	force = WEAPON_FORCE_PAINFUL
 	throwforce = WEAPON_FORCE_PAINFUL
-	throw_speed = 1
+	throw_speed = 0.8
 	throw_range = 5
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_MATERIAL = 2) //Redundant values that yer free ta' change later.

--- a/code/game/objects/items/weapons/caution.dm
+++ b/code/game/objects/items/weapons/caution.dm
@@ -5,7 +5,7 @@
 	icon_state = "caution"
 	force = WEAPON_FORCE_HARMLESS
 	throwforce = WEAPON_FORCE_HARMLESS
-	throw_speed = 1
+	throw_speed = 0.8
 	throw_range = 5
 	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("warned", "cautioned", "smashed")

--- a/code/game/objects/items/weapons/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/weapons/circuitboards/circuitboard.dm
@@ -24,7 +24,7 @@
 	flags = CONDUCT
 	force = WEAPON_FORCE_HARMLESS
 	throwforce = WEAPON_FORCE_HARMLESS
-	throw_speed = 3
+	throw_speed = 0.3
 	throw_range = 15
 	bad_type = /obj/item/electronics/circuitboard
 

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -28,7 +28,7 @@
 	icon_state = "soap"
 	w_class = ITEM_SIZE_SMALL
 	throwforce = 0
-	throw_speed = 4
+	throw_speed = 0.3
 	throw_range = 20
 	matter = list(MATERIAL_BIOMATTER = 12)
 	spawn_tags = SPAWN_TAG_ITEM_CLOWN
@@ -129,7 +129,7 @@
 	item_state = "bike_horn"
 	throwforce = WEAPON_FORCE_HARMLESS
 	w_class = ITEM_SIZE_SMALL
-	throw_speed = 3
+	throw_speed = 0.2
 	throw_range = 15
 	matter = list(MATERIAL_PLASTIC = 5)
 	attack_verb = list("HONKED")

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -9,7 +9,7 @@
 	reagent_flags = AMOUNT_VISIBLE
 	throwforce = WEAPON_FORCE_DANGEROUS
 	w_class = ITEM_SIZE_NORMAL
-	throw_speed = 2
+	throw_speed = 0.3
 	throw_range = 10
 	force = WEAPON_FORCE_DANGEROUS
 	matter = list(MATERIAL_STEEL = 3)

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -7,7 +7,7 @@
 	flags = CONDUCT | NOBLUDGEON
 	force = WEAPON_FORCE_NORMAL
 	throwforce = WEAPON_FORCE_NORMAL
-	throw_speed = 1
+	throw_speed = 0.3
 	throw_range = 5
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_COMBAT = 2, TECH_PLASMA = 1)

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -127,7 +127,7 @@
 	icon_state = "c_tube"
 	throwforce = WEAPON_FORCE_HARMLESS
 	w_class = ITEM_SIZE_SMALL
-	throw_speed = 4
+	throw_speed = 0.2
 	throw_range = 5
 	rarity_value = 10
 	spawn_tags = SPAWN_TAG_JUNK

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "grenade"
 	item_state = "grenade"
-	throw_speed = 4
+	throw_speed = 0.2
 	throw_range = 20
 	flags = CONDUCT
 	slot_flags = SLOT_BELT|SLOT_MASK

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -10,7 +10,7 @@
 	slot_flags = SLOT_BELT
 	throwforce = WEAPON_FORCE_WEAK
 	w_class = ITEM_SIZE_SMALL
-	throw_speed = 2
+	throw_speed = 0.4
 	throw_range = 5
 	origin_tech = list(TECH_MATERIAL = 1)
 	matter = list(MATERIAL_STEEL = 2)

--- a/code/game/objects/items/weapons/holyvacuum.dm
+++ b/code/game/objects/items/weapons/holyvacuum.dm
@@ -5,7 +5,7 @@
 	icon_state = "vacuum"
 	force = WEAPON_FORCE_WEAK
 	throwforce = WEAPON_FORCE_WEAK
-	throw_speed = 5
+	throw_speed = 0.4
 	throw_range = 3
 	w_class = ITEM_SIZE_BULKY
 	attack_verb = list("bashed", "bludgeoned", "whacked")
@@ -89,7 +89,7 @@
 	icon_state = "filth-biomatter"
 	force = WEAPON_FORCE_HARMLESS
 	throwforce = WEAPON_FORCE_HARMLESS
-	throw_speed = 5
+	throw_speed = 0.3
 	throw_range = 6
 	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("bashed", "bludgeoned", "whacked")

--- a/code/game/objects/items/weapons/maneki_neko.dm
+++ b/code/game/objects/items/weapons/maneki_neko.dm
@@ -9,7 +9,7 @@
 	force = WEAPON_FORCE_WEAK
 	w_class = ITEM_SIZE_SMALL
 	throwforce = WEAPON_FORCE_WEAK
-	throw_speed = 3
+	throw_speed = 0.4
 	throw_range = 15
 	price_tag = 20000
 	origin_tech = list(TECH_MATERIAL = 10)

--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -5,7 +5,7 @@
 	health = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	gender = NEUTER
-	throw_speed = 3
+	throw_speed = 1
 	throw_range = 7
 	w_class = ITEM_SIZE_NORMAL
 	sharp = FALSE

--- a/code/game/objects/items/weapons/material/thrown.dm
+++ b/code/game/objects/items/weapons/material/thrown.dm
@@ -4,7 +4,7 @@
 	icon_state = "star"
 	force_divisor = 0.1 // 6 with hardness 60 (steel)
 	thrown_force_divisor = 0.75 // 15 with weight 20 (steel)
-	throw_speed = 10
+	throw_speed = 0.1
 	throw_range = 15
 	sharp = TRUE
 	edge = TRUE

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -8,7 +8,7 @@
 	icon_state = "mop"
 	force = WEAPON_FORCE_WEAK
 	throwforce = WEAPON_FORCE_WEAK
-	throw_speed = 5
+	throw_speed = 0.2
 	throw_range = 10
 	w_class = ITEM_SIZE_NORMAL
 	attack_verb = list("mopped", "bashed", "bludgeoned", "whacked")

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -160,7 +160,7 @@
 	slot_flags = SLOT_BACK | SLOT_BELT
 	throwforce = WEAPON_FORCE_LETHAL * 1.5
 	armor_divisor = ARMOR_PEN_MASSIVE
-	throw_speed = 3
+	throw_speed = 0.3
 	price_tag = 450
 	allow_spin = FALSE
 	extended_reach = TRUE
@@ -360,7 +360,7 @@
 	slot_flags = SLOT_BACK | SLOT_BELT
 	throwforce = WEAPON_FORCE_LETHAL
 	armor_divisor = ARMOR_PEN_DEEP
-	throw_speed = 3
+	throw_speed = 0.3
 	price_tag = 150
 	allow_spin = FALSE
 	matter = list(MATERIAL_BIOMATTER = 10, MATERIAL_STEEL = 5) // Easy to mass-produce and arm the faithful

--- a/code/game/objects/items/weapons/phone.dm
+++ b/code/game/objects/items/weapons/phone.dm
@@ -6,7 +6,7 @@
 	flags = CONDUCT
 	force = WEAPON_FORCE_HARMLESS
 	throwforce = WEAPON_FORCE_HARMLESS
-	throw_speed = 1
+	throw_speed = 0.9
 	throw_range = 4
 	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("called", "rang")

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -123,7 +123,7 @@
 	icon_state = "m_st"
 	w_class = ITEM_SIZE_SMALL
 	force = WEAPON_FORCE_HARMLESS
-	throw_speed = 5
+	throw_speed = 0.2
 	throw_range = 7
 	maxcharge = CELL_MEDIUM_BASE_CHARGE//600
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2)
@@ -222,7 +222,7 @@
 	icon_state = "s_st"
 	w_class = ITEM_SIZE_TINY
 	force = WEAPON_FORCE_HARMLESS
-	throw_speed = 5
+	throw_speed = 0.2
 	throw_range = 7
 	maxcharge = CELL_SMALL_BASE_CHARGE//100
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_SILVER = 1)
@@ -333,7 +333,7 @@
 	icon_state = "s_st"
 	w_class = ITEM_SIZE_TINY
 	force = WEAPON_FORCE_HARMLESS
-	throw_speed = 5
+	throw_speed = 0.2
 	throw_range = 7
 	origin_tech = list(TECH_POWER = 1)
 	matter = list(MATERIAL_STEEL = 1)  //some cost just in case you manage to get this in a disk or something

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -142,7 +142,7 @@
 	slot_flags = SLOT_BELT|SLOT_BACK
 	force = WEAPON_FORCE_PAINFUL
 	throwforce = WEAPON_FORCE_PAINFUL
-	throw_speed = 2
+	throw_speed = 0.6
 	throw_range = 6
 	w_class = ITEM_SIZE_BULKY
 	origin_tech = list(TECH_MATERIAL = 2)
@@ -198,7 +198,7 @@
 	slot_flags = SLOT_BACK
 	force = WEAPON_FORCE_PAINFUL
 	throwforce = WEAPON_FORCE_PAINFUL
-	throw_speed = 1
+	throw_speed = 0.9
 	throw_range = 4
 	w_class = ITEM_SIZE_HUGE
 	origin_tech = list(TECH_MATERIAL = 2)
@@ -299,7 +299,7 @@
 	slot_flags = SLOT_BACK
 	force = WEAPON_FORCE_DANGEROUS
 	throwforce = WEAPON_FORCE_DANGEROUS
-	throw_speed = 1
+	throw_speed = 0.9
 	throw_range = 4
 	w_class = ITEM_SIZE_HUGE
 	origin_tech = list()
@@ -408,7 +408,7 @@
 	icon_state = "buckler"
 	item_state = "buckler"
 	flags = null
-	throw_speed = 2
+	throw_speed = 1
 	throw_range = 6
 	matter = list(MATERIAL_STEEL = 6)
 	base_block_chance = 35
@@ -427,7 +427,7 @@
 	icon_state = "tray_shield"
 	item_state = "tray_shield"
 	flags = CONDUCT
-	throw_speed = 2
+	throw_speed = 1
 	throw_range = 4
 	matter = list(MATERIAL_STEEL = 4)
 	base_block_chance = 40

--- a/code/game/objects/items/weapons/space_harpoon.dm
+++ b/code/game/objects/items/weapons/space_harpoon.dm
@@ -7,7 +7,7 @@
 	icon_state = "harpoon-1"
 	icon = 'icons/obj/items.dmi'
 	w_class = ITEM_SIZE_NORMAL
-	throw_speed = 4
+	throw_speed = 0.4
 	throw_range = 20
 	origin_tech = list(TECH_BLUESPACE = 5)
 	price_tag = 4000

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -12,7 +12,7 @@
 	name = "first-aid kit"
 	desc = "An emergency medical kit for those serious boo-boos."
 	icon_state = "firstaid"
-	throw_speed = 2
+	throw_speed = 0.4
 	throw_range = 8
 	rarity_value = 10
 	spawn_tags = SPAWN_TAG_FIRSTAID

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -14,7 +14,7 @@
 	item_state = "electronic"
 	throwforce = WEAPON_FORCE_HARMLESS
 	w_class = ITEM_SIZE_SMALL
-	throw_speed = 3
+	throw_speed = 0.3
 	throw_range = 5
 	origin_tech = list(TECH_MAGNET = 1, TECH_BLUESPACE = 3)
 	matter = list(MATERIAL_PLASTIC = 3, MATERIAL_GLASS = 1, MATERIAL_SILVER = 1, MATERIAL_URANIUM = 1)

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -1,6 +1,6 @@
 /obj/item/beartrap
 	name = "mechanical trap"
-	throw_speed = 2
+	throw_speed = 0.4
 	throw_range = 1
 	gender = PLURAL
 	icon = 'icons/obj/traps.dmi'

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -7,7 +7,7 @@
 	w_class = ITEM_SIZE_SMALL
 	matter = list(MATERIAL_PLASTIC = 1)
 	throwforce = WEAPON_FORCE_HARMLESS
-	throw_speed = 3
+	throw_speed = 0.3
 	throw_range = 10
 	origin_tech = list(TECH_MAGNET = 1)
 

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -4,7 +4,7 @@
 	item_state = "assembly"
 	throwforce = WEAPON_FORCE_NORMAL
 	w_class = ITEM_SIZE_NORMAL
-	throw_speed = 2
+	throw_speed = 0.5
 	throw_range = 4
 	flags = CONDUCT | PROXMOVE
 	spawn_frequency = 0

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -6,7 +6,7 @@
 	flags = CONDUCT | PROXMOVE
 	throwforce = 5
 	w_class = ITEM_SIZE_SMALL
-	throw_speed = 3
+	throw_speed = 0.3
 	throw_range = 10
 
 	var/secured = FALSE

--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -37,7 +37,7 @@
 	item_state = "corncob"
 	w_class = ITEM_SIZE_SMALL
 	throwforce = 0
-	throw_speed = 4
+	throw_speed = 0.6
 	throw_range = 20
 	spawn_tags = SPAWN_TAG_JUNK
 
@@ -57,6 +57,6 @@
 	item_state = "banana_peel"
 	w_class = ITEM_SIZE_SMALL
 	throwforce = 0
-	throw_speed = 4
+	throw_speed = 0.6
 	throw_range = 20
 	spawn_tags = SPAWN_TAG_JUNK_CLOWN

--- a/code/modules/hydroponics/trays/tray_reagents.dm
+++ b/code/modules/hydroponics/trays/tray_reagents.dm
@@ -6,7 +6,7 @@
 	slot_flags = SLOT_BELT
 	throwforce = 4
 	w_class = ITEM_SIZE_SMALL
-	throw_speed = 2
+	throw_speed = 0.6
 	throw_range = 10
 	spawn_tags = SPAWN_TAG_ITEM_BOTANICAL
 	bad_type = /obj/item/plantspray

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -4,7 +4,7 @@
 	throwforce = WEAPON_FORCE_NORMAL
 	w_class = ITEM_SIZE_NORMAL
 	icon = 'icons/obj/stack/material.dmi'
-	throw_speed = 3
+	throw_speed = 1
 	throw_range = 3
 	max_amount = 120
 	bad_type = /obj/item/stack/material

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -312,7 +312,7 @@
 	icon_state = "bucket_proxy"
 	force = 3
 	throwforce = 10
-	throw_speed = 2
+	throw_speed = 1
 	throw_range = 5
 	w_class = ITEM_SIZE_NORMAL
 	var/created_name = "Cleanbot"

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -374,7 +374,7 @@
 	icon_state = "toolbox_tiles"
 	force = 3
 	throwforce = 10
-	throw_speed = 2
+	throw_speed = 1
 	throw_range = 5
 	w_class = ITEM_SIZE_NORMAL
 	var/created_name = "Floorbot"
@@ -405,7 +405,7 @@
 	icon_state = "toolbox_tiles_sensor"
 	force = 3
 	throwforce = 10
-	throw_speed = 2
+	throw_speed = 1
 	throw_range = 5
 	w_class = ITEM_SIZE_NORMAL
 	var/created_name = "Floorbot"

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -11,7 +11,7 @@
 	w_class = ITEM_SIZE_SMALL
 	specific_organ_size = 2
 	throwforce = 1
-	throw_speed = 3
+	throw_speed = 0.3
 	throw_range = 5
 	origin_tech = list(TECH_BIO = 3)
 	attack_verb = list("attacked", "slapped", "whacked")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -284,13 +284,18 @@
 			var/turf/end_T = get_turf(target)
 			if(start_T && end_T)
 				var/mob/M = item
+				var/CalcThrowSpeed = src.stats.getStat(STAT_ROB, FALSE) < 0 ? 1 : src.stats.getStat(STAT_ROB, FALSE)
+				CalcThrowSpeed = round(100 / CalcThrowSpeed) / 10
+				CalcThrowSpeed = clamp(CalcThrowSpeed, 0.1 , 1) // this is  10ths of a second per movement delay
+				var/CalcThrowRange = clamp(1,13 - CalcThrowSpeed * 10 - M.mob_size/10,13)
+
 				var/start_T_descriptor = "<font color='#6b5d00'>tile at [start_T.x], [start_T.y], [start_T.z] in area [get_area(start_T)]</font>"
 				var/end_T_descriptor = "<font color='#6b4400'>tile at [end_T.x], [end_T.y], [end_T.z] in area [get_area(end_T)]</font>"
 
 				M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been thrown by [usr.name] ([usr.ckey]) from [start_T_descriptor] with the target [end_T_descriptor]</font>")
 				usr.attack_log += text("\[[time_stamp()]\] <font color='red'>Has thrown [M.name] ([M.ckey]) from [start_T_descriptor] with the target [end_T_descriptor]</font>")
 				msg_admin_attack("[usr.name] ([usr.ckey]) has thrown [M.name] ([M.ckey]) from [start_T_descriptor] with the target [end_T_descriptor] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[usr.x];Y=[usr.y];Z=[usr.z]'>JMP</a>)")
-				item.throw_at(target, item.throw_range, item.throw_speed, src)
+				item.throw_at(target, CalcThrowRange, CalcThrowSpeed, src)
 				return
 
 	//Grab processing has a chance of returning null

--- a/code/modules/mob/living/carbon/slime/items.dm
+++ b/code/modules/mob/living/carbon/slime/items.dm
@@ -7,7 +7,7 @@
 	force = 1
 	w_class = ITEM_SIZE_TINY
 	throwforce = 0
-	throw_speed = 3
+	throw_speed = 0.3
 	throw_range = 6
 	origin_tech = list(TECH_BIO = 4)
 	reagent_flags = REFILLABLE | DRAINABLE | AMOUNT_VISIBLE

--- a/code/modules/mob/living/carbon/superior_animal/golem/golem_core.dm
+++ b/code/modules/mob/living/carbon/superior_animal/golem/golem_core.dm
@@ -9,7 +9,7 @@
 	icon_state = "golem_core"
 	w_class = ITEM_SIZE_SMALL
 	throwforce = 0
-	throw_speed = 4
+	throw_speed = 0.25
 	throw_range = 20
 	origin_tech = list(TECH_BIO = 2)
 	matter = list(MATERIAL_BIOMATTER = 5)
@@ -34,7 +34,7 @@
 	if(!do_mob(user, M, 2 SECOND))
 		to_chat(user, SPAN_NOTICE("You must stand still to apply \the [src]."))
 		return TRUE
-	
+
 	// Heal the target
 	M.adjustBruteLoss(-GOLEM_CORE_HEAL)
 	M.adjustFireLoss(-GOLEM_CORE_HEAL)

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -10,7 +10,7 @@
 	slot_flags = SLOT_BELT
 	throwforce = 3
 	w_class = ITEM_SIZE_SMALL
-	throw_speed = 5
+	throw_speed = 0.2
 	throw_range = 10
 	origin_tech = list(TECH_MAGNET = 2, TECH_BIO = 1, TECH_ENGINEERING = 2)
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -6,7 +6,7 @@
 	throwforce = 0
 	w_class = ITEM_SIZE_SMALL
 	item_flags = DRAG_AND_DROP_UNEQUIP
-	throw_speed = 3
+	throw_speed = 0.3
 	throw_range = 10
 	spawn_tags = SPAWN_TAG_ITEM
 	var/obj/item/pen/haspen		//The stored pen.

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -5,7 +5,7 @@
 	item_state = "sheet-metal"
 	throwforce = 1
 	w_class = ITEM_SIZE_NORMAL
-	throw_speed = 3
+	throw_speed = 1
 	throw_range = 7
 	layer = OBJ_LAYER - 0.1
 	var/amount = 30					//How much paper is in the bin.

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -18,7 +18,7 @@
 	slot_flags = SLOT_BELT | SLOT_EARS
 	throwforce = 0
 	w_class = ITEM_SIZE_TINY
-	throw_speed = 7
+	throw_speed = 0.4
 	throw_range = 15
 	matter = list(MATERIAL_STEEL = 1)
 	spawn_tags = SPAWN_TAG_JUNK

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -6,7 +6,7 @@
 	item_state = "stamp"
 	throwforce = 0
 	w_class = ITEM_SIZE_TINY
-	throw_speed = 7
+	throw_speed = 0.4
 	throw_range = 15
 	matter = list(MATERIAL_PLASTIC = 1)
 	attack_verb = list("stamped")

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -12,7 +12,7 @@
 	origin_tech = list(TECH_POWER = 1)
 	force = WEAPON_FORCE_WEAK
 	throwforce = WEAPON_FORCE_WEAK
-	throw_speed = 3
+	throw_speed = 0.3
 	throw_range = 5
 	w_class = ITEM_SIZE_NORMAL
 	//Spawn_values

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -202,7 +202,7 @@
 	matter = list(MATERIAL_STEEL = 2)
 	throwforce = 5
 	w_class = ITEM_SIZE_SMALL
-	throw_speed = 4
+	throw_speed = 0.8
 	throw_range = 10
 
 	spawn_tags = SPAWN_TAG_AMMO

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -17,7 +17,7 @@
 	matter = list(MATERIAL_STEEL = 6)
 	w_class = ITEM_SIZE_NORMAL
 	throwforce = 5
-	throw_speed = 4
+	throw_speed = 0.7
 	throw_range = 5
 	force = WEAPON_FORCE_WEAK
 	origin_tech = list(TECH_COMBAT = 1)
@@ -1028,7 +1028,7 @@
 
 	if(firemodes.len)
 		very_unsafe_set_firemode(sel_mode) // Reset the firemode so it gets the new changes
-	
+
 	update_icon()
 	//then update any UIs with the new stats
 	SSnano.update_uis(src)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -9,7 +9,7 @@
 	slot_flags = SLOT_BELT
 	throwforce = 3
 	w_class = ITEM_SIZE_SMALL
-	throw_speed = 2
+	throw_speed = 1
 	throw_range = 10
 	amount_per_transfer_from_this = 10
 	unacidable = TRUE //plastic

--- a/code/modules/research/experiment.dm
+++ b/code/modules/research/experiment.dm
@@ -227,7 +227,7 @@ GLOBAL_LIST_EMPTY(explosion_watcher_list)
 	slot_flags = SLOT_BELT
 	throwforce = 3
 	w_class = ITEM_SIZE_SMALL
-	throw_speed = 5
+	throw_speed = 0.2
 	throw_range = 10
 	matter = list(MATERIAL_STEEL = 5)
 	origin_tech = list(TECH_ENGINEERING = 1, TECH_BIO = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Throwing now takes a speed movement delay as input instead of turfs per milisecond
Windows now no longer have RNG stuns
Windows-smashing now uses the division of the smasher's robustness and the target's toughness (from 0.3 to 3)  to increase/decrease the damage dealt to the target, and for agressive and neck grab , a possibility to stun. Ass of concrete greatly reduces damage taken from being smashed against windows and only lets you get stunned by smashes at neck-grab level.
Weak grabs will deal 10*TghRatio*health_ratio  , with a division by 3 if you have ass of concrete
Aggro-Grabs will just do 20 as default , Neck ones do 30
Being thrown against a widow  will stun if the product of  your toughness and your mob size is smaller than that of the window's resistance , window's health ratio and the speed you were thrown at, and will deal more damage. Having ass of concrete reduces this damage by a lot and prevent stuns
Throwing speed now scales from 0.1 to 1 tenths of a second for mobs , with the equation being (100 / your_rob ) / 10
Throwing range now scales from 1 to 13 , based on (13 - throwing_speed * 10 - mob_size / 10)
Tools with hammering quality now deal double damage to any window and are the only tools that can displace it
Tools with excavation , digging or drilling qualities deal normal damage to windows
Any other tool has their damage divided by 4
Added a minimum click delay to smashing so you can longer spam it , you can at most do 2 smashes now before your grab is removed
Added flimsy resistance (2) for weak windows.



## Why It's Good For The Game
More usefull perk , more tactical combat , hammering is more usefull , and throwing is uh, more dramatic.

## Changelog
:cl:
balance: Windows now take double damage from hammering tools, normal damage from excavation , digging and drilling , and 1/4 from every other tool type
balance: All window stuns had their RNG removed and they are now based of the victim's toughness stat and the attacker's robustness , with ass of concrete greatly buffing the victim.
balance: Window smashing now deals more damage to the victim , and also to the window itself in general(10,20,30 for weak,aggro,neck grabs),  with this being multiplied/divided by the skill difference between victim and attacker
balance: Throwing people against a window is no longer a RNG chance to stun , and is guaranted if they are extremly weak
balance: Added a minimum click delay to smashing people against windows ( you can only do it 2 times before your grab is removed)
code: Reworked throwing to use movement delays
balance: Adjusted throw-speeds of a lot of items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
