### PR TITLE
Update trade beacon vendors for new AK frame

### DIFF
--- a/code/modules/trade/datums/trade_stations_presets/1-common/hellcat.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/hellcat.dm
@@ -92,7 +92,7 @@
 		/obj/item/part/armor/artwork = offer_data("artistic armor part", 1000, 1),
 		/obj/item/part/gun/artwork = offer_data("artistic gun part", 1000, 1),
 		//obj/item/gun = offer_data_mods("modified gun (3 upgrades)", 3200, 2, OFFER_MODDED_GUN, 3),	// Stops guns from exporting
-		/obj/item/part/gun/frame/ak47 = offer_data("AK frame", 800, 1),
+		/obj/item/gun/projectile/automatic/modular = offer_data("AK frame", 800, 1),
 		/obj/item/part/gun/frame/boltgun  = offer_data("boltgun frame", 800, 1),
 		/obj/item/part/gun/frame/sol = offer_data("Sol frame", 2000, 1),
 		/obj/item/part/gun/frame/straylight = offer_data("Straylight frame", 2000, 1),

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/tb_cheapammofactorys.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/tb_cheapammofactorys.dm
@@ -86,7 +86,7 @@
 	)
 	offer_types = list(
 		//obj/item/gun = offer_data_mods("modified gun (3 upgrades)", 3200, 2, OFFER_MODDED_GUN, 3),	// Stops guns from exporting
-		/obj/item/part/gun/frame/ak47 = offer_data("AK frame", 800, 1),
+		/obj/item/gun/projectile/automatic/modular = offer_data("AK frame", 800, 1),
 		/obj/item/part/gun/frame/boltgun  = offer_data("boltgun frame", 800, 1),
 		/obj/item/part/gun/frame/sol = offer_data("Sol frame", 2000, 1),
 		/obj/item/part/gun/frame/straylight = offer_data("Straylight frame", 2000, 1),

--- a/code/modules/trade/datums/trade_stations_presets/3-rare/fs_experimental_factory.dm
+++ b/code/modules/trade/datums/trade_stations_presets/3-rare/fs_experimental_factory.dm
@@ -33,7 +33,7 @@
 	)
 	offer_types = list(
 		//obj/item/gun = offer_data_mods("modified gun (3 upgrades)", 3200, 2, OFFER_MODDED_GUN, 3),	// Stops guns from exporting
-		/obj/item/part/gun/frame/ak47 = offer_data("AK frame", 800, 1),
+		/obj/item/gun/projectile/automatic/modular = offer_data("AK frame", 800, 1),
 		/obj/item/part/gun/frame/boltgun  = offer_data("boltgun frame", 800, 1),
 		/obj/item/part/gun/frame/sol = offer_data("Sol frame", 2000, 1),
 		/obj/item/part/gun/frame/straylight = offer_data("Straylight frame", 2000, 1),

--- a/code/modules/trade/datums/trade_stations_presets/3-rare/serbianship.dm
+++ b/code/modules/trade/datums/trade_stations_presets/3-rare/serbianship.dm
@@ -63,7 +63,7 @@
 		)
 	)
 	offer_types = list(
-		/obj/item/part/gun/frame/ak47 = offer_data("AK frame", 800, 1),
+		/obj/item/gun/projectile/automatic/modular = offer_data("AK frame", 800, 1),
 		/obj/item/part/gun/frame/kovacs = offer_data("Kovacs frame", 1400, 2),
 		/obj/item/part/gun/frame/zoric = offer_data("Zoric frame", 2000, 1),
 		/obj/item/part/gun/frame/bojevic = offer_data("Bojevic frame", 6000, 1),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Update trade beacon inventories for the new modular AK introduced by #7975 

Necessary for compilation after merging #7975 

## Changelog
:cl: Hyperio
fix: Update trade beacon vendors for new AK frame
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
