### PR TITLE
Aheal fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -993,14 +993,9 @@ var/list/rank_prefix = list(\
 	return gender
 
 /mob/living/carbon/human/revive()
-
 	if(species && !(species.flags & NO_BLOOD))
 		vessel.add_reagent("blood",species.blood_volume-vessel.total_volume)
 		fixblood()
-
-	// Fix up all organs.
-	// This will ignore any prosthetics in the prefs currently.
-	rebuild_organs()
 
 	if(!client || !key) //Don't boot out anyone already in the mob.
 		for(var/obj/item/organ/internal/brain/H in world)

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -357,10 +357,9 @@
 	return mod_data
 
 /obj/item/organ/internal/rejuvenate()
-	refresh_organ_stats()
+	status = null
 	for(var/datum/component/comp as anything in GetComponents(/datum/component))
 		istype(comp, /datum/component/internal_wound) ? remove_wound(comp) : qdel(comp)
-	apply_modifiers()
 
 // Store these so we can properly restore them when installing/removing mods
 /obj/item/organ/internal/proc/initialize_organ_efficiencies()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When ahealing, FBPs will not turn human, cruciforms won't pop out, and dead organs will be revived.

Note: ghosting will cause the limb rebuilding logic to default to flesh or makeshift prosthetics depending on whether the upper body is robotic or not. If you want to retain your character's missing prosthetics, get in your body before getting ahealed.

## Why It's Good For The Game

Lets admins do what they intend to do.

## Testing

- Replaced a limb with a prosthetic, cleanly amputated a limb (no stump), and smashed a limb off (leaves a stump). Then, used Rejuvenate from the drop down menu. Limbs restored, prosthetic retained, and cruciform stayed inside.
![human](https://user-images.githubusercontent.com/95178278/227752913-f122cd6b-6dc4-45b6-9455-a1c3ce6c0807.png)
![human2](https://user-images.githubusercontent.com/95178278/227752917-0d04a4b7-85cc-4792-9fd8-0c89ed405800.png)
- Removed FBP head and used Rejuvenate. Body was makeshift and head was Serbian.
![fbp](https://user-images.githubusercontent.com/95178278/227752921-04115270-b577-41ea-b5a7-b397071699ac.png)
![fbp2](https://user-images.githubusercontent.com/95178278/227752928-384b670b-837b-443e-979b-a33235f836c6.png)



## Changelog
:cl:
code: Human revive() doesn't use the rebuild_organs() logic anymore
code: Added limb rebuilding logic to human rejuvenate()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
