### PR TITLE
Add tech level to bonsai tree

### DIFF
--- a/code/modules/reagents/bonsai.dm
+++ b/code/modules/reagents/bonsai.dm
@@ -19,6 +19,7 @@
 	spawn_blacklisted = TRUE
 
 	matter = list(MATERIAL_BIOMATTER = 50)
+	origin_tech = list(TECH_BIO = 4)
 	var/ticks
 
 /obj/item/reagent_containers/bonsai/New()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/64754494/224505211-8639ade5-8237-4e87-b616-b02262c496b8.png)

Laurelin bonsai could not be deconstructed in research item destructor because it did not have a tech level.

PS: It could already be destroyed in bioreactor as it is made of biomass so completion was not impossible with Church cooperation. Still, the PR provides another way.

## Why It's Good For The Game

New way to complete this item personal objective.

## Testing
![image](https://user-images.githubusercontent.com/64754494/224505395-a15c756a-f0e6-498d-913e-65cdb8e8e90f.png)

## Changelog
:cl: Hyperio
add: Add tech level to bonsai tree
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
