### PR TITLE
MMI Insertion no longer asks for permission , MMI extra-description 

### DIFF
--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -21,7 +21,7 @@
 /obj/item/device/mmi
 	name = "man-machine interface"
 	desc = "The Warrior's bland acronym, MMI, obscures the true horror of this monstrosity."
-	description_info = "Brains can be inserted by clicking on it. Brains can be removed by swiping a ID with roboticist acces and clicking with an empty hand."
+	description_info = "Brains can be inserted by clicking on it. Brains can be removed by swiping a ID with roboticist access and clicking with an empty hand."
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "mmi_empty"
 	w_class = ITEM_SIZE_NORMAL

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -21,6 +21,7 @@
 /obj/item/device/mmi
 	name = "man-machine interface"
 	desc = "The Warrior's bland acronym, MMI, obscures the true horror of this monstrosity."
+	description_info = "Brains can be inserted by clicking on it. Brains can be removed by swiping a ID with roboticist acces and clicking with an empty hand."
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "mmi_empty"
 	w_class = ITEM_SIZE_NORMAL

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -48,9 +48,8 @@
 		if(!BM.client)
 			for(var/mob/observer/ghost/G in GLOB.player_list)
 				if(G.can_reenter_corpse && G.mind == BM.mind)
-					if(alert(G, "Somebody is attempting to put your brain in an MMI. Would you like to return to it?","Become brain","OH YES","No") == "OH YES")
-						G.reenter_corpse()
-						break
+					G.reenter_corpse()
+					break
 			if(!BM.client)
 				to_chat(user, SPAN_WARNING("\The [src] indicates that \the [B] is unresponsive."))
 				return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
MMI Insertion no longer asks for permission to insert brains
Adds description extras detailing how to remove and add brains

## Why It's Good For The Game
Causes bugs with brains in hands  , spams ghosts needlessly , original PR did not mention it locks people.
## Testing
Tested on local, very simple change.

## Changelog
:cl:
fix: Hands being bugged due to MMI insertion
fix: Ghost-alert spam using MMI's
add: Added extra-description to the MMI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
