### PR TITLE
Give MBO a dartgun instead of a Anne and some ammo/poison roundstart

### DIFF
--- a/code/datums/outfits/jobs/medical.dm
+++ b/code/datums/outfits/jobs/medical.dm
@@ -21,7 +21,7 @@
 	id_type = /obj/item/card/id/cmo
 	pda_type = /obj/item/modular_computer/pda/heads/cmo
 	belt = /obj/item/storage/belt/medical/
-	backpack_contents = list(/obj/item/gun/projectile/selfload/moebius = 1, /obj/item/ammo_magazine/pistol/rubber = 2)
+	backpack_contents = list(/obj/item/gun/projectile/dartgun = 1, /obj/item/ammo_magazine/chemdart = 6, /obj/item/reagent_containers/glass/beaker/vial/random/toxin = 1)
 
 /decl/hierarchy/outfit/job/medical/doctor
 	name = OUTFIT_JOB_NAME("Moebius Doctor")

--- a/code/datums/outfits/jobs/medical.dm
+++ b/code/datums/outfits/jobs/medical.dm
@@ -21,7 +21,7 @@
 	id_type = /obj/item/card/id/cmo
 	pda_type = /obj/item/modular_computer/pda/heads/cmo
 	belt = /obj/item/storage/belt/medical/
-	backpack_contents = list(/obj/item/gun/projectile/dartgun = 1, /obj/item/ammo_magazine/chemdart = 6, /obj/item/reagent_containers/glass/beaker/vial/random/toxin = 1)
+	backpack_contents = list(/obj/item/gun/projectile/dartgun = 1, /obj/item/ammo_magazine/chemdart = 3, /obj/item/reagent_containers/glass/beaker/vial/random/toxin = 1)
 
 /decl/hierarchy/outfit/job/medical/doctor
 	name = OUTFIT_JOB_NAME("Moebius Doctor")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces his roundstart anne and a dartgun, three mags for it and a random poison vial
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Dartgun is a pretty forgotten weapon - it's essentially a syringe gun+ and it's foudn either only from junk or uplink. Given MBO works in medical and has access to chemistry I believe it would be more fitting for him to be armed with a dartgun.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: MBO now starts with a dartgun, 3 mags and random poison vial instead of Anne and 2 rubber mags for it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
