### PR TITLE
Edged burn weapons can delimb

### DIFF
--- a/code/__DEFINES/damage_organs.dm
+++ b/code/__DEFINES/damage_organs.dm
@@ -130,6 +130,7 @@
 #define DROPLIMB_EDGE 0
 #define DROPLIMB_BLUNT 1
 #define DROPLIMB_BURN 2
+#define DROPLIMB_EDGE_BURN 3
 
 #define MODIFICATION_ORGANIC 0	// Organic
 #define MODIFICATION_ASSISTED 1 // Like pacemakers, not robotic

--- a/code/modules/organs/external/damage.dm
+++ b/code/modules/organs/external/damage.dm
@@ -103,7 +103,7 @@
 				if((brute + prev_brute) >= max_damage * DROPLIMB_THRESHOLD_EDGE && prob(brute))
 					droplimb(0, DROPLIMB_EDGE)
 				if((burn + prev_burn) >= max_damage * DROPLIMB_THRESHOLD_EDGE && prob(burn))
-					droplimb(TRUE, DROPLIMB_EDGE)
+					droplimb(TRUE, DROPLIMB_EDGE_BURN)
 			else if((burn + prev_burn) >= max_damage * DROPLIMB_THRESHOLD_DESTROY && prob(burn/3))
 				droplimb(0, DROPLIMB_BURN)
 			else if((brute + prev_brute) >= max_damage * DROPLIMB_THRESHOLD_DESTROY && prob(brute/3))

--- a/code/modules/organs/external/damage.dm
+++ b/code/modules/organs/external/damage.dm
@@ -99,8 +99,11 @@
 				else
 					edge_eligible = 1
 
-			if(edge_eligible && (brute + prev_brute) >= max_damage * DROPLIMB_THRESHOLD_EDGE && prob(brute))
-				droplimb(0, DROPLIMB_EDGE)
+			if(edge_eligible)
+				if((brute + prev_brute) >= max_damage * DROPLIMB_THRESHOLD_EDGE && prob(brute))
+					droplimb(0, DROPLIMB_EDGE)
+				if((burn + prev_burn) >= max_damage * DROPLIMB_THRESHOLD_EDGE && prob(burn))
+					droplimb(TRUE, DROPLIMB_EDGE)
 			else if((burn + prev_burn) >= max_damage * DROPLIMB_THRESHOLD_DESTROY && prob(burn/3))
 				droplimb(0, DROPLIMB_BURN)
 			else if((brute + prev_brute) >= max_damage * DROPLIMB_THRESHOLD_DESTROY && prob(brute/3))

--- a/code/modules/organs/external/dismemberment.dm
+++ b/code/modules/organs/external/dismemberment.dm
@@ -9,7 +9,7 @@
 		return
 
 	switch(disintegrate)
-		if(DROPLIMB_EDGE)
+		if(DROPLIMB_EDGE, DROPLIMB_EDGE_BURN)
 			if(!clean)
 				var/gore_sound = "[BP_IS_ROBOTIC(src) ? "tortured metal" : "ripping tendons and flesh"]"
 				owner.visible_message(
@@ -54,7 +54,7 @@
 		dir = 2
 
 	switch(disintegrate)
-		if(DROPLIMB_EDGE)
+		if(DROPLIMB_EDGE, DROPLIMB_EDGE_BURN)
 			compile_icon()
 			add_blood(victim)
 			var/matrix/M = matrix()

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -392,7 +392,7 @@ datum/wound/puncture/massive
 				"clotted stump" = damage_amt*0.5,
 				"scarred stump" = 0
 				)
-		if(DROPLIMB_BURN)
+		if(DROPLIMB_BURN, DROPLIMB_EDGE_BURN)
 			damage_type = BURN
 			stages = list(
 				"ripped charred stump" = damage_amt*1.3,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows burn weapons with the edge characteristic to delimb instead of ash. The logic for delimbing will be similar the logic used for brute damage, except it uses burn values and prevents bleeding.

## Why It's Good For The Game

Gives burn-dealing melee weapons a bit of mechanical flavor.

## Testing

- Delimbed a human mob with a melee weapon with `damtype = BURN`.

![image](https://user-images.githubusercontent.com/95178278/216488836-71dbbdc0-6299-4c55-9c68-e948233d775d.png)

## Changelog
:cl:
tweak: Edged burn weapons can delimb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
