### PR TITLE
You can't spawn infinite mice by spamming "respawn as mouse" as a ghost.

### DIFF
--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -461,17 +461,19 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		to_chat(src, "<span class='warning'>You may not spawn as a mouse on this Z-level.</span>")
 		return
 
-	var/response = alert(src, "Are you -sure- you want to become a mouse? This will not affect your crew or drone respawn time. You can choose to spawn near your ghost or at a random vent on this deck.","Are you sure you want to squeek?","Near Ghost", "Random","Cancel")
-	if(response == "Cancel") return  //Hit the wrong key...again.
-
-
-	//find a viable mouse candidate
 	var/mob/living/simple_animal/mouse/host
 	var/obj/machinery/atmospherics/unary/vent_pump/spawnpoint
-	if (response == "Random")
-		spawnpoint = find_mouse_random_spawnpoint(T.z)
-	else if (response == "Near Ghost")
-		spawnpoint = find_mouse_near_spawnpoint(T)
+
+	switch(alert(src, "Are you -sure- you want to become a mouse? This will not affect your crew or drone respawn time. You can choose to spawn near your ghost or at a random vent on this deck.","Are you sure you want to squeek?","Near Ghost", "Random","Cancel"))
+		if("Cancel")
+			return  //Hit the wrong key...again.
+		if ("Random")
+			spawnpoint = find_mouse_random_spawnpoint(T.z) //find a viable mouse spawn candidate.
+		if ("Near Ghost")
+			spawnpoint = find_mouse_near_spawnpoint(T)
+
+	if(!isobserver(src) || !src.ckey)
+		return //So we can't spawn infinite mice if we've already used this
 
 	if (spawnpoint)
 		host = new /mob/living/simple_animal/mouse(spawnpoint.loc)
@@ -483,6 +485,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			host.universal_understand = 0
 		announce_ghost_joinleave(src, 0, "They are now a mouse.")
 		host.ckey = src.ckey
+		qdel(src)
 		to_chat(host, "<span class='info'>You are now a mouse. Interact with players, cause mischief, avoid cats, find food, and try to survive!</span>")
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can't spam the "respawn as mouse" verb as a ghost to spawn as many mice as you want anymore.
closes #7939
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ghosts shouldn't spawn infinite mice
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spammed the verb a bunch and then clicked through the alerts, only one mouse was spawned as expected.

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->
![Screenshot_1559](https://user-images.githubusercontent.com/53474257/230919059-31d53973-4e24-4f23-92c3-87ece4c51127.png)

## Changelog
:cl:
fix: You can't spawn infinite mice by spamming "respawn as mouse" as a ghost.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
