### PR TITLE
Uranium Spear Radiation Damage Rebalance

### DIFF
--- a/code/game/objects/items/weapons/tools/knives.dm
+++ b/code/game/objects/items/weapons/tools/knives.dm
@@ -402,7 +402,7 @@
 /obj/item/tool/spear/uranium/apply_hit_effect(mob/living/carbon/human/target, mob/living/user, hit_zone)
 	..()
 	if(istype(target))
-		target.apply_effect(rand(5, 10), IRRADIATE)
+		target.apply_effect(rand(60, 65), IRRADIATE)
 
 /obj/item/tool/spear/makeshift_halberd
 	name = "makeshift halberd"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Noticed that the uranium spear did too little radiation damage.

This PR changes the radiation damage the uranium spear does from 5 (min) & 10 (max) to 60 (min) & 65 (max)

- The previous values meant you would kill whoever you were attacking before reaching the tumour threshold (75)
- This meant the uranium spear was no different from a steel one
- New values mean you max out someone's radiation in two hits (this is blocked or nullified depending on your armours radiation resistance)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

- Gives the uranium spear some utility (you can do hit and runs and wait for rads to mutate your enemy)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

- Launched a test server
- Went to medbay, spawned a uranium spear and 3 dummies (Normal Armor, Techno Rig, IH Rig)
- Attacked each dummy with the uranium spear
- Noted the normal armor dummy took 2 hits to max out, IH rig took 6, Techno rig nullified the radiation damage)
- Observed the armored dummy in the medbay scanner, saw it gain tumors as time passed, saw it get deformed limbs

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
balance: Uranium spear used to do 5 - 10 radiation damage, it now does 60 - 65
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
