### PR TITLE
Von Krabin Nerf (Only links humans now)

### DIFF
--- a/code/game/objects/items/devices/von-krabin.dm
+++ b/code/game/objects/items/devices/von-krabin.dm
@@ -91,6 +91,8 @@
 	..()
 
 /obj/item/device/von_krabin/attack(mob/living/M, mob/living/user, target_zone)
+	if(!ishuman(M) || M.isMonkey())
+		return ..()
 	if(user.a_intent == I_HELP && !is_neotheology_disciple(M))
 		if(M in the_hiveminded)
 			user.visible_message(SPAN_NOTICE("[user] begins unlinking [M]'s mind from the [src]"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I noticed Moesci players using the krabin on dead roaches while observing, and after testing found that roaches & spiders (dead or alive), mice (alive) and monkeys all could be linked to the krabin for a stat boost.

On a test server it took me 10 minutes of casual walking around in the maints to boost my mental stats by 70 points. If I had tried harder to not gib weaker roaches I could have easier gotten higher.

Talking to the original coder confirmed this interaction wasn't intended, so this pr disallows linking anyone that isnt human to the Krabin.

(Cheers to SPCR for the code checking)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

- Removes the unintended interaction of linking animals to the krabin for quick stats
- Pushes Moesci towards using the Krabin on actual crew and sharing it's benefits, rather than linking dead/alive animals and monopolizing them
- Personal opinion but I feel it makes more sense that only thinking humans can be linked now, how is a roach or monkey supposed to increase your ability to dissemble a wall or do heart surgery?

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

- Launched test server
- Took the krabin
- Linked myself
- Walked into maints
- Tried linking roaches (dead and alive) with no result
- Tried linking spiders (dead and alive) with no result
- Tried linking a mouse with no result
- Tried linking monkeys with no result

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
balance: The Krabin only accepts humans in it's link now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
