### PR TITLE
Adds hydroponics trays circuit boards to the guild vendor with other circuit boards

### DIFF
--- a/code/datums/autolathe/circuits.dm
+++ b/code/datums/autolathe/circuits.dm
@@ -80,6 +80,10 @@
 	name = "tracker electronics"
 	build_path = /obj/item/electronics/tracker
 
+/datum/design/autolathe/circuit/hydroponics
+	name = "hydroponics tray"
+	build_path = /obj/item/electronics/circuitboard/hydroponics
+
 //Exelsior ciruits
 /datum/design/autolathe/circuit/shieldgen_excelsior
 	name = "excelsior shield wall generator"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1484,9 +1484,9 @@
 	product_ads = "Praise!;Pray!;Obey!"
 	icon_state = "teomat"
 	vendor_department = DEPARTMENT_CHURCH
-	products = list(/obj/item/book/ritual/cruciform = 10, /obj/item/storage/fancy/candle_box = 10, /obj/item/reagent_containers/food/drinks/bottle/ntcahors = 20)
+	products = list(/obj/item/book/ritual/cruciform = 10, /obj/item/storage/fancy/candle_box = 10, /obj/item/reagent_containers/food/drinks/bottle/ntcahors = 20, /obj/machinery/portable_atmospherics/hydroponics = 60)
 	contraband = list(/obj/item/implant/core_implant/cruciform = 3)
-	prices = list(/obj/item/book/ritual/cruciform = 500, /obj/item/storage/fancy/candle_box = 200, /obj/item/reagent_containers/food/drinks/bottle/ntcahors = 250,
+	prices = list(/obj/item/book/ritual/cruciform = 500, /obj/item/storage/fancy/candle_box = 200, /obj/item/reagent_containers/food/drinks/bottle/ntcahors = 250, /obj/machinery/portable_atmospherics/hydroponics = 100,
 				/obj/item/implant/core_implant/cruciform = 1000)
 	custom_vendor = TRUE // So they can sell pouches and other printed goods, if they bother to stock them
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1484,9 +1484,9 @@
 	product_ads = "Praise!;Pray!;Obey!"
 	icon_state = "teomat"
 	vendor_department = DEPARTMENT_CHURCH
-	products = list(/obj/item/book/ritual/cruciform = 10, /obj/item/storage/fancy/candle_box = 10, /obj/item/reagent_containers/food/drinks/bottle/ntcahors = 20, /obj/machinery/portable_atmospherics/hydroponics = 60)
+	products = list(/obj/item/book/ritual/cruciform = 10, /obj/item/storage/fancy/candle_box = 10, /obj/item/reagent_containers/food/drinks/bottle/ntcahors = 20)
 	contraband = list(/obj/item/implant/core_implant/cruciform = 3)
-	prices = list(/obj/item/book/ritual/cruciform = 500, /obj/item/storage/fancy/candle_box = 200, /obj/item/reagent_containers/food/drinks/bottle/ntcahors = 250, /obj/machinery/portable_atmospherics/hydroponics = 100,
+	prices = list(/obj/item/book/ritual/cruciform = 500, /obj/item/storage/fancy/candle_box = 200, /obj/item/reagent_containers/food/drinks/bottle/ntcahors = 250,
 				/obj/item/implant/core_implant/cruciform = 1000)
 	custom_vendor = TRUE // So they can sell pouches and other printed goods, if they bother to stock them
 
@@ -1559,7 +1559,8 @@
 					/obj/item/computer_hardware/hard_drive/portable/design/guns/fs_slaught_o_matic = 5,
 					/obj/item/computer_hardware/hard_drive/portable/design/nonlethal_ammo = 10,
 					/obj/item/electronics/circuitboard/autolathe = 3,
-					/obj/item/electronics/circuitboard/vending = 10)
+					/obj/item/electronics/circuitboard/vending = 10,
+					/obj/item/electronics/circuitboard/hydroponics = 60)
 	contraband = list(
 			/obj/item/computer_hardware/hard_drive/portable/design/lethal_ammo = 3,
 			/obj/item/electronics/circuitboard/autolathe_disk_cloner = 3
@@ -1583,7 +1584,8 @@
 					/obj/item/electronics/circuitboard/autolathe = 700,
 					/obj/item/electronics/circuitboard/autolathe_disk_cloner = 1000,
 					/obj/item/electronics/circuitboard/vending = 500,
-					/obj/item/computer_hardware/hard_drive/portable/design/lethal_ammo = 1200,)
+					/obj/item/computer_hardware/hard_drive/portable/design/lethal_ammo = 1200,
+					/obj/item/electronics/circuitboard/hydroponics = 250)
 
 /obj/machinery/vending/serbomat
 	name = "From Serbia with love"

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -636,3 +636,8 @@
 	closed_system = !closed_system
 	to_chat(user, "You [closed_system ? "close" : "open"] the tray's lid.")
 	update_icon()
+
+/obj/item/electronics/circuitboard/hydroponics
+	name = "Circuit board (hydroponics tray)"
+	build_path = /obj/machinery/portable_atmospherics/hydroponics
+	origin_tech = list(TECH_DATA = 3)

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -8,6 +8,7 @@
 	anchored = TRUE
 	reagent_flags = OPENCONTAINER
 	volume = 100
+	circuit = /obj/item/electronics/circuitboard/hydroponics
 
 	var/mechanical = TRUE         // Set to 0 to stop it from drawing the alert lights.
 	var/base_name = "tray"
@@ -638,6 +639,8 @@
 	update_icon()
 
 /obj/item/electronics/circuitboard/hydroponics
-	name = "Circuit board (hydroponics tray)"
+	name = T_BOARD("hydroponics tray")
 	build_path = /obj/machinery/portable_atmospherics/hydroponics
-	origin_tech = list(TECH_DATA = 3)
+	board_type = "machine"
+	req_components = list(
+	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds hydroponics trays circuit boards to the guild vendor.

## Why It's Good For The Game

Has been suggested in feedback and it's a good idea overall.

## Testing

![Screenshot_1](https://user-images.githubusercontent.com/61051786/208242392-78c1dac4-1f13-4f72-9298-09d6dbcad0f4.png)


## Changelog
:cl:
tweak: guild vendor now sells hydroponics trays circuit boards
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
