### PR TITLE
Buffs upon the death of a clanmate

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -938,6 +938,16 @@ Checks if a list has the same entries and values as an element of big.
 
 	return TRUE
 
+/proc/compareListOrderless(list/first,list/second)
+	if(!islist(first) || !islist(second))
+		return FALSE
+	if(length(first) != length(second))
+		return FALSE
+	var/list/temp = first & second
+	if(length(temp) == length(first))
+		return TRUE
+	return FALSE
+
 /proc/try_json_decode(t)
 	. = list()
 	if(istext(t))

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -365,22 +365,23 @@
 					penalty *= 0
 		//extra stuff if same departament
 		var/mob/living/carbon/human/fellow_human = M
-		if(GetDepartment(fellow_human) == GetDepartment(owner))
-			var/list/ownerAntag = owner.mind?.antagonist
-			var/list/deadAntag = fellow_human?.mind.antagonist
+		var/list/ownerAntag = owner.mind?.antagonist
+		var/list/deadAntag = fellow_human?.mind.antagonist
+		// part of same departament or  both excels (since they are the only teambased antag with differing departaments)
+		if(GetDepartment(owner) != "Unassigned")
+		if(GetDepartment(fellow_human) == GetDepartment(owner) || (ownerAntag & list(/datum/antagonist/excelsior) && deadAntag & list(/datum/antagonist/excelsior)))
 			// these 3 are loners , so they don't count for any buffs
 			if(!(ownerAntag & list(/datum/antagonist/carrion, /datum/antagonist/contractor, /datum/antagonist/marshal)))
 				// team based antagonists, // same antagonist list length and same antagonist datums , so they count (or a inquisitor who still cares about fellow believers)
 				var/effect_prob = rand(1, 100)
 				if(ownerAntag & list(/datum/antagonist/excelsior, /datum/antagonist/mercenary, /datum/antagonist/inquisitor) && (deadAntag & ownerAntag).len == ownerAntag.len || ownerAntag & list(/datum/antagonist/inquisitor))
 					// Better ones for antagonists because they are often outnumbered
+					// Its a good idea to not tell them if they received any effects to avoid antag detection by these
 					switch(effect_prob)
 						if(1 to 25)
-							to_chat(owner, SPAN_DANGER("Seeing the death of [M] floods your mind with rage!"))
 							owner.stats.addTempStat(STAT_TGH, 30, 5 MINUTES, "DeathRage")
 							owner.adjustHalLoss(-5)
 						if(25 to 50)
-							to_chat(owner, SPAN_DANGER("Vengeance. Vengeance. Vengeance for [M]"))
 							owner.stats.addTempStat(STAT_VIG, 25, 5 MINUTES, "DeathRage")
 							owner.stats.addTempStat(STAT_TGH, 20, 2 MINUTES, "DeathRage")
 						if(50 to 75)
@@ -390,16 +391,14 @@
 				else if(!deadAntag.len)
 					switch(effect_prob)
 						if(1 to 25)
-							to_chat(owner, SPAN_DANGER("Seeing the death of [M] floods your mind with rage!"))
 							owner.stats.addTempStat(STAT_TGH, 15, 5 MINUTES, "DeathRage")
 						if(25 to 50)
-							to_chat(owner, SPAN_DANGER("Vengeance. Vengeance. Vengeance for [M]"))
 							owner.stats.addTempStat(STAT_VIG, 15, 5 MINUTES, "DeathRage")
 							owner.stats.addTempStat(STAT_TGH, 10, 2 MINUTES, "DeathRage")
 						if(50 to 75)
 							owner.adjustHalLoss(-15)
 						if(75 to 100)
-							owner.stats.addTempStat(STAT_ROB, 5, 5 MINUTES, "DeathRage")
+							owner.stats.addTempStat(STAT_ROB, 10, 5 MINUTES, "DeathRage")
 
 		if(M.stats.getPerk(PERK_TERRIBLE_FATE) && prob(100-owner.stats.getStat(STAT_VIG)))
 			setLevel(0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If a player sees the death of another player who is 1)Part of the same departament , or 2)Part of the same team-based antagonist , they will receive one of the 4 random buffs
For antagonist buffs (bigger since they are more often outnumbered
1) 5 minute , 30 tgh buff , with -5 hallos adjustment
2) 5 minute , 25 vig buff,  2 minute 20 tgh buff
3)-25 hallos adjustment
4)5 minute , 20 rob adjustment
and for normal people (same amount of time)
1) 15 tgh , no hallos adjustment
2)15 vig , 10 tgh 
3) -15 hallos adjustment
4) 10 rob

## Why It's Good For The Game
Lets people fight for longer when they fight togheter as a group , encourages people to play less vaga , less pain knockout during intense fights
Carrion , marshal and contractors , borer , blitz , malf AI do not count for team-based antagonists
Excel , Inquis and Mercenaries do.

## Changelog
:cl:
balance: experiencing the death of a fellow clanmate / team based antagonist  will give you temporary combat buffs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
