### PR TITLE
Reverts through armor agony nerf

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -1,4 +1,4 @@
-#define ARMOR_HALLOS_COEFFICIENT 0.25
+#define ARMOR_HALLOS_COEFFICIENT 0.4
 
 
 //This calculation replaces old run_armor_check in favor of more complex and better system


### PR DESCRIPTION
## About The Pull Request

Reverts #7770

## Why It's Good For The Game

The reason that #7770 was merged was because there was a huge misunderstanding in through-armor agony. 
A (now fixed) bug made it so if a attack was reduced to 0 damage, it'd resort to dealing agony damage to you according to your melee armor value, so 15 melee armor meant roaches could obliterate you in a few swings. People thought this was proof through armor agony was overtuned. That wasn't the case, and this new value is too low, so TGHmaxing makes through armor agony useless.

## Testing
No testing done for this one.

## Changelog
:cl:
balance: pain gained from armor blocking bullets is now 40% of the original damage. Should make shotguns viable again.
/:cl: