### PR TITLE
double tact changes

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -160,12 +160,13 @@
 	// A is a turf or is on a turf, or in something on a turf (pen in a box); but not something in something on a turf (pen in a box in a backpack)
 	sdepth = A.storage_depth_turf()
 	if(isturf(A) || isturf(A.loc) || (sdepth != -1 && sdepth <= 1))
-		if(A.Adjacent(src)) // see adjacent.dm
+		var/adjacent = A.Adjacent(src)
+		if(adjacent) // see adjacent.dm
 			if(W)
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
 				var/resolved = (SEND_SIGNAL(W, COMSIG_IATTACK, A, src, params)) || (SEND_SIGNAL(A, COMSIG_ATTACKBY, W, src, params))
 				if(!resolved && A && W)
-					if(W.double_tact(src, A))
+					if(W.double_tact(src, A, adjacent))
 						resolved = W.resolve_attackby(A, src, params)
 					if(!resolved)
 						W.afterattack(A, src, 1, params) // 1: clicking something Adjacent

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -46,34 +46,35 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	return A.attackby(src, user, params)
 
 //Returns TRUE if attack is to be carried out, FALSE otherwise.
-/obj/item/proc/double_tact(mob/user, atom/atom_target)
-	if(user.a_intent == I_HELP)//no damage on help intent, no need for raising
-		return TRUE
+/obj/item/proc/double_tact(mob/user, atom/atom_target, adjacent)
 	if(atom_target.loc == user)//putting stuff in your backpack, or something else on your person?
 		return TRUE //regular bags won't even be able to hold items this big, but who knows
 	if(w_class >= ITEM_SIZE_BULKY && !abstract && !istype(src, /obj/item/gun))//grabs have colossal w_class. You can't raise something that does not exist.
-		if(!(ready))						//guns have the point blank privilege
-			user.visible_message(SPAN_DANGER("[user] raises [src]!"))
-			ready = TRUE
-			var/obj/effect/effect/melee/alert/A = new()
-			user.vis_contents += A
-			qdel(A)
-			var/unready_time = world.time + (10 SECONDS)
-			while(world.time < unready_time)
-				sleep(1)
-				if(!(ready))
-					user.vis_contents -= A
-					return FALSE
-				if(!(is_equipped()))
-					ready = FALSE
-					user.vis_contents -= A
-					return FALSE
-			user.visible_message(SPAN_NOTICE("[user] lowers \his [src]."))
-			ready = FALSE
-			user.vis_contents -= A
-			return FALSE
+		if(!adjacent || istype(atom_target, /turf) || istype(atom_target, /mob) || user.a_intent == I_HURT)//guns have the point blank privilege
+			if(!ready)
+				user.visible_message(SPAN_DANGER("[user] raises [src]!"))
+				ready = TRUE
+				var/obj/effect/effect/melee/alert/A = new()
+				user.vis_contents += A
+				qdel(A)
+				var/unready_time = world.time + (10 SECONDS)
+				while(world.time < unready_time)
+					sleep(1)
+					if(!(ready))
+						user.vis_contents -= A
+						return FALSE
+					if(!(is_equipped()))
+						ready = FALSE
+						user.vis_contents -= A
+						return FALSE
+				user.visible_message(SPAN_NOTICE("[user] lowers \his [src]."))
+				ready = FALSE
+				user.vis_contents -= A
+				return FALSE
+			else
+				ready = FALSE
+				return TRUE
 		else
-			ready = FALSE
 			return TRUE
 	else
 		return TRUE

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -272,9 +272,6 @@ meteor_act
 	if(!affecting)
 		return FALSE//should be prevented by attacked_with_item() but for sanity.
 
-	if(user.a_intent == I_HELP)
-		visible_message(SPAN_WARNING("[src] has been [pick("lightly poked", "tapped")] in the [affecting.name] with [I.name] by [user]!"))
-		return FALSE
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Firstly , being on help intent no longer deals no damage to humans. Yeah.

Secondly, for weapons with double tact, you will no longer raise your weapon if you click on items that are directly adjacent to you, unless you have harm intent on. For the non-coding folk, Items exclude turfs (floors and walls) and mobs. This should remove the brunt of non-attacking interactions, such as placing items on a table, requiring double tact to use, while practically not affecting combat.

With harm intent, you will double tact regardless of what you click on, if you want to be absolutely sure you don't even miss 1% of that precious gamer DPS. Again, this is only for weapons with double tact.

This should be a good tradeoff for making double tact not cancer to interact with (who am I kidding).
## Why It's Good For The Game

See #7828 

## Changelog
:cl:
balance: melee attacks will deal damage to humans again when in help intent
balance: you will no longer double tact if you click on items that are directly adjacent to you, unless you have harm intent on.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
