### PR TITLE
Revert "recycling matter oversight"

### DIFF
--- a/code/datums/autolathe/basic_stuff.dm
+++ b/code/datums/autolathe/basic_stuff.dm
@@ -39,7 +39,7 @@
 	build_path = /obj/item/light/bulb
 
 /datum/design/autolathe/misc/ashtray
-	name = "ashtray"
+	name = "glass ashtray"
 	build_path = /obj/item/material/ashtray
 
 /datum/design/autolathe/misc/cane

--- a/code/game/objects/items/devices/lighting/glowstick.dm
+++ b/code/game/objects/items/devices/lighting/glowstick.dm
@@ -5,8 +5,6 @@
 	icon_state = "glowstick"
 	action_button_name = null
 	brightness_on = 2.5
-	matter = list(MATERIAL_PLASTIC = 1)
-	matter_reagents = list("radium" = 1)
 	var/fuel = 0
 	var/max_fuel = 2000
 

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -196,7 +196,6 @@
 	icon_state = "dusters"
 	item_state = "dusters"
 	var/punch_increase = 5
-	matter = list(MATERIAL_STEEL = 3)
 	price_tag = 20
 	spawn_blacklisted = TRUE
 
@@ -205,7 +204,6 @@
 	desc = "More pain for them, more bling for you."
 	icon_state = "dusters_silver"
 	item_state = "dusters_silver"
-	matter = list(MATERIAL_SILVER = 3)
 	price_tag = 40
 	style = STYLE_LOW
 
@@ -215,7 +213,6 @@
 	icon_state = "dusters_plasteel"
 	item_state = "dusters_plasteel"
 	punch_increase = 10
-	matter = list(MATERIAL_PLASTEEL = 3)
 	price_tag = 60
 
 /obj/item/clothing/gloves/dusters/gold
@@ -224,7 +221,6 @@
 	icon_state = "dusters_gold"
 	item_state = "dusters_gold"
 	punch_increase = 10
-	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_GOLD = 3)
 	price_tag = 100
 	style = STYLE_HIGH
 
@@ -234,7 +230,6 @@
 	icon_state = "dusters_platinum"
 	item_state = "dusters_platinum"
 	punch_increase = 15
-	matter = list(MATERIAL_PLATINUM = 3, MATERIAL_PLASTEEL = 3, MATERIAL_STEEL = 2)
 	price_tag = 120
 	style = STYLE_HIGH
 
@@ -254,7 +249,6 @@
 		bio = 0,
 		rad = 0
 	)
-	matter = list(MATERIAL_BIOMATTER = 10, MATERIAL_PLASTEEL = 3)
 	price_tag = 540
 
 /obj/item/clothing/gloves/dusters/New()

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -12,7 +12,6 @@
 	var/hanging = 0
 	style_coverage = COVERS_MOUTH
 	style = STYLE_NEG_LOW
-	matter = list(MATERIAL_PLASTIC = 1)
 
 /obj/item/clothing/mask/breath/proc/adjust_mask(mob/user)
 	if(!usr.incapacitated())

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -25,7 +25,6 @@
 	)
 	price_tag = 20
 	style = STYLE_NEG_LOW
-	matter = list(MATERIAL_PLASTIC = 2)
 	muffle_voice = TRUE
 
 /obj/item/clothing/mask/gas/filter_air(datum/gas_mixture/air)

--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -7,7 +7,6 @@ var/list/disciples = list()
 	icon_state = "cruciform_green"
 	desc = "Soul holder for every disciple. With the proper rituals, this can be implanted to induct a new believer into NeoTheology."
 	description_info = "The cruciform ensures genetic purity, it will purge any cybernetic attachments, or mutation that are not part of the standard human genome"
-	matter = list(MATERIAL_BIOMATTER = 10, MATERIAL_PLASTEEL = 5, MATERIAL_GOLD = 2)
 	allowed_organs = list(BP_CHEST)
 	implant_type = /obj/item/implant/core_implant/cruciform
 	layer = ABOVE_MOB_LAYER

--- a/code/modules/reagents/reagent_containers/food/drinks/jar.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/jar.dm
@@ -6,7 +6,6 @@
 	center_of_mass = list("x"=15, "y"=8)
 	unacidable = 1
 	spawn_tags = SPAWN_TAG_JUNK
-	matter = list(MATERIAL_GLASS = 2)
 	rarity_value = 20
 
 /obj/item/reagent_containers/food/drinks/jar/on_reagent_change()


### PR DESCRIPTION
Reverts discordia-space/CEV-Eris#8037

why is it good for the game:
cruciforms are now currently melted by the bioreactor and broken down into components. this happens because they were given materiel value