### PR TITLE
Bio armor now reduces the amount of spider toxin injected into someone

### DIFF
--- a/code/__DEFINES/damage_organs.dm
+++ b/code/__DEFINES/damage_organs.dm
@@ -34,6 +34,9 @@
 #define ARMOR_BIO			"bio"
 #define ARMOR_RAD			"rad"
 
+//  Any armor with more than 95 bio will completly block mob-related injections
+#define BIO_MOB_INJECTION_THRESHOLD 95
+
 //Blood levels. These are percentages based on the species blood_volume
 #define BLOOD_VOLUME_SAFE_MODIFIER    45
 #define BLOOD_VOLUME_OKAY_MODIFIER    35

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
@@ -48,5 +48,9 @@
 
 	var/mob/living/L = A
 	if(istype(L) && L.reagents)
-		L.reagents.add_reagent(poison_type, poison_per_bite)
+		var/armorCheck =  L.getarmor(NULL , ARMOR_BIO)// gets us the average
+		if(!armorCheck)
+			L.reagents.add_reagent(poison_type, poison_per_bite)
+		else if(armorCheck < BIO_MOB_INJECTION_THRESHOLD)
+			L.reagents.add_reagent(poison_type, round(poison_per_bite * (1 - armorCheck/100)))
 

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
@@ -48,7 +48,7 @@
 
 	var/mob/living/L = A
 	if(istype(L) && L.reagents)
-		var/armorCheck =  L.getarmor(NULL , ARMOR_BIO)// gets us the average
+		var/armorCheck =  L.getarmor(null, ARMOR_BIO)// gets us the average
 		if(!armorCheck)
 			L.reagents.add_reagent(poison_type, poison_per_bite)
 		else if(armorCheck < BIO_MOB_INJECTION_THRESHOLD)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Bio armor now procentually reduces the amount of spider toxin injected into someone (BY GIANT SPIDERS, not carrion ones)
If its above 95 , its taken as a full block
anything below is inject_amount * ( 1 - bio_armor/100)

## Why It's Good For The Game 
I have fucking bio armor and spider goes through everything, general upside to using bio suits (and epic NT dev bias since they get to melle a lot)

## Changelog
:cl:
balance: Bio armor now reduces the amount of toxin injected by spiders , with values above 95 being complete protection
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
