### PR TITLE
Possibly fixes teleporting borers

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -127,6 +127,18 @@
 	verbs -= abilities_standalone
 	verbs -= abilities_in_host
 	host?.verbs -= abilities_in_control
+	
+	// Borer gets host abilities before actually getting inside the host
+	// Workaround for a BYOND bug: http://www.byond.com/forum/post/1833666
+	/*if(force_host)
+		if(ishuman(host))
+			verbs += abilities_in_host
+			return
+		for(var/ability in abilities_in_host)
+			if(istype(ability, /mob/living/carbon/human))
+				continue
+			verbs += ability
+		return*/
 
 	// Re-grant some of the abilities, depending on the situation
 	if(!host)

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -81,6 +81,13 @@
 /mob/living/simple_animal/borer/roundstart
 	roundstart = TRUE
 
+/mob/living/simple_animal/borer/Destroy()
+	if(ishuman(host))
+		var/mob/living/carbon/human/H = host
+		var/obj/item/organ/external/head = H.get_organ(BP_HEAD)
+		head.implants.Remove(src) // This should be safe.
+	return ..()
+
 /mob/living/simple_animal/borer/Login()
 	..()
 	if(!roundstart && mind && !mind.antagonist.len)

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -79,7 +79,7 @@
 		)
 
 /mob/living/simple_animal/borer/roundstart
-	roundstart = 1
+	roundstart = TRUE
 
 /mob/living/simple_animal/borer/Login()
 	..()
@@ -120,18 +120,6 @@
 	verbs -= abilities_standalone
 	verbs -= abilities_in_host
 	host?.verbs -= abilities_in_control
-
-	// Borer gets host abilities before actually getting inside the host
-	// Workaround for a BYOND bug: http://www.byond.com/forum/post/1833666
-	/*if(force_host)
-		if(ishuman(host))
-			verbs += abilities_in_host
-			return
-		for(var/ability in abilities_in_host)
-			if(istype(ability, /mob/living/carbon/human))
-				continue
-			verbs += ability
-		return*/
 
 	// Re-grant some of the abilities, depending on the situation
 	if(!host)
@@ -214,11 +202,6 @@
 
 	if(!host || !controlling) return
 
-	if(ishuman(host))
-		var/mob/living/carbon/human/H = host
-		var/obj/item/organ/external/head = H.get_organ(BP_HEAD)
-		head.implants -= src
-
 	controlling = FALSE
 
 	host.remove_language(LANGUAGE_CORTICAL)
@@ -265,7 +248,12 @@
 	if(host.mind)
 		clear_antagonist_type(host.mind, ROLE_BORER)
 
-	src.loc = get_turf(host)
+	if(ishuman(host))
+		var/mob/living/carbon/human/H = host
+		var/obj/item/organ/external/head = H.get_organ(BP_HEAD)
+		head.implants.Remove(src)
+
+	loc = get_turf(host)
 
 	reset_view(null)
 	machine = null
@@ -273,8 +261,7 @@
 	host.reset_view(null)
 	host.machine = null
 
-	var/mob/living/H = host
-	H.status_flags &= ~PASSEMOTES
+	host.status_flags &= ~PASSEMOTES
 	host = null
 	update_abilities()
 
@@ -359,3 +346,4 @@
 		else
 			//sight = initial(sight)
 			see_in_dark = initial(see_in_dark)
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Deletion of implants was in the wrong place.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes an annoying bug.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->
Var-edit human in game after infecting, implant doesn't show up after disinfecting. Issue was causing due to a reference to the borer lingering in implants after disinfecting a host. Letting people murder a borer after it hopped to a completely different body.
## Changelog
:cl:
fix: Fixes borer teleportation from extraction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
