### PR TITLE
Several map changes

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -40373,8 +40373,8 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/quartermaster/hangarsupply)
 "bRs" = (
-/obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
 /area/eris/rnd/storage)
 "bRt" = (
@@ -41722,14 +41722,14 @@
 /obj/structure/sign/atmos_waste{
 	pixel_y = -32
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/railing{
 	anchored = 1;
 	dir = 4;
 	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
@@ -46348,6 +46348,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/eris/medical/surgery)
 "cgh" = (
@@ -47461,12 +47462,6 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white/golden,
-/area/eris/neotheology/chapelritualroom)
-"ciV" = (
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapelritualroom)
 "ciW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -49002,6 +48997,10 @@
 	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
 "cmT" = (
@@ -50166,7 +50165,8 @@
 	name = "Technomancer Desk"
 	},
 /obj/machinery/door/window/westright{
-	name = "Technomancer Desk"
+	name = "Technomancer Desk";
+	req_access = list(10)
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -52612,7 +52612,7 @@
 /area/eris/medical/reception)
 "cwD" = (
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawn,
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/eris/quartermaster/office)
 "cwE" = (
@@ -53259,10 +53259,10 @@
 /area/eris/quartermaster/office)
 "cxY" = (
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/eris/quartermaster/office)
 "cxZ" = (
@@ -53874,10 +53874,10 @@
 /area/eris/hallway/side/section3starboard)
 "czw" = (
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/eris/quartermaster/office)
 "czx" = (
@@ -54044,6 +54044,9 @@
 	req_access = list(31)
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/window/westleft{
+	name = "Cargo Desk"
+	},
 /turf/simulated/floor/tiled,
 /area/eris/quartermaster/office)
 "czU" = (
@@ -68810,6 +68813,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
 "djv" = (
@@ -72645,7 +72652,7 @@
 /area/eris/hallway/main/section2)
 "dsd" = (
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawn,
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/reception)
 "dse" = (
@@ -74080,13 +74087,6 @@
 "dvB" = (
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/command/meeting_room)
-"dvC" = (
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white/golden,
-/area/eris/neotheology/churchbooth)
 "dvD" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /turf/simulated/open,
@@ -75114,7 +75114,7 @@
 	frequency = 1380;
 	id_tag = "research_dock_airlock";
 	pixel_y = 25;
-	req_one_access = list(13,65);
+	req_one_access = list(5);
 	tag_airpump = "research_dock_pump";
 	tag_chamber_sensor = "research_dock_sensor";
 	tag_exterior_door = "research_dock_outer";
@@ -75236,7 +75236,7 @@
 	id_tag = "research_dock_inner";
 	locked = 1;
 	name = "Shuttle Airlock";
-	req_access = list(13)
+	req_access = list(5)
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -75244,7 +75244,7 @@
 	master_tag = "research_dock_airlock";
 	name = "interior access button";
 	pixel_y = -28;
-	req_one_access = list(13,65)
+	req_one_access = list(5)
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/rnd/docking)
@@ -75330,7 +75330,7 @@
 	master_tag = "research_dock_airlock";
 	name = "exterior access button";
 	pixel_y = -28;
-	req_one_access = list(13,65)
+	req_one_access = list(5)
 	},
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
@@ -75339,7 +75339,7 @@
 	id_tag = "research_dock_outer";
 	locked = 1;
 	name = "Shuttle Airlock";
-	req_access = list(13)
+	req_access = list(5)
 	},
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -78109,17 +78109,10 @@
 	},
 /area/eris/hallway/main/section2)
 "dEW" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "North APC";
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/white/golden,
-/area/eris/neotheology/churchbooth)
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/eris/hallway/side/section3starboard)
 "dEZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -78310,13 +78303,9 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
-"dFz" = (
-/turf/simulated/floor/tiled/white/golden,
-/area/eris/neotheology/churchbooth)
 "dFB" = (
-/obj/effect/window_lwall_spawn/smartspawn,
-/turf/simulated/floor/plating,
-/area/eris/neotheology/churchbooth)
+/turf/simulated/wall/r_wall,
+/area/eris/hallway/side/section3port)
 "dFC" = (
 /obj/structure/bed/chair/office/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -78572,15 +78561,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
 "dGo" = (
-/obj/machinery/door/window/southright,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/white/golden,
-/area/eris/neotheology/churchbooth)
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating,
+/area/eris/hallway/side/section3port)
 "dGp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -78814,8 +78800,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
 "dGV" = (
@@ -80032,8 +80016,12 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
 "dJq" = (
@@ -82545,8 +82533,8 @@
 /area/eris/quartermaster/office)
 "dPh" = (
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/eris/quartermaster/office)
 "dPi" = (
@@ -86188,8 +86176,8 @@
 /area/eris/crew_quarters/barquarters)
 "dYj" = (
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/eris/quartermaster/office)
 "dYk" = (
@@ -89917,7 +89905,7 @@
 	master_tag = "vasiliy_dokuchaev_shuttle";
 	name = "exterior access button";
 	pixel_y = 25;
-	req_one_access = list(13,65)
+	req_one_access = list(5)
 	},
 /turf/simulated/shuttle/floor/science{
 	icon_state = "4,12"
@@ -89928,7 +89916,7 @@
 	frequency = 1380;
 	id_tag = "vasiliy_dokuchaev_shuttle";
 	pixel_y = 28;
-	req_one_access = list(13,48);
+	req_one_access = list(5);
 	tag_airpump = "research_shuttle_pump";
 	tag_chamber_sensor = "research_shuttle_sensor";
 	tag_exterior_door = "research_shuttle_outer";
@@ -89964,7 +89952,7 @@
 	master_tag = "vasiliy_dokuchaev_shuttle";
 	name = "interior access button";
 	pixel_y = 25;
-	req_one_access = list(13,65)
+	req_one_access = list(5)
 	},
 /turf/simulated/shuttle/floor/science{
 	icon_state = "7,12"
@@ -90351,7 +90339,7 @@
 	id_tag = "research_shuttle_outer";
 	locked = 1;
 	name = "Vasiliy Dokuchaev External Access";
-	req_access = list(13)
+	req_access = list(5)
 	},
 /turf/simulated/shuttle/floor/science{
 	icon_state = "4,11"
@@ -90386,7 +90374,7 @@
 	id_tag = "research_shuttle_inner";
 	locked = 1;
 	name = "Vasiliy Dokuchaev Internal Access";
-	req_access = list(13)
+	req_access = list(5)
 	},
 /turf/simulated/shuttle/floor/science{
 	icon_state = "7,11"
@@ -94459,16 +94447,6 @@
 /obj/structure/multiz/ladder,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/eris/maintenance/section2deck3port)
-"ess" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/eris/neotheology/chapel)
 "esu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -95124,13 +95102,6 @@
 "etS" = (
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
-"etT" = (
-/obj/structure/table/rack,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/golden,
-/area/eris/neotheology/churchbooth)
 "etU" = (
 /obj/structure/railing{
 	dir = 4
@@ -95233,10 +95204,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/eris/medical/medbay/iso)
-"euc" = (
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/white/golden,
-/area/eris/neotheology/churchbooth)
 "eud" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -95687,19 +95654,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics/garden)
-"evm" = (
-/turf/simulated/wall/r_wall,
-/area/eris/neotheology/churchbooth)
 "evn" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 26
+/obj/structure/bed/chair/comfy/beige{
+	dir = 4
 	},
-/obj/machinery/camera/network/third_section{
-	dir = 8
+/obj/item/device/radio/intercom{
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/white/golden,
-/area/eris/neotheology/churchbooth)
+/area/eris/neotheology/chapelritualroom)
 "evo" = (
 /obj/structure/table/standard,
 /obj/item/packageWrap,
@@ -95865,12 +95828,12 @@
 /area/eris/hallway/side/section3port)
 "evD" = (
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawn,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/eris/quartermaster/office)
 "evE" = (
@@ -101194,7 +101157,7 @@
 "fiZ" = (
 /obj/structure/sign/faction/neotheology,
 /turf/simulated/wall/r_wall,
-/area/eris/neotheology/churchbooth)
+/area/eris/hallway/side/section3port)
 "fjl" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/railing/grey,
@@ -101388,18 +101351,6 @@
 /obj/effect/shuttle_landmark/merc/sec3east4,
 /turf/space,
 /area/space)
-"fMA" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/golden,
-/area/eris/neotheology/churchbooth)
 "fOG" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/wood,
@@ -101860,15 +101811,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/eris/neotheology/churchbarracks)
-"gXz" = (
-/obj/structure/bed/chair/comfy/beige,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/white/golden,
-/area/eris/neotheology/churchbooth)
 "gXX" = (
 /obj/machinery/conveyor/north{
 	id = "disposal_conveyor"
@@ -103030,9 +102972,8 @@
 /area/eris/crew_quarters/fitness)
 "jFt" = (
 /obj/machinery/door/airlock/maintenance_common,
-/obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/techmaint_cargo,
 /area/eris/maintenance/section2deck3port)
 "jFQ" = (
 /obj/structure/cable/green{
@@ -103145,9 +103086,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
-"jTt" = (
-/turf/simulated/wall,
-/area/eris/neotheology/churchbooth)
 "jUO" = (
 /obj/effect/shuttle_landmark/merc/atmos,
 /turf/space,
@@ -103865,19 +103803,6 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
-"lQD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/tiled/white/golden,
-/area/eris/neotheology/churchbooth)
 "lQM" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
@@ -104274,17 +104199,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
@@ -105445,9 +105359,10 @@
 /turf/simulated/floor/hull,
 /area/space)
 "pNw" = (
-/obj/item/device/radio/intercom,
-/turf/simulated/wall/r_wall,
-/area/eris/neotheology/chapelritualroom)
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/eris/medical/reception)
 "pRL" = (
 /obj/structure/closet/secure_closet/personal/doctor,
 /obj/machinery/camera/network/medbay{
@@ -105896,12 +105811,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/storage)
-"qYg" = (
-/obj/structure/multiz/stairs/active/bottom{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/eris/neotheology/chapelritualroom)
 "qZg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -106165,22 +106074,6 @@
 	},
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
-"rNL" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/holy,
-/turf/simulated/floor/tiled/white/golden,
-/area/eris/neotheology/churchbooth)
 "rNW" = (
 /obj/machinery/holoposter,
 /turf/simulated/wall,
@@ -107181,19 +107074,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/security/exerooms)
-"tXm" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "ScienceTotalLockdown";
-	layer = 2.6;
-	name = "Science Total Lockdown";
-	opacity = 0
-	},
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/eris/rnd/lab)
 "tYy" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -107541,19 +107421,15 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/crew_quarters/fitness)
 "uOi" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/bed/chair/wood{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white/golden,
-/area/eris/neotheology/churchbooth)
+/turf/simulated/floor/carpet/bcarpet,
+/area/eris/neotheology/chapel)
 "uPp" = (
 /obj/structure/table/standard,
 /obj/machinery/button/remote/blast_door{
@@ -107675,12 +107551,6 @@
 "vhi" = (
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/section3deck2port)
-"vhA" = (
-/obj/structure/multiz/stairs/enter{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/eris/neotheology/churchbooth)
 "vhD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -107718,20 +107588,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/medbay/uppercor)
-"viY" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/golden,
-/area/eris/neotheology/churchbooth)
 "vjw" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawn,
@@ -107757,8 +107613,7 @@
 	name = "Research Desk Shutters"
 	},
 /obj/machinery/door/window/westleft{
-	name = "Research Desk";
-	req_access = list(5)
+	name = "Research Desk"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
@@ -108227,12 +108082,6 @@
 /obj/machinery/papershredder,
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/barconference)
-"wqw" = (
-/obj/structure/multiz/stairs/active{
-	dir = 8
-	},
-/turf/simulated/open,
-/area/eris/neotheology/churchbooth)
 "wqX" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -108258,12 +108107,6 @@
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/engineering/breakroom)
-"wur" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/golden,
-/area/eris/neotheology/churchbooth)
 "wwg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -108915,13 +108758,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/hull,
 /area/eris/command/exultant)
-"ygl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/camera/network/third_section,
-/turf/simulated/floor/tiled/white/golden,
-/area/eris/neotheology/chapelritualroom)
 "yit" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28
@@ -165805,10 +165641,10 @@ bnl
 bmx
 aad
 aad
+aad
 ccU
-ccU
-pNw
 tSV
+pHi
 rBd
 hQD
 hQD
@@ -166007,9 +165843,9 @@ bkW
 bmx
 bmx
 abF
+abF
 ccU
-ckV
-wHF
+evn
 pHi
 rBd
 hQD
@@ -166209,9 +166045,9 @@ boi
 boj
 bmx
 abF
+abF
 ccU
-ckV
-wHF
+vGD
 pHi
 rBd
 hQD
@@ -166411,10 +166247,10 @@ bnV
 cpR
 bmx
 abF
+abF
 ccU
-ciV
-ccU
-ygl
+vGD
+ptn
 bRk
 hQD
 cPv
@@ -166613,9 +166449,9 @@ boi
 bnV
 bmx
 abF
+abF
 ccU
-qYg
-ccU
+oUj
 utY
 bQW
 hQD
@@ -166815,7 +166651,7 @@ bnU
 bnU
 bmx
 abF
-ccU
+abF
 ccU
 ccU
 ccU
@@ -204390,7 +204226,7 @@ cmE
 cmE
 duY
 etS
-cor
+etS
 evu
 evu
 ctk
@@ -204588,11 +204424,11 @@ llD
 bSx
 abF
 abF
+aaa
 cmE
-ess
+ewb
 etS
 etS
-cor
 evu
 evu
 ctk
@@ -204790,11 +204626,11 @@ dAM
 dAO
 dAO
 vGy
+abF
 duY
 etS
 etS
 etS
-cor
 evu
 evu
 ctk
@@ -204992,11 +204828,11 @@ dAv
 dAv
 dAv
 uqj
+abF
 ykt
 etS
 esF
 esF
-cor
 evu
 evu
 fgt
@@ -205194,11 +205030,11 @@ fnk
 dEN
 dAv
 uqj
+abF
 kGo
 etS
 cws
 esF
-cor
 cor
 cqg
 jSY
@@ -205396,11 +205232,11 @@ dDO
 dDO
 dAv
 uqj
+abF
 kGo
 etS
 cws
 esF
-cor
 cor
 cor
 cql
@@ -205598,11 +205434,11 @@ xuU
 tti
 dAv
 uqj
+aaa
 ykt
 etS
 esF
 esF
-cor
 evu
 evu
 sZs
@@ -205800,11 +205636,11 @@ tlr
 pJc
 dAv
 uqj
+aaa
 duY
 etS
 etS
 etS
-cor
 evu
 evu
 ctk
@@ -206002,11 +205838,11 @@ hab
 duo
 dAv
 uqj
+aaa
 cmE
 ewb
 etS
 etS
-cor
 evu
 evu
 ctk
@@ -206204,16 +206040,16 @@ xYK
 pRL
 dAv
 uqj
-cmE
+aaa
 cmE
 duY
 qhN
-cor
+etS
 evu
 evu
 ctk
 crX
-evu
+uOi
 anJ
 anJ
 aqa
@@ -206613,7 +206449,7 @@ aaa
 cmE
 cmE
 cmE
-rNL
+cmE
 cmE
 pVZ
 ksp
@@ -206812,10 +206648,10 @@ dAv
 flX
 dqQ
 aaa
-evm
-wqw
-evm
-viY
+aaa
+abF
+abF
+abF
 fiZ
 eeB
 evC
@@ -207014,11 +206850,11 @@ dAv
 bmx
 bmx
 aaa
-evm
-vhA
-evm
-viY
-dFB
+aaa
+abF
+abF
+abF
+dGo
 eeB
 evC
 anJ
@@ -207215,12 +207051,12 @@ qym
 csg
 eaT
 abF
-aaa
-evm
-dvC
-lQD
-uOi
-dFB
+aad
+aad
+abF
+abF
+abF
+dGo
 eeB
 jkF
 anJ
@@ -207418,10 +207254,10 @@ csg
 dYl
 abF
 aaa
-evm
-dEW
-fMA
-gXz
+aaa
+abF
+abF
+abF
 dGo
 eeB
 evC
@@ -207619,12 +207455,12 @@ xZy
 cnN
 dYl
 abF
-aaa
-evm
-euc
-wur
-euc
-dFB
+aad
+aad
+abF
+abF
+abF
+dGo
 eeB
 dJu
 anJ
@@ -207822,11 +207658,11 @@ oLn
 dYl
 abF
 aaa
-evm
-etT
-dFz
-euc
-dFB
+aaa
+abF
+abF
+abF
+dGo
 eeB
 evC
 anJ
@@ -208024,10 +207860,10 @@ dkl
 dYl
 abF
 aaa
-evm
-euc
-evn
-euc
+aaa
+abF
+abF
+abF
 dFB
 eeB
 evC
@@ -208226,10 +208062,10 @@ gEy
 eaT
 abF
 aaa
-evm
-evm
-jTt
-jTt
+duu
+duu
+duu
+duu
 bsS
 cId
 dJu
@@ -209424,7 +209260,7 @@ chM
 chM
 chM
 cnh
-dqC
+pNw
 dAI
 dAI
 dCN
@@ -211063,7 +210899,7 @@ bvy
 bvy
 avn
 avn
-arQ
+dEW
 cYE
 dTr
 dyd
@@ -211454,7 +211290,7 @@ ciZ
 fBO
 crN
 cnz
-tXm
+crb
 abF
 abF
 aaa
@@ -211656,7 +211492,7 @@ cqU
 crN
 crN
 cnJ
-tXm
+crb
 abF
 abF
 aaa

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -105297,17 +105297,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white/golden,
 /area/eris/neotheology/churchbooth)
 "pkU" = (
@@ -206880,8 +206869,8 @@ dqQ
 aaa
 jaM
 hdR
+dJp
 phq
-xMI
 fiZ
 eeB
 evC

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -44010,6 +44010,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	name = "First Officer Line Access";
+	id = "firstofficer_access"
+	},
 /turf/simulated/floor/plating,
 /area/eris/command/fo)
 "caS" = (
@@ -44041,6 +44046,11 @@
 /obj/structure/cable/green,
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	name = "First Officer Line Access";
+	id = "firstofficer_access"
+	},
 /turf/simulated/floor/plating,
 /area/eris/command/fo)
 "caW" = (
@@ -44218,6 +44228,11 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "First Officer Line Access";
+	name = "First Officer Line Access";
+	pixel_x = -26
 	},
 /turf/simulated/floor/wood,
 /area/eris/command/fo)
@@ -44782,6 +44797,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	name = "First Officer Line Access";
+	id = "firstofficer_access"
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/command/fo)
@@ -50168,13 +50188,10 @@
 	name = "Technomancer Desk";
 	req_access = list(10)
 	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
+/obj/machinery/door/blast/shutters{
+	dir = 4;
 	id = "TechnomancerShopLockdown";
-	layer = 2.6;
-	name = "Technomancer Shop Lockdown";
-	opacity = 0
+	name = "Technomancer Shop Lockdown"
 	},
 /turf/simulated/floor/plating,
 /area/eris/engineering/foyer)
@@ -78292,20 +78309,29 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck3starboard)
 "dFy" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
 "dFB" = (
-/turf/simulated/wall/r_wall,
-/area/eris/hallway/side/section3port)
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "neotheology_shop";
+	name = "NeoTheology Shop Access"
+	},
+/turf/simulated/floor/plating,
+/area/eris/neotheology/churchbooth)
 "dFC" = (
 /obj/structure/bed/chair/office/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -78552,21 +78578,33 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck5central)
 "dGn" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 26
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
 "dGo" = (
-/obj/effect/window_lwall_spawn/smartspawn,
-/turf/simulated/floor/plating,
-/area/eris/hallway/side/section3port)
+/obj/structure/table/standard,
+/obj/machinery/door/window{
+	dir = 1;
+	name = "NeoTheology Shop"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "neotheology_shop";
+	name = "NeoTheology Shop Access"
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/eris/neotheology/churchbooth)
 "dGp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -78792,14 +78830,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section3)
 "dGU" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
 "dGV" = (
@@ -80012,9 +80047,9 @@
 /area/eris/command/exultant)
 "dJp" = (
 /obj/structure/cable/green{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80022,8 +80057,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/eris/neotheology/chapel)
+/turf/simulated/floor/tiled/white/golden,
+/area/eris/neotheology/churchbooth)
 "dJq" = (
 /obj/structure/table/rack/shelf,
 /obj/spawner/lowkeyrandom/low_chance,
@@ -95586,7 +95621,9 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/medical/chemistry)
 "evf" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/machinery/chemical_dispenser,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/medical/chemistry)
@@ -101082,6 +101119,16 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
+"faY" = (
+/obj/structure/table/standard,
+/obj/machinery/button/remote/blast_door{
+	pixel_y = -4;
+	pixel_x = 4;
+	name = "NeoTheology Shop Access";
+	id = "neotheology_shop"
+	},
+/turf/simulated/floor/tiled/white/golden,
+/area/eris/neotheology/churchbooth)
 "fbD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -101155,9 +101202,9 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
 "fiZ" = (
-/obj/structure/sign/faction/neotheology,
+/obj/machinery/vending/theomat,
 /turf/simulated/wall/r_wall,
-/area/eris/hallway/side/section3port)
+/area/eris/neotheology/churchbooth)
 "fjl" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/railing/grey,
@@ -101173,6 +101220,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/barconference)
+"flS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/eris/neotheology/chapel)
 "flX" = (
 /turf/simulated/open,
 /area/eris/medical/morgue)
@@ -101208,6 +101266,20 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/crew_quarters/fitness)
+"fuj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/eris/neotheology/chapel)
 "fuR" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -101240,6 +101312,12 @@
 /obj/spawner/medical/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
+"fyY" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/golden,
+/area/eris/neotheology/churchbooth)
 "fzU" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 4
@@ -101870,6 +101948,16 @@
 /obj/machinery/camera/network/medbay,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/medical/chemistry)
+"hdR" = (
+/obj/structure/table/rack/shelf,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/machinery/light_switch{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/white/golden,
+/area/eris/neotheology/churchbooth)
 "hgI" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -102298,6 +102386,16 @@
 	},
 /turf/simulated/open,
 /area/eris/engineering/gravity_generator)
+"igk" = (
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	name = "First Officer Line Access";
+	id = "firstofficer_access"
+	},
+/turf/simulated/floor/plating,
+/area/eris/command/fo)
 "igC" = (
 /obj/structure/table/rack,
 /obj/item/device/von_krabin,
@@ -102717,6 +102815,9 @@
 	},
 /turf/simulated/floor/tiled/white/golden,
 /area/eris/neotheology/chapelritualroom)
+"jaM" = (
+/turf/simulated/wall/r_wall,
+/area/eris/neotheology/churchbooth)
 "jbk" = (
 /obj/effect/shuttle_landmark/merc/mining,
 /turf/space,
@@ -103204,6 +103305,27 @@
 /obj/machinery/light,
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/neotheology/chapel)
+"khS" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/holy,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/cargo,
+/area/eris/neotheology/chapel)
 "khZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -103213,6 +103335,22 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/crew_quarters/fitness)
+"kio" = (
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/eris/neotheology/chapel)
 "kiY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -104078,13 +104216,10 @@
 "myt" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/reinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
+/obj/machinery/door/blast/shutters{
+	dir = 4;
 	id = "TechnomancerShopLockdown";
-	layer = 2.6;
-	name = "Technomancer Shop Lockdown";
-	opacity = 0
+	name = "Technomancer Shop Lockdown"
 	},
 /turf/simulated/floor/plating,
 /area/eris/engineering/foyer)
@@ -104159,9 +104294,19 @@
 /turf/simulated/floor/plating,
 /area/eris/engineering/construction)
 "mDn" = (
-/obj/machinery/vending/theomat,
-/turf/simulated/floor/tiled/dark/golden,
-/area/eris/neotheology/chapel)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/golden,
+/area/eris/neotheology/churchbooth)
 "mDD" = (
 /obj/structure/closet/secure_closet/reinforced/chaplain,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -104195,11 +104340,12 @@
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/crew_quarters/fitness)
 "mKQ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 26
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
 "mLc" = (
@@ -104532,6 +104678,14 @@
 /obj/structure/railing,
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
+"nHG" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/eris/neotheology/chapel)
 "nJh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/floor_decal/industrial/warning,
@@ -105139,6 +105293,23 @@
 /obj/structure/cyberplant,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
+"phq" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/golden,
+/area/eris/neotheology/churchbooth)
 "pkU" = (
 /obj/machinery/light/small,
 /obj/machinery/portable_atmospherics/canister/plasma,
@@ -105160,6 +105331,20 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck2port)
+"ppW" = (
+/obj/structure/table/rack/shelf,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "North APC";
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white/golden,
+/area/eris/neotheology/churchbooth)
 "prw" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/item/tool/knife/butch,
@@ -105363,6 +105548,17 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/eris/medical/reception)
+"pRq" = (
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/eris/neotheology/chapel)
 "pRL" = (
 /obj/structure/closet/secure_closet/personal/doctor,
 /obj/machinery/camera/network/medbay{
@@ -105873,6 +106069,13 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
+"rhY" = (
+/obj/structure/table/rack/shelf,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/golden,
+/area/eris/neotheology/churchbooth)
 "ris" = (
 /obj/structure/closet/boxinggloves,
 /turf/simulated/floor/tiled/white,
@@ -106152,6 +106355,10 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/crew_quarters/fitness)
+"rVC" = (
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/white/golden,
+/area/eris/neotheology/churchbooth)
 "rXJ" = (
 /obj/structure/bed/chair/custom/bar_special,
 /turf/simulated/floor/tiled/steel/bar_light,
@@ -107509,6 +107716,10 @@
 	},
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
+"vcS" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white/golden,
+/area/eris/neotheology/churchbooth)
 "vdS" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/camera/network/third_section{
@@ -107548,6 +107759,12 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/medical/chemistry)
+"vgQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white/golden,
+/area/eris/neotheology/churchbooth)
 "vhi" = (
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/section3deck2port)
@@ -108064,6 +108281,10 @@
 	},
 /turf/simulated/floor/carpet,
 /area/eris/medical/psych)
+"wnJ" = (
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/white/golden,
+/area/eris/neotheology/churchbooth)
 "woZ" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -108551,6 +108772,9 @@
 /obj/machinery/gym,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/crew_quarters/fitness)
+"xMI" = (
+/turf/simulated/floor/tiled/white/golden,
+/area/eris/neotheology/churchbooth)
 "xNN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -108714,6 +108938,12 @@
 	},
 /turf/simulated/open,
 /area/eris/medical/chemstor)
+"xZV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/golden,
+/area/eris/neotheology/churchbooth)
 "yad" = (
 /mob/living/simple_animal/chicken{
 	name = "D'Artagnan"
@@ -204030,7 +204260,7 @@ cqb
 oOP
 crG
 cta
-mDn
+etS
 cmE
 cmE
 cmE
@@ -206044,11 +206274,11 @@ aaa
 cmE
 duY
 qhN
-etS
-evu
-evu
-ctk
-crX
+nHG
+pRq
+kio
+flS
+fuj
 uOi
 anJ
 anJ
@@ -206250,7 +206480,7 @@ dFy
 mKQ
 dGn
 dGU
-dJp
+ctd
 dOc
 anJ
 evS
@@ -206448,7 +206678,7 @@ bmx
 aaa
 cmE
 cmE
-cmE
+khS
 cmE
 cmE
 pVZ
@@ -206648,10 +206878,10 @@ dAv
 flX
 dqQ
 aaa
-aaa
-abF
-abF
-abF
+jaM
+hdR
+phq
+xMI
 fiZ
 eeB
 evC
@@ -206850,11 +207080,11 @@ dAv
 bmx
 bmx
 aaa
-aaa
-abF
-abF
-abF
-dGo
+jaM
+rVC
+dJp
+xMI
+dFB
 eeB
 evC
 anJ
@@ -207052,11 +207282,11 @@ csg
 eaT
 abF
 aad
-aad
-abF
-abF
-abF
-dGo
+jaM
+rVC
+dJp
+faY
+dFB
 eeB
 jkF
 anJ
@@ -207254,10 +207484,10 @@ csg
 dYl
 abF
 aaa
-aaa
-abF
-abF
-abF
+jaM
+ppW
+mDn
+wnJ
 dGo
 eeB
 evC
@@ -207456,11 +207686,11 @@ cnN
 dYl
 abF
 aad
-aad
-abF
-abF
-abF
-dGo
+jaM
+rVC
+xZV
+vcS
+dFB
 eeB
 dJu
 anJ
@@ -207658,11 +207888,11 @@ oLn
 dYl
 abF
 aaa
-aaa
-abF
-abF
-abF
-dGo
+jaM
+rVC
+vgQ
+rhY
+dFB
 eeB
 evC
 anJ
@@ -207860,10 +208090,10 @@ dkl
 dYl
 abF
 aaa
-aaa
-abF
-abF
-abF
+jaM
+rVC
+fyY
+rVC
 dFB
 eeB
 evC
@@ -210651,10 +210881,10 @@ bwr
 bwA
 caS
 caS
-caA
+igk
 ccP
 caR
-caA
+igk
 caV
 caS
 caS
@@ -248913,7 +249143,7 @@ aaa
 aaa
 aaa
 aaa
-abF
+aaa
 dLf
 eng
 dTl


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Dokuchaev moebius access fix
~~Removed NT shop~~ NT shop revamped, stairs access removed, vendor moved toward it
First Officer gets shutters, start with them closed
Research desk proper windoor access
Reinforced windows for guild lobby, double windoor
Technomancer desk proper windoor access, starts with shutters closed
Shrinked chapel by 1 tile so last row of chairs can see the guy at the table speaking and so it doesn't touches second section
Fixes medbay disposal issues (surgery disposals, both the bin and morgue express)
Medbay lobby reinforced windows
Several low wall windows fixes around moebius (they used reinforced ones instead of smart-spawn)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Moebius scientists can now access Dokuchaev
~~NT shop was more of a hindrance than useful - the windoor lacked access and you needed to hack only three doors to get to
EOTP. You can put it back once someone creates windoor with cruciform access~~ Revamped, now without stairs but with shutters.
Research desk outside windoor now can be opened by anyone (like it should be)
Technomancer desk inside can now be opened only by technos, outside by anyone
Chapel is now smaller so you can both see and hear the preacher
You can now use surgery disposals
Guild lobby: I frequently noticed how guild members replaced their windows with better ones, I see no problem with giving them some better protection
Same goes for medbay - they had non-reinforced full-tile but reinforced single-direction windows

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![изображение](https://user-images.githubusercontent.com/57810301/205309127-964eaa5a-5bc9-4b0c-b436-7bde524c031e.png)
![изображение](https://user-images.githubusercontent.com/57810301/205309730-ec4d8f5b-f96d-401e-bcd4-af84a00113bb.png)
![изображение](https://user-images.githubusercontent.com/57810301/205309754-c472548c-25ec-4ef9-bb9e-40126f3f616f.png)
![изображение](https://user-images.githubusercontent.com/57810301/205310205-56ff5f73-bd74-46ac-9625-8254ea4049b0.png)
![изображение](https://user-images.githubusercontent.com/57810301/205352527-8a7f0fcd-ed8b-47af-821e-013e4bc26e47.png)
![изображение](https://user-images.githubusercontent.com/57810301/205352709-a5dc931d-35d8-45b8-8702-9d00b00a157a.png)
![изображение](https://user-images.githubusercontent.com/57810301/205352728-1332feab-a530-4961-beea-11500a80780d.png)


https://user-images.githubusercontent.com/57810301/205310019-ab71ae08-edde-4bc2-950d-2094a1bb53b0.mp4
(video is so scuffed because my hardware sucks)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: fixed surgery disposals
fix: moebius scientists can access dokuchaev
tweak: NT shop changed, NT vendor moved to it
del: NT shop stairs
tweak: guild now has reinforced windows and double windoor
tweak: medbay lobby gets some reinforced windows
tweak: chapel is now smaller so last row of chairs can see the preacher
fix: moebius desk windoor access
fix: technomancer start with shutter closed, fixed desk windoor access
fadd: First officer gets shutters, start with closed
fix: some low wall spawners in moebius replaced with smart spawns (no visible change)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
