### PR TITLE
Fixes division by zero runtime in damage calcs

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -227,11 +227,11 @@ mob/living/carbon/human/airflow_hit(atom/A)
 		bloody_body(src)
 	var/b_loss = airflow_speed * vsc.airflow_damage
 
-	damage_through_armor(b_loss/3, BRUTE, BP_HEAD, ARMOR_MELEE, 0, "Airflow")
+	damage_through_armor(b_loss/3, BRUTE, BP_HEAD, ARMOR_MELEE, 1, "Airflow")
 
-	damage_through_armor(b_loss/3, BRUTE, BP_CHEST, ARMOR_MELEE, 0, "Airflow")
+	damage_through_armor(b_loss/3, BRUTE, BP_CHEST, ARMOR_MELEE, 1, "Airflow")
 
-	damage_through_armor(b_loss/3, BRUTE, BP_GROIN, ARMOR_MELEE, 0, "Airflow")
+	damage_through_armor(b_loss/3, BRUTE, BP_GROIN, ARMOR_MELEE, 1, "Airflow")
 
 	if(airflow_speed > 10)
 		Paralyse(round(airflow_speed * vsc.airflow_stun))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -18,12 +18,13 @@
 		show_message(msg1, 1)
 
 /mob/living/proc/damage_through_armor(damage = 0, damagetype = BRUTE, def_zone, attack_flag = ARMOR_MELEE, armor_divisor = 1, used_weapon, sharp = FALSE, edge = FALSE, wounding_multiplier = 1, list/dmg_types = list(), return_continuation = FALSE)
-
 	if(damage) // If damage is defined, we add it to the list
 		if(!dmg_types[damagetype])
 			dmg_types += damagetype
 		dmg_types[damagetype] += damage
 
+	if(!armor_divisor)
+		armor_divisor = 1
 
 	var/total_dmg = 0
 	var/dealt_damage = 0

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -25,6 +25,7 @@
 
 	if(!armor_divisor)
 		armor_divisor = 1
+		log_debug("[used_weapon] applied damage to [name] with an armor divisor of 0")
 
 	var/total_dmg = 0
 	var/dealt_damage = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

## Why It's Good For The Game

Bug fix

## Testing

- Got hit by airflow.

## Changelog
:cl:
tweak: Gave airflow an AD of 1
fix: AD defaults to 1 if 0 is passed to damage_through_armor()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
