### PR TITLE
Intermediate wounding multiplier for .20 caliber

### DIFF
--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -22,7 +22,11 @@
 #define ARMOR_PEN_MAX				10
 
 //Wounding Multiplier: Increases damage taken, applied after armor.
+
+#define WOUNDING_TRIVIAL			0.1
+#define WOUNDING_TINY				0.25
 #define WOUNDING_SMALL				0.5
+#define WOUNDING_INTERMEDIATE		0.75
 #define WOUNDING_NORMAL				1
 #define WOUNDING_WIDE				1.5
 #define WOUNDING_EXTREME			2

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -51,12 +51,12 @@ There are important things regarding this file:
 
 /obj/item/projectile/bullet/srifle
 	name = ".20 caliber bullet"
-	damage_types = list(BRUTE = 34)
+	damage_types = list(BRUTE = 24)
 	armor_divisor = 1.5
 	penetrating = 2
 	can_ricochet = TRUE
 	recoil = 3
-	wounding_mult = WOUNDING_SMALL
+	wounding_mult = WOUNDING_INTERMEDIATE
 
 /obj/item/projectile/bullet/srifle/nomuzzle
 	muzzle_type = null
@@ -78,6 +78,7 @@ There are important things regarding this file:
 	damage_types = list(BRUTE = 9, HALLOSS = 9)
 	embed = FALSE
 	sharp = FALSE
+	wounding_mult = WOUNDING_SMALL
 
 /obj/item/projectile/bullet/srifle/scrap
 	armor_divisor = 1.2


### PR DESCRIPTION
## About The Pull Request

Implements the intermediate wounding multiplier (0.75) alongside other currently not used multipliers (tiny and trivial, at 0.25 and 0.1 respectively)

This causes a decrease in penetration power, but increase in damage (from 17 to 18)

## Why It's Good For The Game

Will open up further balancing and tweaking options, helps .20 become more than a one-trick pony

## Testing

Localtested, guns shot fine

## Changelog
:cl:
balance: .20 changed to intermediate wounding level (more damage, less penetration), now statistically closer to .25
/:cl: