### PR TITLE
Pipe GC fix

### DIFF
--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -69,6 +69,7 @@
 		QDEL_NULL(air_temporary)
 
 	. = ..()
+	return QDEL_HINT_QUEUE
 
 /obj/machinery/atmospherics/pipe/attackby(obj/item/I, mob/user)
 	if (istype(src, /obj/machinery/atmospherics/pipe/tank))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Atmos pipes did not return a qdel hint and would be hard deleted by default.

- Fixed an issue where atmos pipes would hard delete at roundstart

## Why It's Good For The Game

Early round performance

## Testing
Before:
![image](https://user-images.githubusercontent.com/95178278/228409664-b116f5a5-305c-44f3-a0bf-7f7c02551f32.png)

After:
![image](https://user-images.githubusercontent.com/95178278/228409757-a436c287-988b-4608-9021-af6c22852274.png)

## Changelog
:cl:
fix: Fixed an issue where atmos pipes would hard delete at roundstart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
