### PR TITLE
Fire rate and burst fire fix

### DIFF
--- a/code/__DEFINES/items.dm
+++ b/code/__DEFINES/items.dm
@@ -31,9 +31,6 @@
 //flags
 #define UPGRADE_ITEMFLAGPLUS "item_flag_add"
 
-// Weapon minimum fire_delay
-#define GUN_MINIMUM_FIRETIME 1.1 // 110 MS , ~9 shots per second.
-
 //Weapon upgrade defines
 
 //Int multiplier

--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -54,6 +54,9 @@
 #define STRUCTURE_DAMAGE_POWERFUL    	2
 #define STRUCTURE_DAMAGE_DESTRUCTIVE 	3
 
+// Weapon minimum fire_delay
+#define GUN_MINIMUM_FIRETIME 1.1 // 110 MS , ~9 shots per second.
+
 //Quick defines for fire modes
 #define FULL_AUTO_300		list(mode_name = "full auto",  mode_desc = "300 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 4  , icon="auto")
 #define FULL_AUTO_400		list(mode_name = "full auto",  mode_desc = "400 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 3, icon="auto")

--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -55,7 +55,7 @@
 #define STRUCTURE_DAMAGE_DESTRUCTIVE 	3
 
 // Weapon minimum fire_delay
-#define GUN_MINIMUM_FIRETIME 1.1 // 110 MS , ~9 shots per second.
+#define GUN_MINIMUM_FIRETIME 1.1 // 110 MS , ~9 shots per second, 545 RPM
 
 //Quick defines for fire modes
 #define FULL_AUTO_300		list(mode_name = "full auto",  mode_desc = "300 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 4  , icon="auto")

--- a/code/datums/datum_click_handlers.dm
+++ b/code/datums/datum_click_handlers.dm
@@ -109,18 +109,17 @@
 	return TRUE
 
 /datum/click_handler/fullauto/proc/shooting_loop()
+	while(target)
+		if(!owner || !owner.mob || owner.mob.resting)
+			return FALSE
 
-	if(!owner || !owner.mob || owner.mob.resting)
-		return FALSE
-	if(target)
 		owner.mob.face_atom(target)
 
-	while(time_since_last_shot < world.time)
-		do_fire()
-		time_since_last_shot = world.time + (reciever.fire_delay < GUN_MINIMUM_FIRETIME ? GUN_MINIMUM_FIRETIME : reciever.fire_delay) * min(world.tick_lag, 1)
+		while(time_since_last_shot < world.time)
+			do_fire()
+			time_since_last_shot += (reciever.fire_delay < GUN_MINIMUM_FIRETIME ? GUN_MINIMUM_FIRETIME : reciever.fire_delay) * min(world.tick_lag, 1)
 
-	spawn(1)
-		shooting_loop()
+		sleep(1)
 
 /datum/click_handler/fullauto/MouseDrag(over_object, src_location, over_location, src_control, over_control, params)
 	src_location = resolve_world_target(src_location)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -360,13 +360,13 @@
 		return ..() //Pistolwhippin'
 
 /obj/item/gun/proc/Fire(atom/target, mob/living/user, clickparams, pointblank=0, reflex=0)
-	if(!user || !target) return
+	if(!user || !target)
+		return
 
 	if(world.time < next_fire_time)
 		if (!suppress_delay_warning && world.time % 3) //to prevent spam
 			to_chat(user, SPAN_WARNING("[src] is not ready to fire again!"))
 		return
-
 
 	add_fingerprint(user)
 
@@ -375,9 +375,9 @@
 
 	currently_firing = TRUE
 
-	var/shoot_time = (burst - 1)* burst_delay
-	user.setClickCooldown(shoot_time) //no clicking on things while shooting
+	var/shoot_time = (burst - 1) * burst_delay + ((fire_delay < GUN_MINIMUM_FIRETIME ? GUN_MINIMUM_FIRETIME : fire_delay) * ((!twohanded && user.stats.getPerk(PERK_GUNSLINGER)) ? 0.66 : 1))
 	next_fire_time = world.time + shoot_time
+	user.setClickCooldown(shoot_time)
 
 	//actually attempt to shoot
 	var/turf/targloc = get_turf(target) //cache this in case target gets deleted during shooting, e.g. if it was a securitron that got destroyed.
@@ -427,18 +427,11 @@
 			update_icon()
 
 		if(i < burst)
-			next_fire_time = world.time + shoot_time
 			sleep(burst_delay)
 
 		if(!(target && target.loc))
 			target = targloc
-			pointblank = 0
-	if(!twohanded && user.stats.getPerk(PERK_GUNSLINGER))
-		next_fire_time = world.time + (fire_delay < GUN_MINIMUM_FIRETIME ? GUN_MINIMUM_FIRETIME : fire_delay) * 0.66
-		user.setClickCooldown(fire_delay * 0.66)
-	else
-		next_fire_time = world.time + fire_delay < GUN_MINIMUM_FIRETIME ? GUN_MINIMUM_FIRETIME : fire_delay
-		user.setClickCooldown(fire_delay)
+			pointblank = FALSE
 
 	user.set_move_cooldown(move_delay)
 	if(muzzle_flash)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes an issue where fire delay would set a shorter click cooldown than burst delay, causing certain guns to be able to fire multiple bursts at once. Includes Humonitarian's shooting loop cleanup.

## Why It's Good For The Game

Bug fixes and cleanup

## Testing

- Live test

## Changelog
:cl:
tweak: Click cooldown from firing uses both burst delay and fire delay
code: Changed the shooting loop to use sleep() instead of spawn(), uses Humonitarian's logic
code: Moved a define to weapons.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
