### PR TITLE
Kovacs caliber change and improvement to the Kadmin and Vintorez

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1598,7 +1598,7 @@
 					/obj/item/storage/deferred/crate/uniform_flak  = 2,
 					/obj/item/storage/deferred/crate/uniform_light = 2,
 					/obj/item/gun/projectile/kovacs = 2,
-					/obj/item/ammo_magazine/srifle = 6,
+					/obj/item/ammo_magazine/lrifle = 6,
 					/obj/item/gun/projectile/boltgun/serbian = 10,
 					/obj/item/ammo_magazine/sllrifle = 20,
 					/obj/item/ammo_magazine/ammobox/lrifle_small = 30,

--- a/code/game/objects/items/weapons/design_disks/serbian_arms.dm
+++ b/code/game/objects/items/weapons/design_disks/serbian_arms.dm
@@ -70,12 +70,12 @@
 	)
 
 /obj/item/computer_hardware/hard_drive/portable/design/guns/sa_br
-	disk_name = "Serbian Arms - .20 Kovacs"
+	disk_name = "Serbian Arms - .30 Kovacs"
 	icon_state = "serbian"
 	spawn_tags = SPAWN_TAG_DESIGN_ADVANCED
 	rarity_value = 80
 	license = 12
 	designs = list(
 		/datum/design/autolathe/gun/kovacs = 3, // "SA BR .20 \"Kovacs\""
-		/datum/design/autolathe/ammo/srifle
+		/datum/design/autolathe/ammo/lrifle
 	)

--- a/code/game/objects/items/weapons/design_disks/serbian_arms.dm
+++ b/code/game/objects/items/weapons/design_disks/serbian_arms.dm
@@ -76,6 +76,6 @@
 	rarity_value = 80
 	license = 12
 	designs = list(
-		/datum/design/autolathe/gun/kovacs = 3, // "SA BR .20 \"Kovacs\""
+		/datum/design/autolathe/gun/kovacs = 3, // "SA BR .30 \"Kovacs\""
 		/datum/design/autolathe/ammo/lrifle
 	)

--- a/code/game/objects/items/weapons/storage/deferred.dm
+++ b/code/game/objects/items/weapons/storage/deferred.dm
@@ -169,7 +169,7 @@
 	desc = "A crate containing six \"Kovacs\" battle rifles, and plenty of mags."
 	icon_state = "serbcrate_deferred_green"
 	initial_contents = list(/obj/item/gun/projectile/kovacs = 6,
-	/obj/item/ammo_magazine/srifle = 18)
+	/obj/item/ammo_magazine/lrifle = 18)
 
 /obj/item/storage/deferred/crate/grenadier
 	name = "grenadier crate"

--- a/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
@@ -1,7 +1,7 @@
 /obj/item/gun/projectile/automatic/vintorez
 	name = "Excelsior .20 \"Vintorez\""
 	desc = "This gun is a copy of a design from a country that no longer exists. It is still highly prized for its armor piercing capabilities. \
-			The design was made to be able to fit long magazine alongside the standard ones."
+			The design was made to be able to fit long magazine alongside the standard ones. Uses .20 Rifle rounds."
 	icon = 'icons/obj/guns/projectile/vintorez.dmi'
 	icon_state = "vintorez"
 	item_state = "vintorez"
@@ -17,8 +17,8 @@
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 5)
 	price_tag = 4000
 	zoom_factors = list(0.8) // double as IH_heavy
-	penetration_multiplier = 0
-	damage_multiplier = 1.2
+	penetration_multiplier = 0.2
+	damage_multiplier = 1.5
 	init_recoil = RIFLE_RECOIL(0.65)
 	silenced = TRUE
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/battle_rifle/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/battle_rifle/boltgun.dm
@@ -146,8 +146,8 @@
 	force = WEAPON_FORCE_DANGEROUS // weaker than novakovic, but with a bayonet installed it will be slightly stronger
 	armor_divisor = ARMOR_PEN_GRAZING
 	caliber = CAL_SRIFLE
-	damage_multiplier = 1.7
-	penetration_multiplier = 0.7
+	damage_multiplier = 1.8
+	penetration_multiplier = 1
 	init_recoil = RIFLE_RECOIL(1.8)
 	init_offset = 0 //no bayonet
 	max_shells = 6

--- a/code/modules/projectiles/guns/projectile/battle_rifle/kovacs.dm
+++ b/code/modules/projectiles/guns/projectile/battle_rifle/kovacs.dm
@@ -13,7 +13,7 @@
 	slot_flags = SLOT_BACK
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_RIFLE
-	magazine_type = /obj/item/ammo_magazine/srifle
+	magazine_type = /obj/item/ammo_magazine/lrifle
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 12)
 	price_tag = 2200
 	fire_sound = 'sound/weapons/guns/fire/sniper_fire.ogg'

--- a/code/modules/projectiles/guns/projectile/battle_rifle/kovacs.dm
+++ b/code/modules/projectiles/guns/projectile/battle_rifle/kovacs.dm
@@ -1,8 +1,8 @@
 /obj/item/gun/projectile/kovacs
-	name = "SA BR .20 \"Kovacs\""
-	desc = "The \"Kovacs\" is a refined battle rifle fit for taking down heavily armoured targets. \
+	name = "SA BR .30 \"Kovacs\""
+	desc = "The \"Kovacs\" is a refined battle rifle fit for taking down tough targets. \
 			This extremely efficient rifle design has gone into disuse over the years but still sees use by mercenaries. \
-			Uses .20 Rifle rounds."
+			Uses .30 Rifle rounds."
 	icon = 'icons/obj/guns/projectile/kovacs.dmi'
 	icon_state = "kovacs"
 	item_state = "kovacs"
@@ -12,20 +12,20 @@
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 1)
 	slot_flags = SLOT_BACK
 	load_method = MAGAZINE
-	mag_well = MAG_WELL_RIFLE|MAG_WELL_RIFLE_L
+	mag_well = MAG_WELL_RIFLE
 	magazine_type = /obj/item/ammo_magazine/srifle
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 12)
-	price_tag = 2000
+	price_tag = 2200
 	fire_sound = 'sound/weapons/guns/fire/sniper_fire.ogg'
 	unload_sound = 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound = 'sound/weapons/guns/interact/ltrifle_magin.ogg'
 	cocked_sound = 'sound/weapons/guns/interact/ltrifle_cock.ogg'
 	damage_multiplier = 1.4
-	penetration_multiplier = 0.2
-	init_recoil = RIFLE_RECOIL(1)
+	penetration_multiplier = 0
+	init_recoil = RIFLE_RECOIL(1.3)
 	zoom_factors = list(0.6)
 	fire_delay = 6.5
-	gun_parts = list(/obj/item/part/gun/frame/kovacs = 1, /obj/item/part/gun/grip/serb = 1, /obj/item/part/gun/mechanism/autorifle = 1, /obj/item/part/gun/barrel/srifle = 1)
+	gun_parts = list(/obj/item/part/gun/frame/kovacs = 1, /obj/item/part/gun/grip/serb = 1, /obj/item/part/gun/mechanism/autorifle = 1, /obj/item/part/gun/barrel/lrifle = 1)
 	serial_type = "SA"
 
 
@@ -34,9 +34,17 @@
 	..()
 
 	var/iconstring = initial(icon_state)
-	iconstring = initial(icon_state) + (ammo_magazine ? "_mag" + (ammo_magazine.mag_well == MAG_WELL_RIFLE_L ? "_l" : (ammo_magazine.mag_well == MAG_WELL_RIFLE_D ? "_d" : "")) : "")
+	var/itemstring = ""
+
+	if (ammo_magazine)
+		iconstring += "_mag"
+		itemstring += "_mag"
+
+	if (!ammo_magazine || !length(ammo_magazine.stored_ammo))
+		iconstring += "_slide"
 
 	icon_state = iconstring
+	set_item_state(itemstring)
 
 /obj/item/gun/projectile/kovacs/Initialize()
 	. = ..()
@@ -44,9 +52,9 @@
 
 /obj/item/part/gun/frame/kovacs
 	name = "Kovacs frame"
-	desc = "A Kovacs battle rifle frame. To punch through armor with panache."
+	desc = "A Kovacs battle rifle frame. To punch through people with panache."
 	icon_state = "frame_kovacs"
 	resultvars = list(/obj/item/gun/projectile/kovacs)
 	gripvars = list(/obj/item/part/gun/grip/serb)
 	mechanismvar = /obj/item/part/gun/mechanism/autorifle
-	barrelvars = list(/obj/item/part/gun/barrel/srifle)
+	barrelvars = list(/obj/item/part/gun/barrel/lrifle)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes Kovacs from the .20 marksman role (already done by the vintorez and kadmin) to a .30 battle rifle purpose: hits hard, scope, though high recoil (not as hard as bolt guns since it is magazine fed and semi auto).
Slighly improves the Kadmin and Vintorez as they were seriouly anemic and overall very weak. The stats were low and it was a mistake on my part because I did not take into account the fact both of these guns were _slow firing and thus seriouly under performing_ compared to automatic guns of any other caliber.

the Kovacs was approved by [REDACTED] (who is he and how did he shit my pants????).
![image](https://user-images.githubusercontent.com/40152611/204851125-393b484b-b429-48cd-be5e-0b4821c2a507.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The kovacs, vintorez and kadmin treated on each other's feet and were altogether too similar (kovacs and vintores in particular). Why have three guns with the same fucking role and purpose? all .20 guns but the wintermute are marskman guns, while the .30 lacks their own scoped battle rifle.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
It's literally a number change and I have an autistic spreadsheet for number changes.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
balance: the Kovacs is now .30 caliber and designed to hit hard at the cost of high recoil
balance: improved the Kadmin and Vintorez stats as they were too weak
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
