### PR TITLE
Space weather tweaks and fixes

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -13,11 +13,13 @@ GLOBAL_VAR_INIT(random_parallax, pick("space0", "space1", "space2", "space3", "s
 /obj/parallax/New(mob/M)
 	owner = M
 	owner.parallax += src
+	SSevent.all_parallaxes += src
 	update()
 	..(null)
 
 /obj/parallax/Destroy()
 	owner = null
+	SSevent.all_parallaxes -= src
 	return ..()
 
 /obj/parallax/proc/update() //This proc updates your parallax (duh). If your view has been altered by binoculars, admin fuckery, and so on. We need to make the space bigger by applying a matrix transform to it. This is hardcoded for now.
@@ -27,27 +29,6 @@ GLOBAL_VAR_INIT(random_parallax, pick("space0", "space1", "space2", "space3", "s
 	if(!T)
 		return
 	screen_loc = "CENTER:[-224-T.x],CENTER:[-224-T.y]"
-	//And now we change depending on what is happening in processing events
-	for(var/datum/event/E in SSevent.active_events)
-		switch(E.storyevent.id)
-			if("bluespace_interphase")
-				icon_state = "bluespace_interphase"
-			if("graveyard")
-				icon_state = "graveyard"
-			if("bluespace_storm")
-				icon_state = "bluespace_storm"
-			if("ion_blizzard")
-				icon_state = "ion_blizzard"
-				//no close layer here
-			if("photon_vortex")
-				icon_state = "photon_vortex"
-			if("micro_debris")
-				icon_state = "micro_debris"
-			if("nebula")
-				icon_state = "nebula"
-			else
-				icon_state = GLOB.random_parallax
-		continue //Only one event changes our state, priority should be from up to down if there are multiple
 	var/matrix/M = matrix()	//create matrix for transformation
 	if(owner.client.view != world.view)	//Not bigger than world view. We don't need transforming
 		var/toscale = owner.client.view	//How many extra tiles we need to fill with parallax. EG. Their view is 8. World view is 7. So one extra tile is needed.
@@ -73,13 +54,16 @@ GLOBAL_VAR_INIT(random_parallax, pick("space0", "space1", "space2", "space3", "s
 		M.Scale(1)
 	transform = M
 
+/obj/parallax/update_icon(new_icon_state)
+	icon_state = new_icon_state
+
 /obj/parallax/update_plane()
 	return
 
 /obj/parallax/set_plane(var/np)
 	plane = np
 
-
+// Mob stuff
 /mob
 	var/obj/parallax/parallax
 

--- a/code/controllers/subsystems/event.dm
+++ b/code/controllers/subsystems/event.dm
@@ -20,6 +20,7 @@ SUBSYSTEM_DEF(event)
 
 	var/list/datum/event/all_events
 
+	var/list/all_parallaxes = list()	// For parallax changes due to space weather
 
 //Subsystem procs
 /datum/controller/subsystem/event/Initialize(start_timeofday)
@@ -32,6 +33,7 @@ SUBSYSTEM_DEF(event)
 	active_events = SSevent.active_events
 	finished_events = SSevent.finished_events
 	all_events = SSevent.all_events
+	all_parallaxes = SSevent.all_parallaxes
 
 /datum/controller/subsystem/event/fire(resumed = FALSE)
 	if (!resumed)
@@ -47,7 +49,6 @@ SUBSYSTEM_DEF(event)
 		if (MC_TICK_CHECK)
 			return
 
-
 /datum/controller/subsystem/event/proc/event_complete(datum/event/E)
 	active_events -= E
 
@@ -57,9 +58,11 @@ SUBSYSTEM_DEF(event)
 
 	finished_events += E
 
-
-
 	log_debug("Event '[name]' has completed at [stationtime2text()].")
+
+/datum/controller/subsystem/event/proc/change_parallax(new_parallax)
+	for(var/obj/parallax/P in all_parallaxes)
+		P.update_icon(new_parallax)
 
 /datum/controller/subsystem/event/proc/RoundEnd()
 	if(!report_at_round_end)

--- a/code/game/gamemodes/events/space_weather.dm
+++ b/code/game/gamemodes/events/space_weather.dm
@@ -1,7 +1,8 @@
 /datum/storyevent/bluespace_storm
 	id = "bluespace_storm"
 	name = "Bluespace storm"
-	weight = 0.8
+	weight = 0.1
+	occurrences_max = 1
 	event_type = /datum/event/bluespace_storm
 	parallel = FALSE
 	event_pools = list(EVENT_LEVEL_MUNDANE = POOL_THRESHOLD_MUNDANE, EVENT_LEVEL_MODERATE = POOL_THRESHOLD_MODERATE)
@@ -15,21 +16,26 @@
 /datum/event/bluespace_storm/setup()
 	endWhen = rand(300, 600)
 
+/datum/event/bluespace_storm/start()
+	SSevent.change_parallax("bluespace_storm")
+
 /datum/event/bluespace_storm/announce()
 	command_announcement.Announce("The scanners have detected a bluespace storm near the ship. Bluespace distortions are likely to happen while it lasts.", "Bluespace Storm")
 
 /datum/event/bluespace_storm/end()
 	command_announcement.Announce("The bluespace storm has ended.", "Bluespace Storm")
+	SSevent.change_parallax(GLOB.random_parallax)
 
 /datum/event/bluespace_storm/tick()
-	if(prob(1))
+	if(!(activeFor % 50))
 		var/area/A = random_ship_area(filter_maintenance = TRUE, filter_critical = TRUE)
 		bluespace_distorsion(A.random_space())
 
 /datum/storyevent/ion_blizzard
 	id = "ion_blizzard"
 	name = "Ion blizzard"
-	weight = 0.9
+	weight = 0.1
+	occurrences_max = 1
 	event_type = /datum/event/ion_blizzard
 	parallel = FALSE
 	event_pools = list(EVENT_LEVEL_MUNDANE = POOL_THRESHOLD_MUNDANE, EVENT_LEVEL_MODERATE = POOL_THRESHOLD_MODERATE)
@@ -43,24 +49,31 @@
 /datum/event/ion_blizzard/setup()
 	endWhen = rand(300, 600)
 
+/datum/event/ion_blizzard/start()
+	SSevent.change_parallax("ion_blizzard")
+
 /datum/event/ion_blizzard/announce()
 	command_announcement.Announce("A severe ion storm has been detected near the ship. Lighting subsystems are currently overloaded and may not work properly.", "Ion Blizzard")
 
 /datum/event/ion_blizzard/end()
 	command_announcement.Announce("The ion blizzard has ended.", "Ion Blizzard")
+	SSevent.change_parallax(GLOB.random_parallax)
 
 /datum/event/ion_blizzard/tick() //get random ship area and do things to all light in there
-	if(prob(10)) //don't check every single light every single tick jesus christ
-		for(var/obj/machinery/light/L in random_ship_area())
-			L.broken()
-	else if(prob(80))
-		for(var/obj/machinery/light/L in random_ship_area())
-			L.flick_light(rand(2,5))
+	if(!(activeFor % 20))	// Every 20th tick
+		if(activeFor % 2)
+			for(var/obj/machinery/light/L in random_ship_area())
+				L.broken()
+		else
+			for(var/obj/machinery/light/L in random_ship_area())
+				L.flick_light(rand(2,5))
 
+/*	This event is very un-optimized at the moment.
 /datum/storyevent/photon_vortex
 	id = "photon_vortex"
 	name = "Photon vortex"
-	weight = 0.9
+	weight = 0.05
+	occurrences_max = 1
 	event_type = /datum/event/photon_vortex
 	parallel = FALSE
 	event_pools = list(EVENT_LEVEL_MUNDANE = POOL_THRESHOLD_MUNDANE, EVENT_LEVEL_MODERATE = POOL_THRESHOLD_MODERATE)
@@ -75,6 +88,7 @@
 	endWhen = rand(300, 800)
 
 /datum/event/photon_vortex/start()
+	SSevent.change_parallax("photon_vortex")
 	for(var/obj/item/device/lighting/L in world)
 		L.brightness_on = L.brightness_on / 4
 		L.update_icon()
@@ -92,7 +106,7 @@
 
 /datum/event/photon_vortex/end()
 	command_announcement.Announce("The photon vortex anomaly has moved away from the ship.", "Photon Vortex Anomaly")
-
+	SSevent.change_parallax(GLOB.random_parallax)
 	for(var/obj/item/device/lighting/L in world)
 		L.brightness_on = initial(L.brightness_on)
 		L.update_icon()
@@ -104,11 +118,13 @@
 			l.brightness_range = initial(l.brightness_range)
 			l.brightness_power = initial(l.brightness_power)
 			l.update()
+*/
 
 /datum/storyevent/harmonic_feedback
 	id = "harmonic_feedback_surge"
 	name = "Harmonic feedback surge anomaly"
-	weight = 0.5
+	weight = 0.1
+	occurrences_max = 1
 	event_type = /datum/event/harmonic_feedback
 	parallel = FALSE
 	event_pools = list(EVENT_LEVEL_MUNDANE = POOL_THRESHOLD_MUNDANE, EVENT_LEVEL_MODERATE = POOL_THRESHOLD_MODERATE)
@@ -122,20 +138,26 @@
 /datum/event/harmonic_feedback/setup()
 	endWhen = rand(300, 450)
 
+/datum/event/harmonic_feedback/start()
+	SSevent.change_parallax("photon_vortex")	// Vortex is unused at the moment
+
 /datum/event/harmonic_feedback/announce()
 	command_announcement.Announce("The ship is currently passing through intense gravitational wavefronts. They will heavily disrupt hull shields for a short duration.", "Harmonic Feedback Surge Anomaly")
 
 /datum/event/harmonic_feedback/end()
 	command_announcement.Announce("The gravitational wavefronts have passed.", "Harmonic Feedback Surge Anomaly")
+	SSevent.change_parallax(GLOB.random_parallax)
 
 /datum/event/harmonic_feedback/tick() //around two seconds
 	for(var/obj/machinery/power/shield_generator/G in GLOB.machines)
-		G.take_damage(10, SHIELD_DAMTYPE_EM)
+		if(G.running != SHIELD_OFF)
+			G.take_damage(100, SHIELD_DAMTYPE_EM)
 
 /datum/storyevent/micro_debris
 	id = "micro_debris"
 	name = "micro debris field"
-	weight = 0.9
+	weight = 0.1
+	occurrences_max = 1
 	parallel = FALSE
 	event_type = /datum/event/micro_debris
 	event_pools = list(EVENT_LEVEL_MUNDANE = POOL_THRESHOLD_MUNDANE, EVENT_LEVEL_MODERATE = POOL_THRESHOLD_MODERATE)
@@ -152,14 +174,18 @@
 		/obj/effect/meteor/dust/ice=10
 	)
 
+/datum/event/micro_debris/start()
+	SSevent.change_parallax("micro_debris")
+
 /datum/event/micro_debris/announce()
 	command_announcement.Announce("The ship is now passing through a micro debris field.", "Micro Debris Field Alert")
 
 /datum/event/micro_debris/end()
 	command_announcement.Announce("The ship has now passed through the micro debris field.", "Micro Debris Field Notice")
+	SSevent.change_parallax(GLOB.random_parallax)
 
 /datum/event/micro_debris/tick()
-	if(prob(30))
+	if(!(activeFor % 3))	// Every 3rd tick
 		for(var/i in 0 to rand(1,3))
 			spawn_debris(pickweight(debris_types), pick(cardinal), pick(GLOB.maps_data.station_levels))
 
@@ -174,7 +200,8 @@
 /datum/storyevent/graveyard
 	id = "graveyard"
 	name = "Space Graveryard"
-	weight = 0.6
+	weight = 0.1
+	occurrences_max = 1
 	parallel = FALSE
 	event_type = /datum/event/graveyard
 	event_pools = list(EVENT_LEVEL_MUNDANE = POOL_THRESHOLD_MUNDANE, EVENT_LEVEL_MODERATE = POOL_THRESHOLD_MODERATE)
@@ -190,12 +217,13 @@
 
 /datum/event/graveyard/start()
 	GLOB.GLOBAL_SANITY_MOD = 1.5
+	SSevent.change_parallax("graveyard")
 
 /datum/event/graveyard/announce()
 	command_announcement.Announce("Drifting wrecks of a space station have been detected near the ship. Telecommunication systems are not responsible for any strain on the crew's psychological wellbeing.", "Space Graveyard")
 
 /datum/event/graveyard/tick()
-	if(prob(2))
+	if(!(activeFor % 50))		// Every 50th tick
 		switch(rand(1,3))
 			if(1) //random broadcasts
 				var/message = pick("They are ", "He is ", "All of them are ", "I'm ", "We are ")
@@ -223,11 +251,13 @@
 /datum/event/graveyard/end()
 	command_announcement.Announce("The station wrecks have moved away from the ship.", "Space Graveyard")
 	GLOB.GLOBAL_SANITY_MOD = 1
+	SSevent.change_parallax(GLOB.random_parallax)
 
 /datum/storyevent/nebula
 	id = "nebula"
 	name = "Dark matter nebula"
-	weight = 0.8
+	weight = 0.1
+	occurrences_max = 1
 	parallel = FALSE
 	event_type = /datum/event/nebula
 	event_pools = list(EVENT_LEVEL_MUNDANE = POOL_THRESHOLD_MUNDANE, EVENT_LEVEL_MODERATE = POOL_THRESHOLD_MODERATE)
@@ -243,6 +273,7 @@
 
 /datum/event/nebula/start()
 	GLOB.GLOBAL_INSIGHT_MOD = 0.5
+	SSevent.change_parallax("nebula")
 
 /datum/event/nebula/announce()
 	command_announcement.Announce("Uncharacteristically high concentrations of dark matter from a nearby nebula currently envelop the ship. Crew might experience certain issues with their mental wellbeing.", "Dark Matter Nebula")
@@ -250,11 +281,13 @@
 /datum/event/nebula/end()
 	command_announcement.Announce("The dark matter nebula has moved away from the ship.", "Dark Matter Nebula")
 	GLOB.GLOBAL_INSIGHT_MOD = 1
+	SSevent.change_parallax(GLOB.random_parallax)
 
 /datum/storyevent/interphase
 	id = "bluespace_interphase"
 	name = "Bluespace Interphase"
-	weight = 0.5
+	weight = 0.1
+	occurrences_max = 1
 	parallel = FALSE
 	event_type = /datum/event/interphase
 	event_pools = list(EVENT_LEVEL_MODERATE = POOL_THRESHOLD_MODERATE, EVENT_LEVEL_MAJOR = POOL_THRESHOLD_MAJOR)
@@ -268,11 +301,14 @@
 /datum/event/interphase/setup()
 	endWhen = rand(300, 600)
 
+/datum/event/interphase/start()
+	SSevent.change_parallax("bluespace_interphase")
+
 /datum/event/interphase/announce()
 	command_announcement.Announce("The fabric of bluespace has begun to break up, allowing an overlap of parallel universes on different dimensional planes. There is no additional data.", "Bluespace Interphase")
 
 /datum/event/interphase/tick()
-	if(prob(1))
+	if(!(activeFor % 50))		// Every 50th tick
 		var/list/servers = list()
 		for(var/obj/machinery/telecomms/server/S in telecomms_list)
 			if(S.network == "eris" && LAZYLEN(S.log_entries)) //yep, only for eris so that non-eris servers don't get involved(duh!)
@@ -281,7 +317,7 @@
 			var/obj/machinery/telecomms/server/chosen_server = pick(servers)
 			var/datum/comm_log_entry/C = pick(chosen_server.log_entries)
 			global_announcer.autosay(C.parameters["message"], C.parameters["name"])
-	if(prob(5) && LAZYLEN(GLOB.human_mob_list)) //spooky bluspess ghost
+	if(!(activeFor % 20) && LAZYLEN(GLOB.human_mob_list)) //spooky bluspess ghost
 		var/area/location = random_ship_area()
 		var/mob/living/carbon/human/to_copy = pick(GLOB.human_mob_list)
 		var/mob/ghost = new(location.random_space())
@@ -299,3 +335,4 @@
 
 /datum/event/interphase/end()
 	command_announcement.Announce("The bluespace interphase stabilized itself.", "Bluespace Interphase")
+	SSevent.change_parallax(GLOB.random_parallax)

--- a/code/game/gamemodes/roleset/faction/mercenary.dm
+++ b/code/game/gamemodes/roleset/faction/mercenary.dm
@@ -3,7 +3,7 @@
 	name = "serbian mercenaries"
 	role_id = ROLE_MERCENARY
 	weight = 0.4
-	ocurrences_max = 1
+	occurrences_max = 1
 	req_crew = 5
 	tags = list(TAG_DESTRUCTIVE, TAG_NEGATIVE)
 	

--- a/code/game/gamemodes/roleset/simple.dm
+++ b/code/game/gamemodes/roleset/simple.dm
@@ -88,7 +88,7 @@
 	name = "malfunctioning AI"
 	role_id = ROLE_MALFUNCTION
 	req_crew = 20
-	ocurrences_max = 1
+	occurrences_max = 1
 	tags = list(TAG_DESTRUCTIVE, TAG_NEGATIVE)
 */
 /datum/storyevent/roleset/marshal

--- a/code/game/gamemodes/storyevent.dm
+++ b/code/game/gamemodes/storyevent.dm
@@ -38,8 +38,8 @@
 	var/max_stage_diff_lower = 0
 	var/max_stage_diff_higher = 10
 
-	var/ocurrences = 0 //How many times this round, this storyevent has happened
-	var/ocurrences_max = -1
+	var/occurrences = 0 //How many times this round, this storyevent has happened
+	var/occurrences_max = -1
 	var/last_trigger_time = 0
 
 	var/has_priest = -1
@@ -71,7 +71,7 @@
 		if (report) to_chat(report, SPAN_NOTICE("Failure: The event is disabled"))
 		return FALSE
 
-	if (ocurrences_max > 0 && ocurrences >= ocurrences_max)
+	if (occurrences_max > 0 && occurrences >= occurrences_max)
 		if (report) to_chat(report, SPAN_NOTICE("Failure: The event has already triggered the maximum number of times for a single round"))
 		return FALSE
 
@@ -96,7 +96,7 @@
 
 /datum/storyevent/proc/create(var/severity)
 	if(trigger_event(severity))
-		ocurrences++
+		occurrences++
 		last_trigger_time = world.time
 		if(processing)
 			start_processing(TRUE)

--- a/code/game/gamemodes/storyteller.dm
+++ b/code/game/gamemodes/storyteller.dm
@@ -334,10 +334,10 @@ The actual fire event proc is located in storyteller_meta*/
 			new_weight = 0
 		else
 			new_weight = calculate_event_weight(a)
-			//Reduce the weight based on number of ocurrences.
+			//Reduce the weight based on number of occurrences.
 			//This is mostly for the sake of midround handovers
-			if (a.ocurrences >= 1)
-				new_weight *= repetition_multiplier ** a.ocurrences
+			if (a.occurrences >= 1)
+				new_weight *= repetition_multiplier ** a.occurrences
 
 		//We setup the event pools as an associative list in preparation for a pickweight call
 		if (EVENT_LEVEL_MUNDANE in a.event_pools)
@@ -359,8 +359,8 @@ The actual fire event proc is located in storyteller_meta*/
 /datum/storyteller/proc/update_pool_weights(var/list/pool)
 	for(var/datum/storyevent/a in pool)
 		var/new_weight = calculate_event_weight(a)
-		if (a.ocurrences >= 1)
-			new_weight *= repetition_multiplier ** a.ocurrences
+		if (a.occurrences >= 1)
+			new_weight *= repetition_multiplier ** a.occurrences
 
 		pool[a] = new_weight
 	return pool


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Moves the parallax image logic off of update(), which is called each move.
- Changes chance-based space weather triggers to tick-based.
- Reduces the storyteller weight of all space weather events, making them much less frequent. Also, limits each space weather event to one per round.
- Commented out photon vortex until a more performant solution is coded.

## Why It's Good For The Game

Minor optimizations. Space weather is supposed to be splashy, but the novelty wears off fast when we see them multiple times in a round with repeats.

## Testing

- Force spawned each event.

## Changelog
:cl:
del: Removed photon vortex from the pool
tweak: Space weather behavior is now tick-based
tweak: Space weather event weight reduced, limited to one per round for each event
code: Parallax icon logic moved to event subsystem
code: Spell-checked a variable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
