### PR TITLE
Fixes full auto click handler bug

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -867,8 +867,8 @@
 	update_firemode()
 
 /obj/item/gun/dropped(mob/user)
-	.=..()
 	update_firemode(FALSE)
+	.=..()
 
 /obj/item/gun/swapped_from()
 	.=..()
@@ -1028,7 +1028,7 @@
 
 	if(firemodes.len)
 		very_unsafe_set_firemode(sel_mode) // Reset the firemode so it gets the new changes
-	
+
 	update_icon()
 	//then update any UIs with the new stats
 	SSnano.update_uis(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Dropping a gun while zoomed in will no longer allow you to fire the gun.

## Why It's Good For The Game

Bug fix

## Testing

- Pre-fix: dropped gun while zoomed in and left-clicked.
- Post-fix: dropped gun while zoomed in and left-clicked.

## Changelog
:cl:
fix: Fixed full auto click handler not being removed when a zoomed gun was dropped
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
