### PR TITLE
z-level shooting

### DIFF
--- a/code/__DEFINES/projectile_defines.dm
+++ b/code/__DEFINES/projectile_defines.dm
@@ -41,3 +41,7 @@
 #define SLOT_UNDERBARREL "underbarrel"
 #define SLOT_MECHANICS "mechanics"
 #define SLOT_BAYONET "bayonet slot"
+
+#define HEIGHT_LOW 1
+#define HEIGHT_CENTER 0
+#define HEIGHT_HIGH 2

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -133,6 +133,7 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 	var/welder_vision = 1
 	var/generate_asteroid = 0
 	var/no_click_cooldown = 0
+	var/z_level_shooting = TRUE
 
 	var/admin_legacy_system = 0	//Defines whether the server uses the legacy admin system with admins.txt or the SQL system. Config option in config.txt
 	var/ban_legacy_system = 0	//Defines whether the server uses the legacy banning system with the files in /data or the SQL system. Config option in config.txt

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -133,7 +133,7 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 	var/welder_vision = 1
 	var/generate_asteroid = 0
 	var/no_click_cooldown = 0
-	var/z_level_shooting = TRUE
+	var/z_level_shooting = FALSE
 
 	var/admin_legacy_system = 0	//Defines whether the server uses the legacy admin system with admins.txt or the SQL system. Config option in config.txt
 	var/ban_legacy_system = 0	//Defines whether the server uses the legacy banning system with the files in /data or the SQL system. Config option in config.txt

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -163,6 +163,12 @@ for reference:
 		return 0
 
 /obj/structure/barricade/proc/check_cover(obj/item/projectile/P, turf/from)
+
+	if(config.z_level_shooting)
+		if(P.height == HEIGHT_HIGH)
+			return TRUE // Bullet is too high to hit
+		P.height = P.height == HEIGHT_LOW ? HEIGHT_LOW : HEIGHT_CENTER
+
 	if (get_dist(P.starting, loc) <= 1) //Cover won't help you if people are THIS close
 		return TRUE
 	if(get_dist(loc, P.trajectory.target) > 1 ) // Target turf must be adjacent for it to count as cover
@@ -178,6 +184,11 @@ for reference:
 		var/mob/M = P.original
 		if (M.lying)
 			valid = TRUE			//Lying down covers your whole body
+
+	// Bullet is low enough to hit the wall
+	if(config.z_level_shooting && P.height == HEIGHT_LOW)
+		valid = TRUE
+
 	if(valid)
 		var/pierce = P.check_penetrate(src)
 		health -= P.get_structure_damage()/2
@@ -336,6 +347,12 @@ for reference:
 		return 1
 
 /obj/machinery/deployable/barrier/proc/check_cover(obj/item/projectile/P, turf/from)
+
+	if(config.z_level_shooting)
+		if(P.height == HEIGHT_HIGH)
+			return TRUE // Bullet is too high to hit
+		P.height = P.height == HEIGHT_LOW ? HEIGHT_LOW : HEIGHT_CENTER
+
 	if (get_dist(P.starting, loc) <= 1) //Cover won't help you if people are THIS close
 		return 1
 	if(get_dist(loc, P.trajectory.target) > 1 ) // Target turf must be adjacent for it to count as cover
@@ -351,6 +368,11 @@ for reference:
 		var/mob/M = P.original
 		if (M.lying)
 			valid = TRUE			//Lying down covers your whole body
+
+	// Bullet is low enough to hit the wall
+	if(config.z_level_shooting && P.height == HEIGHT_LOW)
+		valid = TRUE
+
 	if(valid)
 		var/pierce = P.check_penetrate(src)
 		health -= P.get_structure_damage()/2

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -167,7 +167,7 @@ for reference:
 	if(config.z_level_shooting)
 		if(P.height == HEIGHT_HIGH)
 			return TRUE // Bullet is too high to hit
-		P.height = P.height == HEIGHT_LOW ? HEIGHT_LOW : HEIGHT_CENTER
+		P.height = (P.height == HEIGHT_LOW) ? HEIGHT_LOW : HEIGHT_CENTER
 
 	if (get_dist(P.starting, loc) <= 1) //Cover won't help you if people are THIS close
 		return TRUE
@@ -351,7 +351,7 @@ for reference:
 	if(config.z_level_shooting)
 		if(P.height == HEIGHT_HIGH)
 			return TRUE // Bullet is too high to hit
-		P.height = P.height == HEIGHT_LOW ? HEIGHT_LOW : HEIGHT_CENTER
+		P.height = (P.height == HEIGHT_LOW) ? HEIGHT_LOW : HEIGHT_CENTER
 
 	if (get_dist(P.starting, loc) <= 1) //Cover won't help you if people are THIS close
 		return 1

--- a/code/game/objects/structures/low_wall.dm
+++ b/code/game/objects/structures/low_wall.dm
@@ -156,7 +156,7 @@
 	if(config.z_level_shooting)
 		if(P.height == HEIGHT_HIGH)
 			return TRUE // Bullet is too high to hit
-		P.height = P.height == HEIGHT_LOW ? HEIGHT_LOW : HEIGHT_CENTER
+		P.height = (P.height == HEIGHT_LOW) ? HEIGHT_LOW : HEIGHT_CENTER
 
 	if (get_dist(P.starting, loc) <= 1) //Tables won't help you if people are THIS close
 		return 1

--- a/code/game/objects/structures/low_wall.dm
+++ b/code/game/objects/structures/low_wall.dm
@@ -152,6 +152,12 @@
 
 //checks if projectile 'P' from turf 'from' can hit whatever is behind the table. Returns 1 if it can, 0 if bullet stops.
 /obj/structure/low_wall/proc/check_cover(obj/item/projectile/P, turf/from)
+
+	if(config.z_level_shooting)
+		if(P.height == HEIGHT_HIGH)
+			return TRUE // Bullet is too high to hit
+		P.height = P.height == HEIGHT_LOW ? HEIGHT_LOW : HEIGHT_CENTER
+
 	if (get_dist(P.starting, loc) <= 1) //Tables won't help you if people are THIS close
 		return 1
 	if(get_dist(loc, P.trajectory.target) > 1 ) // Target turf must be adjacent for it to count as cover
@@ -167,6 +173,11 @@
 		var/mob/M = P.original
 		if (M.lying)
 			valid = TRUE			//Lying down covers your whole body
+
+	// Bullet is low enough to hit the wall
+	if(config.z_level_shooting && P.height == HEIGHT_LOW)
+		valid = TRUE
+
 	if(valid)
 		var/pierce = P.check_penetrate(src)
 		health -= P.get_structure_damage()/2

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -147,10 +147,22 @@
 
 /obj/structure/window/bullet_act(var/obj/item/projectile/Proj)
 
-	var/proj_damage = Proj.get_structure_damage()
-	if(proj_damage)
-		hit(proj_damage)
-	..()
+	if(config.z_level_shooting && Proj.height)
+		if(Proj.height == HEIGHT_LOW)// Bullet is too low
+			return TRUE
+		else if(Proj.height == HEIGHT_HIGH) // Guaranteed hit
+			var/proj_damage = Proj.get_structure_damage()
+			if(proj_damage)
+				hit(proj_damage)
+			..()
+			return TRUE
+
+	var/targetzone = check_zone(Proj.def_zone)
+	if(targetzone in list(BP_CHEST, BP_HEAD, BP_L_ARM, BP_R_ARM))
+		var/proj_damage = Proj.get_structure_damage()
+		if(proj_damage)
+			hit(proj_damage)
+		..()
 
 	return TRUE
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1279,3 +1279,18 @@ ADMIN_VERB_ADD(/datum/admins/proc/paralyze_mob, R_ADMIN, FALSE)
 			return 0
 		return 1
 	return 0
+
+ADMIN_VERB_ADD(/datum/admins/proc/z_level_shooting, R_SERVER, FALSE)
+/datum/admins/proc/z_level_shooting()
+	set category = "Server"
+	set name = "Toggle shooting between z-levels"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	config.z_level_shooting = !(config.z_level_shooting)
+	if (config.z_level_shooting)
+		to_chat(world, "<B>Shooting between z-levels has been globally enabled! Use the lookup verb to shoot up, click on empty spaces to shoot down!</B>")
+	else
+		to_chat(world, "<B>Shooting between z-levels has been globally disabled!</B>")
+	log_and_message_admins("toggled z_level_shooting.")

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -168,8 +168,8 @@
 		IgniteMob()
 
 	if(config.z_level_shooting && P.height) // If the bullet came from above or below, limit what bodyparts can be hit for consistency
-		if(resting == TRUE || stat == TRUE)
-			return FALSE // Bullet flies overhead
+		if(resting || lying)
+			return PROJECTILE_CONTINUE // Bullet flies overhead
 
 		switch(P.height)
 			if(HEIGHT_HIGH)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -167,6 +167,16 @@
 	if (P.is_hot() >= HEAT_MOBIGNITE_THRESHOLD)
 		IgniteMob()
 
+	if(config.z_level_shooting && P.height) // If the bullet came from above or below, limit what bodyparts can be hit for consistency
+		if(resting == TRUE || stat == TRUE)
+			return FALSE // Bullet flies overhead
+
+		switch(P.height)
+			if(HEIGHT_HIGH)
+				def_zone_hit = pick(list(BP_CHEST, BP_HEAD, BP_L_ARM, BP_R_ARM))
+			if(HEIGHT_LOW)
+				def_zone_hit = pick(list(BP_CHEST, BP_GROIN, BP_L_LEG, BP_R_LEG))
+
 	//Being hit while using a deadman switch
 	if(istype(get_active_hand(),/obj/item/device/assembly/signaler))
 		var/obj/item/device/assembly/signaler/signaler = get_active_hand()

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -108,12 +108,12 @@ see multiz/movement.dm for some info.
 /turf/simulated/open/fallThrough(var/atom/movable/mover)
 
 	// If the target is open space or a shadow, the projectile traverses down
-	if( config.z_level_shooting && ( istype(mover,/obj/item/projectile) || (istype(mover, /mob/shadow)) ) )
+	if( config.z_level_shooting && istype(mover,/obj/item/projectile) )
 		var/obj/item/projectile/P = mover
-		if(isnull(P.height) && istype(P.original, /turf/simulated/open) && get_dist(P.starting, P.original) <= get_dist(P.starting, src))
-			P.bumped = FALSE
-			P.forceMove(below)
+		if(isnull(P.height) && ( istype(P.original, /turf/simulated/open) || (istype(mover, /mob/shadow)) ) && get_dist(P.starting, P.original) <= get_dist(P.starting, src))
+			P.Move(below) // We want proc/Enter to get called on the turf, so we can't use forcemove()
 			P.trajectory.loc_z = below.z
+			P.bumped = FALSE
 			P.height = HEIGHT_LOW // We are shooting from above, this protects windows from damage
 			return // We are done here
 

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -106,6 +106,17 @@ see multiz/movement.dm for some info.
 	return
 
 /turf/simulated/open/fallThrough(var/atom/movable/mover)
+
+	// If we are the target, the projectile traverses down
+	if(config.z_level_shooting && istype(mover,/obj/item/projectile))
+		var/obj/item/projectile/P = mover
+		if(!P.height && istype(P.original, /turf/simulated/open) && get_dist(P.starting, P.original) <= get_dist(P.starting, src))
+			P.forceMove(below)
+			P.trajectory.loc_z = below.z
+			P.bumped = FALSE
+			P.height = HEIGHT_LOW // We are shooting from above, this protects windows from damage
+			return // We are done here
+
 	if(!mover.can_fall())
 		return
 

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -110,7 +110,7 @@ see multiz/movement.dm for some info.
 	// If we are the target, the projectile traverses down
 	if(config.z_level_shooting && istype(mover,/obj/item/projectile))
 		var/obj/item/projectile/P = mover
-		if(!P.height && istype(P.original, /turf/simulated/open) && get_dist(P.starting, P.original) <= get_dist(P.starting, src))
+		if(isnull(P.height) && istype(P.original, /turf/simulated/open) && get_dist(P.starting, P.original) <= get_dist(P.starting, src))
 			P.forceMove(below)
 			P.trajectory.loc_z = below.z
 			P.bumped = FALSE

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -107,13 +107,13 @@ see multiz/movement.dm for some info.
 
 /turf/simulated/open/fallThrough(var/atom/movable/mover)
 
-	// If we are the target, the projectile traverses down
-	if(config.z_level_shooting && istype(mover,/obj/item/projectile))
+	// If the target is open space or a shadow, the projectile traverses down
+	if( config.z_level_shooting && ( istype(mover,/obj/item/projectile) || (istype(mover, /mob/shadow)) ) )
 		var/obj/item/projectile/P = mover
 		if(isnull(P.height) && istype(P.original, /turf/simulated/open) && get_dist(P.starting, P.original) <= get_dist(P.starting, src))
+			P.bumped = FALSE
 			P.forceMove(below)
 			P.trajectory.loc_z = below.z
-			P.bumped = FALSE
 			P.height = HEIGHT_LOW // We are shooting from above, this protects windows from damage
 			return // We are done here
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -247,6 +247,7 @@
 				if(!(locate(/obj/structure/catwalk) in newTurf)) // Can't shoot through catwalks
 					loc = newTurf
 					height = HEIGHT_HIGH // We are shooting from below, this protects resting players at the expense of windows
+					original = get_turf(original) // Aim at turfs instead of mobs, to ensure we don't hit players
 
 	firer = user
 	shot_from = launcher.name

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -34,6 +34,7 @@
 	var/atom/original = null // the target clicked (not necessarily where the projectile is headed). Should probably be renamed to 'target' or something.
 	var/turf/starting = null // the projectile's starting turf
 	var/list/permutated = list() // we've passed through these atoms, don't try to hit them again
+	var/height // starts undefined, used for Zlevel shooting
 
 	var/p_x = 16
 	var/p_y = 16 // the pixel location of the tile that the player clicked. Default is the center
@@ -235,12 +236,17 @@
 		recoil = aimer.recoil
 		recoil -= projectile_accuracy
 
-		if(iscarbon(user))
-			var/mob/living/carbon/human/blanker = user
-			if(blanker.can_multiz_pb && (!isturf(target)))
-				loc = get_turf(blanker.client.eye)
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			if(H.can_multiz_pb && (!isturf(target)))
+				loc = get_turf(H.client.eye)
 				if(!(loc.Adjacent(target)))
-					loc = get_turf(blanker)
+					loc = get_turf(H)
+			if(config.z_level_shooting && H.client.eye == H.shadow && !height) // Player is watching a higher zlevel
+				var/newTurf = get_turf(H.shadow)
+				if(!(locate(/obj/structure/catwalk) in newTurf)) // Can't shoot through catwalks
+					loc = newTurf
+					height = HEIGHT_HIGH // We are shooting from below, this protects resting players at the expense of windows
 
 	firer = user
 	shot_from = launcher.name
@@ -316,6 +322,10 @@
 	miss_modifier = 0
 
 	var/result = PROJECTILE_CONTINUE
+
+	if(config.z_level_shooting && height == HEIGHT_HIGH)
+		if(target_mob.resting == TRUE || target_mob.stat == TRUE)
+			return FALSE // Bullet flies overhead
 
 	if(target_mob != original) // If mob was not clicked on / is not an NPC's target, checks if the mob is concealed by cover
 		var/turf/cover_loc = get_step(get_turf(target_mob), get_dir(get_turf(target_mob), starting))
@@ -430,6 +440,7 @@
 			trajectory.loc_z = loc.z
 			bumped = FALSE
 			return FALSE
+
 	if(ismob(A))
 		var/mob/M = A
 		if(isliving(A))

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -21,6 +21,12 @@
 
 //checks if projectile 'P' from turf 'from' can hit whatever is behind the table. Returns 1 if it can, 0 if bullet stops.
 /obj/structure/table/proc/check_cover(obj/item/projectile/P, turf/from)
+
+	if(config.z_level_shooting)
+		if(P.height == HEIGHT_HIGH)
+			return TRUE // Bullet is too high to hit
+		P.height = P.height == HEIGHT_LOW ? HEIGHT_LOW : HEIGHT_CENTER
+
 	if (get_dist(P.starting, loc) <= 1) //Tables won't help you if people are THIS close
 		return TRUE
 	if(get_dist(loc, P.trajectory.target) > 1 ) // Target turf must be adjacent for it to count as cover
@@ -42,6 +48,11 @@
 				valid = TRUE
 		else
 			valid = FALSE					//But only from one side
+
+	// Bullet is low enough to hit the table
+	if(config.z_level_shooting && P.height == HEIGHT_LOW)
+		valid = TRUE
+
 	if(valid)
 		var/pierce = P.check_penetrate(src)
 		health -= P.get_structure_damage()/2
@@ -51,8 +62,8 @@
 		else
 			visible_message(SPAN_WARNING("[src] breaks down!"))
 			break_to_parts()
-			return 1
-	return 1
+			return TRUE
+	return TRUE
 
 /obj/structure/table/CheckExit(atom/movable/O as mob|obj, target as turf)
 	if(istype(O) && O.checkpass(PASSTABLE))

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -25,7 +25,7 @@
 	if(config.z_level_shooting)
 		if(P.height == HEIGHT_HIGH)
 			return TRUE // Bullet is too high to hit
-		P.height = P.height == HEIGHT_LOW ? HEIGHT_LOW : HEIGHT_CENTER
+		P.height = (P.height == HEIGHT_LOW) ? HEIGHT_LOW : HEIGHT_CENTER
 
 	if (get_dist(P.starting, loc) <= 1) //Tables won't help you if people are THIS close
 		return TRUE


### PR DESCRIPTION
## About The Pull Request

Unlocks shooting between zlevels.

Such method of shooting cannot be used to hit prone targets, nor to shoot targets behind cover.
Can be toggled on and off by admins during the round, making it a fun feature for events specifically. This lifts most balance concerns, as by default z-level shooting will be toggled off.

## Why It's Good For The Game

I can kill the roaches on sector 3 hallway by spraying down from tool storage.

## Testing

Compiled and tested locally, requested test server. Issues were found and addressed. 
Current version is the test version with z-level shooting toggled on by default, make sure the configs are changed before pushing to live permanently. Livetesting outside monday only with project leader permission.

## Changelog
:cl:
add: shooting between zlevels, toggled by admins
fix: minor bugfixes for tables
/:cl:
