### PR TITLE
Adds console screen to means revolution disk and makes it craftable

### DIFF
--- a/code/datums/craft/recipes/misc.dm
+++ b/code/datums/craft/recipes/misc.dm
@@ -317,3 +317,12 @@
 		list(CRAFT_MATERIAL,5, MATERIAL_PLASTIC), //Thick plastic bag
 		list(/obj/item/stack/cable_coil, 1, "time" = 20) //And the draw string
 	)
+
+/datum/craft_recipe/console_screen
+	name = "console screen"
+	result = /obj/item/stock_parts/console_screen
+	steps = list(
+		list(CRAFT_MATERIAL, 3, MATERIAL_GLASS),
+		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTIC)
+	)
+	related_stats = list(STAT_MEC)

--- a/code/game/objects/items/weapons/design_disks/excelsior.dm
+++ b/code/game/objects/items/weapons/design_disks/excelsior.dm
@@ -29,6 +29,7 @@
 		/datum/design/autolathe/part/igniter,						//regular parts
 		/datum/design/autolathe/part/signaler,
 		/datum/design/autolathe/part/sensor_prox,
+		/datum/design/autolathe/part/consolescreen,
 		/datum/design/autolathe/cell/large/excelsior,				//power cells
 		/datum/design/autolathe/cell/medium/excelsior,
 		/datum/design/autolathe/cell/small/excelsior,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds console screen to means revolution disk and makes it craftable.

## Why It's Good For The Game

Some excelsior machines use them, it should probably be on it plus it having an easy recipe makes it easier to build many machines.

## Testing

It works.
![Screenshot_3](https://user-images.githubusercontent.com/61051786/206191512-ac6b9983-d2be-481c-b626-0a6be37cc568.png)


## Changelog
:cl:
tweak: console screen can now be printed from means of production disk and crafted too
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
