### PR TITLE
Premade custom vendor stock tweaks

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1181,7 +1181,7 @@
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 	auto_price = FALSE
 	custom_vendor = TRUE // Chemists can load it for MDs
-	can_stock = list(/obj/item/reagent_containers/glass, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/pill, /obj/item/stack/medical, /obj/item/bodybag, /obj/item/device/scanner/health, /obj/item/reagent_containers/hypospray, /obj/item/storage/pill_bottle)
+	can_stock = list(/obj/item/reagent_containers/glass, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/pill, /obj/item/stack/medical, /obj/item/bodybag, /obj/item/device/scanner/health, /obj/item/reagent_containers/hypospray, /obj/item/storage/pill_bottle, /obj/item/reagent_containers/food/snacks/moecube, /obj/item/organ/internal)
 	vendor_department = DEPARTMENT_MEDICAL
 	shut_up = TRUE
 
@@ -1203,7 +1203,7 @@
 	icon_deny = "wallmed-deny"
 	product_ads = "Self-medication can be healthy!;Natural chemicals!;This stuff saves lives.;Don't you want some?;Hook it up to your veins!"
 	custom_vendor = TRUE // Chemists can load it for customers
-	can_stock = list(/obj/item/reagent_containers/glass, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/pill, /obj/item/stack/medical, /obj/item/bodybag, /obj/item/device/scanner/health, /obj/item/reagent_containers/hypospray, /obj/item/storage/pill_bottle)
+	can_stock = list(/obj/item/reagent_containers/glass, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/pill, /obj/item/stack/medical, /obj/item/bodybag, /obj/item/device/scanner/health, /obj/item/reagent_containers/hypospray, /obj/item/storage/pill_bottle, /obj/item/reagent_containers/food/snacks/moecube, /obj/item/organ/internal)
 	vendor_department = DEPARTMENT_MEDICAL
 
 /obj/machinery/vending/wallmed/minor
@@ -1489,6 +1489,7 @@
 	prices = list(/obj/item/book/ritual/cruciform = 500, /obj/item/storage/fancy/candle_box = 200, /obj/item/reagent_containers/food/drinks/bottle/ntcahors = 250,
 				/obj/item/implant/core_implant/cruciform = 1000)
 	custom_vendor = TRUE // So they can sell pouches and other printed goods, if they bother to stock them
+	can_stock = list(/obj/item)
 
 /obj/machinery/vending/theomat/proc/check_NT(mob/user)
 	var/bingo = FALSE

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1523,7 +1523,7 @@
 
 /obj/machinery/vending/theomat/attackby(obj/item/I, mob/user)
 	if(I.tool_qualities || check_NT(user))
-		..()
+		..(I, user)
 
 /obj/machinery/vending/powermat
 	name = "Asters Guild Power-Mat"


### PR DESCRIPTION
## About The Pull Request

Moebius vendors can be stocked with organs and moecubes, NeoTheology vendor actually interacts with items.

Requested map changes for this PR:

- A labeler in Bioengineering to label cubes with their effects

Suggested code changes after this PR:

- A way to identify the mutation within cubes, as well as within the reagent itself
- A way to rename organ scaffolds so their effects can be better noted within a vendor, and to ensure they can stack properly (objects of identical name stack within vendors)

## Why It's Good For The Game

NT is a bugfix, Moe is a QOL addition, allowing Bioengineer to sell their wares even while outside.

## Testing

Compiled successfully
![image](https://user-images.githubusercontent.com/61586732/207138385-cf397065-948f-4174-9a28-ae8a25f44073.png)
![image](https://user-images.githubusercontent.com/61586732/207144047-918dcb13-b71c-4904-87c9-d0e646944fb2.png)

## Changelog
:cl:
tweak: Moebius MicroMed and MiniPharma vendors can now hold genetic cubes and organs
fix: Theomat can now be stocked with new items, and actually accepts payment
/:cl: