### PR TITLE
Cancer adjustments

### DIFF
--- a/code/modules/organs/internal/internal_wounds/_internal_wound.dm
+++ b/code/modules/organs/internal/internal_wounds/_internal_wound.dm
@@ -38,6 +38,7 @@
 	var/current_hallucination_tick
 
 	// Organ adjustments - preferably used for more severe wounds
+	var/list/organ_efficiency_mod = list()
 	var/specific_organ_size_multiplier = null
 	var/max_blood_storage_multiplier = null
 	var/blood_req_multiplier = null
@@ -215,6 +216,25 @@
 
 /datum/component/internal_wound/proc/apply_effects()
 	var/obj/item/organ/internal/O = parent
+
+	if(!islist(O.organ_efficiency))
+		O.organ_efficiency = list()
+
+	if(LAZYLEN(organ_efficiency_mod))
+		for(var/organ in organ_efficiency_mod)
+			var/added_efficiency = organ_efficiency_mod[organ]
+			if(O.organ_efficiency.Find(organ))
+				O.organ_efficiency[organ] += round(added_efficiency, 1)
+			else
+				O.organ_efficiency.Add(organ)
+				O.organ_efficiency[organ] = round(added_efficiency, 1)
+
+		if(O.owner && istype(O.owner, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = O.owner
+			for(var/process in organ_efficiency_mod)
+				if(!islist(H.internal_organs_by_efficiency[process]))
+					H.internal_organs_by_efficiency[process] = list()
+				H.internal_organs_by_efficiency[process] |= O
 
 	if(specific_organ_size_multiplier)
 		O.specific_organ_size *= 1 + round(specific_organ_size_multiplier, 0.01)

--- a/code/modules/organs/internal/internal_wounds/organic.dm
+++ b/code/modules/organs/internal/internal_wounds/organic.dm
@@ -183,24 +183,45 @@
 	name = "chemical poisoning"
 
 // Clone/radiation
+// There are a lot of dummy wounds that exist for cosmetic purposes
 /datum/component/internal_wound/organic/radiation
 	treatments_tool = list(QUALITY_CUTTING = FAILCHANCE_NORMAL)
 	treatments_chem = list(CE_ONCOCIDAL = 1)
-	severity = 1
-	severity_max = 1
-	hal_damage = IWOUND_LIGHT_DAMAGE
-	status_flag = ORGAN_WOUNDED|ORGAN_MUTATED
+	characteristic_flag = IWOUND_PROGRESS	// Does not apply any damage to the parent organ
+	severity = 0
+	severity_max = 2
+	hal_damage = 0
+	status_flag = ORGAN_WOUNDED
 
-/datum/component/internal_wound/organic/radiation/benign
-	name = "benign tumor"
+/datum/component/internal_wound/organic/radiation/abnormal
+	name = "abnormal growth"
+
+/datum/component/internal_wound/organic/radiation/strange
+	name = "strange growth"
+
+/datum/component/internal_wound/organic/radiation/polyp
+	name = "polyp"
+
+/datum/component/internal_wound/organic/radiation/polyp_benign
+	name = "benign polyp"
+
+/datum/component/internal_wound/organic/radiation/polyp_strange
+	name = "strange polyp"
+
+/datum/component/internal_wound/organic/radiation/neoplasm
+	name = "neoplasm"
+
+/datum/component/internal_wound/organic/radiation/neoplasm_benign
+	name = "benign neoplasm"
 
 /datum/component/internal_wound/organic/radiation/malignant
-	name = "malignant tumor"
+	name = "malignant neoplasm"
 	treatments_chem = list(CE_ONCOCIDAL = 2)
-	characteristic_flag = IWOUND_CAN_DAMAGE|IWOUND_PROGRESS|IWOUND_SPREAD
-	severity = 0
-	severity_max = IORGAN_MAX_HEALTH	// Will kill any organ
-	spread_threshold = IORGAN_SMALL_HEALTH	// This will spread at the same moment it kills a small organ
+	next_wound = /datum/component/internal_wound/organic/tumor
+
+/datum/component/internal_wound/organic/radiation/metaplasm
+	name = "metaplasm"
+	next_wound = /datum/component/internal_wound/organic/parenchyma
 
 // Secondary wounds
 /datum/component/internal_wound/organic/swelling
@@ -217,6 +238,57 @@
 
 /datum/component/internal_wound/organic/swelling/abcess
 	name = "abcess"
+
+/datum/component/internal_wound/organic/tumor
+	treatments_tool = list(QUALITY_CUTTING = FAILCHANCE_NORMAL)
+	treatments_chem = list(CE_ONCOCIDAL = 2)
+	characteristic_flag = IWOUND_CAN_DAMAGE|IWOUND_PROGRESS|IWOUND_SPREAD
+	severity = 0
+	severity_max = IORGAN_MAX_HEALTH	// Will kill any organ
+	spread_threshold = IORGAN_SMALL_HEALTH	// This will spread at the same moment it kills a small organ
+	status_flag = ORGAN_WOUNDED|ORGAN_MUTATED
+
+/datum/component/internal_wound/organic/tumor/malignant
+	name = "malignant tumor"
+
+/datum/component/internal_wound/organic/parenchyma
+	treatments_tool = list(QUALITY_LASER_CUTTING = FAILCHANCE_NORMAL)	// Players may not want to remove this
+	characteristic_flag = null
+	severity = 0
+	severity_max = 0
+	status_flag = null
+
+/datum/component/internal_wound/organic/parenchyma/heart
+	name = "heart parenchyma"
+	organ_efficiency_add = list(OP_HEART = 10)
+
+/datum/component/internal_wound/organic/parenchyma/lungs
+	name = "lung parenchyma"
+	organ_efficiency_add = list(OP_LUNGS = 10)
+
+/datum/component/internal_wound/organic/parenchyma/liver
+	name = "liver parenchyma"
+	organ_efficiency_add = list(OP_LIVER = 10)
+
+/datum/component/internal_wound/organic/parenchyma/kidney
+	name = "kidney parenchyma"
+	organ_efficiency_add = list(OP_KIDNEYS = 10)
+
+/datum/component/internal_wound/organic/parenchyma/stomach
+	name = "stomach parenchyma"
+	organ_efficiency_add = list(OP_STOMACH = 10)
+
+/datum/component/internal_wound/organic/parenchyma/blood_vessel
+	name = "blood vessel parenchyma"
+	organ_efficiency_add = list(OP_BLOOD_VESSEL = 10)
+
+/datum/component/internal_wound/organic/parenchyma/nerve
+	name = "nerve parenchyma"
+	organ_efficiency_add = list(OP_NERVE = 10)
+
+/datum/component/internal_wound/organic/parenchyma/muscle
+	name = "muscle parenchyma"
+	organ_efficiency_add = list(OP_MUSCLE = 10)
 
 // Other wounds
 /datum/component/internal_wound/organic/oxy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Reworked radiation wounds as polyps or plasms. Most of these wounds are harmless and will only notify the player of their existence when they grow until they stop growing, which is usually around 8 minutes. Instead of receiving a tumor from rad/clone damage, humans will grow these.
- Added a malignant neoplasm that will progress into a malignant tumor.
- Added a metaplasm that will progress into parenchyma (similar to parenchymal tissue from the organ fabricator). These are harmless wounds that add a random organ efficiency to their parent organ. Bones have been intentionally excluded from the pool for use in a future wound type.

## Why It's Good For The Game

Tumors were a little too annoying in rounds where maintshrooms would squirt cancer-causing reagents at players. This change reduces odds of receving a lethal tumor to 10% from 50%, adds an 8 minute buffer between receiving a radiation organ wound and experience removes the mutated limb effect from all radiation-related wounds except the malignant tumor.

## Testing

Will be tested on Monday.

## Changelog
:cl:
tweak: Reworked radiation wounds as polyps or plasms
balance: reduces odds of receving a lethal tumor to 10% from 50% and removes the mutated limb effect from all radiation-related wounds except the malignant tumor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
