### PR TITLE
Some fireaxe love

### DIFF
--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -66,7 +66,7 @@
 	w_class = ITEM_SIZE_HUGE
 	slot_flags = SLOT_BACK
 	force = WEAPON_FORCE_NORMAL
-	force_wielded_multiplier = 3.7
+	force_wielded_multiplier = 3.4
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -61,12 +61,12 @@
 	wielded_icon = "fireaxe1"
 	sharp = TRUE
 	edge = TRUE
-	armor_divisor = ARMOR_PEN_MODERATE
+	armor_divisor = ARMOR_PEN_DEEP
 	tool_qualities = list(QUALITY_CUTTING = 10, QUALITY_PRYING = 20)
 	w_class = ITEM_SIZE_HUGE
 	slot_flags = SLOT_BACK
 	force = WEAPON_FORCE_NORMAL
-	force_wielded_multiplier = 3.3
+	force_wielded_multiplier = 3.7
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING

--- a/code/game/objects/structures/fireaxe_cabinet.dm
+++ b/code/game/objects/structures/fireaxe_cabinet.dm
@@ -87,7 +87,7 @@
 		if(has_access(list(), req_one_access, ID.GetAccess()))
 			toggle_lock(user)
 		else
-			to_chat(user, SPAN_NOTICE("Insufficient access"))
+			to_chat(user, SPAN_NOTICE("You try to unlock the cabinet, but nothing happens."))
 	if(istype(O, /obj/item/tool/fireaxe))
 		if(open)
 			if(fireaxe)

--- a/code/game/objects/structures/fireaxe_cabinet.dm
+++ b/code/game/objects/structures/fireaxe_cabinet.dm
@@ -10,7 +10,7 @@
 	var/unlocked
 	var/shattered
 	var/obj/item/tool/fireaxe/fireaxe
-	req_access = list(access_moebius, access_heads)
+	req_one_access = list(access_moebius, access_heads)
 
 /obj/structure/fireaxecabinet/attack_generic(var/mob/user, var/damage, var/attack_verb, var/wallbreaker)
 	attack_animation(user)
@@ -84,8 +84,10 @@
 		return
 	if(istype(O, /obj/item/card/id))	
 		var/obj/item/card/id/ID = O
-		if (has_access(req_access, list(), ID.GetAccess()))
+		if(has_access(list(), req_one_access, ID.GetAccess()))
 			toggle_lock(user)
+		else
+			to_chat(user, SPAN_NOTICE("Insufficient access"))
 	if(istype(O, /obj/item/tool/fireaxe))
 		if(open)
 			if(fireaxe)

--- a/code/game/objects/structures/fireaxe_cabinet.dm
+++ b/code/game/objects/structures/fireaxe_cabinet.dm
@@ -10,7 +10,7 @@
 	var/unlocked
 	var/shattered
 	var/obj/item/tool/fireaxe/fireaxe
-	req_one_access = list(access_moebius, access_heads)
+	req_one_access = list(access_moebius, access_heads, access_engine)
 
 /obj/structure/fireaxecabinet/attack_generic(var/mob/user, var/damage, var/attack_verb, var/wallbreaker)
 	attack_animation(user)

--- a/code/game/objects/structures/fireaxe_cabinet.dm
+++ b/code/game/objects/structures/fireaxe_cabinet.dm
@@ -10,6 +10,7 @@
 	var/unlocked
 	var/shattered
 	var/obj/item/tool/fireaxe/fireaxe
+	req_access = list(access_moebius, access_heads)
 
 /obj/structure/fireaxecabinet/attack_generic(var/mob/user, var/damage, var/attack_verb, var/wallbreaker)
 	attack_animation(user)
@@ -81,7 +82,10 @@
 	if(istype(O, /obj/item/tool/multitool))
 		toggle_lock(user)
 		return
-
+	if(istype(O, /obj/item/card/id))	
+		var/obj/item/card/id/ID = O
+		if (has_access(req_access, list(), ID.GetAccess()))
+			toggle_lock(user)
 	if(istype(O, /obj/item/tool/fireaxe))
 		if(open)
 			if(fireaxe)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Fire axe has received a small damage and penetration buff (from 33 damage wielded to 34 damage wielded and from 1.6 AP to 1.8 AP), since it was pretty shit for a weapon that doesn't fit into a bag.

The fire axe cabinet can now also be unlocked by an ID with head or medical access without smashing the glass.

## Why It's Good For The Game

No longer neglected

## Changelog
:cl:
add: the fire axe cabinet can now be opened by an ID with head or medical access.
balance: slightly buffed fire axe damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
