### PR TITLE
Another projectile qdel fix (this one is for real)

### DIFF
--- a/code/__HELPERS/vector.dm
+++ b/code/__HELPERS/vector.dm
@@ -23,13 +23,13 @@ return_angle()
 	Returns the direction (angle in degrees) the object is travelling in.
 
              (N)
-             90�
+             90°
               ^
               |
-  (W) 180� <--+--> 0� (E)
+  (W) 180° <--+--> 0° (E)
               |
               v
-             -90�
+             -90°
              (S)
 
 return_hypotenuse()

--- a/code/__HELPERS/vector.dm
+++ b/code/__HELPERS/vector.dm
@@ -23,13 +23,13 @@ return_angle()
 	Returns the direction (angle in degrees) the object is travelling in.
 
              (N)
-             90°
+             90ï¿½
               ^
               |
-  (W) 180° <--+--> 0° (E)
+  (W) 180ï¿½ <--+--> 0ï¿½ (E)
               |
               v
-             -90°
+             -90ï¿½
              (S)
 
 return_hypotenuse()
@@ -51,6 +51,11 @@ return_location()
 	var/loc_z = 0	// loc z is in world space coordinates (i.e. z level) - we don't care about measuring pixels for this
 	var/offset_x = 0	// distance to increment each step
 	var/offset_y = 0
+
+/datum/plot_vector/Destroy()
+	source = null
+	target = null
+	return ..()
 
 /datum/plot_vector/proc/setup(var/turf/S, var/turf/T, var/xo = 0, var/yo = 0, var/angle_offset=0)
 	source = S
@@ -136,6 +141,10 @@ return_turf()
 	var/turf/loc
 	var/pixel_x
 	var/pixel_y
+
+/datum/vector_loc/Destroy()
+	loc = null
+	return ..()
 
 /datum/vector_loc/proc/return_turf()
 	return loc

--- a/code/__HELPERS/vector.dm
+++ b/code/__HELPERS/vector.dm
@@ -23,13 +23,13 @@ return_angle()
 	Returns the direction (angle in degrees) the object is travelling in.
 
              (N)
-             90°
+             90�
               ^
               |
-  (W) 180° <--+--> 0° (E)
+  (W) 180� <--+--> 0� (E)
               |
               v
-             -90°
+             -90�
              (S)
 
 return_hypotenuse()

--- a/code/__HELPERS/vector.dm
+++ b/code/__HELPERS/vector.dm
@@ -52,11 +52,6 @@ return_location()
 	var/offset_x = 0	// distance to increment each step
 	var/offset_y = 0
 
-/datum/plot_vector/Destroy()
-	source = null
-	target = null
-	return ..()
-
 /datum/plot_vector/proc/setup(var/turf/S, var/turf/T, var/xo = 0, var/yo = 0, var/angle_offset=0)
 	source = S
 	target = T
@@ -141,10 +136,6 @@ return_turf()
 	var/turf/loc
 	var/pixel_x
 	var/pixel_y
-
-/datum/vector_loc/Destroy()
-	loc = null
-	return ..()
 
 /datum/vector_loc/proc/return_turf()
 	return loc

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -235,9 +235,9 @@
 			Proj.damage_types[BRUTE] = round(Proj.damage_types[BRUTE] / 2 + Proj.damage_types[BRUTE] * ricochetchance / 200)
 			Proj.damage_types[BURN] = round(Proj.damage_types[BURN] / 2 + Proj.damage_types[BURN] * ricochetchance / 200)
 			Proj.def_zone = ran_zone()
-			take_damage(min(proj_damage - damagediff, 100))
+			projectile_reflection(Proj)		// Reflect before damage, runtimes occur in some cases if damage happens first.
 			visible_message("<span class='danger'>\The [Proj] ricochets off the surface of wall!</span>")
-			projectile_reflection(Proj)
+			take_damage(min(proj_damage - damagediff, 100))
 			new /obj/effect/sparks(get_turf(Proj))
 			return PROJECTILE_CONTINUE // complete projectile permutation
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -94,10 +94,7 @@
 /obj/item/projectile/Destroy()
 	firer = null
 	original = null
-	starting = null
 	LAZYCLEARLIST(permutated)
-	QDEL_NULL(trajectory)
-	QDEL_NULL(location)
 	return ..()
 
 /obj/item/projectile/is_hot()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -638,7 +638,7 @@
 			damage_types -= dmg_type
 	if(!damage_types.len)
 		on_impact(A)
-		qdel(A)
+		qdel(src)
 
 	return dmg_total ? (dmg_remaining / dmg_total) : 0
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -96,6 +96,8 @@
 	original = null
 	starting = null
 	LAZYCLEARLIST(permutated)
+	QDEL_NULL(trajectory)
+	QDEL_NULL(location)
 	return ..()
 
 /obj/item/projectile/is_hot()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes low-damage bullets deleting walls and mobs wearing RIGs. Also, fixes a runtime when a bullet ricochets off of a wall that it destroyed (not related to wall-deleting bug).

## Why It's Good For The Game

Bug fix

## Changelog
:cl:
tweak: Fixed a runtime when a wall is destroyed while a bullet is ricocheting
fix: Fixed issue with low damage bullets qdeling walls and mobs wearing RIGs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
