### PR TITLE
Block people from leaving/entering shuttles through their ceiling

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -81,6 +81,12 @@
 		to_chat(src, SPAN_WARNING("\The [destination] blocks you."))
 		return FALSE
 
+	// Prevent people from going directly inside or outside a shuttle through the ceiling 
+	// Would be possible if the shuttle is not on the highest z-level
+	if(istype(start, /turf/simulated/shuttle) || istype(destination, /turf/simulated/shuttle))
+		to_chat(src, SPAN_WARNING("An invisible energy shield on top of the shuttle blocks you."))
+		return FALSE
+
 	// Check for blocking atoms at the destination.
 	for (var/atom/A in destination)
 		if (!A.CanPass(mover, start, 1.5, 0))

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -81,10 +81,11 @@
 		to_chat(src, SPAN_WARNING("\The [destination] blocks you."))
 		return FALSE
 
-	// Prevent people from going directly inside or outside a shuttle through the ceiling 
+	// Prevent people from going directly inside or outside a shuttle through the ceiling
 	// Would be possible if the shuttle is not on the highest z-level
+	// Also prevent the bug where people could get in from under the shuttle
 	if(istype(start, /turf/simulated/shuttle) || istype(destination, /turf/simulated/shuttle))
-		to_chat(src, SPAN_WARNING("An invisible energy shield on top of the shuttle blocks you."))
+		to_chat(src, SPAN_WARNING("An invisible energy shield around the shuttle blocks you."))
 		return FALSE
 
 	// Check for blocking atoms at the destination.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Prevent people from directly breaking into merc shuttle from the ceiling when it does not land on the upmost zlevel (since shuttle has no roof). Easy solution with a simple check. A better solution would be to spawn an opaque roof on top of the shuttle by that would required manipulating turfs to spawn the roof then return them to space when shuttle moves.

Also applies to other shuttles (but for now the problem never arises with them because their roof is covered and planets only have 1 zlevel).

Also prevent the bug where people could go inside the shuttle from under it.

## Why It's Good For The Game

Merc shuttle is not an open bar anymore.

## Testing

With a jetpack turned on, going up from inside the shuttle, then going down from above the shuttle.

![image](https://user-images.githubusercontent.com/64754494/224502395-4ce4d960-3d65-4982-9c84-8b9cf4b61b0a.png)

## Changelog
:cl: Hyperio
add: Block people from leaving/entering shuttles through their ceiling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
