### PR TITLE
Sets FPS/ticklag on /world to match config (40 FPS)

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -17,4 +17,4 @@
 	view = "15x15"
 	hub = "Exadv1.spacestation13"
 	cache_lifespan = 0	//stops player uploaded stuff from being kept in the rsc past the current session
-	fps = 20
+	fps = 40


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Got spooked by some high tick drift last time, but we might as well run this on the test server. Setting /world default FPS to 40 sets the ticklag to match the config-defined ticklag. The difference was causing the timer subsystem (and possibly others) to pre-initialize at 20 FPS, which caused timers to reset at roundstart. Unsure if this will impact gameplay as timers have been solid lately.

## Why It's Good For The Game

Bug fix

## Changelog
:cl:
tweak: Sets FPS/ticklag on /world to match config (40 FPS)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
