### PR TITLE
Nerfs hornet and mandella

### DIFF
--- a/code/modules/projectiles/guns/projectile/pistol/mandella.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mandella.dm
@@ -19,8 +19,8 @@
 	mag_well = MAG_WELL_PISTOL
 	magazine_type = /obj/item/ammo_magazine/cspistol
 	proj_step_multiplier = 0.8
-	damage_multiplier = 1.7
-	penetration_multiplier = 0.8
+	damage_multiplier = 1.6
+	penetration_multiplier = 0.5 // Penetration level of 2, penetrates much more reliably than most rifles
 	init_recoil = HANDGUN_RECOIL(0.6)
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE

--- a/code/modules/projectiles/guns/projectile/revolver/hornet.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/hornet.dm
@@ -14,10 +14,10 @@
 	max_shells = 8 // makes more sense than 7 shot .40 revolvers
 	proj_step_multiplier = 0.8
 	price_tag = 2400 // middle ground between miller and deckard
-	damage_multiplier = 2
-	penetration_multiplier = 0.5
+	damage_multiplier = 1.4 // much less raw damage than deckard due to caliber
+	penetration_multiplier = 2 // raises AP to 3.5, makes armor close to worthless, yet still only barely allows penetrating reinforced walls
 	zoom_factors = list(0.2) // same scope as z8
-	init_recoil = HANDGUN_RECOIL(1.6)
+	init_recoil = HANDGUN_RECOIL(2) // same as .40
 	gun_parts = list(/obj/item/part/gun/frame/hornet = 1, /obj/item/part/gun/grip/rubber = 1, /obj/item/part/gun/mechanism/revolver = 1, /obj/item/part/gun/barrel/srifle = 1)
 	serial_type = "OR"
 


### PR DESCRIPTION
## About The Pull Request

Hornet is reworked after testing with new walls to be capable of penetrating reinforced walls, allowing it to be used in a similar fashion to the sky diver against AMR users. Its damage is significantly worse, making it not superior to the deckard in every aspect.

Mandella received smaller nerfs to its stats. If more is needed, it will be done at a later date.

## Why It's Good For The Game

Balance good.

## Testing

Tested, guns fired as intended and dealt damage as intended.

## Changelog
:cl:
balance: Hornet can pierce reinforced walls, but deals much less damage than other revolvers
balance: Mandella received minor decrease to damage, and moderate decrease to penetration
/:cl: