### PR TITLE
No more dallas spam & dallas and purger delay fix

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -781,7 +781,6 @@ var/global/list/default_medbay_channels = list(
 	var/bluespace_cooldown = 10 MINUTES
 	var/last_bluespace = 0
 	var/bluespace_items = list(
-		/obj/item/gun/energy/plasma/stranger = 25,
 		/obj/item/computer_hardware/hard_drive/portable/design/guns/fs_wintermute = 5,
 		/obj/item/computer_hardware/hard_drive/portable/design/excelsior/ak47 = 5,
 		/obj/item/computer_hardware/hard_drive/portable/design/nt/nt_lightfall = 5,

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -781,7 +781,6 @@ var/global/list/default_medbay_channels = list(
 	var/bluespace_cooldown = 10 MINUTES
 	var/last_bluespace = 0
 	var/bluespace_items = list(
-		/obj/item/computer_hardware/hard_drive/portable/design/guns/dallas = 25,
 		/obj/item/gun/energy/plasma/stranger = 25,
 		/obj/item/computer_hardware/hard_drive/portable/design/guns/fs_wintermute = 5,
 		/obj/item/computer_hardware/hard_drive/portable/design/excelsior/ak47 = 5,

--- a/code/modules/projectiles/guns/energy/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma.dm
@@ -56,8 +56,6 @@
 	slot_flags = SLOT_BACK
 	fire_delay = 20
 	charge_cost = 200
-	wield_delay = 0.8 SECOND
-	wield_delay_factor = 0.9 // 90 vig for instant wield
 
 	init_firemodes = list(
 		list(mode_name="DISINTEGRATE", mode_desc="Removes heresy from sight", projectile_type=/obj/item/projectile/plasma/aoe/heat/strong, fire_sound='sound/weapons/energy/incinerate.ogg', fire_delay=20, charge_cost=200, icon="destroy", projectile_color = "#ff1212"),

--- a/code/modules/projectiles/guns/projectile/automatic/dallas.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/dallas.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/automatic/dallas //it's a good way to die
+/obj/item/gun/projectile/automatic/dallas //it's a good day to die
 	name = "PAR .25 CS \"Dallas\""
 	desc = "Dallas is a pulse-action air-cooled automatic assault rifle made by unknown manufacturer. This weapon is very rare, but deadly efficient. \
 			It's used by elite mercenaries, assassins or bald marines. Uses .25 Caseless rounds."
@@ -23,9 +23,6 @@
 	penetration_multiplier = 0
 	init_recoil = LMG_RECOIL(1)
 	rarity_value = 65
-	gun_parts = list(/obj/item/part/gun = 5 ,/obj/item/stack/material/plasteel = 6)
-	wield_delay = 1 SECOND
-	wield_delay_factor = 0.4 // 40 vig for insta wield
 	gun_parts = list(/obj/item/part/gun/frame/dallas = 1, /obj/item/part/gun/grip/black = 1, /obj/item/part/gun/mechanism/machinegun = 1, /obj/item/part/gun/barrel/clrifle = 1)
 
 	gun_tags = list(GUN_SILENCABLE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
this PR makes it so that the Dallas no longer spawns in the guild radio when upgraded. also removes its wield delay as its not supposed to have it (it was removed from all LMGs a long while ago)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
the rarest and strongest gun in the game shouldn't be common as dirt
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
i went in game, upgraded the radio with the siphon and waited. no dallases spawned
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
balance: Dallas no longer spawns in guild radio when upgraded
fix: Dallas no longer has a delay on wielding, dallas now gives gun parts correctly 
balance: Purger gun no longar has a delay on wielding
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
