### PR TITLE
Converts some missed proc refs to the new macro

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -106,7 +106,7 @@
 	. = ..()
 	START_PROCESSING(SSobj, src)
 	set_light(1.5 ,1, "#00FF7F")
-	addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, src), 120 SECONDS)
+	addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(qdel), src), 120 SECONDS)
 
 /obj/effect/decal/cleanable/greenglow/Process()
 	. = ..()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -112,7 +112,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		return
 	..() //redirect to hsrc.Topic()
 
-///dumb workaround because byond doesnt seem to recognize the .proc/Topic() typepath for /datum/proc/Topic() from the client Topic,
+///dumb workaround because byond doesnt seem to recognize the PROC_REF(Topic) typepath for /datum/proc/Topic() from the client Topic,
 ///so we cant queue it without this
 /client/proc/_Topic(datum/hsrc, href, list/href_list)
 	return hsrc.Topic(href, href_list)

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -25,7 +25,7 @@
 
 /obj/item/organ/internal/brain/New()
 	..()
-	timer_id = addtimer(CALLBACK(src, .proc/clear_hud), 5, TIMER_STOPPABLE)
+	timer_id = addtimer(CALLBACK(src, PROC_REF(clear_hud)), 5, TIMER_STOPPABLE)
 
 /obj/item/organ/internal/brain/Destroy()
 	if(timer_id)

--- a/code/modules/organs/internal/internal_wounds/_internal_wound.dm
+++ b/code/modules/organs/internal/internal_wounds/_internal_wound.dm
@@ -49,15 +49,15 @@
 
 /datum/component/internal_wound/RegisterWithParent()
 	// Internal organ parent
-	RegisterSignal(parent, COMSIG_IWOUND_EFFECTS, .proc/apply_effects)
-	RegisterSignal(parent, COMSIG_IWOUND_LIMB_EFFECTS, .proc/apply_limb_effects)
-	RegisterSignal(parent, COMSIG_IWOUND_FLAGS_ADD, .proc/apply_flags)
-	RegisterSignal(parent, COMSIG_IWOUND_FLAGS_REMOVE, .proc/remove_flags)
-	RegisterSignal(parent, COMSIG_IWOUND_DAMAGE, .proc/apply_damage)
-	RegisterSignal(parent, COMSIG_IWOUND_TREAT, .proc/treatment)
+	RegisterSignal(parent, COMSIG_IWOUND_EFFECTS, PROC_REF(apply_effects))
+	RegisterSignal(parent, COMSIG_IWOUND_LIMB_EFFECTS, PROC_REF(apply_limb_effects))
+	RegisterSignal(parent, COMSIG_IWOUND_FLAGS_ADD, PROC_REF(apply_flags))
+	RegisterSignal(parent, COMSIG_IWOUND_FLAGS_REMOVE, PROC_REF(remove_flags))
+	RegisterSignal(parent, COMSIG_IWOUND_DAMAGE, PROC_REF(apply_damage))
+	RegisterSignal(parent, COMSIG_IWOUND_TREAT, PROC_REF(treatment))
 
 	// Surgery
-	RegisterSignal(src, COMSIG_ATTACKBY, .proc/apply_tool)
+	RegisterSignal(src, COMSIG_ATTACKBY, PROC_REF(apply_tool))
 
 	START_PROCESSING(SSinternal_wounds, src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Missed some proc refs when doing the TG components port

## Why It's Good For The Game

Byond 515 compatibility

## Testing

TBD

## Changelog
:cl:
code: Changed some missed proc paths to proc refs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
