### PR TITLE
Njoy buffs

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -297,7 +297,7 @@
 	name = "bottle of Njoy pills"
 	desc = "Contains pills used to stop all breakdowns."
 	icon_state = "bottle_njoy_red"
-	prespawned_content_type = /obj/item/reagent_containers/pill/suppressital
+	prespawned_content_type = /obj/item/reagent_containers/pill/suppressital/red
 
 /obj/item/storage/pill_bottle/njoy/green
 	icon_state = "bottle_njoy_green"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -134,18 +134,28 @@
 	preloaded_reagents = list("citalopram" = 15)
 
 /obj/item/reagent_containers/pill/suppressital
-	name = "Njoy red pill"
+	name = "Njoy pill"
 	desc = "Stops all breakdowns."
 	icon_state = "pill_njoy_red"
 	preloaded_reagents = list("suppressital" = 15)
 
+/obj/item/reagent_containers/pill/suppressital/red
+	name = "Njoy red pill"
+	desc = "Stops all breakdowns. Tastes faintly of cherry."
+	icon_state = "pill_njoy_red"
+	preloaded_reagents = list("suppressital" = 15, "cherryjelly" = 5)
+
 /obj/item/reagent_containers/pill/suppressital/blue
 	name = "Njoy blue pill"
+	desc = "Stops all breakdowns. Tastes faintly of blueberry."
 	icon_state = "pill_njoy_blue"
+	preloaded_reagents = list("suppressital" = 15, "berryjuice" = 5)
 
 /obj/item/reagent_containers/pill/suppressital/green
 	name = "Njoy green pill"
+	desc = "Stops all breakdowns. Tastes faintly of watermelon."
 	icon_state = "pill_njoy_green"
+	preloaded_reagents = list("suppressital" = 15, "watermelonjuice" = 5)
 
 
 /obj/item/reagent_containers/pill/inaprovaline

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -875,8 +875,9 @@
 	reagent_state = LIQUID
 	color = "#001aff"
 	overdose = REAGENTS_OVERDOSE
+	metabolism = REM/2
 
-/datum/reagent/medicine/suppressital/affect_ingest/(mob/living/carbon/M)
+/datum/reagent/medicine/suppressital/affect_blood/(mob/living/carbon/M)
 	if(!M.stats.getPerk(PERK_NJOY))
 		M.stats.addPerk(PERK_NJOY)
 

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -444,6 +444,9 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 /datum/sanity/proc/breakdown(var/positive_breakdown = FALSE)
 	breakdown_time = world.time + SANITY_COOLDOWN_BREAKDOWN
 
+	if(owner.stats.getPerk(PERK_NJOY))
+		return // No breakdowns when you're Njoying life. TODO: once Psychosis is added, reduce to 50% chance
+
 	for(var/obj/item/device/mind_fryer/M in GLOB.active_mind_fryers)
 		if(get_turf(M) in view(get_turf(owner)))
 			M.reg_break(owner)
@@ -453,9 +456,9 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 			S.reg_break(owner)
 
 	var/list/possible_results
-	if((prob(positive_prob) && positive_prob_multiplier > 0 || positive_breakdown) && !owner.stats.getPerk(PERK_NJOY))
+	if((prob(positive_prob) && positive_prob_multiplier > 0 || positive_breakdown))
 		possible_results = subtypesof(/datum/breakdown/positive)
-	else if(prob(negative_prob) && !owner.stats.getPerk(PERK_NJOY))
+	else if(prob(negative_prob))
 		possible_results = subtypesof(/datum/breakdown/negative)
 	else
 		possible_results = subtypesof(/datum/breakdown/common)


### PR DESCRIPTION
## About The Pull Request

Njoy metabolises half as fast, works in the bloodstream, and contains 5 units of flavouring, depending on colour.
Red = cherry
Blue = berry
Green = watermelon

Instead of reducing negative and positive breakdown chance to 0, Njoy now prevents all breakdowns while it is in your system.

## Why It's Good For The Game

Improves Njoy significantly, which is necessary to make it a viable alternative to drug abuse.

## Testing

Compiled and ran, requesting the PR to be added to next test server to check edge-cases.

## Changelog
:cl:
balance: njoy lasts twice as long
tweak: you no longer get neutral breakdowns while on njoy
tweak: njoy has flavouring
tweak: njoy works when injected
/:cl: