### PR TITLE
Crafting GC cleanup and runtime fix

### DIFF
--- a/code/datums/craft/item.dm
+++ b/code/datums/craft/item.dm
@@ -5,7 +5,6 @@
 	var/datum/craft_recipe/recipe
 	var/step = 1
 
-
 /obj/item/craft/New(loc, new_recipe)
 	..(loc)
 	recipe = new_recipe
@@ -13,6 +12,11 @@
 	src.icon_state = recipe.icon_state
 	update()
 
+/obj/item/craft/Destroy(force)
+	for(var/datum/craft_step/CS in recipe.steps)
+		CS.craft_items -= src
+	recipe = null
+	. = ..()
 
 /obj/item/craft/proc/update()
 	desc = recipe.get_description(step-1, src)
@@ -34,4 +38,6 @@
 	return continue_crafting(I, user)
 
 /obj/item/craft/MouseDrop_T(atom/A, mob/user, src_location, over_location, src_control, over_control, params)
+	if(isturf(A))
+		return
 	return continue_crafting(A, user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a runtime related to crafting and fixes a hard deletion source.

## Why It's Good For The Game

Bug fix

## Testing

Dragged a turf to a craft object

## Changelog
:cl:
fix: Fixed a runtime when dragging a turf to a craft object
fix: Added cleanup to /obj/item/craft/Destroy()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
