### PR TITLE
Enables zlevel shooting by default

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -132,7 +132,7 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 	var/welder_vision = 1
 	var/generate_asteroid = 0
 	var/no_click_cooldown = 0
-	var/z_level_shooting = FALSE
+	var/z_level_shooting = TRUE
 
 	var/admin_legacy_system = 0	//Defines whether the server uses the legacy admin system with admins.txt or the SQL system. Config option in config.txt
 	var/ban_legacy_system = 0	//Defines whether the server uses the legacy banning system with the files in /data or the SQL system. Config option in config.txt


### PR DESCRIPTION
## About The Pull Request

Changes the config to be on

## Why It's Good For The Game

Admins don't need to click the funny button

## Testing

Effects tested on live extensively.

## Changelog
:cl:
config: zlevel shooting is enabled by default
/:cl: