### PR TITLE
Toxin damage fix

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/roach/blattedin.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/blattedin.dm
@@ -5,7 +5,7 @@
 	taste_description = "chicken"
 	reagent_state = LIQUID
 	color = "#0F4800"
-	strength = 12
+	strength = 6
 	var/heal_strength = 5
 	metabolism = REM * 0.1
 

--- a/code/modules/organs/internal/internal_organ_processes.dm
+++ b/code/modules/organs/internal/internal_organ_processes.dm
@@ -68,7 +68,7 @@
 
 	// Bad stuff
 	if(kidneys_efficiency < BROKEN_2_EFFICIENCY)
-		if(toxin_strength > 0)
+		if(toxin_strength > 0 && prob(10))
 			apply_damage(toxin_strength, TOX)	// If your kidneys aren't working, your body will start to take damage
 
 	if(toxin_damage > 0 && kidney)
@@ -88,7 +88,7 @@
 	if(liver_efficiency < BROKEN_2_EFFICIENCY)
 		if(alcohol_strength)
 			toxin_damage += 0.5 * max(2 - (liver_efficiency * 0.01), 0) * alcohol_strength
-		if(toxin_strength > 0)
+		if(toxin_strength > 0 && prob(10))
 			apply_damage(toxin_strength, TOX)	// If your liver isn't working, your body will start to take damage
 
 	if(toxin_damage > 0 && liver)

--- a/code/modules/organs/internal/internal_wounds/organic.dm
+++ b/code/modules/organs/internal/internal_wounds/organic.dm
@@ -143,7 +143,8 @@
 
 /// Cheap hack, but prevents unbalanced toxins from killing someone immediately
 /datum/component/internal_wound/organic/poisoning/InheritComponent()
-	return
+	if(prob(5))
+		progress()
 
 /datum/component/internal_wound/organic/poisoning/pustule
 	name = "pustule"

--- a/code/modules/organs/internal/internal_wounds/organic.dm
+++ b/code/modules/organs/internal/internal_wounds/organic.dm
@@ -141,6 +141,10 @@
 	severity_max = 3
 	hal_damage = IWOUND_LIGHT_DAMAGE
 
+/// Cheap hack, but prevents unbalanced toxins from killing someone immediately
+/datum/component/internal_wound/organic/poisoning/InheritComponent()
+	return
+
 /datum/component/internal_wound/organic/poisoning/pustule
 	name = "pustule"
 	specific_organ_size_multiplier = 0.20


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Blattedin strength halved since it makes its way into blood and ingest.
- Toxin wounds won't build up rapidly when poisoned.
- Toxin damage from failing liver/kidney significantly slowed down.

## Why It's Good For The Game

No more instant tox deaths.

## Testing

Inhaled blattedin on local.

## Changelog
:cl:
balance: Blattedin strength halved since it makes its way into blood and ingest
balance: Toxin wounds won't build up rapidly when poisoned
balance: Toxin damage from failing liver/kidney significantly slowed down
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
