### PR TITLE
Roaches don't bump

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -330,9 +330,8 @@ Proc for attack log creation, because really why not
 	return FALSE
 
 /proc/is_superior_animal(var/mob/M)
-	if(istype(M, /mob/living/carbon/superior_animal)
+	if(istype(M, /mob/living/carbon/superior_animal))
 		return TRUE
-
 	return FALSE
 
 /proc/mob_hearers(var/atom/movable/heard_atom, var/range = world.view)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -329,11 +329,6 @@ Proc for attack log creation, because really why not
 
 	return FALSE
 
-/proc/is_superior_animal(var/mob/M)
-	if(istype(M, /mob/living/carbon/superior_animal))
-		return TRUE
-	return FALSE
-
 /proc/mob_hearers(var/atom/movable/heard_atom, var/range = world.view)
 	. = list()
 

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -329,6 +329,12 @@ Proc for attack log creation, because really why not
 
 	return FALSE
 
+/proc/is_superior_animal(var/mob/M)
+	if(istype(M, /mob/living/carbon/superior_animal)
+		return TRUE
+
+	return FALSE
+
 /proc/mob_hearers(var/atom/movable/heard_atom, var/range = world.view)
 	. = list()
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -358,7 +358,6 @@
 			visible_message(SPAN_NOTICE("\The [src] misses [target_mob] narrowly!"))
 			if(issuperioranimal(target_mob))
 				bumped = FALSE // Roaches do not bump when missed, allowing the bullet to attempt to hit the rest of the roaches in a single cluster
-			else
 		return FALSE
 
 	//hit messages

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -356,7 +356,7 @@
 	if(result == PROJECTILE_FORCE_MISS || result == PROJECTILE_FORCE_MISS_SILENCED)
 		if(!silenced && result == PROJECTILE_FORCE_MISS)
 			visible_message(SPAN_NOTICE("\The [src] misses [target_mob] narrowly!"))
-			if(is_superior_animal(target_mob))
+			if(issuperioranimal(target_mob))
 				bumped = FALSE // Roaches do not bump when missed, allowing the bullet to attempt to hit the rest of the roaches in a single cluster
 			else
 		return FALSE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -437,6 +437,10 @@
 				visible_message(SPAN_DANGER("\The [M] uses [G.affecting] as a shield!"))
 				if(Bump(G.affecting, TRUE))
 					return //If Bump() returns 0 (keep going) then we continue on to attack M.
+			if(is_superior_animal(A))
+				passthrough = !attack_mob(M)
+				bumped = FALSE // Roaches do not bump, allowing multiple roaches to be hit by one bullet
+			else
 			passthrough = !attack_mob(M)
 		else
 			passthrough = FALSE //so ghosts don't stop bullets

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -356,6 +356,9 @@
 	if(result == PROJECTILE_FORCE_MISS || result == PROJECTILE_FORCE_MISS_SILENCED)
 		if(!silenced && result == PROJECTILE_FORCE_MISS)
 			visible_message(SPAN_NOTICE("\The [src] misses [target_mob] narrowly!"))
+			if(is_superior_animal(target_mob))
+				bumped = FALSE // Roaches do not bump when missed, allowing the bullet to attempt to hit the rest of the roaches in a single cluster
+			else
 		return FALSE
 
 	//hit messages
@@ -437,10 +440,6 @@
 				visible_message(SPAN_DANGER("\The [M] uses [G.affecting] as a shield!"))
 				if(Bump(G.affecting, TRUE))
 					return //If Bump() returns 0 (keep going) then we continue on to attack M.
-			if(is_superior_animal(A))
-				passthrough = !attack_mob(M)
-				bumped = FALSE // Roaches do not bump, allowing multiple roaches to be hit by one bullet
-			else
 			passthrough = !attack_mob(M)
 		else
 			passthrough = FALSE //so ghosts don't stop bullets

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -356,7 +356,7 @@
 	if(result == PROJECTILE_FORCE_MISS || result == PROJECTILE_FORCE_MISS_SILENCED)
 		if(!silenced && result == PROJECTILE_FORCE_MISS)
 			visible_message(SPAN_NOTICE("\The [src] misses [target_mob] narrowly!"))
-			if(issuperioranimal(target_mob))
+			if(isroach(target_mob))
 				bumped = FALSE // Roaches do not bump when missed, allowing the bullet to attempt to hit the rest of the roaches in a single cluster
 		return FALSE
 


### PR DESCRIPTION
## About The Pull Request

When you miss a roach, currently every other roach on that tile is automatically missed too. Now, it will still attempt to hit the rest of the roaches.

## Why It's Good For The Game

Makes more sense this way

## Testing

Compiled successfully, tested and functional

## Changelog
:cl:
balance: when missing a roach in a cluster, the bullet will still attempt to hit the rest without missing all of them automatically
/:cl:
