### PR TITLE
Maintshrooms follow original design, now with 75% less cancer

### DIFF
--- a/code/controllers/subsystems/migration.dm
+++ b/code/controllers/subsystems/migration.dm
@@ -388,6 +388,7 @@ This proc will attempt to create a burrow against a wall, within view of the tar
 	while (i < plantspread_burrows_num && sorted.len)
 		var/obj/structure/burrow/C = sorted[1] //Grab the first element
 		sorted.Cut(1,2)//And remove it from the list
+		var/turf/simulated/T = get_turf(C)
 
 
 		//It already has plants, no good
@@ -397,6 +398,10 @@ This proc will attempt to create a burrow against a wall, within view of the tar
 		//We don't want to send to other burrows in the same room as us.
 		//The point of burrows is to let things move between rooms
 		if (C in viewlist)
+			continue
+
+		//We don't want maintshrooms to spread into places that are too bright
+		if (B.plant.type == /datum/seed/mushroom/maintshroom && T.get_lumcount() > 0.5)
 			continue
 
 		//Chance to reject it anyways to make plant spreading less predictable

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -38,10 +38,6 @@
 		//There also can be special conditions handling
 		if (!floor.Enter(src))
 
-			if(CanPass(src, floor))
-				neighbors |= floor
-				continue
-
 			//Maintshooms cannot, spread trait must be 3 or more
 			if(seed.get_trait(TRAIT_SPREAD) < 3)
 				continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the code for maintshroom spreading, removing a block of code that was letting it spread through shutters, windows, and closed airlocks when that was not the intended effect. Maintshrooms will now only grow in places a human can move, which includes tables and low walls but not closed airlocks or lockers. Spacevines will still spread .through doors (the original point of the code), but not windows. Additionally adds a check to plant migration to check if the tile is over 0.5 lumens and stop the spread if so, matching all other maintshroom growth sources.

## Why It's Good For The Game

Maintshrooms were never *intended* to go through solid objects, as evidenced by the comments on the file. However, CanPass was always returning true, even in cases it wasn't intended to, and every case that it *should* return true Enter was already covering. With this fix, maintshrooms will still spread through open space, z-levels, and burrows, inevitably (but more slowly) consuming the maintenance tunnels if not combated, but should have far less purchase outside of them and not constantly invade the living spaces of the ship without any way to counter them beyond massively intensive extermination campaigns.

## Testing

- Shrooms don't go through closed airlocks or shutters (Check)
- Shrooms do go through open airlocks and shutters (Check)
- Shrooms don't go through windows (Check)
- Shrooms do go through low walls without windows (Check)
- Spacevines do still go through nonwelded doors (Check)
- Shrooms don't burrow travel to well lilt areas (Check)

## Changelog
:cl:
fix: Maintshrooms no longer treat solid objects as a mere suggestion
fix: Maintshrooms now check if the other end of a burrow is too bright for it to grow before spreading
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
