### PR TITLE
Boris Station Combat Hardsuit

### DIFF
--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/rigprovider.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/rigprovider.dm
@@ -46,6 +46,7 @@
 	hidden_inventory = list(
 		"RIGs II" =  list(
 			/obj/item/rig/light = custom_good_amount_range(list(1, 5)),
+			/obj/item/rig/combat = custom_good_amount_range(list(1, 5)),
 			/obj/item/rig_module/held/shield,
 			/obj/item/rig_module/datajack,
 			/obj/item/rig_module/electrowarfare_suite,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the Combat Rig to the Boris Station.
It's under the same tier as the Light Rig, meaning you have to max out favour with the Suit Up station, then the Boris station in order to unlock it.

It costs 2160 (I'm under the impression this price is constant), which is 500 more than you are paid to sell it to the Boris station (1500), preventing money dupe.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The combat rig is hard to obtain without this change, prior to this change you could obtain it from (to my knowledge)
- Trash Pile RNG
- Guild Perk Spawn RNG

As it's one of the stronger rigs I've placed it behind the contraband section of the Boris station, meaning it can't be gotten off the bat unless the captain brute forces the process.

While a similar rig (the Crimson Hardsuit) is locked behind an endgame station, and a much higher price. The Crimson Rig also comes fully stacked with illegal modules. (I believe an empty version should be obtainable with less stress honestly but, that's not a hill I'm dying on)

Finally the Combat Rig is very close statwise to the Hazard Rig, which is gotten in the default section of the Boris Station for a much cheaper price.
It loses out in melee by 2 points, comes ahead in bullet and energy by 1 point, has 40 points less in bomb protection, and half the rad protection.
It has also has half the ablative armor of the Hazard Rig (Standard for 10points vs the Hazard Durable for 20 points) but has more max ablative armor than the Hazard Rig (12 v 8).
At least that's what the code says, if I've misread that feel free to tell me so.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Launched the Game as Captain
Bought rigs and resold them at the beacon
Unlocked the Boris Station
Maxxed out it's favour
Bought the Combat Rig and donned it
Confirmed it spawns with only the default internal storage

![Balls](https://user-images.githubusercontent.com/103066653/207425173-242f256a-bbeb-48c5-b891-c7d10dfd37bf.png)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
add: Adds the Combat Hardsuit to the contraband section of the Boris Station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
