### PR TITLE
Fixes infinite materials through recycling

### DIFF
--- a/code/game/machinery/smelter.dm
+++ b/code/game/machinery/smelter.dm
@@ -190,8 +190,14 @@
 		CRASH("Attempted to drop an invalid material: [material]")
 
 	var/ejected_amount = min(initial(stack_type.max_amount), round(stored_material[material]), storage_capacity)
-	var/obj/item/stack/material/S = new stack_type(src, ejected_amount)
+	var/remainder = ejected_amount - round(ejected_amount)
+	var/obj/item/stack/material/S = new stack_type(src, round(ejected_amount))
+	var/shard
+	if(remainder)
+		shard = new /obj/item/material/shard(src, material, _amount = remainder)
 	eject(S, output_side)
+	if(shard)
+		eject(shard, output_side)
 	stored_material[material] -= ejected_amount
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes infinite materials from recycling
This PR should be merged on monday as it touches the very base of the game and i have not tested it at all , albeit it is very simple in design.

## Why It's Good For The Game
No more duping

## Testing
Not tested, merge for monday since i can't be trusted with even the most simple code-changes

## Changelog
:cl:
fix: Fixed infinite material duping exploit using smelters to get fractional sheets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
