### PR TITLE
Revert "Image GC fix"

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -123,8 +123,6 @@
 		loc = null
 
 	QDEL_NULL(hidden_uplink)
-	if(blood_overlay && items_blood_overlay_by_type[type] == blood_overlay)
-		LAZYREMOVE(items_blood_overlay_by_type, type)
 	QDEL_NULL(blood_overlay)
 	QDEL_NULL(action)
 	if(hud_actions)


### PR DESCRIPTION
Reverts discordia-space/CEV-Eris#7775

Doesn't actually prevent image hard dels and causes a bunch of runtimes.