### PR TITLE
Funeral ejector

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -7859,6 +7859,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
 "asq" = (
@@ -29672,8 +29673,11 @@
 /area/eris/medical/virology)
 "bsC" = (
 /obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/sorter)
@@ -100673,9 +100677,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/barquarters)
-"eHY" = (
-/turf/simulated/wall/r_wall,
-/area/eris/maintenance/sorter)
 "eIo" = (
 /turf/simulated/wall,
 /area/eris/engineering/propulsion/right)
@@ -101429,6 +101430,15 @@
 /obj/machinery/camera/network/command,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section1deck4central)
+"fUS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/eris/quartermaster/disposaldrop)
 "fVv" = (
 /obj/structure/closet/crate,
 /obj/item/stack/material/steel{
@@ -101863,9 +101873,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
-"gUi" = (
-/turf/simulated/wall,
-/area/eris/maintenance/sorter)
 "gWZ" = (
 /obj/structure/table/woodentable,
 /obj/machinery/firealarm{
@@ -102145,6 +102152,11 @@
 	},
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
+"hCo" = (
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating,
+/area/eris/maintenance/sorter)
 "hDk" = (
 /obj/landmark/join/start/clubworker,
 /turf/simulated/floor/tiled/steel/bar_dance,
@@ -103177,6 +103189,19 @@
 "jOh" = (
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/maintenance/section3deck2port)
+"jOw" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/sorter)
 "jRe" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -103580,6 +103605,13 @@
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/medical/reception)
+"kVX" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/sorter)
 "kWg" = (
 /obj/spawner/closet,
 /turf/simulated/floor/tiled/techmaint_panels,
@@ -103630,19 +103662,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics/garden)
-"leG" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	pixel_y = 26
-	},
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/sorter)
 "leT" = (
 /obj/structure/reagent_dispensers/cahorsbarrel,
 /obj/structure/sign/faction/neotheology_cross/gold{
@@ -104267,11 +104286,6 @@
 "mzM" = (
 /turf/simulated/wall/r_wall,
 /area/eris/crew_quarters/barconference)
-"mAt" = (
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawn,
-/turf/simulated/floor/plating,
-/area/eris/maintenance/sorter)
 "mAA" = (
 /turf/simulated/wall,
 /area/eris/crew_quarters/clownoffice)
@@ -105128,6 +105142,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/crew_quarters/fitness)
+"oHP" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/sorter)
 "oHW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -105354,16 +105372,6 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
-"peU" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/sorter)
 "peX" = (
 /obj/landmark/join/start/acolyte,
 /turf/simulated/floor/wood,
@@ -105650,6 +105658,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/eris/crew_quarters/barconference)
+"pVr" = (
+/turf/simulated/wall/r_wall,
+/area/eris/maintenance/sorter)
 "pVN" = (
 /obj/structure/railing{
 	dir = 4
@@ -105724,6 +105735,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/barquarters)
+"qdC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/eris/quartermaster/disposaldrop)
 "qeb" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -105910,15 +105930,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/sorter)
-"qyg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/eris/quartermaster/disposaldrop)
 "qyl" = (
 /obj/structure/table/rack/shelf,
 /obj/machinery/light{
@@ -106009,6 +106020,16 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
+"qLQ" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/sorter)
 "qMe" = (
 /obj/spawner/gun/handmade,
 /turf/simulated/floor/plating,
@@ -108514,15 +108535,6 @@
 /obj/spawner/gun/handmade,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/eris/maintenance/section2deck1port)
-"wxv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/eris/quartermaster/disposaldrop)
 "wxB" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -108601,10 +108613,6 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
-"wPX" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/sorter)
 "wQU" = (
 /obj/structure/railing{
 	dir = 8
@@ -108878,16 +108886,6 @@
 /obj/item/reagent_containers/food/drinks/flask/barflask,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/barbackroom)
-"xzK" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/sorter)
 "xAA" = (
 /obj/structure/bed/psych,
 /turf/simulated/floor/carpet,
@@ -109048,6 +109046,9 @@
 	},
 /turf/simulated/floor/tiled/white/golden,
 /area/eris/neotheology/chapelritualroom)
+"xUX" = (
+/turf/simulated/wall,
+/area/eris/maintenance/sorter)
 "xVV" = (
 /obj/structure/table/standard,
 /obj/item/cell/large/high,
@@ -127675,7 +127676,7 @@ aCn
 aCn
 aCn
 aBC
-wPX
+oHP
 bmO
 eBl
 eBl
@@ -128079,7 +128080,7 @@ arI
 apn
 apn
 clU
-bsC
+kVX
 btr
 bBX
 eBl
@@ -128281,7 +128282,7 @@ avQ
 avQ
 apn
 cmm
-xzK
+qLQ
 dQA
 bBX
 eBl
@@ -128686,7 +128687,7 @@ atp
 blT
 apn
 dlO
-wPX
+oHP
 dUG
 efv
 azU
@@ -128887,16 +128888,16 @@ atp
 atp
 awX
 apn
-peU
+bsC
 dTH
 btb
-eHY
+pVr
 aBJ
 aBJ
-gUi
+xUX
 aBJ
 aBJ
-gUi
+xUX
 hOx
 arI
 huE
@@ -129089,7 +129090,7 @@ atp
 atp
 blT
 apn
-leG
+jOw
 dUo
 afx
 iCc
@@ -129499,10 +129500,10 @@ btu
 apV
 ewo
 ewo
-gUi
+xUX
 ewo
 ewo
-gUi
+xUX
 ewo
 bOg
 bQI
@@ -129699,13 +129700,13 @@ bsR
 atM
 avz
 apV
-mAt
+hCo
 eyd
-eHY
-eHY
-eHY
-eHY
-eHY
+pVr
+pVr
+pVr
+pVr
+pVr
 apn
 bRh
 arI
@@ -129897,7 +129898,7 @@ apV
 awi
 awi
 aAz
-qyg
+qdC
 btw
 avz
 apV
@@ -130099,7 +130100,7 @@ aur
 awk
 axM
 aAz
-qyg
+qdC
 atM
 avz
 kFA
@@ -130301,7 +130302,7 @@ aCv
 awk
 awW
 aAz
-qyg
+qdC
 atM
 avz
 kFA
@@ -130503,7 +130504,7 @@ avE
 awf
 ayq
 avs
-qyg
+qdC
 atM
 cpB
 apV
@@ -130705,7 +130706,7 @@ aty
 awi
 awi
 awi
-qyg
+qdC
 awy
 drX
 apV
@@ -130907,7 +130908,7 @@ auX
 atM
 atM
 atM
-qyg
+qdC
 atM
 avz
 kFA
@@ -131109,7 +131110,7 @@ atS
 awl
 axO
 aTM
-wxv
+fUS
 atM
 avz
 kFA

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -2222,7 +2222,7 @@
 	id = "cargo_intake"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "afy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall,
@@ -9374,7 +9374,7 @@
 	id = "bioreactor_intake"
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "awx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -9824,10 +9824,10 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/space)
 "axO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/quartermaster/disposaldrop)
 "axP" = (
@@ -10162,7 +10162,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "ayK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10660,7 +10660,7 @@
 	id = "disposal_conveyor"
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "azV" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -11362,7 +11362,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "aBD" = (
 /obj/spawner/mob/spiders/cluster,
 /turf/simulated/floor/tiled/white/panels,
@@ -11409,7 +11409,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "aBK" = (
 /obj/machinery/light,
 /obj/machinery/suit_storage_unit/moebius,
@@ -11572,7 +11572,7 @@
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "aCh" = (
 /obj/spawner/pack/machine,
 /turf/simulated/floor/tiled/techmaint,
@@ -18474,8 +18474,11 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/security/main)
 "aTM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/quartermaster/disposaldrop)
@@ -23100,6 +23103,12 @@
 	name = "Delivery and Disposal";
 	req_access = list(50)
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/quartermaster/disposaldrop)
 "bdg" = (
@@ -27111,7 +27120,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "bmr" = (
 /obj/machinery/firealarm{
 	pixel_y = 28
@@ -27354,7 +27363,7 @@
 	},
 /obj/spawner/scrap/sparse/low_chance,
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "bmP" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -29663,8 +29672,11 @@
 /area/eris/medical/virology)
 "bsC" = (
 /obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "bsD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29774,6 +29786,12 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/quartermaster/disposaldrop)
 "bsS" = (
@@ -29830,7 +29848,7 @@
 	id = "cargo_intake"
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "btc" = (
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/rnd/lab)
@@ -29923,7 +29941,7 @@
 /obj/structure/catwalk,
 /obj/spawner/lowkeyrandom,
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "btq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_cargo{
@@ -29944,8 +29962,11 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "bts" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -30696,7 +30717,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "bvt" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -32919,7 +32940,7 @@
 /obj/structure/catwalk,
 /obj/spawner/pack/gun_loot/low_chance,
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "bAt" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -33552,13 +33573,13 @@
 	id = "bioreactor_intake"
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "bBX" = (
 /obj/machinery/conveyor/west{
 	id = "bioreactor_intake"
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "bBY" = (
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/command/teleporter)
@@ -33685,7 +33706,7 @@
 /obj/structure/catwalk,
 /obj/spawner/mob/roaches/cluster,
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "bCp" = (
 /obj/structure/multiz/ladder/up,
 /turf/simulated/floor/tiled/steel,
@@ -46839,7 +46860,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "cht" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -48612,7 +48633,7 @@
 /obj/structure/railing,
 /obj/spawner/scrap/sparse/low_chance,
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "clV" = (
 /obj/machinery/button/remote/blast_door{
 	id = "maint_hatch_conference_2";
@@ -48744,7 +48765,7 @@
 /obj/structure/railing,
 /obj/spawner/scrap/sparse,
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "cmn" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -64156,7 +64177,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "cYV" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -64935,7 +64956,7 @@
 	id = "bioreactor_intake"
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "daP" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -66851,8 +66872,14 @@
 	pixel_y = 32
 	},
 /obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "dfi" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/drinks/bottle/small/beer{
@@ -69876,8 +69903,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "dlP" = (
 /obj/machinery/camera/network/third_section{
 	dir = 8
@@ -70014,8 +70047,23 @@
 	icon_state = "2-4"
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "North APC";
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "dmh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/spawner/lowkeyrandom/low_chance,
@@ -83042,8 +83090,11 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "dQB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84299,7 +84350,7 @@
 	id = "disposal_conveyor"
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "dTI" = (
 /obj/machinery/power/apc{
 	name = "South APC";
@@ -84530,7 +84581,7 @@
 /obj/structure/railing,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "dUp" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -84669,7 +84720,7 @@
 	refuse_output_side = 1
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "dUI" = (
 /obj/structure/closet/secure_closet/personal/hydroponics{
 	name = "gardener's locker";
@@ -85167,7 +85218,7 @@
 	id = "cargo_intake"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "dVY" = (
 /obj/structure/railing{
 	dir = 4
@@ -89018,7 +89069,7 @@
 	},
 /obj/structure/plasticflaps/mining,
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "efw" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -95917,7 +95968,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "evS" = (
 /obj/structure/table/bar_special,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -96147,7 +96198,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "ewp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -96940,7 +96991,7 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "eye" = (
 /obj/structure/railing{
 	dir = 8
@@ -100622,6 +100673,9 @@
 	},
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/barquarters)
+"eHY" = (
+/turf/simulated/wall/r_wall,
+/area/eris/maintenance/sorter)
 "eIo" = (
 /turf/simulated/wall,
 /area/eris/engineering/propulsion/right)
@@ -101809,6 +101863,9 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
+"gUi" = (
+/turf/simulated/wall,
+/area/eris/maintenance/sorter)
 "gWZ" = (
 /obj/structure/table/woodentable,
 /obj/machinery/firealarm{
@@ -101833,7 +101890,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "hab" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -102193,7 +102250,7 @@
 	},
 /obj/spawner/pack/gun_loot/low_chance,
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "hPg" = (
 /obj/structure/railing{
 	dir = 4
@@ -102492,7 +102549,7 @@
 	req_access = list(12)
 	},
 /turf/simulated/floor/tiled/dark/cargo,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "iCY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -103049,7 +103106,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/cargo,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "jFW" = (
 /obj/machinery/button/remote/blast_door{
 	id = "TechnomancerShopLockdown";
@@ -103573,6 +103630,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics/garden)
+"leG" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/sorter)
 "leT" = (
 /obj/structure/reagent_dispensers/cahorsbarrel,
 /obj/structure/sign/faction/neotheology_cross/gold{
@@ -104197,6 +104267,11 @@
 "mzM" = (
 /turf/simulated/wall/r_wall,
 /area/eris/crew_quarters/barconference)
+"mAt" = (
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating,
+/area/eris/maintenance/sorter)
 "mAA" = (
 /turf/simulated/wall,
 /area/eris/crew_quarters/clownoffice)
@@ -104911,7 +104986,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "owL" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
@@ -105279,6 +105354,16 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
+"peU" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/sorter)
 "peX" = (
 /obj/landmark/join/start/acolyte,
 /turf/simulated/floor/wood,
@@ -105721,7 +105806,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "qmJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/golden,
@@ -105824,6 +105909,15 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
+/area/eris/maintenance/sorter)
+"qyg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/quartermaster/disposaldrop)
 "qyl" = (
 /obj/structure/table/rack/shelf,
@@ -106142,7 +106236,7 @@
 	},
 /obj/spawner/lowkeyrandom,
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "rxV" = (
 /obj/structure/sign/faction/frozenstar{
 	pixel_y = -32
@@ -107887,7 +107981,7 @@
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "voT" = (
 /obj/structure/ore_box,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -108420,6 +108514,15 @@
 /obj/spawner/gun/handmade,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/eris/maintenance/section2deck1port)
+"wxv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/eris/quartermaster/disposaldrop)
 "wxB" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -108498,6 +108601,10 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
+"wPX" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/sorter)
 "wQU" = (
 /obj/structure/railing{
 	dir = 8
@@ -108595,7 +108702,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "xdz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -108697,7 +108804,7 @@
 /obj/structure/catwalk,
 /obj/spawner/scrap/sparse,
 /turf/simulated/floor/plating/under,
-/area/eris/quartermaster/disposaldrop)
+/area/eris/maintenance/sorter)
 "xqY" = (
 /obj/structure/cryofeed{
 	dir = 4
@@ -108771,6 +108878,16 @@
 /obj/item/reagent_containers/food/drinks/flask/barflask,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/barbackroom)
+"xzK" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/sorter)
 "xAA" = (
 /obj/structure/bed/psych,
 /turf/simulated/floor/carpet,
@@ -127558,7 +127675,7 @@ aCn
 aCn
 aCn
 aBC
-bsC
+wPX
 bmO
 eBl
 eBl
@@ -128164,7 +128281,7 @@ avQ
 avQ
 apn
 cmm
-bsC
+xzK
 dQA
 bBX
 eBl
@@ -128569,7 +128686,7 @@ atp
 blT
 apn
 dlO
-bsC
+wPX
 dUG
 efv
 azU
@@ -128770,16 +128887,16 @@ atp
 atp
 awX
 apn
-bsC
+peU
 dTH
 btb
-apV
+eHY
 aBJ
 aBJ
-btF
+gUi
 aBJ
 aBJ
-btF
+gUi
 hOx
 arI
 huE
@@ -128972,7 +129089,7 @@ atp
 atp
 blT
 apn
-bsC
+leG
 dUo
 afx
 iCc
@@ -129382,10 +129499,10 @@ btu
 apV
 ewo
 ewo
-btF
+gUi
 ewo
 ewo
-btF
+gUi
 ewo
 bOg
 bQI
@@ -129582,13 +129699,13 @@ bsR
 atM
 avz
 apV
-kFA
+mAt
 eyd
-apV
-apV
-apV
-apV
-apV
+eHY
+eHY
+eHY
+eHY
+eHY
 apn
 bRh
 arI
@@ -129780,7 +129897,7 @@ apV
 awi
 awi
 aAz
-atM
+qyg
 btw
 avz
 apV
@@ -129982,7 +130099,7 @@ aur
 awk
 axM
 aAz
-atM
+qyg
 atM
 avz
 kFA
@@ -130184,7 +130301,7 @@ aCv
 awk
 awW
 aAz
-atM
+qyg
 atM
 avz
 kFA
@@ -130386,7 +130503,7 @@ avE
 awf
 ayq
 avs
-atM
+qyg
 atM
 cpB
 apV
@@ -130588,7 +130705,7 @@ aty
 awi
 awi
 awi
-atM
+qyg
 awy
 drX
 apV
@@ -130790,7 +130907,7 @@ auX
 atM
 atM
 atM
-atM
+qyg
 atM
 avz
 kFA
@@ -130992,7 +131109,7 @@ atS
 awl
 axO
 aTM
-atM
+wxv
 atM
 avz
 kFA

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -7840,11 +7840,7 @@
 /turf/simulated/wall,
 /area/eris/rnd/podbay)
 "asp" = (
-/obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -7852,8 +7848,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
@@ -9906,12 +9910,16 @@
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/library)
 "aye" = (
-/obj/machinery/door/airlock/maintenance_common{
-	name = "Service Maintenance";
-	req_access = list(12)
+/obj/machinery/door/holy,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section3deck5port)
+/area/eris/neotheology/funeral)
 "ayf" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -92802,9 +92810,8 @@
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/maintenance/section2deck1starboard)
 "eoI" = (
-/obj/spawner/traps/low_chance,
-/turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section3deck5port)
+/turf/simulated/floor/tiled/dark/golden,
+/area/eris/neotheology/funeral)
 "eoJ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
@@ -96690,9 +96697,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck2port)
 "exE" = (
-/obj/spawner/junk,
-/turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section3deck5port)
+/turf/simulated/wall/r_wall,
+/area/eris/neotheology/funeral)
 "exF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -101758,6 +101764,13 @@
 	},
 /turf/simulated/floor/tiled/white/golden,
 /area/eris/neotheology/chapelritualroom)
+"gOf" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/eris/neotheology/funeral)
 "gPx" = (
 /obj/structure/table/woodentable,
 /obj/item/device/lighting/toggleable/lamp/green,
@@ -102223,6 +102236,15 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
 /area/eris/neotheology/chapelritualroom)
+"hRj" = (
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/eris/neotheology/funeral)
 "hRl" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/blast/shutters{
@@ -102620,6 +102642,20 @@
 /obj/item/storage/firstaid/surgery,
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/security/exerooms)
+"iPh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck5port)
 "iPY" = (
 /obj/structure/railing{
 	dir = 8
@@ -102712,6 +102748,15 @@
 "iYV" = (
 /obj/spawner/closet,
 /turf/simulated/floor/tiled/white/brown_platform,
+/area/space)
+"iZN" = (
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/hull,
 /area/space)
 "jak" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -104327,6 +104372,13 @@
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/engineering/engine_room)
+"mYH" = (
+/obj/spawner/junk/low_chance,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck5port)
 "nab" = (
 /obj/structure/table/bar_special,
 /turf/simulated/floor/tiled/steel/bar_flat,
@@ -105125,6 +105177,20 @@
 /obj/item/storage/freezer/medical,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/surgery)
+"oTx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck5port)
 "oUj" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 8
@@ -105583,6 +105649,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/eris/neotheology/storage)
+"qet" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/eris/neotheology/funeral)
 "qeV" = (
 /obj/machinery/light_switch/dimmer_switch{
 	pixel_x = 22
@@ -106264,6 +106336,12 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
+"rUN" = (
+/obj/machinery/conveyor/west{
+	id = "body_disposal"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/eris/neotheology/funeral)
 "rVB" = (
 /obj/machinery/shower,
 /obj/structure/curtain/open/shower,
@@ -106299,6 +106377,15 @@
 /obj/spawner/mob/roaches/cluster,
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/eris/maintenance/section3deck5port)
+"sbP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "body_disposal"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/eris/neotheology/funeral)
 "sbX" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -106518,6 +106605,16 @@
 /obj/spawner/tool_upgrade/low_chance,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/engineering/breakroom)
+"sxh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck5port)
 "syp" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/black,
 /obj/machinery/meter,
@@ -106565,6 +106662,12 @@
 /obj/spawner/junkfood/rotten/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck5port)
+"sBv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/eris/neotheology/funeral)
 "sBN" = (
 /obj/structure/table/standard,
 /obj/item/cell/large/high,
@@ -106722,6 +106825,16 @@
 	},
 /turf/simulated/floor/tiled/white/golden,
 /area/eris/neotheology/chapelritualroom)
+"sRC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/eris/neotheology/funeral)
 "sRW" = (
 /obj/structure/catwalk,
 /obj/structure/catwalk,
@@ -107218,6 +107331,18 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/crew_quarters/fitness)
+"uaq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/eris/neotheology/funeral)
 "ubu" = (
 /obj/machinery/holomap{
 	pixel_y = 32
@@ -107926,6 +108051,12 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/eris/crew_quarters/kitchen)
+"vHq" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/eris/neotheology/funeral)
 "vIB" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
@@ -107971,6 +108102,12 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section3)
+"vNv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/eris/neotheology/funeral)
 "vNI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -108478,10 +108615,23 @@
 	},
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/security/exerooms)
+"xgV" = (
+/obj/machinery/disposal/deliveryChute{
+	name = "Funeral Ejector";
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/eris/neotheology/funeral)
 "xhf" = (
 /obj/item/stool/padded,
 /turf/simulated/floor/tiled/white,
 /area/eris/crew_quarters/fitness)
+"xhY" = (
+/turf/simulated/wall,
+/area/eris/neotheology/funeral)
 "xij" = (
 /obj/machinery/light/small,
 /obj/structure/bed/chair{
@@ -119534,9 +119684,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+abF
+crY
+abF
 aaa
 aaa
 aaa
@@ -119736,9 +119886,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+abF
+iZN
+abF
 aaa
 aaa
 aaa
@@ -119937,11 +120087,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+exE
+exE
+sBv
+exE
+exE
 aaa
 aaa
 aaa
@@ -120139,11 +120289,11 @@ alg
 alg
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+exE
+eoI
+xgV
+eoI
+exE
 aaa
 aaa
 aaa
@@ -120341,11 +120491,11 @@ bYm
 alg
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+exE
+vHq
+rUN
+eoI
+exE
 aaa
 aaa
 aaa
@@ -120543,11 +120693,11 @@ bYI
 alg
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+exE
+hRj
+rUN
+gOf
+exE
 aaa
 aaa
 aaa
@@ -120745,11 +120895,11 @@ bYR
 alg
 alg
 alg
-alg
-alg
-alg
-alg
-alg
+exE
+sbP
+rUN
+qet
+exE
 aaa
 aaa
 aaa
@@ -120944,14 +121094,14 @@ aaa
 alg
 aqn
 azd
-bBQ
-bBQ
-bBQ
+oTx
+sxh
+sxh
 aye
-eoI
+uaq
+sRC
+vNv
 exE
-apt
-alg
 alg
 alg
 alg
@@ -121145,15 +121295,15 @@ avK
 alg
 alg
 asp
+sxh
+iPh
 bBQ
 bBQ
-bBQ
-bBQ
-ayb
-ayb
-ayb
-ayb
-ayb
+xhY
+xhY
+xhY
+xhY
+xhY
 qhD
 bBQ
 aHP
@@ -121349,10 +121499,10 @@ ayb
 atj
 azf
 awJ
-awJ
-awJ
-awR
-asR
+vSl
+bBQ
+bBQ
+bBQ
 bBQ
 bBQ
 ocY
@@ -121552,9 +121702,9 @@ avk
 wFh
 caN
 dnb
-caN
-awR
-asR
+mYH
+awJ
+nCx
 bBQ
 eye
 ayb

--- a/maps/CEVEris/_Eris_areas.dm
+++ b/maps/CEVEris/_Eris_areas.dm
@@ -559,6 +559,11 @@
 	icon_state = "chapeloffice"
 	area_light_color = COLOR_LIGHTING_NEOTHEOLOGY_DARK
 
+/area/eris/neotheology/funeral
+	name = "\improper Funeral Chamber"
+	icon_state = "erisyellow"
+	area_light_color = COLOR_LIGHTING_NEOTHEOLOGY_DARK
+
 /area/eris/neotheology/chapelritualroom
 	name = "Chapel Rituals Room"
 	icon_state = "erisgreen"

--- a/maps/CEVEris/_Eris_areas.dm
+++ b/maps/CEVEris/_Eris_areas.dm
@@ -38,6 +38,9 @@
 	name = "Fueltank Storage"
 	icon_state = "erisblue"
 
+/area/eris/maintenance/sorter
+	name = "Trash Sorter"
+
 /area/eris/maintenance/section1deck1central
 	name = "First Section Deck 1 Fore Maintenance"
 	icon_state = "section1deck1central"


### PR DESCRIPTION
Adds a disposal for NT to commit bodies to space. Also adds a basic air system to the NT disposal sorting area

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a disposal to space for NT to use to commit coffins to the depths of space, which then allows the players inside to get the high tier respawn buff.
![image](https://user-images.githubusercontent.com/29682682/220734982-0c0899bc-5d90-4006-b1fa-9cba83e5a5c7.png)


## Why It's Good For The Game

This is in the Preacher job description and all the code to support this still exists, there just wasn't a mapped space to actually do it. (I was told it got overlooked in a NT remap) This allows NT to perform another service for nonbelievers and enables the RP of a funeral and burial in space (which most will probably ignore in favor of the meager biomatter from putting a body in there, but oh well).

## Testing

Went into the room, checked the APC and Air Alarm are functioning properly, checked the conveyor is working properly, spaced myself to make sure I got ejected into the depths properly.

## Changelog
:cl: SingingSpock
add: funeral disposal for NT to use.
/:cl: