### PR TITLE
Erismed fixes and adjustments

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -244,7 +244,6 @@
 		"dermaline_amount" = H.reagents.get_reagent_amount("dermaline"),
 		"blood_amount" = round((H.vessel.get_reagent_amount("blood") / H.species.blood_volume)*100),
 		"disabilities" = H.sdisabilities,
-		"lung_ruptured" = H.is_lung_ruptured(),
 		"external_organs" = H.organs.Copy(),
 		"internal_organs" = H.internal_organs.Copy(),
 		"species_organs" = H.species.has_process, //Just pass a reference for this, it shouldn't ever be modified outside of the datum.
@@ -343,8 +342,6 @@
 				dat += "<td>[I.name],<br><i>[e.name]</i></td><td>[total_burn_damage]</td><td>[total_brute_and_misc_damage]</td><td>[internal_wounds_details ? internal_wounds_details : "None"]</td><td></td>"
 				dat += "</tr>"
 
-		if(e.organ_tag == BP_CHEST && occ["lung_ruptured"])
-			other_wounds += "Lung ruptured"
 		if(e.status & ORGAN_SPLINTED)
 			other_wounds += "Splinted"
 		if(e.status & ORGAN_BLEEDING)

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -129,7 +129,7 @@
 
 							if(!(M.organ_list_by_process(OP_LUNGS).len) || M.losebreath)
 								sound += " and no respiration"
-							else if(M.is_lung_ruptured() || M.getOxyLoss() > 50)
+							else if(M.getOxyLoss() > 50)
 								sound += " and [pick("wheezing","gurgling")] sounds"
 							else
 								sound += " and healthy respiration"

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -46,6 +46,15 @@
 		health = 0
 		..(wound_damage, damage_type, wounding_multiplier, sharp, edge, silent)
 
+/// Brain blood oxygenation is handled via oxyloss
+/obj/item/organ/internal/brain/handle_blood()
+	if(BP_IS_ROBOTIC(src) || !owner)
+		return
+	if(!blood_req)
+		return
+
+	current_blood = max_blood_storage
+
 /obj/item/organ/internal/brain/proc/clear_hud()
 	if(brainmob && brainmob.client)
 		brainmob.client.screen.len = null //clear the hud

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1019,17 +1019,6 @@ var/list/rank_prefix = list(\
 
 	..()
 
-/mob/living/carbon/human/proc/is_lung_ruptured()
-	var/obj/item/organ/internal/lungs/L = random_organ_by_process(OP_LUNGS)
-	return L && L.is_bruised()
-
-/mob/living/carbon/human/proc/rupture_lung()
-	var/obj/item/organ/internal/lungs/L = random_organ_by_process(OP_LUNGS)
-
-	if(L && !L.is_bruised())
-		src.custom_pain("You feel a stabbing pain in your chest!", 1)
-		L.bruise()
-
 /mob/living/carbon/human/add_blood(mob/living/carbon/human/M)
 	if(!..())
 		return 0
@@ -1595,7 +1584,7 @@ var/list/rank_prefix = list(\
 //			output for machines^	^^^^^^^output for people^^^^^^^^^
 
 /mob/living/carbon/human/proc/pulse()
-	if(!(organ_list_by_process(OP_HEART).len))
+	if(stat == DEAD || !(organ_list_by_process(OP_HEART).len))
 		return PULSE_NONE
 	else
 		return pulse

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -160,6 +160,8 @@
 	return ..()
 
 /mob/living/carbon/human/adjustOxyLoss(amount)
+	if(in_stasis && amount > 0)		// Stasis prevents oxy loss
+		return
 	if(species.flags & NO_BREATHE)
 		oxyloss = 0
 	else

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -28,7 +28,7 @@
 	if(stats.getPerk(PERK_BALLS_OF_PLASTEEL))
 		hard_crit_threshold += 20
 
-	. = 0.9	* get_limb_damage() + 0.6 * oxyloss
+	. = get_limb_damage()
 
 	//Constant Pain above 80% of the crit treshold gets converted to dynamic pain (hallos)
 	//Damage from the last tick gets saved as last_tick_pain and compared to current pain, if the current pain is larger hallos gets applied again

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/toxic.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/toxic.dm
@@ -48,7 +48,7 @@
 	icon = 'icons/obj/hivemind.dmi'
 	icon_state = "goo_proj"
 	damage_types = list(TOX = 15)
-	irradiate = 15
+	irradiate = 5
 	check_armour = ARMOR_BIO
 	step_delay = 2
 

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/toxic.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/toxic.dm
@@ -38,7 +38,7 @@
 		if(isliving(A))
 			var/mob/living/L = A
 			var/damage = rand(melee_damage_lower, melee_damage_upper)
-			L.apply_effect(40, IRRADIATE)
+			L.apply_effect(10, IRRADIATE)
 			L.damage_through_armor(damage, TOX, attack_flag = ARMOR_BIO)
 			playsound(src, 'sound/voice/insect_battle_screeching.ogg', 30, 1, -3)
 			L.visible_message(SPAN_DANGER("\the [src] globs up some glowing bile all over \the [L]!"))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -167,7 +167,7 @@ default behaviour is:
 
 /mob/living/verb/succumb()
 	set hidden = TRUE
-	if (health < 0) // Health below Zero but above 5-away-from-death, as before, but variable
+	if (health < 0)
 		adjustOxyLoss(health + maxHealth * 2) // Deal 2x health in OxyLoss damage, as before but variable.
 		health = -maxHealth
 		to_chat(src, "\blue You have given up life and succumbed to death.")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -167,9 +167,9 @@ default behaviour is:
 
 /mob/living/verb/succumb()
 	set hidden = TRUE
-	if ((src.health < 0 && src.health > (5-src.maxHealth))) // Health below Zero but above 5-away-from-death, as before, but variable
-		src.adjustOxyLoss(src.health + src.maxHealth * 2) // Deal 2x health in OxyLoss damage, as before but variable.
-		src.health = src.maxHealth - src.getOxyLoss() - src.getToxLoss() - src.getFireLoss() - src.getBruteLoss()
+	if (health < 0) // Health below Zero but above 5-away-from-death, as before, but variable
+		adjustOxyLoss(health + maxHealth * 2) // Deal 2x health in OxyLoss damage, as before but variable.
+		health = -maxHealth
 		to_chat(src, "\blue You have given up life and succumbed to death.")
 
 

--- a/code/modules/organs/external/damage.dm
+++ b/code/modules/organs/external/damage.dm
@@ -15,10 +15,10 @@
 		if(BURN)
 			amount = round(amount * burn_mod, 0.1)
 
-	// Damage is transferred to internal organs. Chest and head must be broken before transferring.
+	// Damage is transferred to internal organs. Chest and head must be broken before transferring unless they're slime limbs.
 	if(LAZYLEN(internal_organs))
 		var/can_transfer = FALSE	// Only applies to brute and burn
-		if((organ_tag != BP_CHEST && organ_tag != BP_HEAD) || status & ORGAN_BROKEN)
+		if((organ_tag != BP_CHEST && organ_tag != BP_HEAD) || status & ORGAN_BROKEN || cannot_break)
 			can_transfer = TRUE
 		var/obj/item/organ/internal/I = pick(internal_organs)
 		var/transferred_damage_amount

--- a/code/modules/organs/external/damage.dm
+++ b/code/modules/organs/external/damage.dm
@@ -34,8 +34,8 @@
 				transferred_damage_amount = amount
 
 		if(transferred_damage_amount > 0)
-			I.take_damage(transferred_damage_amount, damage_type, wounding_multiplier, sharp, edge, FALSE)
-			amount = round(max(amount / 2, amount - transferred_damage_amount), 0.1)
+			if(I.take_damage(transferred_damage_amount, damage_type, wounding_multiplier, sharp, edge, FALSE))
+				amount = round(max(amount / 2, amount - transferred_damage_amount), 0.1)
 
 	if(amount <= 0)
 		return FALSE

--- a/code/modules/organs/external/damage.dm
+++ b/code/modules/organs/external/damage.dm
@@ -26,7 +26,8 @@
 			if(BRUTE)
 				transferred_damage_amount = can_transfer ? (amount - (max_damage - brute_dam) / armor_divisor) / 2 : 0
 			if(BURN)
-				transferred_damage_amount = can_transfer ? (amount - (max_damage - burn_dam) / armor_divisor) / 2 : 0
+				var/damage_divisor = can_transfer ? 2 : 4
+				transferred_damage_amount = (amount - (max_damage - burn_dam) / armor_divisor) / damage_divisor
 			if(HALLOSS)
 				transferred_damage_amount = 0
 			else

--- a/code/modules/organs/external/damage.dm
+++ b/code/modules/organs/external/damage.dm
@@ -34,8 +34,8 @@
 				transferred_damage_amount = amount
 
 		if(transferred_damage_amount > 0)
-			if(I.take_damage(transferred_damage_amount, damage_type, wounding_multiplier, sharp, edge, FALSE))
-				amount = round(max(amount / 2, amount - transferred_damage_amount), 0.1)
+			I.take_damage(transferred_damage_amount, damage_type, wounding_multiplier, sharp, edge, FALSE)
+			amount = round(max(amount / 2, amount - transferred_damage_amount), 0.1)
 
 	if(amount <= 0)
 		return FALSE

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -92,12 +92,12 @@
 
 /obj/item/organ/internal/take_damage(amount, damage_type = BRUTE, wounding_multiplier = 1, sharp = FALSE, edge = FALSE, silent = FALSE)	//Deals damage to the organ itself
 	if(!damage_type || status & ORGAN_DEAD)
-		return
+		return FALSE
 
 	var/wound_count = max(0, round((amount * wounding_multiplier) / 8))	// At base values, every 8 points of damage is 1 wound
 
 	if(!wound_count)
-		return
+		return FALSE
 
 	var/list/possible_wounds = get_possible_wounds(damage_type, sharp, edge)
 
@@ -110,6 +110,9 @@
 				break
 
 		owner.custom_pain("Something inside your [parent.name] hurts a lot.", 0)		// Let em know they're hurting
+
+		return TRUE
+	return FALSE
 
 /obj/item/organ/internal/proc/get_possible_wounds(damage_type, sharp, edge)
 	var/list/possible_wounds = list()

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -177,10 +177,14 @@
 					break
 			if(BV)
 				BV.current_blood = max(BV.current_blood - blood_req, 0)
-			if(BV?.current_blood == 0)	//When all blood from the organ and blood vessel is lost,
+			if(!damage && BV?.current_blood == 0)	//When all blood from the organ and blood vessel is lost,
 				add_wound(/datum/component/internal_wound/organic/oxy/blood_loss)
 
 		return
+
+	// If the bleedout status is removed, remove blood loss wound
+	if(damage)
+		remove_wound(GetComponent(/datum/component/internal_wound/organic/oxy/blood_loss))
 
 	current_blood = min(current_blood + blood_req, max_blood_storage)
 

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -396,6 +396,8 @@
 	SEND_SIGNAL(src, COMSIG_APPVAL, src)
 	SEND_SIGNAL(src, COMSIG_IWOUND_FLAGS_ADD)
 
+	refresh_damage()
+
 	for(var/prefix in prefixes)
 		name = "[prefix] [name]"
 

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -92,12 +92,12 @@
 
 /obj/item/organ/internal/take_damage(amount, damage_type = BRUTE, wounding_multiplier = 1, sharp = FALSE, edge = FALSE, silent = FALSE)	//Deals damage to the organ itself
 	if(!damage_type || status & ORGAN_DEAD)
-		return FALSE
+		return
 
 	var/wound_count = max(0, round((amount * wounding_multiplier) / 8))	// At base values, every 8 points of damage is 1 wound
 
 	if(!wound_count)
-		return FALSE
+		return
 
 	var/list/possible_wounds = get_possible_wounds(damage_type, sharp, edge)
 
@@ -110,9 +110,6 @@
 				break
 
 		owner.custom_pain("Something inside your [parent.name] hurts a lot.", 0)		// Let em know they're hurting
-
-		return TRUE
-	return FALSE
 
 /obj/item/organ/internal/proc/get_possible_wounds(damage_type, sharp, edge)
 	var/list/possible_wounds = list()

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -72,6 +72,8 @@
 	owner = null //overrides removed() call
 	. = ..()
 
+/obj/item/organ/internal/carrion/core/take_damage(amount, damage_type = BRUTE, wounding_multiplier = 1, sharp = FALSE, edge = FALSE, silent = FALSE)
+	return
 
 /obj/item/organ/internal/carrion/core/proc/make_spider()
 	set category = "Carrion"

--- a/code/modules/organs/internal/internal_organ_processes.dm
+++ b/code/modules/organs/internal/internal_organ_processes.dm
@@ -60,7 +60,7 @@
 	var/toxin_strength = chem_effects[CE_TOXIN] * IORGAN_KIDNEY_TOX_RATIO + chem_toxicity
 
 	// Existing damage is subtracted to prevent weaker toxins from maxing out tox wounds on the organ
-	var/toxin_damage = (toxin_strength / (stats.getPerk(PERK_BLOOD_OF_LEAD) ? 2 : 1)) - (kidneys_efficiency / 100) - kidney.damage
+	var/toxin_damage = kidney ? (toxin_strength / (stats.getPerk(PERK_BLOOD_OF_LEAD) ? 2 : 1)) - (kidneys_efficiency / 100) - kidney.damage : 0
 
 	// Organ functions
 	// Blood regeneration if there is some space
@@ -81,9 +81,7 @@
 	var/toxin_strength = chem_effects[CE_TOXIN] * IORGAN_LIVER_TOX_RATIO + chem_effects[CE_ALCOHOL_TOXIC]
 
 	// Existing damage is subtracted to prevent weaker toxins from maxing out tox wounds on the organ
-	var/toxin_damage = (toxin_strength / (stats.getPerk(PERK_BLOOD_OF_LEAD) ? 2 : 1)) - (liver_efficiency / 100) - liver.damage
-
-	// Organ functions
+	var/toxin_damage = liver ? (toxin_strength / (stats.getPerk(PERK_BLOOD_OF_LEAD) ? 2 : 1)) - (liver_efficiency / 100) - liver.damage : 0
 
 	// Bad stuff
 	// If you're not filtering well, you're in trouble. Ammonia buildup to toxic levels and damage from alcohol
@@ -112,13 +110,14 @@
 /mob/living/carbon/human/proc/handle_pulse()
 	var/roboheartcheck = TRUE //Check if all hearts are robotic
 	for(var/obj/item/organ/internal/heart in organ_list_by_process(OP_HEART))
-		if(!(heart.nature == MODIFICATION_SILICON || heart.nature == MODIFICATION_LIFELIKE))
+		if(!BP_IS_ROBOTIC(heart))
 			roboheartcheck = FALSE
 			break
 
 	if(stat == DEAD || roboheartcheck)
 		pulse = PULSE_NONE	//that's it, you're dead (or your metal heart is), nothing can influence your pulse
 		return
+
 	if(life_tick % 5 == 0)//update pulse every 5 life ticks (~1 tick/sec, depending on server load)
 		pulse = PULSE_NORM
 
@@ -132,17 +131,15 @@
 
 /mob/living/carbon/human/proc/handle_heart_blood()
 	var/heart_efficiency = get_organ_efficiency(OP_HEART)
-	if(stat == DEAD || bodytemperature <= 170)	//Dead or cryosleep people do not pump the blood.
-		return
-
+	var/blood_oxygenation = 0.4 * chem_effects[CE_OXYGENATED] - 0.2 * chem_effects[CE_BLOODCLOT]
 	var/blood_volume_raw = vessel.get_reagent_amount("blood")
 	var/blood_volume = round((blood_volume_raw/species.blood_volume)*100) // Percentage.
 
 	// Damaged heart virtually reduces the blood volume, as the blood isn't being pumped properly anymore.
 	if(heart_efficiency <= 100)	//flat scaling up to 100
-		blood_volume *= heart_efficiency / 100
+		blood_volume *= (heart_efficiency / 100) + blood_oxygenation
 	else	//half scaling at over 100
-		blood_volume *= 1 + ((heart_efficiency - 100) / 200)
+		blood_volume *= 1 + ((heart_efficiency - 100) / 200) + blood_oxygenation
 
 	//Effects of bloodloss
 	var/blood_safe = total_blood_req + BLOOD_VOLUME_SAFE_MODIFIER

--- a/code/modules/organs/internal/internal_organ_processes.dm
+++ b/code/modules/organs/internal/internal_organ_processes.dm
@@ -160,12 +160,12 @@
 			to_chat(src, SPAN_WARNING("You feel extremely [pick("dizzy","woosey","faint")]"))
 	else if(blood_volume < blood_bad)
 		eye_blurry = max(eye_blurry,6)
-		adjustOxyLoss(6)
+		adjustOxyLoss(2)
 		if(prob(15))
 			to_chat(src, SPAN_WARNING("You feel very [pick("dizzy","woosey","faint")]"))
 	else if(blood_volume < blood_okay)
 		eye_blurry = max(eye_blurry,6)
-		adjustOxyLoss(4)
+		adjustOxyLoss(1.5)
 		if(prob(15))
 			Weaken(rand(1,3))
 			to_chat(src, SPAN_WARNING("You feel very [pick("dizzy","woosey","faint")]"))
@@ -173,7 +173,7 @@
 		if(prob(1))
 			to_chat(src, SPAN_WARNING("You feel [pick("dizzy","woosey","faint")]"))
 		if(getOxyLoss() < 10)
-			adjustOxyLoss(2)
+			adjustOxyLoss(1)
 
 	// Blood loss or heart damage make you lose nutriments
 	if(blood_volume < blood_safe || heart_efficiency < BRUISED_2_EFFICIENCY)
@@ -211,7 +211,7 @@
 			to_chat(src, SPAN_WARNING("Your [heavy_spot] feels too heavy for your body"))
 
 	if(lung_efficiency < BROKEN_2_EFFICIENCY)
-		adjustOxyLoss(2)
+		adjustOxyLoss(1)
 
 /mob/living/carbon/human/proc/stomach_process()
 	var/stomach_efficiency = get_organ_efficiency(OP_STOMACH)

--- a/code/modules/organs/internal/internal_wounds/_internal_wound.dm
+++ b/code/modules/organs/internal/internal_wounds/_internal_wound.dm
@@ -149,6 +149,8 @@
 
 /datum/component/internal_wound/proc/apply_tool(obj/item/I, mob/user)
 	var/success = FALSE
+	var/obj/item/organ/internal/organ = parent
+	var/obj/item/organ/limb = organ.parent
 
 	if(istype(I, /obj/item/reagent_containers/syringe))
 		var/obj/item/reagent_containers/syringe/S = I
@@ -161,14 +163,25 @@
 			to_chat(user, SPAN_WARNING("You cannot draw blood like this."))
 
 	if(!I.tool_qualities || !LAZYLEN(I.tool_qualities))
-		var/charges_needed = LAZYACCESS(treatments_item, I.type)
-		var/can_treat = TRUE
+		var/charges_needed
+		for(var/path in treatments_item)
+			if(istype(I, path))
+				charges_needed = treatments_item[path]
+		var/is_treated = FALSE
+		var/free_use = FALSE
+		var/user_stat_level = user.stats.getStat(diagnosis_stat)
 		if(charges_needed)
 			if(istype(I, /obj/item/stack))
 				var/obj/item/stack/S = I
-				if(!S.use(charges_needed))
-					can_treat = FALSE
-			if(can_treat && do_after(user, WORKTIME_NORMAL - user.stats.getStat(diagnosis_stat), parent))
+				if(do_after(user, WORKTIME_NORMAL - user_stat_level, parent))
+					if(prob(10 + user_stat_level))
+						free_use = TRUE
+						is_treated = TRUE
+					else
+						is_treated = S.use(charges_needed)
+			if(is_treated)
+				if(free_use)
+					to_chat(user, SPAN_NOTICE("You have managed to waste less [I.name]."))
 				success = TRUE
 	else
 		for(var/tool_quality in treatments_tool)
@@ -182,6 +195,8 @@
 	if(user)
 		if(success)
 			to_chat(user, SPAN_NOTICE("You treat the [name] with \the [I]."))
+			if(limb)
+				SSnano.update_user_uis(user, limb)
 		else
 			to_chat(user, SPAN_WARNING("You cannot treat the [name] with \the [I]."))
 

--- a/code/modules/organs/internal/internal_wounds/organic.dm
+++ b/code/modules/organs/internal/internal_wounds/organic.dm
@@ -218,7 +218,7 @@
 	treatments_chem = list(CE_OXYGENATED = 2, CE_BLOODRESTORE = 1)	// Dex+ treats, but it will come back if you don't get blood
 	severity = 0
 	severity_max = IORGAN_MAX_HEALTH
-	progression_threshold = 9	// Kills the organ in approx. 3 minutes
+	progression_threshold = IWOUND_1_MINUTE	// Kills small organs in 7 minutes, normal in 14
 
 /datum/component/internal_wound/organic/oxy/blood_loss
 	name = "blood loss"

--- a/code/modules/organs/internal/internal_wounds/organic.dm
+++ b/code/modules/organs/internal/internal_wounds/organic.dm
@@ -191,7 +191,6 @@
 
 /datum/component/internal_wound/organic/radiation/malignant
 	name = "malignant tumor"
-	treatments_tool = list()
 	treatments_chem = list(CE_ONCOCIDAL = 2)
 	characteristic_flag = IWOUND_CAN_DAMAGE|IWOUND_PROGRESS|IWOUND_SPREAD
 	severity = 0

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -210,9 +210,6 @@
 		if(owner && parent && amount > 0 && !silent)
 			owner.custom_pain("Something inside your [parent.name] hurts a lot.", 1)
 
-/obj/item/organ/proc/bruise()
-	damage = max(damage, min_bruised_damage)
-
 /obj/item/organ/emp_act(severity)
 	if(!BP_IS_ROBOTIC(src))
 		return

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -197,7 +197,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_DAMAGE_RADIATION = 100
+		GUN_UPGRADE_DAMAGE_RADIATION = 25
 	)
 	I.req_gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_35)
 	I.gun_loc_tag = GUN_MECHANISM

--- a/code/modules/projectiles/guns/mods/research_mods.dm
+++ b/code/modules/projectiles/guns/mods/research_mods.dm
@@ -111,7 +111,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-	GUN_UPGRADE_DAMAGE_RADIATION = 15)
+	GUN_UPGRADE_DAMAGE_RADIATION = 7.5)
 	I.req_gun_tags = list(GUN_PROJECTILE)
 	I.gun_loc_tag = GUN_BARREL
 

--- a/code/modules/projectiles/guns/mods/research_mods.dm
+++ b/code/modules/projectiles/guns/mods/research_mods.dm
@@ -111,7 +111,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-	GUN_UPGRADE_DAMAGE_RADIATION = 30)
+	GUN_UPGRADE_DAMAGE_RADIATION = 15)
 	I.req_gun_tags = list(GUN_PROJECTILE)
 	I.gun_loc_tag = GUN_BARREL
 

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -64,7 +64,7 @@
 	name = "demolecularisor"
 	icon_state = "declone"
 	nodamage = 1
-	damage_types = list(CLONE = 5)
+	damage_types = list(CLONE = 12)
 	irradiate = 10
 
 

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -65,7 +65,7 @@
 	icon_state = "declone"
 	nodamage = 1
 	damage_types = list(CLONE = 5)
-	irradiate = 100
+	irradiate = 10
 
 
 /obj/item/projectile/energy/dart

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -137,8 +137,10 @@
 
 /datum/reagent/medicine/dexalin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.adjustOxyLoss(-1.5 * effect_multiplier)
-	M.add_chemical_effect(CE_OXYGENATED, 1)
 	holder.remove_reagent("lexorin", 0.2 * effect_multiplier)
+	var/ce_to_add = 1 - M.chem_effects[CE_OXYGENATED]
+	if(ce_to_add > 0)
+		M.add_chemical_effect(CE_OXYGENATED, ce_to_add)
 
 /datum/reagent/medicine/dexalinp
 	name = "Dexalin Plus"
@@ -152,8 +154,10 @@
 
 /datum/reagent/medicine/dexalinp/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.adjustOxyLoss(-30 * effect_multiplier)
-	M.add_chemical_effect(CE_OXYGENATED, 2)
 	holder.remove_reagent("lexorin", 0.3 * effect_multiplier)
+	var/ce_to_add = 2 - M.chem_effects[CE_OXYGENATED]
+	if(ce_to_add > 0)
+		M.add_chemical_effect(CE_OXYGENATED, ce_to_add)
 
 /datum/reagent/medicine/tricordrazine
 	name = "Tricordrazine"

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -21,7 +21,7 @@
 		if(sanityloss && ishuman(M))
 			var/mob/living/carbon/human/H = M
 			H.sanity.onToxin(src, multi)
-		M.add_chemical_effect(CE_TOXIN, multi * strength)
+		M.add_chemical_effect(CE_TOXIN, strength)
 
 /datum/reagent/toxin/overdose(mob/living/carbon/M, alien)
 	if(strength)

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -588,7 +588,7 @@
 	overdose = REAGENTS_OVERDOSE/3
 	addiction_chance = 0
 	nerve_system_accumulations = 10
-	strength = 8
+	strength = 2
 	sanityloss = 1
 	heating_point = 523
 	heating_products = list("toxin")

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -272,6 +272,7 @@
 	taste_description = "acid"
 	reagent_state = LIQUID
 	color = "#C8A5DC"
+	metabolism = REM * 2.5
 	overdose = REAGENTS_OVERDOSE
 
 /datum/reagent/toxin/lexorin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
@@ -614,14 +615,18 @@
 	addiction_chance = 0
 	nerve_system_accumulations = 5
 
+/datum/reagent/toxin/aranecolmin/on_mob_add(mob/living/L)
+	. = ..()
+	if(iscarbon(L))
+		var/mob/living/carbon/C = L
+		if(LAZYLEN(C.internal_organs) && C.bloodstr && C.bloodstr.has_reagent("pararein"))
+			var/obj/item/organ/internal/I = pick(C.internal_organs)
+			to_chat(C, "Something burns inside your [I.parent.name]...")
+			create_overdose_wound(I, C, /datum/component/internal_wound/organic/heavy_poisoning, "rot", TRUE)
+
 /datum/reagent/toxin/aranecolmin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	..()
 	M.add_chemical_effect(CE_PAINKILLER, 15)
-	if(M.bloodstr && M.bloodstr.has_reagent("pararein"))
-		if(prob(5))
-			to_chat(M, SPAN_WARNING("The blood in your veins burns beneath your flesh!"))
-			if(LAZYLEN(M.internal_organs))	// Check needed because spiders can inject this into roaches
-				create_overdose_wound(pick(M.internal_organs), M, /datum/component/internal_wound/organic/heavy_poisoning, "rot", TRUE)
 
 /datum/reagent/toxin/diplopterum
 	name = "Diplopterum"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### Adjustments
- Burn damage will always transfer at least 25% damage to internal organs.
- Damage to limbs will only be deducted when the transferred damage creates/progresses a wound.
- Oxy damage doesn't contribute to pain. Organ wounds cause pain as a side effect and organ damage to certain organs can causes oxy damage. It doesn't make sense to make organ wounds apply pain from two sources.
- Unbreakable type bones don't break. Slime people are the only ones that use these bones and this change is needed to allow them to die.
- Blood loss organ wounds progression time increased to 1 minute per level instead of 18 seconds.
- Oxy damage from damaged organs reduced by 50% to 75% depending on the case.
- Oxygenation effect from Dexalin and Dexalin Plus don't stack with other effects.
- Glass Widow radiation damage reduced to 25 from 100.
- Atomik radiation damage reduced to 7.5 from 30.
- Demolecularisor laser (used by Prototype: biological demolecularisor) radiation damage reduced to 10 from 100.
- Demolecularisor laser clone damage increased to 12 from 5.
- Gestrahlte melee radiation damage reduced to 10 from 40.
- Gestrahlte bile projectile radiation damage reduced to 5 from 15.
- Malignant tumors can be removed with a cutting tool.
- Lexorin duration significantly reduced. 0.5u is consumed per tick instead of 0.01u.
- Stasis prevents suffocation/oxy damage.
- Toxins don't use the effect multiplier for their base toxin effect.
- Aranecolmin only applies rot wound once.
- Pararein strength reduced to 2 from 8.
- Created blood oxygenation modifier for heart processes. Previously, the chemical effect of Dexalin and Dexalin Plus were unused. This allows them to be used to aid in preventing the negative effects of blood loss. The new blood volume calculation in heart processing is:
  - `(current blood / species blood max) * ((heart efficiency / 100) + 0.4 * oxygenation effect - 0.2 * blood clotting effect)`

### Fixes
- Carrion core won't take damage while inside a human.
- Blood loss wounds won't stack and restoring blood levels will treat them.
- Brains don't suffer blood loss. Oxy loss already handles that behavior. Also, this may handle the issue where resuscitator wouldn't revive a body that should otherwise be revivable.
- Removed legacy lung rupture wound.
- Humans should no longer have a pulse when dead.
- Fixed runtime related to liver and kidney processes.
- Organ wound treatment does the progress bar and stat check before consuming charges. UI will update on a successful treatment.
- Fixed an issue where still live organs wouldn't heal after a wound was treated.
- Fixed an issue where succumb wouldn't let you die if you were too close to death.

## Why It's Good For The Game

Bug fixes and balancing

## Testing

Live test

## Changelog
:cl:
tweak: Burn damage will always transfer at least 25% damage to internal organs
tweak: Damage to limbs will only be deducted when the transferred damage creates/progresses a wound
tweak: Oxy loss doesn't contribute to pain
tweak: Unbreakable type bones don't break
tweak: Blood loss organ wounds progression time increased to 1 minute per level instead of 18 seconds
tweak: Oxy damage from damaged organs reduced by 50% to 75% depending on the case
tweak: Oxygenation effect from Dexalin and Dexalin Plus don't stack with other effects
tweak: Stasis prevents suffocation/oxy damage
tweak: Aranecolmin only applies rot wound once
tweak: Created blood oxygenation modifier for heart processes
tweak: Malignant tumors can be removed with a cutting tool
tweak: Toxins don't use effect multiplier for base toxin effect
balance: Glass Widow rad damage reduced to 25 from 100
balance: Atomik radiation damage reduced to 7.5 from 30
balance: Demolecularisor laser (used by Prototype: biological demolecularisor) radiation damage reduced to 10 from 100
balance: Gestrahlte melee radiation build-up reduced to 10 from 40
balance: Gestrahlte bile projectile radiation damage reduced to 5 from 15
balance: Lexorin duration significantly reduced, 0.5u is consumed per tick instead of 0.01u
balance: Pararein strength reduced to 2 from 8
fix: Carrion core won't take damage while inside a human
fix: Blood loss wounds won't stack and restoring blood levels will treat them
fix: Brains don't suffer blood loss
fix: Humans should no longer have a pulse when dead
fix: Fixed runtime related to liver and kidney processes
fix: Organ wound treatment does the progress bar and stat check before consuming charges, UI will update on a successful treatment
fix: Fixed an issue where still live organs wouldn't heal after a wound was treated
fix: Fixed an issue where succumb wouldn't let you die if you were too close to death
del: Removed legacy lung rupture wound
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
