### PR TITLE
Gun scope fix maybe

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -867,6 +867,10 @@
 	update_firemode()
 
 /obj/item/gun/dropped(mob/user)
+	// I really fucking hate this but this is how this is going to work.
+	var/mob/living/carbon/human/H = user
+	if (H.using_scope)
+		toggle_scope(H)
 	update_firemode(FALSE)
 	.=..()
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -869,7 +869,7 @@
 /obj/item/gun/dropped(mob/user)
 	// I really fucking hate this but this is how this is going to work.
 	var/mob/living/carbon/human/H = user
-	if (H.using_scope)
+	if (istype(H) && H.using_scope)
 		toggle_scope(H)
 	update_firemode(FALSE)
 	.=..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Apparently gun scopes weren't un-scoping on drop so I guess here you go, scopes definitely stop zooming your view when the gun is dropped for any reason.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I'm not sure I really need to describe this. How are you looking through a scope without it attached to an object in your hands?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I ran the server, scoped my gun and dropped it.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: You no longer retain your zoomed view when dropping your scoped weapon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
