### PR TITLE
Has_brain_worms now returns null instead of FALSE

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1085,8 +1085,7 @@ mob/proc/yank_out_object()
 	for(var/I in contents)
 		if(istype(I, /mob/living/simple_animal/borer))
 			return I
-
-	return FALSE
+	return
 
 /mob/proc/updateicon()
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For #7941 

`has_brain_worms()` was a mix between a `get_brain_worms()` (it returns the borer when there is one) and a proper `has_brain_worms()` (it returns FALSE when there is no borer). Now it returns either the borer or `null`. I will rename the function into `get_brain_worms()` once #7941 is merged.

I will also add a proper `has_brain_worms` that returns TRUE/FALSE

## Testing

Compilation returns no error, all existing calls are compatible with this change and will work with a `null` value instead of FALSE
![image](https://user-images.githubusercontent.com/64754494/212393391-425cc330-4a30-4181-8c06-6246f9d713a4.png)


## Changelog
:cl: Hyperio
code: Has_brain_worms now returns null instead of FALSE
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
