### PR TITLE
OS Stalker fix

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
+++ b/code/modules/mob/living/carbon/superior_animal/stalker/stalker.dm
@@ -50,6 +50,7 @@
 	light_range = 3
 	light_color = COLOR_LIGHTING_BLUE_BRIGHT
 	mob_classification = CLASSIFICATION_SYNTHETIC
+	bloodcolor = "#030303"
 
 	ranged = 1 //will it shoot?
 	rapid = 0 //will it shoot fast?
@@ -63,10 +64,9 @@
 
 /mob/living/carbon/superior_animal/stalker/death()
 	. = ..()
-	visible_message("[src] blows apart!")
+	visible_message("Critical components of \the [src] blow apart!")
 	new /obj/effect/decal/cleanable/blood/gibs/robot(loc)
 	do_sparks(3, TRUE, src)
-	qdel(src)
 
 /mob/living/carbon/superior_animal/stalker/dual
 	name = "OneStar Stalker Mk2"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Removed a qdel() from Stalker death(). They're supposed to leave a corpse to be harvested.
- Changed Stalker blood color to that of oil. This is used when generating gibs.

## Why It's Good For The Game

Stalkers were intended to be lootable after death.

## Testing

Left is a dead Stalker, right is a gibbed Stalker.
![image](https://user-images.githubusercontent.com/95178278/230506342-0b917a06-c4d3-4029-9f65-3ed988d45912.png)

## Changelog
:cl:
del: Removed a qdel() from Stalker death()
fix: Changed Stalker blood color to that of oil
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
