### PR TITLE
Removes pointless damage procs during cloning

### DIFF
--- a/code/modules/core_implant/cruciform/machinery/cloning.dm
+++ b/code/modules/core_implant/cruciform/machinery/cloning.dm
@@ -186,16 +186,6 @@
 			else
 				stop()
 
-		if(occupant && ishuman(occupant))
-			occupant.setCloneLoss(max(CLONING_DONE-progress, clone_damage))
-			occupant.setBrainLoss(CLONING_DONE-progress)
-
-			occupant.adjustOxyLoss(-4)
-			occupant.Paralyse(4)
-
-			occupant.updatehealth()
-
-
 		if(progress >= CLONING_MEAT && !occupant)
 			var/datum/core_module/cruciform/cloning/R = reader.implant.get_module(CRUCIFORM_CLONING)
 			if(!R)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Clone and brain damage are being adjusted throughout the cloning process, but are overwritten when the body is done cloning. This gets rid of those procs, which also clears up the cloning issues in Erismed 4.

## Why It's Good For The Game

Bug fix

## Testing

- Cloned a disciple

## Changelog
:cl:
fix: Removes pointless procs during cloning
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
