### PR TITLE
Add proper examine() to HUD elements

### DIFF
--- a/code/_onclick/hud/screen_objects/base_screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/base_screen_objects.dm
@@ -382,9 +382,9 @@
 /obj/screen/sanity
 	name = "sanity"
 	desc = "Soundness of your mind. Not keeping it in check may result in a breakdown.\
-	<br>Damaged by feeling pain, as well as seeing grime and gore;\
+	<br>Damaged by feeling pain, as well as seeing grime and gore; \
 	soothed by taking drugs, drinking, eating decent food and talking, preferably in a clean place with fellow humans around.\
-	<br>Sanity damage scales with your Vigilance."
+	<br>Sanity damage scales with your Vigilance. Left-click eye icon to see your current sanity, insight and style."
 	icon_state = "blank"
 
 /obj/screen/sanity/New()

--- a/code/_onclick/hud/screen_objects/base_screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/base_screen_objects.dm
@@ -32,6 +32,9 @@
 		src.icon_state = _icon_state
 	..()
 
+/obj/screen/examine(mob/user)
+	if(desc)
+		to_chat(user, SPAN_NOTICE(desc))
 
 /obj/screen/Process()
 	return
@@ -51,11 +54,13 @@
 
 
 /obj/screen/Click(location, control, params)
-	if(!usr)
-		return TRUE
+	// Object Click() processed before and separately from mob's ClickOn(), thus every shift click doubles as just click
+	// This is a band aid to prevent such behavior
+	var/list/modifiers = params2list(params)
+	if(desc && modifiers["shift"])
+		return
 
 	switch(name)
-
 		if("equip")
 			if(ishuman(usr))
 				var/mob/living/carbon/human/H = usr
@@ -63,8 +68,7 @@
 
 		if("Reset Machine")
 			usr.unset_machine()
-		else
-			return FALSE
+
 	return TRUE
 //--------------------------------------------------close---------------------------------------------------------
 
@@ -322,6 +326,9 @@
 //--------------------------------------------------health---------------------------------------------------------
 /obj/screen/health
 	name = "health"
+	desc = "Not your actual health, but an estimate of how much pain you feel.\
+	<br>Experience too much of it, and you will lose consciousness.\
+	<br>Pain tolerance scales with your toughness."
 	icon = 'icons/mob/screen/ErisStyle.dmi'
 	icon_state = "health0"
 	screen_loc = "15,7"
@@ -364,6 +371,8 @@
 	overlays += ovrls["health7"]
 
 /obj/screen/health/Click()
+	if(!..())
+		return
 	if(ishuman(parentmob))
 		var/mob/living/carbon/human/H = parentmob
 		H.check_self_for_injuries()
@@ -372,6 +381,10 @@
 //--------------------------------------------------sanity---------------------------------------------------------
 /obj/screen/sanity
 	name = "sanity"
+	desc = "Soundness of your mind. Not keeping it in check may result in a breakdown.\
+	<br>Damaged by feeling pain, as well as seeing grime and gore;\
+	soothed by taking drugs, drinking, eating decent food and talking, preferably in a clean place with fellow humans around.\
+	<br>Sanity damage scales with your vigilance."
 	icon_state = "blank"
 
 /obj/screen/sanity/New()
@@ -433,6 +446,8 @@
 	overlays += ovrls["sanity0"]
 
 /obj/screen/sanity/Click()
+	if(!..())
+		return
 	if(!ishuman(parentmob))
 		return FALSE
 	var/mob/living/carbon/human/H = parentmob
@@ -443,6 +458,8 @@
 //--------------------------------------------------nsa---------------------------------------------------------
 /obj/screen/nsa
 	name = "nsa"
+	desc = "Neural System Accumulation is a variable, that shows how many augmentations, mutations and chemicals you can handle.\
+	<br>Going beyond your body's limits may have consequences. NSA scales with your cognition stat."
 	icon_state = "blank"
 
 /obj/screen/nsa/New()
@@ -497,6 +514,7 @@
 //--------------------------------------------------nutrition---------------------------------------------------------
 /obj/screen/nutrition
 	name = "nutrition"
+	desc = "This shows how much hunger you feel. Being malnourished significantly slows you down. Not updated immediately after eating."
 	icon = 'icons/mob/screen/ErisStyle.dmi'
 	icon_state = "blank"
 	screen_loc = "15,6"
@@ -534,6 +552,8 @@
 //--------------------------------------------------bodytemp---------------------------------------------------------
 /obj/screen/bodytemp
 	name = "bodytemp"
+	desc = "Temperature of your body. Affected by environment, health and ingested chemicals.\
+	<br>Fever might be a sign of untreated infection."
 	icon = 'icons/mob/screen/ErisStyle.dmi'
 	icon_state = "blank"
 	screen_loc = "15,8"
@@ -603,6 +623,8 @@
 //--------------------------------------------------pressure---------------------------------------------------------
 /obj/screen/pressure
 	name = "pressure"
+	desc = "Barometric pressure experienced by your body.\
+	<br>Being in an environment with extreme pressure without a voidsuit is fatal."
 	icon = 'icons/mob/screen/ErisStyle.dmi'
 	icon_state = "blank"
 	screen_loc = "15,13"
@@ -1341,7 +1363,7 @@ obj/screen/fire/DEADelize()
 		var/obj/item/clothing/glasses/G = H.wearing_rig.getCurrentGlasses()
 		if(G && H.wearing_rig.visor.active)
 			overlays |= G.overlay
-	
+
 	if(get_active_mutation(H, MUTATION_NIGHT_VISION))
 		overlays |= global_hud.nvg
 

--- a/code/_onclick/hud/screen_objects/base_screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/base_screen_objects.dm
@@ -328,7 +328,7 @@
 	name = "health"
 	desc = "Not your actual health, but an estimate of how much pain you feel.\
 	<br>Experience too much of it, and you will lose consciousness.\
-	<br>Pain tolerance scales with your toughness."
+	<br>Pain tolerance scales with your Toughness."
 	icon = 'icons/mob/screen/ErisStyle.dmi'
 	icon_state = "health0"
 	screen_loc = "15,7"
@@ -384,7 +384,7 @@
 	desc = "Soundness of your mind. Not keeping it in check may result in a breakdown.\
 	<br>Damaged by feeling pain, as well as seeing grime and gore;\
 	soothed by taking drugs, drinking, eating decent food and talking, preferably in a clean place with fellow humans around.\
-	<br>Sanity damage scales with your vigilance."
+	<br>Sanity damage scales with your Vigilance."
 	icon_state = "blank"
 
 /obj/screen/sanity/New()
@@ -458,8 +458,9 @@
 //--------------------------------------------------nsa---------------------------------------------------------
 /obj/screen/nsa
 	name = "nsa"
-	desc = "Neural System Accumulation is a variable, that shows how many augmentations, mutations and chemicals you can handle.\
-	<br>Going beyond your body's limits may have consequences. NSA scales with your cognition stat."
+	desc = "Neural System Accumulation depicts strain your body is experiencing.\
+	<br>It is increased by chemicals and mutations.\
+	<br>Going beyond your body's limits has negative consequences. NSA limit scales with your Cognition."
 	icon_state = "blank"
 
 /obj/screen/nsa/New()
@@ -553,7 +554,8 @@
 /obj/screen/bodytemp
 	name = "bodytemp"
 	desc = "Temperature of your body. Affected by environment, health and ingested chemicals.\
-	<br>Fever might be a sign of untreated infection."
+	<br>Fever might be a sign of untreated infection.\
+	<br>You are slowed down if your body temperature is low enough."
 	icon = 'icons/mob/screen/ErisStyle.dmi'
 	icon_state = "blank"
 	screen_loc = "15,8"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -254,8 +254,8 @@
 	if((is_blind(src) || usr.stat) && !isobserver(src))
 		to_chat(src, "<span class='notice'>Something is there but you can't see it.</span>")
 		return
-
-	face_atom(examinify)
+	if(!istype(examinify, /obj/screen))
+		face_atom(examinify)
 	var/obj/item/device/lighting/toggleable/flashlight/FL = locate() in src
 	if (FL?.on && stat != DEAD && !incapacitated())
 		FL.afterattack(examinify, src)


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/65828539/208250089-56f4e140-f2b8-4904-94c9-670cfd526257.png)

Fixed people seeing message about examining HUD objects.
Added descriptions to health, sanity, NSA, body temperature, nutrition and pressure.
Ideas for other element's descriptions are welcome (especially for "block" button, it's important, but idk how it works).

## Why It's Good For The Game

You know why.

## Testing

Compiled and launched local server, examined HUD elements.

## Changelog
:cl:
add: Added description for several HUD elements.
/:cl: