### PR TITLE
Obelisk-B-Gone PART 1

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/construction.dm
+++ b/code/modules/core_implant/cruciform/rituals/construction.dm
@@ -110,7 +110,7 @@ GLOBAL_LIST_INIT(nt_constructs, init_nt_constructs())
 		fail("There is no mistake to remove here.",user,C,targets)
 		return
 
-	user.visible_message(SPAN_NOTICE("You see as [user] places one hand upon their cruciform, and the other stretched forward."),SPAN_NOTICE("You take back what is, returning it to what was."))
+	user.visible_message(SPAN_NOTICE("[user] places one hand on their chest, and the other stretched forward."),SPAN_NOTICE("You take back what is, returning it to what was."))
 
 	var/obj/effect/overlay/nt_construction/effect = new(target_turf, 5 SECONDS)
 

--- a/code/modules/core_implant/cruciform/rituals/construction.dm
+++ b/code/modules/core_implant/cruciform/rituals/construction.dm
@@ -128,7 +128,7 @@ GLOBAL_LIST_INIT(nt_constructs, init_nt_constructs())
 			scrap = new scrap(target_turf)
 
 	effect.success()
-	user.visible_message(SPAN_NOTICE("DING FRIES ARE DONE"),SPAN_NOTICE("WOULD YOU LIKE AN APPLE PIE WITH THAAAAAT"))
+	user.visible_message(SPAN_NOTICE("Clanking of parts hit the floor as [user] finishes their prayer and the machine falls apart."),SPAN_NOTICE("Collect the evidence, and begin to atone."))
 
 	qdel(reclaimed)
 

--- a/code/modules/core_implant/cruciform/rituals/construction.dm
+++ b/code/modules/core_implant/cruciform/rituals/construction.dm
@@ -1,5 +1,6 @@
 #define CRUCIFORM_TYPE obj/item/implant/core_implant/cruciform
 
+//Create a list of what can be created via construction ritual
 GLOBAL_LIST_INIT(nt_blueprints, init_nt_blueprints())
 
 /proc/init_nt_blueprints()
@@ -11,7 +12,17 @@ GLOBAL_LIST_INIT(nt_blueprints, init_nt_blueprints())
 			continue
 		var/datum/nt_blueprint/pb = new blueprint_type()
 		list[pb.name] = pb
-	return list
+	. = list
+
+//Create a list of what the blueprints actually make, and the materials required to make them. Blueprints list generation turns them into text format, not datums.
+GLOBAL_LIST_INIT(nt_constructs, init_nt_constructs())
+
+/proc/init_nt_constructs()
+	var/list/nt_constructs = list()
+	for(var/name in GLOB.nt_blueprints)
+		var/datum/nt_blueprint/accessed = GLOB.nt_blueprints[name]
+		nt_constructs[accessed.build_path] = accessed.materials
+	. = nt_constructs
 
 /datum/ritual/cruciform/priest/acolyte/blueprint_check
 	name = "Divine Guidance"
@@ -74,6 +85,49 @@ GLOBAL_LIST_INIT(nt_blueprints, init_nt_blueprints())
 	var/build_path = blueprint.build_path
 	new build_path(target_turf)
 
+/datum/ritual/cruciform/priest/acolyte/deconstruction
+	name = "Uproot"
+	phrase = "Dominus dedit, Dominus abstulit."
+	desc = "Mistakes are to be a lesson, but first we must correct it by deconstructing its form."
+
+/datum/ritual/cruciform/priest/acolyte/deconstruction/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/C, list/targets)
+	if(!GLOB.nt_constructs) //Makes sure the list we curated earlier actually exists
+		fail("You have no idea what constitutes a church construct.",user,C,targets)
+		return
+	
+	var/obj/reclaimed //Variable to be defined later as the removed construct
+	var/loot //Variable to be defined later as materials resulting from deconstruction
+	var/turf/target_turf = get_step(user,user.dir) //Gets the turf in front of the user
+	
+	for(reclaimed in target_turf) 
+		if(reclaimed.type in GLOB.nt_constructs)
+			loot = GLOB.nt_constructs[reclaimed.type]
+			break
+
+	if(isnull(loot))
+		fail("There is no mistake to remove here.",user,C,targets)
+		return
+
+	user.visible_message(SPAN_NOTICE("You see as [user] places one hand upon their cruciform, and the other stretched forward."),SPAN_NOTICE("You take back what is, returning it to what was."))
+
+	var/obj/effect/overlay/nt_construction/effect = new(target_turf, 5 SECONDS)
+
+	if(!do_after(user, 5 SECONDS, target_turf)) //"Sit still" timer
+		fail("You feel something is judging you upon your impatience",user,C,targets)
+		effect.failure()
+		return
+	
+	for(var/obj/scrap as anything in loot)
+		if(ispath(scrap, /obj/item/stack))
+			var/obj/item/stack/mat = new scrap(target_turf)
+			mat.amount = loot[scrap]
+		else
+			scrap = new scrap(target_turf)
+
+	effect.success()
+	user.visible_message(SPAN_NOTICE("DING FRIES ARE DONE"),SPAN_NOTICE("WOULD YOU LIKE AN APPLE PIE WITH THAAAAAT"))
+
+	qdel(reclaimed)
 
 /datum/ritual/cruciform/priest/acolyte/construction/proc/items_check(mob/user,turf/target, datum/nt_blueprint/blueprint)
 	var/list/turf_contents = target.contents
@@ -218,7 +272,7 @@ GLOBAL_LIST_INIT(nt_blueprints, init_nt_blueprints())
 
 /datum/nt_blueprint/machinery/bioreactor_metrics
 	name = "Biomatter Reactor: Metrics"
-	build_path = /obj/machinery/multistructure/biogenerator_part/console
+	build_path = /obj/machinery/multistructure/bioreactor_part/console
 	materials = list(
 		/obj/item/stack/material/steel = 2,
 		/obj/item/stack/material/silver = 5,

--- a/code/modules/core_implant/cruciform/rituals/construction.dm
+++ b/code/modules/core_implant/cruciform/rituals/construction.dm
@@ -89,6 +89,7 @@ GLOBAL_LIST_INIT(nt_constructs, init_nt_constructs())
 	name = "Uproot"
 	phrase = "Dominus dedit, Dominus abstulit."
 	desc = "Mistakes are to be a lesson, but first we must correct it by deconstructing its form."
+	power = 40
 
 /datum/ritual/cruciform/priest/acolyte/deconstruction/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/C, list/targets)
 	if(!GLOB.nt_constructs) //Makes sure the list we curated earlier actually exists
@@ -99,6 +100,7 @@ GLOBAL_LIST_INIT(nt_constructs, init_nt_constructs())
 	var/loot //Variable to be defined later as materials resulting from deconstruction
 	var/turf/target_turf = get_step(user,user.dir) //Gets the turf in front of the user
 	
+	//Find the NT Structure in front of the player
 	for(reclaimed in target_turf) 
 		if(reclaimed.type in GLOB.nt_constructs)
 			loot = GLOB.nt_constructs[reclaimed.type]
@@ -117,6 +119,7 @@ GLOBAL_LIST_INIT(nt_constructs, init_nt_constructs())
 		effect.failure()
 		return
 	
+	//Lets spawn and drop the materials resulting from deconstruction
 	for(var/obj/scrap as anything in loot)
 		if(ispath(scrap, /obj/item/stack))
 			var/obj/item/stack/mat = new scrap(target_turf)

--- a/code/modules/core_implant/ritual_book.dm
+++ b/code/modules/core_implant/ritual_book.dm
@@ -18,6 +18,31 @@
 		), rand(40,80), 1)
 	interact(H)
 
+/obj/item/book/ritual/proc/burnbible(obj/item/I, mob/user)
+	var/class = "warning"
+
+	user.visible_message("<span class='[class]'>[user] holds \the [I] up to \the [src], it looks like \he's trying to burn it!</span>", \
+	"<span class='[class]'>You hold \the [I] up to \the [src], burning it slowly.</span>") //Optimize to make louder to cruciforms
+
+	spawn(100) //Optimize to progress bar
+		if(get_dist(src, user) < 2 && user.get_active_hand() == I)
+			user.visible_message("<span class='[class]'>[user] burns right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>", \
+			"<span class='[class]'>You burn right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>")
+
+			if(user.get_inactive_hand() == src)
+				user.drop_from_inventory(src)
+
+			new /obj/effect/decal/cleanable/ash(src.loc)
+			qdel(src)
+
+		else
+			to_chat(user, "\red You must hold \the [I] steady to burn \the [src].")
+
+/obj/item/book/ritual/attackby(obj/item/I, mob/user)
+    if(isflamesource(I))
+        burnbible(I, user)
+        return
+
 /obj/item/book/ritual/nano_ui_data(mob/user)
 	var/obj/item/implant/core_implant/cruciform/CI
 	if(isliving(user))

--- a/code/modules/core_implant/ritual_book.dm
+++ b/code/modules/core_implant/ritual_book.dm
@@ -18,31 +18,6 @@
 		), rand(40,80), 1)
 	interact(H)
 
-/obj/item/book/ritual/proc/burnbible(obj/item/I, mob/user)
-	var/class = "warning"
-
-	user.visible_message("<span class='[class]'>[user] holds \the [I] up to \the [src], it looks like \he's trying to burn it!</span>", \
-	"<span class='[class]'>You hold \the [I] up to \the [src], burning it slowly.</span>") //Optimize to make louder to cruciforms
-
-	spawn(100) //Optimize to progress bar
-		if(get_dist(src, user) < 2 && user.get_active_hand() == I)
-			user.visible_message("<span class='[class]'>[user] burns right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>", \
-			"<span class='[class]'>You burn right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>")
-
-			if(user.get_inactive_hand() == src)
-				user.drop_from_inventory(src)
-
-			new /obj/effect/decal/cleanable/ash(src.loc)
-			qdel(src)
-
-		else
-			to_chat(user, "\red You must hold \the [I] steady to burn \the [src].")
-
-/obj/item/book/ritual/attackby(obj/item/I, mob/user)
-    if(isflamesource(I))
-        burnbible(I, user)
-        return
-
 /obj/item/book/ritual/nano_ui_data(mob/user)
 	var/obj/item/implant/core_implant/cruciform/CI
 	if(isliving(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is Part One of my goal to make Obelisks destructible in meaningful and interesting ways.

This is the Deconstruction Litany, added to the Acolyte tab of the ritual book that allows any Acolyte to deconstruct anything they can construct with litanies back to their base materials.

More interesting/nonchurch ways will be done in the coming future, soon(tm).

Also a minor fix related to the list generation, the Construction.dm contained a duplicated build_path for both the biogenerator console and bioreactor console. This has been corrected, as it fixed my own list generation.

An absolute special thank you to both Handyman and Kirov for their infinite patience with me on this. Without them I never would've gotten this done.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Obelisks are currently indestructible to anything but C4 or a Hatton. This at least opens up a peaceful avenue to allow the church to remove obelisks. Also allows them to deconstruct other Litany Constructs, like biomatter canisters.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
[dreamseeker_B2KiBtkznR.webm](https://user-images.githubusercontent.com/11076040/205204583-92c85f8d-8f59-4421-b384-4ec0efcdf484.webm)
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->


## Changelog
:cl:
add: Uproot: Deconstruction Litany
fix: Fixed build_path of Bioreactor Metrics console
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
