### PR TITLE
Windows now take double damage from hammers , normal from any tool with digging , excavation or shoveling quality , and a quarter from everything else.

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -383,23 +383,26 @@
 				if(hit(I.force*I.structure_damage_factor*2) && health <= 10)
 					set_anchored(FALSE)
 					step(src, get_dir(user, src))
+				..()
 				return
 			// excavation and drilling, guaranteed to do damage.
 			if(QUALITY_DRILLING)
 				hit(I.force*I.structure_damage_factor)
+				..()
 				return
 			if(QUALITY_EXCAVATION)
 				hit(I.force*I.structure_damage_factor)
+				..()
 				return
 			if(QUALITY_DIGGING)
 				hit(I.force*I.structure_damage_factor)
+				..()
 				return
 			else
 				// everything else kinda sucks
 				hit(I.force*I.structure_damage_factor*0.25)
+				..()
 				return
-		..()
-	return
 
 /obj/structure/window/proc/hit(damage, sound_effect = TRUE, ignore_resistance = FALSE)
 	damage = take_damage(damage, TRUE, ignore_resistance)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -374,14 +374,30 @@
 
 	else
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		if(I.damtype == BRUTE || I.damtype == BURN)
-			user.do_attack_animation(src)
-			hit(I.force*I.structure_damage_factor)
-			if(health <= 7)
-				set_anchored(FALSE)
-				step(src, get_dir(user, src))
-		else
-			playsound(loc, 'sound/effects/Glasshit.ogg', 75, 1)
+		user.do_attack_animation(src)
+		playsound(loc, 'sound/effects/Glasshit.ogg', 75, 1)
+		var/tool_type = I.get_tool_type(user, usable_qualities, src)
+		switch(tool_type)
+			// hammers are perfect for breaking windows , and will be less likely to get you hurt
+			if(QUALITY_HAMMERING)
+				if(hit(I.force*I.structure_damage_factor*2) && health <= 10)
+					set_anchored(FALSE)
+					step(src, get_dir(user, src))
+				return
+			// excavation and drilling, guaranteed to do damage.
+			if(QUALITY_DRILLING)
+				hit(I.force*I.structure_damage_factor)
+				return
+			if(QUALITY_EXCAVATION)
+				hit(I.force*I.structure_damage_factor)
+				return
+			if(QUALITY_DIGGING)
+				hit(I.force*I.structure_damage_factor)
+				return
+			else
+				// everything else kinda sucks
+				hit(I.force*I.structure_damage_factor*0.25)
+				return
 		..()
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes windows take double damage from any tool with hammering quality , normal for any with digging/excavation/shoveling , and a quarter for everything else

## Why It's Good For The Game
Buff hammering tools  + a knife shouldn't be that good at breaking a window.
## Changelog
:cl:
balance: Hammering quality tools deal double damage to windows
balance: Any tool with excavation,digging or shoveling quality deals normal damage to windows
balance: Any tool without the aforementioned qualities deals a quarter of their damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
