### PR TITLE
Another projectile qdel fix (this one is for real)

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -235,9 +235,9 @@
 			Proj.damage_types[BRUTE] = round(Proj.damage_types[BRUTE] / 2 + Proj.damage_types[BRUTE] * ricochetchance / 200)
 			Proj.damage_types[BURN] = round(Proj.damage_types[BURN] / 2 + Proj.damage_types[BURN] * ricochetchance / 200)
 			Proj.def_zone = ran_zone()
-			take_damage(min(proj_damage - damagediff, 100))
+			projectile_reflection(Proj)		// Reflect before damage, runtimes occur in some cases if damage happens first.
 			visible_message("<span class='danger'>\The [Proj] ricochets off the surface of wall!</span>")
-			projectile_reflection(Proj)
+			take_damage(min(proj_damage - damagediff, 100))
 			new /obj/effect/sparks(get_turf(Proj))
 			return PROJECTILE_CONTINUE // complete projectile permutation
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -639,7 +639,7 @@
 			damage_types -= dmg_type
 	if(!damage_types.len)
 		on_impact(A)
-		qdel(A)
+		qdel(src)
 
 	return dmg_total ? (dmg_remaining / dmg_total) : 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes low-damage bullets deleting walls and mobs wearing RIGs. Also, fixes a runtime when a bullet ricochets off of a wall that it destroyed (not related to wall-deleting bug).

## Why It's Good For The Game

Bug fix

## Changelog
:cl:
tweak: Fixed a runtime when a wall is destroyed while a bullet is ricocheting
fix: Fixed issue with low damage bullets qdeling walls and mobs wearing RIGs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
