### PR TITLE
Appearance changer cleanup

### DIFF
--- a/code/modules/nano/modules/human_appearance.dm
+++ b/code/modules/nano/modules/human_appearance.dm
@@ -20,6 +20,9 @@
 	src.whitelist = species_whitelist
 	src.blacklist = species_blacklist
 
+/datum/nano_module/appearance_changer/Destroy()
+	owner = null
+	..()
 
 /datum/nano_module/appearance_changer/Topic(ref, href_list, var/datum/nano_topic_state/state = GLOB.default_state)
 	if(..())

--- a/code/modules/nano/modules/human_appearance.dm
+++ b/code/modules/nano/modules/human_appearance.dm
@@ -22,6 +22,7 @@
 
 /datum/nano_module/appearance_changer/Destroy()
 	owner = null
+	topic_manager = null	// The mob is the topic manager and should not be deleted
 	..()
 
 /datum/nano_module/appearance_changer/Topic(ref, href_list, var/datum/nano_topic_state/state = GLOB.default_state)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Deleting a mirror caused any mob that used it to get deleted. Adds cleanup to prevent that.

## Why It's Good For The Game

Bug fix

## Testing

Used a mirror to change appearance and deleted the mirror.

## Changelog
:cl:
add: Added Destroy() cleanup to /datum/nano_module/appearance_changer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
