### PR TITLE
Replaces getter procs with vars in superior animal status updates

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -288,7 +288,7 @@
 	weakened = max(weakened-3,0)
 
 /mob/living/carbon/superior_animal/proc/handle_cheap_regular_status_updates()
-	health = maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss() - getCloneLoss() - halloss
+	health = maxHealth - oxyloss - toxloss - fireloss - bruteloss - cloneloss - halloss
 	if(health <= 0 && stat != DEAD)
 		death()
 		// STOP_PROCESSING(SSmobs, src) This is handled in Superior animal Life().


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Apparently, proc calling is very expensive in byond. Superior animal's handle_cheap_regular_status_updates() was one of the more costly procs used by superior mobs. Based on a local test, replacing the getter procs for damage with the damage vars cut the proc's CPU time cost in half. I doubt we'll see a noticeable improvement in performance, but every little bit counts.

## Why It's Good For The Game

Performance

## Changelog
:cl:
code: Replaced damage getter procs with damage vars in superior animal status updates
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
