### PR TITLE
Allows tables to be flipped while mapping

### DIFF
--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -84,10 +84,22 @@ var/list/custom_table_appearance = list(
 	// reset color/alpha, since they're set for nice map previews
 	color = "#ffffff"
 	alpha = 255
+
+	update_material()
+
+	// If it was flipped with var-editing, we want to be able to put this back
+	if(flipped)
+		// All the changes from flip() without throwing items around
+		if(dir != NORTH)
+			layer = 5
+		climbable = FALSE
+		flags |= ON_BORDER
+		verbs -=/obj/structure/table/verb/do_flip
+		verbs +=/obj/structure/table/proc/do_put
+
 	update_connections(1)
 	update_icon()
 	update_desc()
-	update_material()
 
 /obj/structure/table/Destroy()
 	material = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds logic to table Initialize() that allows mappers to flip their tables.

## Why It's Good For The Game

Helps mappers build better environments

## Testing

![image](https://user-images.githubusercontent.com/95178278/230520232-26c94ee1-1fae-468d-b51e-80d2dfbf526a.png)

## Changelog
:cl:
tweak: Added logic to table Initialize() that allows flipped tables through var editing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
