### PR TITLE
Fixes robot HUD not updating on module storage

### DIFF
--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -51,7 +51,7 @@
 		module_state_3:loc = module
 		module_state_3 = null
 		//inv3.icon_state = "inv3"
-	for (var/obj/screen/inv in src.HUDinventory)
+	for (var/obj/screen/inv as anything in HUDinventory)
 		inv.update_icon()
 	update_robot_modules_display()
 	updateicon()

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -51,7 +51,7 @@
 		module_state_3:loc = module
 		module_state_3 = null
 		//inv3.icon_state = "inv3"
-	for (var/obj/screen/inv as anything in HUDinventory)
+	for(var/obj/screen/inv as anything in HUDinventory)
 		inv.update_icon()
 	update_robot_modules_display()
 	updateicon()

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -51,6 +51,8 @@
 		module_state_3:loc = module
 		module_state_3 = null
 		//inv3.icon_state = "inv3"
+	for (var/obj/screen/inv in src.HUDinventory)
+		inv.update_icon()
 	update_robot_modules_display()
 	updateicon()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fix the robot HUD not updating on module storage
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's very slightly less confusing if you store a module then immediately equip a new one, so it won't look like your newly equipped module is selected. If this description is confusing it's because the issue is confusing and I'm tired as fuck.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I loaded up the game, spawned in as a borg. Then I equipped a module, activated it, then stowed it while active. Additionally checked for runtimes to ensure the logs aren't literally fucking dying.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: Stowing borg modules no longer leaves the inventory slot highlighted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
