### PR TITLE
Energy Sabre and Energy Sword sheath

### DIFF
--- a/code/game/objects/items/weapons/storage/holster.dm
+++ b/code/game/objects/items/weapons/storage/holster.dm
@@ -74,7 +74,8 @@
 		/obj/item/melee,
 		/obj/item/tool/crowbar,
 		/obj/item/tool/hammer/,
-		/obj/item/tool/hatchet
+		/obj/item/tool/hatchet,
+		/obj/item/melee/energy/sword
 		)
 
 
@@ -256,7 +257,8 @@
 	can_hold = list(
 		/obj/item/tool/hammer,
 		/obj/item/tool/hatchet,
-		/obj/item/tool/makeshiftaxe
+		/obj/item/tool/makeshiftaxe,
+		/obj/item/melee/energy/sword/sabre
 		)
 	price_tag = 20
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives the Energy Sword (the antagonist version) and the Energy Sabre (the crafted version) sheaths they can be stored in.
Energy sword gets the baton sheath 
Energy sabre gets the baton sheath and the ring sheath

Both cannot be stored while active.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Easier melee access for weapons is good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

- Launched local
- Spawned in
- Spawned in sheaths
- Spawned in swords
- Tried to sheath when active
- Sheathed while not active
- Made sure energy sword didnt fit in ring sheath
- Made sure energy sabre fit in ring sheath and holster sheath

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: Energy sword and Energy sabre now fit in the baton sheath and ring sheath respectively
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
