### PR TITLE
Minor bugs

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -71,7 +71,7 @@
 	supervisors = "the Ironhammer Commander"
 	selection_color = "#a7bbc6"
 	department_account_access = TRUE
-	wage = WAGE_LABOUR_HAZARD
+	wage = WAGE_PROFESSIONAL
 	also_known_languages = list(LANGUAGE_NEOHONGO = 100)
 
 	outfit_type = /decl/hierarchy/outfit/job/security/gunserg

--- a/code/modules/clothing/spacesuits/rig/modules/storage.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/storage.dm
@@ -2,6 +2,8 @@
 /obj/item/rig_module/storage
 	name = "internal storage compartment"
 	desc = "A storage container designed to be installed in a RIG suit. Allows a few items to be stored inside"
+	interface_name = "internal storage"
+	interface_desc = "A compartment within the suit allowing a few items to be stored."
 
 	var/obj/item/storage/internal/container
 	w_class = ITEM_SIZE_BULKY

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -13590,11 +13590,6 @@
 /obj/structure/catwalk,
 /obj/structure/table/rack,
 /obj/spawner/pack/tech_loot,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "North APC";
-	pixel_y = 28
-	},
 /obj/machinery/camera/network/fourth_section{
 	dir = 8
 	},
@@ -14403,6 +14398,10 @@
 	d1 = 16;
 	d2 = 0;
 	icon_state = "16-0"
+	},
+/obj/machinery/power/apc{
+	name = "South APC";
+	pixel_y = -28
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5starboard)
@@ -24951,6 +24950,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "bhF" = (
@@ -29656,13 +29661,10 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5starboard)
 "bsA" = (
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "bsB" = (
@@ -29719,13 +29721,20 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep/cryo)
 "bsI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "bsJ" = (
 /obj/landmark/join/observer,
@@ -29752,15 +29761,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white/cargo,
 /area/eris/medical/virology)
-"bsN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/section3deck1central)
 "bsP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -30221,6 +30221,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck1central)
 "bua" = (
@@ -30231,6 +30237,12 @@
 "bub" = (
 /obj/spawner/mob/roaches/cluster/low_chance,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plating/under,
@@ -57692,17 +57704,12 @@
 "cID" = (
 /obj/structure/table/standard,
 /obj/spawner/pack/tech_loot,
-/obj/spawner/pack/tech_loot,
-/obj/spawner/pack/tech_loot/low_chance,
 /obj/spawner/pack/tech_loot/low_chance,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/storage/primary)
 "cIE" = (
 /obj/structure/table/standard,
 /obj/spawner/material/building,
-/obj/spawner/material/building,
-/obj/spawner/material/building/low_chance,
-/obj/spawner/material/building/low_chance,
 /obj/spawner/material/building/low_chance,
 /obj/spawner/material/building/low_chance,
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -60231,7 +60238,9 @@
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/engine_room)
 "cPk" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/table/standard,
+/obj/spawner/pack/tech_loot/low_chance,
+/obj/spawner/pack/tech_loot,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/storage/primary)
 "cPl" = (
@@ -60262,7 +60271,10 @@
 /turf/simulated/floor/plating,
 /area/eris/hallway/main/section4)
 "cPo" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/table/standard,
+/obj/spawner/material/building/low_chance,
+/obj/spawner/material/building/low_chance,
+/obj/spawner/material/building,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/storage/primary)
 "cPp" = (
@@ -93404,6 +93416,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/storage/primary)
 "eqd" = (
@@ -93907,6 +93920,12 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -96789,6 +96808,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/side/section3deck2port)
 "exI" = (
@@ -97436,21 +97456,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
-"ezl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/section3deck1central)
 "ezm" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -97496,6 +97501,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -97934,26 +97945,18 @@
 /area/eris/crew_quarters/librarybackroom)
 "eAh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "eAi" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-y"
-	},
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "eAj" = (
@@ -98028,6 +98031,10 @@
 	},
 /obj/structure/railing{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -101303,6 +101310,13 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
+"fAs" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/tiled/steel/cargo,
+/area/eris/hallway/side/section3deck2port)
 "fBx" = (
 /obj/machinery/holomap{
 	dir = 4;
@@ -101992,14 +102006,17 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/crew_quarters/janitor)
 "hjp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-y"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/spawner/junk/nondense,
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "hkv" = (
 /obj/structure/table/rack/shelf,
@@ -102015,6 +102032,12 @@
 	dir = 4
 	},
 /obj/spawner/junk/nondense,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck1central)
 "hlV" = (
@@ -104539,6 +104562,12 @@
 /obj/machinery/door/airlock/maintenance_common{
 	name = "Service Maintenance";
 	req_access = list(12)
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section3deck1central)
@@ -248475,7 +248504,7 @@ cIj
 dIj
 dYo
 eaE
-cFK
+fAs
 dAk
 exS
 cIV
@@ -285651,7 +285680,7 @@ blX
 blX
 blX
 bsA
-bdI
+bsI
 aNe
 aQV
 cNH
@@ -286054,7 +286083,7 @@ aLZ
 boS
 eqI
 boS
-bsI
+cNH
 btZ
 aCh
 boS
@@ -286256,7 +286285,7 @@ aLZ
 aLZ
 aLZ
 aZv
-bsI
+cNH
 btZ
 aCh
 boS
@@ -286458,7 +286487,7 @@ aLZ
 aLZ
 aLZ
 aZv
-bsI
+cNH
 btZ
 eUP
 boS
@@ -286660,7 +286689,7 @@ aLZ
 aLZ
 aLZ
 aZv
-bsI
+cNH
 hlj
 bkF
 boS
@@ -286862,7 +286891,7 @@ aLZ
 aLZ
 aLZ
 aZv
-bsI
+cNH
 btZ
 raY
 boS
@@ -287064,7 +287093,7 @@ aLZ
 aLZ
 aLZ
 aZw
-bsI
+cNH
 btZ
 cNH
 bkF
@@ -287266,7 +287295,7 @@ aLZ
 aLZ
 aZv
 bAU
-hjp
+qLb
 btZ
 cNH
 bkF
@@ -287468,7 +287497,7 @@ uZh
 uZh
 fwf
 lwZ
-bsI
+cNH
 btZ
 aRM
 cNH
@@ -287670,7 +287699,7 @@ aLZ
 aLZ
 aZv
 vpB
-bsI
+cNH
 btZ
 qLb
 aQV
@@ -288074,7 +288103,7 @@ bmU
 bqa
 boS
 bsg
-bsN
+bkK
 bhE
 boS
 aQV
@@ -288276,7 +288305,7 @@ cNH
 bqn
 boS
 bsg
-bsN
+bkK
 bhE
 boS
 cNH
@@ -288478,7 +288507,7 @@ cNH
 bqn
 boS
 bsg
-bsN
+bkK
 bub
 boS
 cNH
@@ -288680,7 +288709,7 @@ esd
 aCh
 boS
 bsg
-bsN
+bkK
 bhE
 boS
 aNe
@@ -288882,7 +288911,7 @@ exN
 eyl
 eyu
 ezi
-ezl
+ezi
 ezp
 ezs
 ezE
@@ -289085,7 +289114,7 @@ eAc
 brA
 ezk
 eAi
-ezk
+hjp
 ezD
 buI
 eAB


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There's a few minor bugfixes and two tweak. Firstly, two mapped areas simply didn't work: a tiny maintenance room had its APC not connected to power, and a disposal and scrubber pipeline was entirely missing a segment. Secondly, the public storage welding and water tanks were moved a bit to a location less likely to get hit with random coins. Thirdly, an interface name and description were added to the rigsuit storage compartment so it doesn't show up as a "generic upgrade". Fourthly, the Gunnery Sergeant is moved up to WAGE_PROFESSIONAL because they're an experienced NCO and 2IC of Ironhammer and deserve to be paid on par with the specialist and investigator, rather than the exact same as the operatives.

Screenshot for the APC fix (The APC was originally on the same tile as the tech loot): 
![image](https://user-images.githubusercontent.com/29682682/224321350-e0ce4185-1808-4b49-88c2-88b5cbfba3fd.png)

Screenshot for the tank moving (the loot now in the corner was taken from the upper corner, total loot in the room is unchanged): 
![image](https://user-images.githubusercontent.com/29682682/224322564-6878494a-015c-4058-8217-631428c1cd46.png)

Screenshot for the piping fix (the pipe used to be one higher, run into the wall above the airlock, and not have anything below the wall. To avoid making pipes under walls, I just moved the whole thing down):
![image](https://user-images.githubusercontent.com/29682682/224322881-9cb89013-dc5f-4cfa-8553-d68e11125c5e.png)


## Why It's Good For The Game

Bugs are bad, people getting paid what they're worth is good.

## Testing

Compiled and ran it, all things work as intended.

## Changelog
:cl: SingingSpock
fix: Disposal/atmos piping above the gym no longer runs into a wall.
fix: A maintenance APC in a tiny room on deck 1 is actually placed where its wire is rather than never charging.
tweak: Tanks in public tools are protected from stray bullets/coins by a windoor.
fix: Harsuit storage module now has a name in the hardsuit interface rather than being generic
tweak: Gunnery Sergeant gets paid on par with the specialist/investigator rather than an operative.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
