### PR TITLE
Add PASS button to HULK smelter

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -1,7 +1,8 @@
 #define ORE_STORING 0
-#define ORE_SMELTING 1
-#define ORE_COMPRESSING 2
-#define ORE_ALLOYING 3
+#define ORE_PASSING 1
+#define ORE_SMELTING 2
+#define ORE_COMPRESSING 3
+#define ORE_ALLOYING 4
 
 /**********************Mineral processing unit console**************************/
 
@@ -50,12 +51,15 @@
 		switch(machine.ores_processing[ore])
 			if(ORE_STORING)
 				ore_list["current_action_string"] = "Storing"
+			if(ORE_PASSING)
+				ore_list["current_action_string"] = "Passing"
 			if(ORE_SMELTING)
 				ore_list["current_action_string"] = "Smelting"
 			if(ORE_COMPRESSING)
 				ore_list["current_action_string"] = "Compressing"
 			if(ORE_ALLOYING)
 				ore_list["current_action_string"] = "Alloying"
+
 		data["materials_data"] += list(ore_list)
 	data["alloy_data"] = list()
 	for(var/datum/alloy/alloy in machine.alloy_data)
@@ -205,6 +209,17 @@
 			continue
 		/// Would've named this ore_data , but it gives infinite cross reference ( and also conflicts with the global version)
 		var/ore/stored_ore_data = ore_data[ore]
+		if(ores_processing[ore] == ORE_PASSING && stored_ore_data.ore)
+			if(ores_stored[ore] < 1)
+				continue
+			var/ore_amount = min(round(ores_stored[ore]), sheets_per_tick)
+			ore_amount = min(ore_amount, sheets_to_process)
+			sheets_to_process -= ore_amount
+			var/ore/product = stored_ore_data.ore
+			while(ore_amount)
+				new product.ore(get_step(src, output_dir))
+				ore_amount--
+				ores_stored[ore] -= 1
 		if(ores_processing[ore] == ORE_SMELTING && stored_ore_data.smelts_to)
 			if(ores_stored[ore] < 1)
 				continue

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -217,7 +217,7 @@
 			sheets_to_process -= ore_amount
 			var/ore/product = stored_ore_data.ore
 			while(ore_amount)
-				new product.ore(get_step(src, output_dir))
+				new product(get_step(src, output_dir))
 				ore_amount--
 				ores_stored[ore] -= 1
 		if(ores_processing[ore] == ORE_SMELTING && stored_ore_data.smelts_to)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds Passing option to Hulk Mineral Smelter unit, allowing certain ore to simply be ejected back out to be recollected by the player.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This enables savvy players to be able to identify what ores they want to export through Guild Offers without having to manually curate the contents of an ore crate by hand, simplifying the process of optimizing both material sheet gathering and offer satisfaction.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
[dreamseeker_SOflH1BkLA.webm](https://user-images.githubusercontent.com/11076040/228982135-a83e4622-c841-449d-b13c-5988b6dd15ba.webm)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
add: Added new Smelter function
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
