### PR TITLE
Make relics go into cryo storage

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -183,7 +183,18 @@
 		/obj/item/clothing/shoes/magboots,
 		/obj/item/blueprints,
 		/obj/item/clothing/head/space,
-		/obj/item/storage/internal
+		/obj/item/storage/internal,
+		/obj/item/device/von_krabin,
+		/obj/item/complicator,
+		/obj/item/biosyphon,
+		/obj/item/device/last_shelter,
+		/obj/item/device/techno_tribalism,
+		/obj/item/device/radio/random_radio,
+		/obj/item/maneki_neko,
+		/obj/item/tool/sword/nt_sword,
+		/obj/item/reagent_containers/atomic_distillery,
+		/obj/item/reagent_containers/bonsai,
+		/obj/item/reagent_containers/enricher
 	)
 
 /obj/machinery/cryopod/robot


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds relics to cryo exclude list
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
So people don't grief entire departments by going SSD
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![изображение](https://user-images.githubusercontent.com/57810301/209814367-d9fa49c7-84dd-4f45-bc6b-dc1f069d8395.png)


## Changelog
:cl:
tweak: When cryoing departmental relics will now go into storage instead of getting deleted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
