### PR TITLE
OS Turret tweaks

### DIFF
--- a/code/modules/onestar/os_turret.dm
+++ b/code/modules/onestar/os_turret.dm
@@ -16,13 +16,14 @@
 
 	// Shooting
 	var/obj/item/projectile/projectile = /obj/item/projectile/bullet/gauss
+	var/shot_sound = 'sound/weapons/guns/fire/energy_shotgun.ogg'
 	var/number_of_shots = 5
 	var/time_between_shots = 0.5 SECONDS
 	var/list/shot_timer_ids = list()
 	var/cooldown_time = null
 
 	// Internal
-	var/emp_cooldown = 4 SECONDS
+	var/emp_cooldown = 8 SECONDS
 	var/emp_timer_id
 	var/on_cooldown = FALSE
 	var/cooldown_timer_id
@@ -32,6 +33,7 @@
 	circuit = /obj/item/electronics/circuitboard/os_turret/laser
 	range = 10
 	projectile = /obj/item/projectile/beam/pulsed_laser
+	shot_sound = 'sound/weapons/Laser.ogg'
 	number_of_shots = 3
 	time_between_shots = 0.3 SECONDS
 	cooldown_time = 2 SECONDS
@@ -201,8 +203,10 @@
 
 /obj/machinery/power/os_turret/proc/take_damage(amount)
 	machine_integrity = max(machine_integrity - amount, 0)
-	if(machine_integrity <= 0)
+	if(!machine_integrity)
 		stat |= BROKEN
+	else if(prob(50))
+		do_sparks(1, 0, loc)
 	return amount
 
 /obj/machinery/power/os_turret/proc/try_shoot(target)
@@ -248,6 +252,7 @@
 	set_dir(get_dir(src, target))
 	var/obj/item/projectile/P = new projectile(loc)
 	P.launch(target, def_zone)
+	playsound(src, shot_sound, 60, 1)
 
 /obj/machinery/power/os_turret/proc/cooldown()
 	on_cooldown = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds firing sounds, damage feedback via sparks, and extended the EMP state duration.

## Why It's Good For The Game

Bug fixes and better feedback

## Changelog
:cl:
add: Added firing sounds to OS turrets
tweak: Added 50% for the turret to spark when taking damage
balance: Extended duration of EMP'd state from 4 seconds to 8 seconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
