### PR TITLE
Roundstart NT disks can be ordered

### DIFF
--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -129,18 +129,21 @@
 	cost = 50
 	min_cost = 50
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter
+	var/purchase_count = 1
 
 /datum/armament/item/disk/clothes
 	name = "Bio-Fabric disk"
 	cost = 50
 	min_cost = 50
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter_clothes
+	var/purchase_count = 1
 
 /datum/armament/item/disk/hastatii
 	name = "Hastatii disk"
 	cost = 50
 	min_cost = 50
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt_melee
+	var/purchase_count = 1
 
 /datum/armament/item/disk/cells
 	name = "Power Cells disk"

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -123,19 +123,20 @@
 			desc = text
 
 
-/datum/armament/item/disk/cells
+//Roundstart disks start at minimal cost, implies they were ordered before
+/datum/armament/item/disk/utilities
 	name = "Utilities disk"
 	cost = 50
 	min_cost = 50
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter
 
-/datum/armament/item/disk/cells
+/datum/armament/item/disk/clothes
 	name = "Bio-Fabric disk"
 	cost = 50
 	min_cost = 50
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter_clothes
 
-/datum/armament/item/disk/cells
+/datum/armament/item/disk/hastatii
 	name = "Hastatii disk"
 	cost = 50
 	min_cost = 50

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -129,18 +129,22 @@
 	cost = 50
 	min_cost = 50
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter
+	purchase_count = 1
+
 
 /datum/armament/item/disk/clothes
 	name = "Bio-Fabric disk"
 	cost = 50
 	min_cost = 50
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter_clothes
+	purchase_count = 1
 
 /datum/armament/item/disk/hastatii
 	name = "Hastatii disk"
 	cost = 50
 	min_cost = 50
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt_melee
+	purchase_count = 1
 
 /datum/armament/item/disk/cells
 	name = "Power Cells disk"

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -129,21 +129,18 @@
 	cost = 50
 	min_cost = 50
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter
-	var/purchase_count = 1
 
 /datum/armament/item/disk/clothes
 	name = "Bio-Fabric disk"
 	cost = 50
 	min_cost = 50
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter_clothes
-	var/purchase_count = 1
 
 /datum/armament/item/disk/hastatii
 	name = "Hastatii disk"
 	cost = 50
 	min_cost = 50
 	path = /obj/item/computer_hardware/hard_drive/portable/design/nt_melee
-	var/purchase_count = 1
 
 /datum/armament/item/disk/cells
 	name = "Power Cells disk"

--- a/code/modules/core_implant/cruciform/machinery/armaments.dm
+++ b/code/modules/core_implant/cruciform/machinery/armaments.dm
@@ -124,6 +124,24 @@
 
 
 /datum/armament/item/disk/cells
+	name = "Utilities disk"
+	cost = 50
+	min_cost = 50
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter
+
+/datum/armament/item/disk/cells
+	name = "Bio-Fabric disk"
+	cost = 50
+	min_cost = 50
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter_clothes
+
+/datum/armament/item/disk/cells
+	name = "Hastatii disk"
+	cost = 50
+	min_cost = 50
+	path = /obj/item/computer_hardware/hard_drive/portable/design/nt_melee
+
+/datum/armament/item/disk/cells
 	name = "Power Cells disk"
 	cost = 75
 	min_cost = 50


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Roundstart NT disks can be ordered from armaments in case you lose them. Prior to that there were no way to obtain the replacement disks if they gone.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes sense. Consistency. Less irreplaceable things.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Ordered each disk
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: Roundstart NT disks can be ordered from EOTP
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
