### PR TITLE
Laser Swords Do Burn Damage Now

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -24,6 +24,7 @@
 	active = 1
 	force = active_force
 	throwforce = active_throwforce
+	damtype = BURN
 	sharp = TRUE
 	edge = TRUE
 	w_class = active_w_class
@@ -38,6 +39,7 @@
 	active = 0
 	force = initial(force)
 	throwforce = initial(throwforce)
+	damtype = initial(damtype)
 	sharp = initial(sharp)
 	edge = initial(edge)
 	w_class = initial(w_class)
@@ -187,6 +189,7 @@
 	icon_state = "blade"
 	force = WEAPON_FORCE_ROBUST //Normal attacks deal very high damage - about the same as wielded fire axe
 	armor_divisor = ARMOR_PEN_MAX
+	damtype = BURN
 	sharp = TRUE
 	edge = TRUE
 	anchored = TRUE    // Never spawned outside of inventory, should be fine.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes all laser swords

- Craftable Laser Sabre
- Antag Laser Sword
- Implanted Laser Sword
- Rig Laser Sword

Do burn damage when switched on.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Laser swords are inspired by light sabres, so it felt weird that they did brute damage like you were being stabbed with a knife.

It is inadvertently a buff since burn; are more painful, can cause infections easier, are resisted by less armor.
But the laser swords tended to ignore most armor anyway.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

- Launched Local
- Spawned in a tech
- Spawned in disciples
- Spawned in each sword type
- Attacked with switched off inhands to confirm those still did brute
- Switched on and attacked with activated laser weapons till the targeted limb flashed away into ashes
- Examined and used a health scanner to confirm burn damage was being done
- Did the same for the implanted and rig versions

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: laser swords do burn damage now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
