### PR TITLE
Microfusion gen buff

### DIFF
--- a/code/modules/onestar/generator.dm
+++ b/code/modules/onestar/generator.dm
@@ -7,8 +7,8 @@
 	power_gen = 0						// Watts output per power_output level
 	var/can_generate_power = FALSE
 	var/is_circuit_fried = FALSE		// Doesn't actually fry anything, maybe it should
-	var/power_gen_gain_per_tick = 100	// How fast this thing ramps up
-	var/max_power_gen = 30000
+	var/power_gen_gain_per_tick = 500	// How fast this thing ramps up
+	var/max_power_gen = 3000000
 	var/max_power_output = 10			// The maximum power setting without emagging.
 
 /obj/machinery/power/port_gen/os_generator/Initialize()

--- a/code/modules/onestar/generator.dm
+++ b/code/modules/onestar/generator.dm
@@ -7,8 +7,8 @@
 	power_gen = 0						// Watts output per power_output level
 	var/can_generate_power = FALSE
 	var/is_circuit_fried = FALSE		// Doesn't actually fry anything, maybe it should
-	var/power_gen_gain_per_tick = 500	// How fast this thing ramps up
-	var/max_power_gen = 3000000
+	var/power_gen_gain_per_tick = 10000	// How fast this thing ramps up
+	var/max_power_gen = 300000
 	var/max_power_output = 10			// The maximum power setting without emagging.
 
 /obj/machinery/power/port_gen/os_generator/Initialize()


### PR DESCRIPTION

## About The Pull Request

Buffed Microfusion gen. Increased output by a factor of ten (300KW to 3MW) and increased charging speed by a factor of 100 (500W per tick to 10KW per tick) 

## Why It's Good For The Game

Considering how difficult it is to get the microfusion generator, it was rather underwhelming in its previous state, being able to barely power a single department and maybe half another. This takes it to about 1/4 the standard power output of the SM so that the reward for this piece of tech is less negligible. 

## Testing

![image](https://user-images.githubusercontent.com/40579231/211700808-4db39978-cfeb-4a48-bb57-7f407ae34009.png)

Yup.

## Changelog
:cl:
balance: Buff Onestar Microfusion Generator
/:cl: