### PR TITLE
fix kovacs and WP grenades

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -289,6 +289,11 @@
 	initial_amount = 7
 	spawn_type = /obj/item/grenade/frag/white_phosphorous
 
+/obj/item/storage/box/phosphorous/populate_contents()
+	for(var/i in 1 to initial_amount)
+		new spawn_type(src)
+
+
 /obj/item/storage/box/flashbangs/uplink_item
 	name = "Box of flashbangs"
 	desc = "A box containing 5 antipersonnel flashbang grenades.<br> WARNING: These devices are extremely dangerous and can cause blindness or deafness in repeated use."

--- a/code/modules/projectiles/guns/projectile/battle_rifle/kovacs.dm
+++ b/code/modules/projectiles/guns/projectile/battle_rifle/kovacs.dm
@@ -8,7 +8,7 @@
 	item_state = "kovacs"
 	w_class = ITEM_SIZE_BULKY
 	force = WEAPON_FORCE_PAINFUL
-	caliber = CAL_SRIFLE
+	caliber = CAL_LRIFLE
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 1)
 	slot_flags = SLOT_BACK
 	load_method = MAGAZINE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes Kovacs not accepting .30 mags and fixes white phosphorous grenade spawning empty
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes are good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

https://user-images.githubusercontent.com/57810301/205442387-c4067eab-468e-45e8-97ef-d01bdf46516d.mp4

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: fixed WP boxes spawning empty
fix: fixed Kovacs not accepting .30 mags (it should)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
