### PR TITLE
Renames the fullauto modes

### DIFF
--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -55,12 +55,12 @@
 #define STRUCTURE_DAMAGE_DESTRUCTIVE 	3
 
 //Quick defines for fire modes
-#define FULL_AUTO_300		list(mode_name = "full auto",  mode_desc = "300 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 4  , icon="auto")
-#define FULL_AUTO_400		list(mode_name = "full auto",  mode_desc = "400 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 3, icon="auto")
-#define FULL_AUTO_600		list(mode_name = "full auto",  mode_desc = "600 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 2  , icon="auto")
-#define FULL_AUTO_800		list(mode_name = "fuller auto",  mode_desc = "800 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 1.6, icon="auto")
+#define FULL_AUTO_150		list(mode_name = "full auto",  mode_desc = "150 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 4  , icon="auto")
+#define FULL_AUTO_200		list(mode_name = "full auto",  mode_desc = "200 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 3, icon="auto")
+#define FULL_AUTO_300		list(mode_name = "full auto",  mode_desc = "300 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 2  , icon="auto")
+#define FULL_AUTO_400		list(mode_name = "fuller auto",  mode_desc = "400 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 1.6, icon="auto")
 
-#define SEMI_AUTO_300	list(mode_name = "semiauto",  mode_desc = "Fire as fast as you can pull the trigger", burst=1, fire_delay=4, move_delay=null, icon="semi")
+#define SEMI_AUTO_150	list(mode_name = "semiauto",  mode_desc = "Fire as fast as you can pull the trigger", burst=1, fire_delay=4, move_delay=null, icon="semi")
 
 //Cog firemode
 #define BURST_2_BEAM		list(mode_name="2-beam bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, move_delay=2, icon="burst")

--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -370,7 +370,7 @@
 
 /datum/component/item_upgrade/proc/add_values_gun(obj/item/gun/G)
 	if(weapon_upgrades[GUN_UPGRADE_FULLAUTO])
-		G.add_firemode(FULL_AUTO_400)
+		G.add_firemode(FULL_AUTO_200)
 
 /datum/component/item_upgrade/proc/apply_values_firemode(datum/firemode/F)
 	for(var/i in F.settings)

--- a/code/modules/projectiles/guns/energy/lasersmg.dm
+++ b/code/modules/projectiles/guns/energy/lasersmg.dm
@@ -19,13 +19,13 @@
 	damage_multiplier = 0.35 //makeshift laser
 	penetration_multiplier = 1
 	projectile_type = /obj/item/projectile/beam
-	init_offset = 0 
+	init_offset = 0
 	suitable_cell = /obj/item/cell/medium
 	charge_cost = 25 // 4 bursts with a 800m cell
 
 	init_firemodes = list(
 		BURST_8_ROUND,
-		FULL_AUTO_300
+		FULL_AUTO_150
 		)
 
 	wield_delay = 1 SECOND

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -19,8 +19,8 @@
 	bad_type = /obj/item/gun/projectile/automatic
 	gun_parts = list(/obj/item/part/gun = 3 ,/obj/item/stack/material/steel = 15)
 	init_firemodes = list(
-		FULL_AUTO_400,
-		SEMI_AUTO_300,
+		FULL_AUTO_200,
+		SEMI_AUTO_150,
 		BURST_3_ROUND,
 		BURST_5_ROUND
 		)

--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -30,8 +30,8 @@
 	gun_tags = list(GUN_SILENCABLE)
 
 	init_firemodes = list(
-		FULL_AUTO_400,
-		SEMI_AUTO_300,
+		FULL_AUTO_200,
+		SEMI_AUTO_150,
 		BURST_5_ROUND
 		)
 	serial_type = "Excelsior"
@@ -172,7 +172,7 @@
 	gun_tags = list(GUN_FA_MODDABLE, GUN_GILDABLE)
 
 	init_firemodes = list(
-		SEMI_AUTO_300,
+		SEMI_AUTO_150,
 		BURST_3_ROUND,
 		BURST_5_ROUND
 	)
@@ -263,7 +263,7 @@
 	penetration_multiplier = 0
 
 	init_firemodes = list(
-		SEMI_AUTO_300	//too poorly made for burst or automatic
+		SEMI_AUTO_150	//too poorly made for burst or automatic
 	)
 	spawn_blacklisted = FALSE
 	spawn_tags = SPAWN_TAG_GUN_HANDMADE

--- a/code/modules/projectiles/guns/projectile/automatic/atreides.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/atreides.dm
@@ -26,8 +26,8 @@
 	init_recoil = SMG_RECOIL(0.4)
 
 	init_firemodes = list(
-		FULL_AUTO_400,
-		SEMI_AUTO_300,
+		FULL_AUTO_200,
+		SEMI_AUTO_150,
 		)
 
 /obj/item/gun/projectile/automatic/atreides/update_icon()

--- a/code/modules/projectiles/guns/projectile/automatic/c20r.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/c20r.dm
@@ -31,8 +31,8 @@
 	gun_tags = list(GUN_SILENCABLE)
 
 	init_firemodes = list(
-		FULL_AUTO_400,
-		SEMI_AUTO_300,
+		FULL_AUTO_200,
+		SEMI_AUTO_150,
 		)
 
 	serial_type = "S"

--- a/code/modules/projectiles/guns/projectile/automatic/dallas.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/dallas.dm
@@ -31,8 +31,8 @@
 	gun_tags = list(GUN_SILENCABLE)
 
 	init_firemodes = list(
-		FULL_AUTO_400,
-		SEMI_AUTO_300,
+		FULL_AUTO_200,
+		SEMI_AUTO_150,
 		)
 
 	serial_type = "PAR"

--- a/code/modules/projectiles/guns/projectile/automatic/drozd.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/drozd.dm
@@ -23,8 +23,8 @@
 	gun_tags = list(GUN_SILENCABLE)
 
 	init_firemodes = list(
-		FULL_AUTO_300,
-		SEMI_AUTO_300
+		FULL_AUTO_150,
+		SEMI_AUTO_150
 		)
 	gun_parts = list(/obj/item/part/gun/frame/drozd = 1, /obj/item/part/gun/grip/excel = 1, /obj/item/part/gun/mechanism/smg = 1, /obj/item/part/gun/barrel/magnum = 1)
 

--- a/code/modules/projectiles/guns/projectile/automatic/lmg.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/lmg.dm
@@ -32,7 +32,7 @@
 	gun_parts = list(/obj/item/part/gun = 1 ,/obj/item/stack/material/plasteel = 4)
 
 	init_firemodes = list(
-		FULL_AUTO_600,
+		FULL_AUTO_300,
 		BURST_5_ROUND,
 		BURST_8_ROUND
 		)

--- a/code/modules/projectiles/guns/projectile/automatic/luty.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/luty.dm
@@ -19,8 +19,8 @@
 	mag_well = MAG_WELL_PISTOL|MAG_WELL_H_PISTOL|MAG_WELL_SMG
 	matter = list(MATERIAL_STEEL = 10, MATERIAL_PLASTIC = 5, MATERIAL_WOOD = 12)
 	init_firemodes = list(
-		FULL_AUTO_400,
-		SEMI_AUTO_300,
+		FULL_AUTO_200,
+		SEMI_AUTO_150,
 		)
 
 	can_dual = 1

--- a/code/modules/projectiles/guns/projectile/automatic/maxim.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/maxim.dm
@@ -27,7 +27,7 @@
 	penetration_multiplier = -0.2
 	burst_delay = 0.8
 	init_firemodes = list(
-		list(mode_name = "full auto",  mode_desc="800 rounds per minute", mode_type = /datum/firemode/automatic, fire_delay=2.4, icon="auto", move_delay=5),
+		list(mode_name = "full auto",  mode_desc="400 rounds per minute", mode_type = /datum/firemode/automatic, fire_delay=1.6, icon="auto", move_delay=5),
 		list(mode_name="short bursts", mode_desc="dakka", burst=5, fire_delay=null, move_delay=5,  icon="burst"),
 		list(mode_name="long bursts", mode_desc="Dakka", burst=8, fire_delay=null, move_delay=7,  icon="burst"),
 		list(mode_name="suppressing fire", mode_desc="DAKKA", burst=16, fire_delay=null, move_delay=13,  icon="burst")

--- a/code/modules/projectiles/guns/projectile/automatic/maxim.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/maxim.dm
@@ -27,7 +27,7 @@
 	penetration_multiplier = -0.2
 	burst_delay = 0.8
 	init_firemodes = list(
-		list(mode_name = "full auto",  mode_desc="400 rounds per minute", mode_type = /datum/firemode/automatic, fire_delay=1.6, icon="auto", move_delay=5),
+		list(mode_name = "full auto",  mode_desc="250 rounds per minute", mode_type = /datum/firemode/automatic, fire_delay=2.4, icon="auto", move_delay=5),
 		list(mode_name="short bursts", mode_desc="dakka", burst=5, fire_delay=null, move_delay=5,  icon="burst"),
 		list(mode_name="long bursts", mode_desc="Dakka", burst=8, fire_delay=null, move_delay=7,  icon="burst"),
 		list(mode_name="suppressing fire", mode_desc="DAKKA", burst=16, fire_delay=null, move_delay=13,  icon="burst")

--- a/code/modules/projectiles/guns/projectile/automatic/molly.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/molly.dm
@@ -20,7 +20,7 @@
 
 	gun_tags = list(GUN_SILENCABLE)
 	init_firemodes = list(
-		SEMI_AUTO_300,
+		SEMI_AUTO_150,
 		BURST_3_ROUND_SMG,
 		BURST_6_ROUND_SMG
 		)

--- a/code/modules/projectiles/guns/projectile/automatic/slaught_o_matic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/slaught_o_matic.dm
@@ -33,8 +33,8 @@
 	gun_tags = list(GUN_SILENCABLE)
 
 	init_firemodes = list(
-		FULL_AUTO_300,
-		FULL_AUTO_800
+		FULL_AUTO_150,
+		FULL_AUTO_400
 		)
 	wield_delay = 0
 

--- a/code/modules/projectiles/guns/projectile/automatic/sol.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sol.dm
@@ -23,7 +23,7 @@
 	gun_tags = list(GUN_FA_MODDABLE)
 
 	init_firemodes = list(
-		SEMI_AUTO_300,
+		SEMI_AUTO_150,
 		BURST_3_ROUND,
 		BURST_3_ROUND_RAPID
 		)

--- a/code/modules/projectiles/guns/projectile/automatic/straylight.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/straylight.dm
@@ -23,8 +23,8 @@
 	gun_tags = list(GUN_SILENCABLE)
 
 	init_firemodes = list(
-		FULL_AUTO_600,
-		SEMI_AUTO_300
+		FULL_AUTO_300,
+		SEMI_AUTO_150
 		)
 
 	wield_delay = 0 // Super weak SMG

--- a/code/modules/projectiles/guns/projectile/automatic/sts35.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts35.dm
@@ -27,8 +27,8 @@
 	gun_tags = list(GUN_SILENCABLE)
 
 	init_firemodes = list(
-		FULL_AUTO_400,
-		SEMI_AUTO_300,
+		FULL_AUTO_200,
+		SEMI_AUTO_150,
 		BURST_3_ROUND
 		)
 	gun_parts = list(/obj/item/part/gun/frame/sts35 = 1, /obj/item/part/gun/grip/black = 1, /obj/item/part/gun/mechanism/autorifle = 1, /obj/item/part/gun/barrel/lrifle = 1)

--- a/code/modules/projectiles/guns/projectile/automatic/type17.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/type17.dm
@@ -25,9 +25,9 @@
 	spawn_tags = SPAWN_TAG_GUN_OS
 	spawn_blacklisted = TRUE
 	init_firemodes = list(
-		SEMI_AUTO_300,
+		SEMI_AUTO_150,
 		BURST_3_ROUND,
-		FULL_AUTO_400
+		FULL_AUTO_200
 		)
 
 	gun_tags = list(GUN_SILENCABLE)

--- a/code/modules/projectiles/guns/projectile/automatic/type47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/type47.dm
@@ -26,9 +26,9 @@
 	gun_tags = list(GUN_SILENCABLE)
 	gun_parts = list(/obj/item/part/gun = 2 ,/obj/item/stack/material/plasteel = 6)
 	init_firemodes = list(
-		SEMI_AUTO_300,
+		SEMI_AUTO_150,
 		BURST_3_ROUND,
-		FULL_AUTO_400
+		FULL_AUTO_200
 		)
 
 	serial_type = "OS"

--- a/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
@@ -22,7 +22,7 @@
 	init_recoil = RIFLE_RECOIL(0.65)
 	silenced = TRUE
 	init_firemodes = list(
-		SEMI_AUTO_300,
+		SEMI_AUTO_150,
 		BURST_2_ROUND
 		)
 	gun_parts = list(/obj/item/part/gun/frame/vintorez = 1, /obj/item/part/gun/grip/excel = 1, /obj/item/part/gun/mechanism/autorifle = 1, /obj/item/part/gun/barrel/srifle = 1)

--- a/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
@@ -28,9 +28,9 @@
 	gun_tags = list(GUN_SILENCABLE)
 
 	init_firemodes = list(
-		SEMI_AUTO_300,
+		SEMI_AUTO_150,
 		BURST_3_ROUND,
-		FULL_AUTO_400
+		FULL_AUTO_200
 		)
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE

--- a/code/modules/projectiles/guns/projectile/automatic/z8.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/z8.dm
@@ -26,7 +26,7 @@
 	gun_tags = list(GUN_FA_MODDABLE)
 
 	init_firemodes = list(
-		SEMI_AUTO_300,
+		SEMI_AUTO_150,
 		BURST_3_ROUND,
 		list(mode_name="fire grenades", mode_desc="Unlocks the underbarrel grenade launcher", burst=null, fire_delay=null, move_delay=null,  icon="grenade", use_launcher=1)
 		)

--- a/code/modules/projectiles/guns/projectile/automatic/zoric.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/zoric.dm
@@ -22,8 +22,8 @@
 	twohanded = FALSE
 
 	init_firemodes = list(
-		FULL_AUTO_300,
-		SEMI_AUTO_300,
+		FULL_AUTO_150,
+		SEMI_AUTO_150,
 		)
 	gun_tags = list(GUN_SILENCABLE)
 	gun_parts = list(/obj/item/part/gun/frame/zoric = 1, /obj/item/part/gun/grip/serb = 1, /obj/item/part/gun/mechanism/smg = 1, /obj/item/part/gun/barrel/magnum = 1)

--- a/code/modules/projectiles/guns/projectile/pistol/selfload.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/selfload.dm
@@ -24,8 +24,8 @@
 
 	gun_tags = list(GUN_SILENCABLE)
 	init_firemodes = list(
-		SEMI_AUTO_300,
-		FULL_AUTO_800
+		SEMI_AUTO_150,
+		FULL_AUTO_400
 		)
 
 
@@ -72,7 +72,7 @@
 	price_tag = 1400
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2, TECH_COVERT = 3)
 	init_firemodes = list(
-		SEMI_AUTO_300
+		SEMI_AUTO_150
 		)
 	gun_parts = list(/obj/item/part/gun/frame/makarov = 1, /obj/item/part/gun/grip/excel = 1, /obj/item/part/gun/mechanism/pistol = 1, /obj/item/part/gun/barrel/pistol = 1)
 

--- a/code/modules/projectiles/guns/projectile/pistol/type62.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/type62.dm
@@ -21,9 +21,9 @@
 	reload_sound = 'sound/weapons/guns/interact/hpistol_magin.ogg'
 	cocked_sound = 'sound/weapons/guns/interact/rifle_boltforward.ogg'
 	init_firemodes = list(
-		FULL_AUTO_600,
-		FULL_AUTO_800,
-		SEMI_AUTO_300
+		FULL_AUTO_300,
+		FULL_AUTO_400,
+		SEMI_AUTO_150
         )
 	spawn_tags = SPAWN_TAG_GUN_OS
 	spawn_blacklisted = TRUE

--- a/code/modules/projectiles/guns/projectile/pistol/type90.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/type90.dm
@@ -25,7 +25,7 @@
 	reload_sound = 'sound/weapons/guns/interact/pistol_magin.ogg'
 	cocked_sound = 'sound/weapons/guns/interact/pistol_cock.ogg'
 	init_firemodes = list(
-        SEMI_AUTO_300,
+        SEMI_AUTO_150,
 		BURST_3_ROUND_DAMAGE
 //		WEAPON_CHARGE    // charge mode on balistics doesnt work. need to make a balistic version of it -Valo
         )

--- a/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
@@ -25,8 +25,8 @@
 
 					//while also preserving ability to shoot as fast as you can click and maintain recoil good enough
 	init_firemodes = list(
-		FULL_AUTO_400,
-		SEMI_AUTO_300
+		FULL_AUTO_200,
+		SEMI_AUTO_150
 		)
 	gun_parts = list(/obj/item/part/gun/frame/bojevic = 1, /obj/item/part/gun/grip/serb = 1, /obj/item/part/gun/mechanism/autorifle = 1, /obj/item/part/gun/barrel/shotgun = 1)
 	serial_type = "SA"

--- a/code/modules/projectiles/guns/projectile/shotgun/type21.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/type21.dm
@@ -25,7 +25,7 @@
 	init_recoil = CARBINE_RECOIL(1.0)
 
 	init_firemodes = list(
-		SEMI_AUTO_300
+		SEMI_AUTO_150
 		)
 
 /obj/item/gun/projectile/shotgun/type_21/update_icon()

--- a/html/changelogs/archive/2022-08.yml
+++ b/html/changelogs/archive/2022-08.yml
@@ -9,7 +9,7 @@
       gun's burst_delay
   - bugfix: Guns are no longer hard locked to a 4 MS fire_delay.
   - balance: Bull shotgun now has a fire_delay of 2 MS.
-  - balance: SEMI_AUTO_NODELAY has been changed to SEMI_AUTO_150, with a firerate
+  - balance: SEMI_AUTO_NODELAY has been changed to SEMI_AUTO_300, with a firerate
       delay of 2 MS
   SirRichardFrancis:
   - rscadd: text-to-speech

--- a/html/changelogs/archive/2022-08.yml
+++ b/html/changelogs/archive/2022-08.yml
@@ -9,7 +9,7 @@
       gun's burst_delay
   - bugfix: Guns are no longer hard locked to a 4 MS fire_delay.
   - balance: Bull shotgun now has a fire_delay of 2 MS.
-  - balance: SEMI_AUTO_NODELAY has been changed to SEMI_AUTO_300, with a firerate
+  - balance: SEMI_AUTO_NODELAY has been changed to SEMI_AUTO_150, with a firerate
       delay of 2 MS
   SirRichardFrancis:
   - rscadd: text-to-speech


### PR DESCRIPTION
## About The Pull Request

Halves the displayed RPM of all gun firemodes to make them show actually realistic values.

Only present balance change is the removal of minimum firerate.

To be merged only after #7841 

## Why It's Good For The Game

Visual QOL, fixes fullauto issues.

## Testing

Game compiled and ran locally, firearms functioned. Firerates could not be measured due to a lack of capable hardware. Test server requested, with #7841 present.

## Changelog
:cl:
fix: firemode RPMs are no longer misleading
balance: firerate minimum cap lowered to FPS
/:cl: