### PR TITLE
Makes borers actually able to copy stats

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -438,7 +438,7 @@
 		return
 
 	var/list/copied_stats = list()
-	if(!host.stats)
+	if(host.stats)
 		for(var/stat_name in ALL_STATS)
 			var/host_stat = host.stats.getStat(stat_name, pure=TRUE)
 			var/borer_stat = stats.getStat(stat_name, pure=TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So apparently, the borer's "Read Mind" ability was checking if the host did NOT have stats, rather than checking if they did.
That's obviously dumb and unintended, so I fixed it.

I fully tested this. Worked as intended, stats were copied, messages regarding copied stats and increased brain/sanity damage work fine, no runtimes or anything nasty.

## Why It's Good For The Game

In all honesty it's probably not, I fully expect this to have balance issues, but it's a bug so I fixed it.

## Changelog
:cl:
fix: Borers can now actually copy stats as intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
