### PR TITLE
Remove reerenglish breakdown line

### DIFF
--- a/code/modules/sanity/breakdowns.dm
+++ b/code/modules/sanity/breakdowns.dm
@@ -222,7 +222,6 @@
 		"You get overwhelmed and start to panic!",
 		"You're inconsolably terrified!",
 		"You can't choke back the tears anymore!",
-		"The hair on your nape stands on end! The fear sends you into a frenzy!",
 		"It's too much! You freak out and lose control!"
 	)
 	end_messages = list(


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/65828539/208241719-635618f0-5dbc-4785-9c01-d77dffe84289.png)

## Why It's Good For The Game

Less confusing lines - better.
Thought about making and alternative to it, but other lines are more than sufficient.

## Testing

Compiled and run the server.

## Changelog
:cl:
del: Removed silly text line from stun breakdown.
/:cl: