### PR TITLE
Health scanner and HUD tweaks

### DIFF
--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -104,7 +104,7 @@
 		dat += "<h2>Analyzing Results for [M]:</h2>"
 		dat += span("highlight", "Overall Status: dead")
 	else
-		dat += span("highlight", "Analyzing Results for [M]:\n\t Overall Status: [M.stat > 1 ? "dead" : "[round(M.health/M.maxHealth*100)]% healthy"]")
+		dat += span("highlight", "Analyzing Results for [M]:\n\t Overall Status: [M.stat > 1 ? "dead" : "alive"]")
 	dat += span("highlight", "    Key: <font color='#0080ff'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='red'>Brute</font>/<font color='#FFA500'>Burns</font>")
 	dat += span("highlight", "    Damage Specifics: <font color='#0080ff'>[OX]</font> - <font color='green'>[TX]</font> - <font color='red'>[BR]</font> - <font color='#FFA500'>[BU]</font>")
 	dat += span("highlight", "Body Temperature: [M.bodytemperature-T0C]&deg;C ([M.bodytemperature*1.8-459.67]&deg;F)")

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -95,7 +95,7 @@
 	var/fake_oxy = max(rand(1, 40), M.getOxyLoss(), (300 - (M.getFireLoss() + M.getBruteLoss())))
 	var/tox_content = M.chem_effects[CE_TOXIN] + M.chem_effects[CE_ALCOHOL_TOXIC]
 	var/OX = M.getOxyLoss() > 50 	? 	"<b>[M.getOxyLoss()]</b>" 		: M.getOxyLoss()
-	var/TX = tox_content > 8		?	"<b>[tox_content]</b>"			: (tox_content ? tox_content : "0")
+	var/TX = tox_content			?	"<b>[tox_content]</b>"			: (tox_content ? tox_content : "0")
 	var/BR = M.getBruteLoss() > 50 	? 	"<b>[M.getBruteLoss()]</b>" 	: M.getBruteLoss()
 	var/BU = M.getFireLoss() > 50 	? 	"<b>[M.getFireLoss()]</b>" 		: M.getFireLoss()
 

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -121,9 +121,9 @@
 				var/internal_wound_severity = org.severity_internal_wounds
 
 				if(internal_wound_severity > 0)
-					if(internal_wound_severity < 6)
+					if(internal_wound_severity < 4)
 						internal_wound_severity = "Light"
-					else if(internal_wound_severity < 10)
+					else if(internal_wound_severity < 7)
 						internal_wound_severity = "Moderate"
 					else
 						internal_wound_severity = "Severe"

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -116,8 +116,8 @@
 		dat += span("highlight", "Localized Damage:")
 		if(length(damaged) > 0)
 			for(var/obj/item/organ/external/org in damaged)
-				var/brute_health = org.max_health - org.brute_dam
-				var/burn_health = org.max_health - org.burn_dam
+				var/brute_health = org.max_damage - org.brute_dam
+				var/burn_health = org.max_damage - org.burn_dam
 				var/internal_wound_severity = org.severity_internal_wounds
 
 				if(internal_wound_severity > 0)
@@ -133,8 +133,8 @@
 				dat += text("<span class='highlight'>     [][]:  [] - [] - [] [] []</span>",
 				capitalize(org.name),
 				(BP_IS_ROBOTIC(org)) ? "(Cybernetic)" : "",
-				"<font color='red'>[brute_health ? brute_health : "0"] / [org.max_health]</font>",
-				"<font color='#FFA500'>[burn_health ? burn_health : "0"] / [org.max_health]</font>",
+				"<font color='red'>[brute_health ? brute_health : "0"] / [org.max_damage]</font>",
+				"<font color='#FFA500'>[burn_health ? burn_health : "0"] / [org.max_damage]</font>",
 				(org.status & ORGAN_BLEEDING) ? "<font color='red'>\[Bleeding\]</font>" : "",
 				(org.status & ORGAN_BROKEN && !(org.status & ORGAN_SPLINTED)) ? "<font color='red'>\[Broken\]</font>" : "",
 				internal_wound_severity ? "<font color='red'>\[[internal_wound_severity] Organ Wounds\]</font>" : "")

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -96,41 +96,58 @@
 	var/tox_content = M.chem_effects[CE_TOXIN] + M.chem_effects[CE_ALCOHOL_TOXIC]
 	var/OX = M.getOxyLoss() > 50 	? 	"<b>[M.getOxyLoss()]</b>" 		: M.getOxyLoss()
 	var/TX = tox_content > 8		?	"<b>[tox_content]</b>"			: (tox_content ? tox_content : "0")
-	var/BU = M.getFireLoss() > 50 	? 	"<b>[M.getFireLoss()]</b>" 		: M.getFireLoss()
 	var/BR = M.getBruteLoss() > 50 	? 	"<b>[M.getBruteLoss()]</b>" 	: M.getBruteLoss()
+	var/BU = M.getFireLoss() > 50 	? 	"<b>[M.getFireLoss()]</b>" 		: M.getFireLoss()
+
 	if(M.status_flags & FAKEDEATH)
 		OX = fake_oxy > 50 			? 	"<b>[fake_oxy]</b>" 			: fake_oxy
 		dat += "<h2>Analyzing Results for [M]:</h2>"
 		dat += span("highlight", "Overall Status: dead")
 	else
 		dat += span("highlight", "Analyzing Results for [M]:\n\t Overall Status: [M.stat > 1 ? "dead" : "[round(M.health/M.maxHealth*100)]% healthy"]")
-	dat += span("highlight", "    Key: <font color='#0080ff'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font>")
-	dat += span("highlight", "    Damage Specifics: <font color='#0080ff'>[OX]</font> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font>")
+	dat += span("highlight", "    Key: <font color='#0080ff'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='red'>Brute</font>/<font color='#FFA500'>Burns</font>")
+	dat += span("highlight", "    Damage Specifics: <font color='#0080ff'>[OX]</font> - <font color='green'>[TX]</font> - <font color='red'>[BR]</font> - <font color='#FFA500'>[BU]</font>")
 	dat += span("highlight", "Body Temperature: [M.bodytemperature-T0C]&deg;C ([M.bodytemperature*1.8-459.67]&deg;F)")
 	if(M.timeofdeath && (M.stat == DEAD || (M.status_flags & FAKEDEATH)))
 		dat += span("highlight", "Time of Death: [worldtime2stationtime(M.timeofdeath)]")
 	if(ishuman(M) && mode == 1)
 		var/mob/living/carbon/human/H = M
 		var/list/damaged = H.get_damaged_organs(1, 1)
-		dat += span("highlight", "Localized Damage, Brute/Burn:")
+		dat += "<hr>"
+		dat += span("highlight", "Localized Damage:")
 		if(length(damaged) > 0)
 			for(var/obj/item/organ/external/org in damaged)
-				dat += text("<span class='highlight'>     [][]: [][] - []</span>",
+				var/brute_health = org.max_health - org.brute_dam
+				var/burn_health = org.max_health - org.burn_dam
+				var/internal_wound_severity = org.severity_internal_wounds
+
+				if(internal_wound_severity > 0)
+					if(internal_wound_severity < 5)
+						internal_wound_severity = "Light"
+					else if(internal_wound_severity < 8)
+						internal_wound_severity = "Moderate"
+					else
+						internal_wound_severity = "Severe"
+				else
+					internal_wound_severity = null
+
+				dat += text("<span class='highlight'>     [][]:  [] - [] - [] [] []</span>",
 				capitalize(org.name),
 				(BP_IS_ROBOTIC(org)) ? "(Cybernetic)" : "",
-				(org.brute_dam > 0) ? SPAN_WARNING("[org.brute_dam]") : 0,
-				(org.status & ORGAN_BLEEDING)?SPAN_DANGER(" \[Bleeding\]"):"",
-				(org.burn_dam > 0) ? "<font color='#FFA500'>[org.burn_dam]</font>" : 0)
+				"<font color='red'>[brute_health ? brute_health : "0"] / [org.max_health]</font>",
+				"<font color='#FFA500'>[burn_health ? burn_health : "0"] / [org.max_health]</font>",
+				(org.status & ORGAN_BLEEDING) ? "<font color='red'>\[Bleeding\]</font>" : "",
+				(org.status & ORGAN_BROKEN && !(org.status & ORGAN_SPLINTED)) ? "<font color='red'>\[Broken\]</font>" : "",
+				internal_wound_severity ? "<font color='red'>\[[internal_wound_severity] Organ Wounds\]</font>" : "")
 		else
-			dat += span("highlight", "    Limbs are OK.")
+			dat += span("highlight", "Limbs are OK.")
+		dat += "<hr>"
 
 	OX = M.getOxyLoss() > 50 ? 	 "<font color='#0080ff'><b>Severe oxygen deprivation detected</b></font>" 		: 	"Subject bloodstream oxygen level normal"
-	TX = tox_content > 8 ? 	 "<font color='green'><b>Dangerous amount of toxins detected</b></font>" 	: 	"Subject bloodstream toxin level minimal"
-	BU = M.getFireLoss() > 50 ?  "<font color='#FFA500'><b>Severe burn damage detected</b></font>" 			:	"Subject burn injury status O.K"
-	BR = M.getBruteLoss() > 50 ? "<font color='red'><b>Severe anatomical damage detected</b></font>" 		: 	"Subject brute-force injury status O.K"
+	TX = tox_content > 12 ? 	 "<font color='green'><b>Dangerous amount of toxins detected</b></font>" 	: 	"Subject bloodstream toxin level minimal"
 	if(M.status_flags & FAKEDEATH)
 		OX = fake_oxy > 50 ? SPAN_WARNING("Severe oxygen deprivation detected") : "Subject bloodstream oxygen level normal"
-	dat += "[OX] | [TX] | [BU] | [BR]"
+	dat += "[OX] | [TX]"
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
 		if(C.reagents.total_volume)
@@ -174,45 +191,15 @@
 		dat += SPAN_WARNING("Significant brain damage detected. Subject may have had a concussion.")
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		var/foundUnlocatedFracture = FALSE
-		for(var/name in H.organs_by_name)
-			var/obj/item/organ/external/E = H.organs_by_name[name]
-			if(!E)
-				continue
-			if(E.status & ORGAN_BROKEN)
-				if(!(E.status & ORGAN_SPLINTED))
-					if(E.organ_tag in list(BP_R_ARM, BP_L_ARM, BP_R_LEG, BP_L_LEG, BP_GROIN, BP_HEAD, BP_CHEST))
-						dat += SPAN_WARNING("Unsecured fracture in subject [E.get_bone()]. Splinting recommended for transport.")
-					else
-						foundUnlocatedFracture = TRUE
-
-		if(foundUnlocatedFracture)
-			dat += SPAN_WARNING("Bone fractures detected. Advanced scanner required for location.")
-
-		for(var/obj/item/organ/external/e in H.organs)
-			if(!e)
-				continue
-			for(var/datum/wound/W in e.wounds) if(W.internal)
-				dat += text(SPAN_WARNING("Internal bleeding detected. Advanced scanner required for location."))
-				break
-			var/internal_wound_severity = e.severity_internal_wounds
-			if(!internal_wound_severity)
-				continue
-			if(internal_wound_severity < 5)
-				dat += text(SPAN_WARNING("Light internal damage detected in \the [e]. Advanced scanner required for location. Treatment recommended."))
-			else if(internal_wound_severity < 9)
-				dat += text(SPAN_WARNING("Moderate internal damage detected \the [e]. Advanced scanner required for location. Treatment recommended."))
-			else
-				dat += text(SPAN_WARNING("Severe internal damage detected \the [e]. Advanced scanner required for location. Immediate treatment recommended."))
 
 		if(H.vessel)
 			var/blood_volume = H.vessel.get_reagent_amount("blood")
 			var/blood_percent =  round((blood_volume / H.species.blood_volume)*100)
 			var/blood_type = H.b_type
 			if((blood_percent <= H.total_blood_req + BLOOD_VOLUME_SAFE_MODIFIER) && (blood_percent > H.total_blood_req + BLOOD_VOLUME_BAD_MODIFIER))
-				dat += SPAN_DANGER("Warning: Blood Level LOW: [blood_percent]% [blood_volume]cl.</span> <span class='highlight'>Type: [blood_type]")
+				dat += "<font color='red'>Warning: Blood Level LOW: [blood_percent]% [blood_volume]cl.</font> <span class='highlight'>Type: [blood_type]</span>"
 			else if(blood_percent <= H.total_blood_req + BLOOD_VOLUME_BAD_MODIFIER)
-				dat += SPAN_DANGER("<i>Warning: Blood Level CRITICAL: [blood_percent]% [blood_volume]cl.</i></span> <span class='highlight'>Type: [blood_type]")
+				dat += "<font color='red'><i>Warning: Blood Level CRITICAL: [blood_percent]% [blood_volume]cl.</i></font> <span class='highlight'>Type: [blood_type]</span>"
 			else
 				dat += span("highlight", "Blood Level Normal: [blood_percent]% [blood_volume]cl. Type: [blood_type]")
 		dat += "<span class='highlight'>Subject's pulse: <font color='[H.pulse() == PULSE_THREADY || H.pulse() == PULSE_NONE ? "red" : "#0080ff"]'>[H.get_pulse(GETPULSE_TOOL)] bpm.</font></span>"

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -113,7 +113,6 @@
 	if(ishuman(M) && mode == 1)
 		var/mob/living/carbon/human/H = M
 		var/list/damaged = H.get_damaged_organs(1, 1)
-		dat += "<hr>"
 		dat += span("highlight", "Localized Damage:")
 		if(length(damaged) > 0)
 			for(var/obj/item/organ/external/org in damaged)
@@ -122,9 +121,9 @@
 				var/internal_wound_severity = org.severity_internal_wounds
 
 				if(internal_wound_severity > 0)
-					if(internal_wound_severity < 5)
+					if(internal_wound_severity < 6)
 						internal_wound_severity = "Light"
-					else if(internal_wound_severity < 8)
+					else if(internal_wound_severity < 10)
 						internal_wound_severity = "Moderate"
 					else
 						internal_wound_severity = "Severe"
@@ -141,8 +140,6 @@
 				internal_wound_severity ? "<font color='red'>\[[internal_wound_severity] Organ Wounds\]</font>" : "")
 		else
 			dat += span("highlight", "Limbs are OK.")
-		dat += "<hr>"
-
 	OX = M.getOxyLoss() > 50 ? 	 "<font color='#0080ff'><b>Severe oxygen deprivation detected</b></font>" 		: 	"Subject bloodstream oxygen level normal"
 	TX = tox_content > 12 ? 	 "<font color='green'><b>Dangerous amount of toxins detected</b></font>" 	: 	"Subject bloodstream toxin level minimal"
 	if(M.status_flags & FAKEDEATH)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -982,7 +982,7 @@
 		var/image/holder = hud_list[HEALTH_HUD]
 		if(stat == DEAD)
 			holder.icon_state = "hudhealth-100" 	// X_X
-		else	
+		else
 			var/organ_health
 			var/organ_damage
 			var/limb_health
@@ -991,7 +991,7 @@
 			for(var/obj/item/organ/external/E in organs)
 				organ_health += E.total_internal_health
 				organ_damage += E.severity_internal_wounds
-				limb_health += E.max_health
+				limb_health += E.max_damage
 				limb_damage += max(E.brute_dam, E.burn_dam)
 
 			var/crit_health = (health / maxHealth) * 100

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -982,8 +982,24 @@
 		var/image/holder = hud_list[HEALTH_HUD]
 		if(stat == DEAD)
 			holder.icon_state = "hudhealth-100" 	// X_X
-		else
-			var/percentage_health = RoundHealth((health-HEALTH_THRESHOLD_CRIT)/(maxHealth-HEALTH_THRESHOLD_CRIT)*100)
+		else	
+			var/organ_health
+			var/organ_damage
+			var/limb_health
+			var/limb_damage
+
+			for(var/obj/item/organ/external/E in organs)
+				organ_health += E.total_internal_health
+				organ_damage += E.severity_internal_wounds
+				limb_health += E.max_health
+				limb_damage += max(E.brute_dam, E.burn_dam)
+
+			var/crit_health = (health / maxHealth) * 100
+			var/external_health = (1 - (limb_health ? limb_damage / limb_health : 0)) * 100
+			var/internal_health = (1 - (organ_health ? organ_damage / organ_health : 0)) * 100
+
+			var/percentage_health = RoundHealth(min(crit_health, external_health, internal_health))	// Old: RoundHealth((health-HEALTH_THRESHOLD_CRIT)/(maxHealth-HEALTH_THRESHOLD_CRIT)*100)
+
 			holder.icon_state = "hud[percentage_health]"
 		hud_list[HEALTH_HUD] = holder
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is a band-aid fix until the med equipment gets TGUI.
- Health scanner shows limb health and statuses in one location.
- Health HUD shows the lowest between critical health, limb health, and organ health.

## Why It's Good For The Game

More info gets to the player

## Testing

![image](https://user-images.githubusercontent.com/95178278/225748152-c0f7c540-cb1e-4e1f-a776-5d71aae84c39.png)

## Changelog
:cl:
tweak: Health scanner shows limb health and statuses in one location
tweak: Health HUD shows the lowest between critical health, limb health, and organ health
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
