### PR TITLE
Add grey satchel, backpack and sport backpack and other colors to loadout

### DIFF
--- a/code/datums/outfits/equipment/backpacks.dm
+++ b/code/datums/outfits/equipment/backpacks.dm
@@ -13,17 +13,29 @@
 	return
 
 /decl/backpack_outfit/backpack
-	name = "Backpack"
+	name = "Department Backpack"
 	path = /obj/item/storage/backpack
 
 /decl/backpack_outfit/backsport
-	name = "Sport Backpack"
+	name = "Department Sport Backpack"
 	path = /obj/item/storage/backpack/sport
 
 /decl/backpack_outfit/satchel
-	name = "Satchel"
+	name = "Department Satchel"
 	path = /obj/item/storage/backpack/satchel
 	is_default = TRUE
+
+/decl/backpack_outfit/grey_satchel
+	name = "Grey Satchel"
+	path = /obj/item/storage/backpack/satchel
+
+/decl/backpack_outfit/grey_backpack
+	name = "Grey Backpack"
+	path = /obj/item/storage/backpack
+
+/decl/backpack_outfit/grey_satchel
+	name = "Grey Sport Backpack"
+	path = /obj/item/storage/backpack/sport
 
 /decl/backpack_outfit/duffelbag
 	name = "Duffelbag"
@@ -36,6 +48,66 @@
 /decl/backpack_outfit/Leather_satchel
 	name = "Leather satchel"
 	path = /obj/item/storage/backpack/satchel/leather
+
+/decl/backpack_outfit/white_satchel
+	name = "White Satchel"
+	path = /obj/item/storage/backpack/satchel/white
+
+/decl/backpack_outfit/purple_satchel
+	name = "Purple Satchel"
+	path = /obj/item/storage/backpack/satchel/purple
+
+/decl/backpack_outfit/blue_satchel
+	name = "Blue Satchel"
+	path = /obj/item/storage/backpack/satchel/blue
+
+/decl/backpack_outfit/green_satchel
+	name = "Green Satchel"
+	path = /obj/item/storage/backpack/satchel/green
+
+/decl/backpack_outfit/orange_satchel
+	name = "Orange Satchel"
+	path = /obj/item/storage/backpack/satchel/orange
+
+/decl/backpack_outfit/white_backpack
+	name = "White Backpack"
+	path = /obj/item/storage/backpack/white
+
+/decl/backpack_outfit/purple_backpack
+	name = "Purple Backpack"
+	path = /obj/item/storage/backpack/purple
+
+/decl/backpack_outfit/blue_backpack
+	name = "Blue Backpack"
+	path = /obj/item/storage/backpack/blue
+
+/decl/backpack_outfit/green_backpack
+	name = "Green Backpack"
+	path = /obj/item/storage/backpack/green
+
+/decl/backpack_outfit/orange_backpack
+	name = "Orange Backpack"
+	path = /obj/item/storage/backpack/orange
+
+/decl/backpack_outfit/white_sportpack
+	name = "White Sport Backpack"
+	path = /obj/item/storage/backpack/sport/white
+
+/decl/backpack_outfit/purple_sportpack
+	name = "Purple Sport Backpack"
+	path = /obj/item/storage/backpack/sport/purple
+
+/decl/backpack_outfit/green_sportpack
+	name = "Green Sport Backpack"
+	path = /obj/item/storage/backpack/sport/green
+
+/decl/backpack_outfit/orange_sportpack
+	name = "Orange Sport Backpack"
+	path = /obj/item/storage/backpack/sport/orange
+
+
+
+
 /* Code */
 /decl/backpack_outfit
 	var/flags


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds grey satchel, backpack and sport backpack and other colors to loadout. Currently game overrides backpack/satchel/sports backpack with your departmental variant, this allows people to get default grey satchel and other colors if they so wish.
Should this mess with the preferences? I dunno, unlikely. Leather satchel has an uppercase letter (unforgivable) in its name but I'm not touching it in case it fucks up anyone's preferences.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's good for the looks if you choose unique clothing from loadout. Or if you're the only scientist, commit a crime in a generic voidsuit and get called out because of your research backpack.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Color satchels, backpacks and sport backpacks added into possible starting backpack selection
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
