### PR TITLE
Revert "Allows tables to be flipped while mapping"

### DIFF
--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -84,22 +84,10 @@ var/list/custom_table_appearance = list(
 	// reset color/alpha, since they're set for nice map previews
 	color = "#ffffff"
 	alpha = 255
-
-	update_material()
-
-	// If it was flipped with var-editing, we want to be able to put this back
-	if(flipped)
-		// All the changes from flip() without throwing items around
-		if(dir != NORTH)
-			layer = 5
-		climbable = FALSE
-		flags |= ON_BORDER
-		verbs -=/obj/structure/table/verb/do_flip
-		verbs +=/obj/structure/table/proc/do_put
-
 	update_connections(1)
 	update_icon()
 	update_desc()
+	update_material()
 
 /obj/structure/table/Destroy()
 	material = null


### PR DESCRIPTION
Reverts discordia-space/CEV-Eris#8091

I'll PR the correct version another time. Note: `flipped` is not binary. If `flipped` is less than 0, the table cannot be flipped.

![image](https://user-images.githubusercontent.com/95178278/230665151-f13e693b-7677-4d0a-9997-8254f5c2457a.png)


