### PR TITLE
Removes all ties of style from combat , makes style buff insight gain from all sources.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -480,10 +480,6 @@ var/global/list/items_blood_overlay_by_type = list()
 		if (grabbed)
 			if (grabbed.stats.getPerk(PERK_ASS_OF_CONCRETE))
 				visible_message(SPAN_WARNING("[src] tries to pick up [grabbed], and fails!"))
-				if (ishuman(src))
-					var/mob/living/carbon/human/depleted = src
-					depleted.regen_slickness(-1) // unlucky and unobservant gets the penalty
-					return
 
 			else
 				if(ishuman(grabbed)) // irish whip if human(grab special), else spin and force rest
@@ -548,9 +544,6 @@ var/global/list/items_blood_overlay_by_type = list()
 			unEquip(I)
 			return
 		I.hand_spin(src)
-	if (ishuman(src))
-		var/mob/living/carbon/human/stylish = src
-		stylish.regen_slickness()
 
 /obj/item/proc/hand_spin(mob/living/carbon/caller) // used for custom behaviour on the above proc
 	return

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -145,7 +145,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			if(ishuman(loc))
 				if (src == C.wear_mask && C.check_has_mouth()) // if it's in the human/monkey mouth, transfer reagents to the mob
 					reagents.trans_to_mob(C, REM, CHEM_INGEST, 0.2) // Most of it is not inhaled... balance reasons.
-					C.regen_slickness() // smoking is cool, but don't try this at home
 			else // else just remove some of the reagents
 				reagents.remove_any(REM)
 

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -166,7 +166,6 @@
 	extended_reach = TRUE
 	push_attack = TRUE
 	matter = list(MATERIAL_BIOMATTER = 20, MATERIAL_PLASTEEL = 10) // More expensive, high-end spear
-	style_damage = 50
 
 /obj/item/tool/sword/nt/spear/equipped(mob/living/W)
 	..()
@@ -364,7 +363,6 @@
 	price_tag = 150
 	allow_spin = FALSE
 	matter = list(MATERIAL_BIOMATTER = 10, MATERIAL_STEEL = 5) // Easy to mass-produce and arm the faithful
-	style_damage = 30
 
 /obj/item/stack/thrown/nt/verutum/launchAt()
 	embed_mult = 600

--- a/code/game/objects/items/weapons/tools/knives.dm
+++ b/code/game/objects/items/weapons/tools/knives.dm
@@ -351,8 +351,6 @@
 	slot_flags = SLOT_BACK
 	structure_damage_factor = STRUCTURE_DAMAGE_BLADE
 	allow_spin = FALSE
-	style_damage = 20
-
 	rarity_value = 20
 	spawn_tags = SPAWN_TAG_KNIFE
 
@@ -368,7 +366,6 @@
 	tool_qualities = list(QUALITY_CUTTING = 10,  QUALITY_WIRE_CUTTING = 5, QUALITY_SCREW_DRIVING = 5)
 	matter = list(MATERIAL_STEEL = 3)
 	structure_damage_factor = STRUCTURE_DAMAGE_WEAK
-	style_damage = 30
 
 	rarity_value = 60
 
@@ -384,7 +381,6 @@
 	tool_qualities = list(QUALITY_CUTTING = 15,  QUALITY_WIRE_CUTTING = 10, QUALITY_SCREW_DRIVING = 10)
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTEEL = 2)
 	structure_damage_factor = STRUCTURE_DAMAGE_NORMAL
-	style_damage = 50
 
 /obj/item/tool/spear/uranium
 	name = "uranium spear"
@@ -397,7 +393,6 @@
 	armor_divisor = ARMOR_PEN_DEEP
 	tool_qualities = list(QUALITY_CUTTING = 10,  QUALITY_WIRE_CUTTING = 5, QUALITY_SCREW_DRIVING = 5)
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_URANIUM = 1)
-	style_damage = 50
 
 /obj/item/tool/spear/uranium/apply_hit_effect(mob/living/carbon/human/target, mob/living/user, hit_zone)
 	..()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -11,7 +11,6 @@
 	var/in_use = 0 // If we have a user using us, this will be set on. We will check if the user has stopped using us, and thus stop updating and LAGGING EVERYTHING!
 	var/damtype = "brute"
 	var/armor_divisor = 1
-	var/style_damage = 30 // used for dealing damage to slickness
 	var/corporation
 	var/heat = 0
 
@@ -250,9 +249,6 @@
 //Same for AP
 /obj/proc/add_projectile_penetration(newmult)
 	armor_divisor = initial(armor_divisor) + newmult
-
-/obj/proc/multiply_projectile_style_damage(newmult)
-	style_damage = initial(style_damage) * newmult
 
 /obj/proc/multiply_pierce_penetration(newmult)
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -466,7 +466,6 @@ BLIND     // can't see anything
 		holding = null
 		if (ishuman(usr))
 			var/mob/living/carbon/human/stylish = usr
-			stylish.regen_slickness()
 	else
 		to_chat(usr, SPAN_WARNING("You need an empty, unbroken hand to do that."))
 		holding.forceMove(src)
@@ -520,9 +519,6 @@ BLIND     // can't see anything
 			user.visible_message(SPAN_NOTICE("\The [user] shoves \the [I] into \the [src]."))
 			verbs |= /obj/item/clothing/shoes/proc/draw_knife
 			update_icon()
-			if (ishuman(user))
-				var/mob/living/carbon/human/depleted = user
-				depleted.regen_slickness(-1)
 	else
 		return ..()
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -464,8 +464,6 @@ BLIND     // can't see anything
 	if(usr.put_in_hands(holding))
 		usr.visible_message(SPAN_DANGER("\The [usr] pulls a knife out of their boot!"))
 		holding = null
-		if (ishuman(usr))
-			var/mob/living/carbon/human/stylish = usr
 	else
 		to_chat(usr, SPAN_WARNING("You need an empty, unbroken hand to do that."))
 		holding.forceMove(src)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -109,16 +109,8 @@
 	if(epicenter != get_turf(src))
 		target_turf = get_turf_away_from_target_simple(src, epicenter, 8)
 	var/throw_distance = 8 - 2*severity
-	var/not_slick = TRUE
 	if(target_turf) // this means explosions on the same tile will not fling you
 		throw_at(target_turf, throw_distance, 5)
-		not_slick = FALSE // only explosions that fling you can be survived with slickness
-	if(slickness < (9-(2*severity)) * 10)
-		Weaken(severity) // If they don't get knocked out , weaken them for a bit.
-		not_slick = TRUE // if you don't have enough slickness, you can't safely ride the boom
-	else
-		slickness -= (9-(2*severity)) * 10 // awesome feats aren't something you can do constantly.
-
 	switch(severity)
 		if(1)
 			b_loss += 500
@@ -131,23 +123,13 @@
 				adjustEarDamage(30, 120)
 
 		if(3)
-			if(not_slick)
-				b_loss += 80
-				if(!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
-					adjustEarDamage(15, 60)
-			else
-				visible_message(SPAN_WARNING("[src] rides the shockwave!"))
-				dodge_time = get_game_time()
-				confidence = FALSE
+			b_loss += 80
+			if(!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
+				adjustEarDamage(15, 60)
 		if(4)
-			if(not_slick)
-				b_loss += 50
-				if(!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
-					adjustEarDamage(10, 30)
-			else
-				visible_message(SPAN_WARNING("[src] rides the shockwave!"))
-				dodge_time = get_game_time()
-				confidence = FALSE
+			b_loss += 50
+			if(!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
+				adjustEarDamage(10, 30)
 
 	if(bomb_defense)
 		b_loss = max(b_loss - bomb_defense, 0)
@@ -700,9 +682,6 @@ var/list/rank_prefix = list(\
 			location.add_vomit_floor(src, 1)
 
 		adjustNutrition(-40)
-		regen_slickness(-3)
-		dodge_time = get_game_time()
-		confidence = FALSE
 		spawn(350)	//wait 35 seconds before next volley
 			lastpuke = 0
 
@@ -1484,9 +1463,7 @@ var/list/rank_prefix = list(\
 	if((species.flags & NO_SLIP) || (shoes && (shoes.item_flags & NOSLIP)))
 		return 0
 	..(slipped_on,stun_duration)
-	regen_slickness(-3)
-	dodge_time = get_game_time()
-	confidence = FALSE
+
 
 /mob/living/carbon/human/reset_view(atom/A, update_hud = 1)
 	..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1498,15 +1498,6 @@ var/list/rank_prefix = list(\
 	to_chat(src, SPAN_NOTICE("You are now [holding_back ? "holding back your attacks" : "not holding back your attacks"]."))
 	return
 
-/mob/living/carbon/human/verb/toggle_dodging()
-	set name = "Toggle Dodging"
-	set desc = "Just stand still while under fire."
-	set category = "IC"
-	if(stat) return
-	dodging = !dodging
-	to_chat(src, "<span class='notice'>You are now [dodging ? "dodging incoming fire" : "not dodging incoming fire"].</span>")
-	return
-
 /mob/living/carbon/human/verb/access_holster()
 	set name = "Holster"
 	set desc = "Try to access your holsters."

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -120,7 +120,6 @@
 						M.put_in_active_hand(G)
 						G.synch()
 						LAssailant = M
-						H.regen_slickness() //sick skills!
 
 						break_all_grabs(H)
 
@@ -280,12 +279,6 @@
 							playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 							visible_message(SPAN_WARNING("[M] attempted to disarm [src]"))
 							return
-					if (ishuman(M))
-						var/mob/living/carbon/human/stylish = M
-						stylish.regen_slickness() // disarming your opponent looks slick
-					regen_slickness(-1) // being disarmed looks clumsy
-					dodge_time = get_game_time()
-					confidence = FALSE
 					if(istype(I, /obj/item/twohanded/offhand)) //did someone dare to switch to offhand to not get disarmed?
 						unEquip(src.get_inactive_hand())
 						visible_message(SPAN_DANGER("[M] has disarmed [src]!"))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -8,21 +8,10 @@ meteor_act
 */
 
 /mob/living/carbon/human/bullet_act(var/obj/item/projectile/P, var/def_zone)
-
-	if (dodging && slickness && P.style_damage <= slickness && !incapacitated(INCAPACITATION_UNMOVING))
-		visible_message(SPAN_WARNING("[src] dodges [P]!"))
-		slickness -= P.style_damage
-		dodge_time = get_game_time()
-		confidence = FALSE
-		external_recoil(P.style_damage)
-		return PROJECTILE_FORCE_MISS_SILENCED // src dodged.
-
 	def_zone = check_zone(def_zone)
 	if(!has_organ(def_zone))
 		return PROJECTILE_FORCE_MISS //if they don't have the organ in question then the projectile just passes by.
 
-	dodge_time = get_game_time() // stylish person got hit in a limb they had
-	confidence = FALSE // so they get the slickness regen delay
 
 	var/obj/item/organ/external/organ = get_organ(def_zone)
 
@@ -425,15 +414,6 @@ meteor_act
 					throw_mode_off()
 					return
 
-		if (dodging && slickness && O.style_damage <= slickness && !incapacitated(INCAPACITATION_UNMOVING))
-			visible_message(SPAN_WARNING("[src] dodges [O]!"))
-			slickness -= O.style_damage
-			dodge_time = get_game_time()
-			confidence = FALSE
-			external_recoil(O.style_damage)
-			return
-
-
 		var/dtype = O.damtype
 		var/throw_damage = O.throwforce
 		var/zone
@@ -452,12 +432,6 @@ meteor_act
 		if(!zone)
 			visible_message(SPAN_NOTICE("\The [O] misses [src] narrowly!"))
 			return
-
-		dodge_time = get_game_time() // stylish person got hit and wasn't saved by RNG
-		confidence = FALSE // so they get the slickness regen delay
-		if (ishuman(O.thrower))
-			var/mob/living/carbon/human/stylish = O.thrower
-			stylish.regen_slickness() // throwing something and hitting your target is slick
 
 
 		O.throwing = 0		//it hit, so stop moving
@@ -498,9 +472,6 @@ meteor_act
 				var/embed_chance = (damage - embed_threshold)*I.embed_mult
 				if (embed_chance > 0 && prob(embed_chance))
 					affecting.embed(I)
-				if (ishuman(I.thrower))
-					var/mob/living/carbon/human/stylish = I.thrower
-					stylish.regen_slickness()
 
 		// Begin BS12 momentum-transfer code.
 		var/mass = 1.5

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -100,8 +100,6 @@
 
 	var/style = 0
 	var/max_style = MAX_HUMAN_STYLE
-	var/slickness = 0 // used for stylish dodging stuff, capped at style * 10
-	var/confidence = TRUE // needed to notify player when slickness passively regens
 
 	var/shock_resist = 0 // Resistance to paincrit
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -71,7 +71,6 @@
 	var/gunshot_residue
 	var/holding_back // Are you trying not to hurt your opponent?
 	var/blocking = FALSE //ready to block melee attacks?
-	var/dodging = TRUE // are you dodging those shots?
 
 	mob_bump_flag = HUMAN
 	mob_push_flags = ~HEAVY

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -36,7 +36,6 @@
 	var/stasis_timeofdeath = 0
 	var/pulse = PULSE_NORM
 	var/global/list/overlays_cache = null
-	var/dodge_time = 0 // will be set to timeofgame on dodging
 
 /mob/living/carbon/human/Life()
 	set invisibility = 0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -80,12 +80,6 @@
 
 		handle_medical_side_effects()
 
-		if (life_tick % 4 == 1 && (get_game_time() >= dodge_time + 5 SECONDS))
-			if (confidence == FALSE && style > 0)
-				to_chat(src, SPAN_NOTICE("You feel confident again."))
-				confidence = TRUE
-			regen_slickness()
-
 		if(life_tick % 2)	//Upadated every 2 life ticks, lots of for loops in this, needs to feel smother in the UI
 			for(var/obj/item/organ/external/E in organs)
 				E.update_limb_efficiency()
@@ -1152,7 +1146,7 @@
 					upper_body_nature = E.nature
 			else
 				qdel(E)		// Will regrow
-		
+
 		var/datum/preferences/user_pref = client ? client.prefs : null
 
 		for(var/tag in tags_to_grow)
@@ -1207,15 +1201,6 @@
 		sight |= SEE_TURFS|SEE_OBJS|SEE_MOBS
 	else if(get_active_mutation(src, MUTATION_THERMAL_VISION))
 		sight |= SEE_MOBS
-
-
-/mob/living/carbon/human/proc/regen_slickness(var/source_modifier = 1)
-	var/slick = TRUE
-	if (slickness == style*10) // is slickness at the maximum?
-		slick = FALSE
-	slickness = max(min(slickness + 1 * source_modifier * style, style*10), 0)
-	if (slick && slickness == style*10 && style > 0) // if slickness was not at the maximum and now is
-		to_chat(src, SPAN_NOTICE("You feel slick!")) // notify of slickness entering maximum
 
 /mob/living/carbon/human/proc/EnterStasis()
 	in_stasis = TRUE

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -83,11 +83,6 @@
 			SPAN_DANGER("[src] rolls on the floor, trying to put themselves out!"),
 			SPAN_NOTICE("You stop, drop, and roll!")
 			)
-		if (ishuman(src))
-			var/mob/living/carbon/human/depleted = src
-			depleted.regen_slickness(-1)
-			depleted.confidence = FALSE
-			depleted.dodge_time = get_game_time()
 		sleep(30)
 		if(fire_stacks <= 0)
 			visible_message(

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -693,7 +693,6 @@ default behaviour is:
 		while(livmomentum > 0 && C.true_dir)
 			Move(get_step(loc, _dir),dir)
 			livmomentum--
-			regen_slickness(0.25) // The longer you slide, the more stylish it is
 			sleep(world.tick_lag + 0.5)
 		C.mloop = 0
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -411,9 +411,6 @@
 
 	var/turf/location = get_turf(src)
 	location.hotspot_expose(fire_burn_temperature(), 50, 1)
-	if (ishuman(src))
-		var/mob/living/carbon/human/stylish = src
-		stylish.regen_slickness() // being on fire is cool, but don't try this at home
 
 /mob/living/fire_act()
 	adjust_fire_stacks(2)

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -16,7 +16,7 @@
 		if(E.wounds.len)
 			to_chat(user, SPAN_WARNING("You find [E.get_wounds_desc()]"))
 			wound_found = TRUE
-	
+
 		if(E.number_internal_wounds)
 			to_chat(user, SPAN_WARNING("You find evidence of one or more internal injuries."))
 			wound_found = TRUE
@@ -143,7 +143,6 @@
 	//deal damage AFTER the kick
 	var/damage = max(1, min(30, (attacker.stats.getStat(STAT_ROB) / 3)))
 	target.damage_through_armor(damage, BRUTE, BP_CHEST, ARMOR_MELEE)
-	attacker.regen_slickness()
 	//admin messaging
 	attacker.attack_log += text("\[[time_stamp()]\] <font color='red'>Dropkicked [target.name] ([target.ckey])</font>")
 	target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Dropkicked by [attacker.name] ([attacker.ckey])</font>")
@@ -167,7 +166,6 @@
 		attacker.Weaken(2)
 		target.Stun(6)
 		playsound(loc, 'sound/weapons/jointORbonebreak.ogg', 50, 1, -1)
-		attacker.regen_slickness()
 		//admin messaging
 		attacker.attack_log += text("\[[time_stamp()]\] <font color='red'>Suplexed [target.name] ([target.ckey])</font>")
 		target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Suplexed by [attacker.name] ([attacker.ckey])</font>")
@@ -273,7 +271,6 @@
 
 	target.Weaken(1)
 	playsound(loc, 'sound/weapons/jointORbonebreak.ogg', 50, 1, -1)
-	attacker.regen_slickness(0.15)//sick, but a dropkick is even sicker
 
 	attacker.attack_log += text("\[[time_stamp()]\] <font color='red'>Fireman-thrown [target.name] ([target.ckey])</font>")
 	target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Fireman-thrown by [attacker.name] ([attacker.ckey])</font>")
@@ -318,7 +315,6 @@
 
 	target.throw_at(get_edge_target_turf(target, dir), 7, 2)//this is very fast, and very painful for any obstacle involved
 	target.damage_through_armor(damage, HALLOSS, armor_divisor = 2)
-	attacker.regen_slickness(0.4)
 
 	//admin messaging
 	attacker.attack_log += text("\[[time_stamp()]\] <font color='red'>Swung [target.name] ([target.ckey])</font>")

--- a/code/modules/onestar/os_turret.dm
+++ b/code/modules/onestar/os_turret.dm
@@ -304,7 +304,6 @@
 	damage_types = list(BRUTE = 15)
 	armor_divisor = 3
 	penetrating = 2
-	style_damage = 15
 	recoil = 30
 	step_delay = 0.4
 	sharp = TRUE	// Until all bullets are turned sharp by default
@@ -316,7 +315,6 @@
 	damage_types = list(BURN = 20)
 	armor_divisor = 2
 	stutter = 3
-	style_damage = 25
 	recoil = 10
 	wounding_mult = WOUNDING_WIDE
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -31,7 +31,6 @@
 
 	var/list/custom_default = list() // used to preserve changes to stats past refresh_upgrades proccing
 	var/damage_multiplier = 1 //Multiplies damage of projectiles fired from this gun
-	var/style_damage_multiplier = 1 // multiplies style damage of projectiles fired from this gun
 	var/penetration_multiplier = 0 //Sum of armor penetration of projectiles fired from this gun
 	var/pierce_multiplier = 0 //Additing wall penetration to projectiles fired from this gun
 	var/ricochet_multiplier = 1 //multiplier for how much projectiles fired from this gun can ricochet, modified by the bullet blender weapon mod
@@ -392,7 +391,6 @@
 
 		projectile.multiply_projectile_damage(damage_multiplier)
 
-		projectile.multiply_projectile_style_damage(style_damage_multiplier)
 
 		projectile.add_projectile_penetration(penetration_multiplier)
 

--- a/code/modules/projectiles/guns/projectile/battle_rifle/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/battle_rifle/boltgun.dm
@@ -13,7 +13,6 @@
 	caliber = CAL_LRIFLE
 	fire_delay = 8
 	damage_multiplier = 1.4
-	style_damage_multiplier = 5
 	penetration_multiplier = 0.3
 	init_recoil = RIFLE_RECOIL(1.5)
 	init_offset = 4 //bayonet's effect on aim, reduced from 4

--- a/code/modules/projectiles/guns/projectile/battle_rifle/levergun.dm
+++ b/code/modules/projectiles/guns/projectile/battle_rifle/levergun.dm
@@ -8,7 +8,6 @@
 	armor_divisor = ARMOR_PEN_GRAZING
 	caliber = CAL_MAGNUM
 	damage_multiplier = 1.6
-	style_damage_multiplier = 1
 	penetration_multiplier = 0
 	proj_step_multiplier = 0.8
 	init_recoil = RIFLE_RECOIL(2)

--- a/code/modules/projectiles/guns/projectile/pistol/handmade.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/handmade.dm
@@ -17,7 +17,6 @@
 	damage_multiplier = 1.35
 	penetration_multiplier = 0
 	init_recoil = HANDGUN_RECOIL(2)
-	style_damage_multiplier = 2
 	spawn_frequency = 0
 	spawn_blacklisted = FALSE
 	spawn_tags = SPAWN_TAG_GUN_HANDMADE

--- a/code/modules/projectiles/guns/projectile/revolver/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/revolver.dm
@@ -27,19 +27,6 @@
 	gun_parts = list(/obj/item/part/gun/frame/miller = 1, /obj/item/part/gun/grip/rubber = 1, /obj/item/part/gun/mechanism/revolver = 1, /obj/item/part/gun/barrel/magnum = 1)
 	serial_type = "FS"
 
-
-/obj/item/gun/projectile/revolver/pickup(mob/user)
-	. = ..()
-	if(ishuman(user))
-		var/mob/living/carbon/human/stylish = user
-		if(stylish.style > 4)
-			style_damage_multiplier = stylish.style / 4 // this is so two stylish users that both shoot each other once at full slickness
-			to_chat(user, SPAN_NOTICE("You feel more confident with a revolver in your hand.")) // ends with the more stylish being the winner, commonly known as High Noon
-		else
-			style_damage_multiplier = 1
-			to_chat(user, SPAN_WARNING("You don't feel stylish enough to use a revolver properly."))
-
-
 /obj/item/gun/projectile/revolver/verb/spin_cylinder()
 	set name = "Spin cylinder"
 	set desc = "Fun when you're bored out of your skull."
@@ -52,9 +39,6 @@
 	loaded = shuffle(loaded)
 	if(rand(1,max_shells) > loaded.len)
 		chamber_offset = rand(0,max_shells - loaded.len)
-	if (ishuman(usr))
-		var/mob/living/carbon/human/stylish = usr
-		stylish.regen_slickness()
 
 /obj/item/gun/projectile/revolver/consume_next_projectile()
 	if(chamber_offset)
@@ -65,9 +49,6 @@
 /obj/item/gun/projectile/revolver/load_ammo(obj/item/A, mob/user)
 	. = ..()
 	chamber_offset = 0
-	if (. && ishuman(user)) // if it actually loaded and the user is human
-		var/mob/living/carbon/human/stylish = user
-		stylish.regen_slickness()
 
 /obj/item/gun/projectile/revolver/proc/update_charge()
 	if(!drawChargeMeter)

--- a/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
@@ -15,7 +15,6 @@
 	slot_flags = SLOT_BACK
 	caliber = CAL_SHOTGUN
 	init_recoil = RIFLE_RECOIL(1.7)
-	style_damage_multiplier = 2
 	damage_multiplier = 1
 	penetration_multiplier = 0.1
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 1)
@@ -80,9 +79,6 @@
 		to_chat(user, SPAN_WARNING("You can't load [src] while the barrel is closed!"))
 		return
 	. = ..()
-	if (. && ishuman(user)) // if it actually loaded and the user is human
-		var/mob/living/carbon/human/stylish = user
-		stylish.regen_slickness()
 
 
 /obj/item/gun/projectile/shotgun/doublebarrel/unload_ammo(mob/user, var/allow_dump=1)

--- a/code/modules/projectiles/guns/projectile/shotgun/handmade.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/handmade.dm
@@ -17,7 +17,6 @@
 	damage_multiplier = 1.2
 	penetration_multiplier = 0.2
 	init_recoil = CARBINE_RECOIL(3.5)
-	style_damage_multiplier = 2
 	price_tag = 250 //cheap as they get
 	spawn_blacklisted = FALSE
 	spawn_tags = SPAWN_TAG_GUN_HANDMADE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -20,7 +20,6 @@
 	spawn_blacklisted = TRUE
 	spawn_frequency = 0
 	spawn_tags = null
-	style_damage = 13 // stylish people can dodge lots of projectiles
 	var/bumped = FALSE		//Prevents it from hitting more than one guy at once
 	var/hitsound_wall = "ricochet"
 	var/list/mob_hit_sound = list('sound/effects/gore/bullethit2.ogg', 'sound/effects/gore/bullethit3.ogg') //Sound it makes when it hits a mob. It's a list so you can put multiple hit sounds there.

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -11,7 +11,6 @@
 	var/frequency = 1
 	hitscan = 1
 	invisibility = 101	//beam projectiles are invisible as they are rendered by the effect engine
-	style_damage = 30 //hitscan, light speed projectiles? Be glad its easier to dodge than a revolver.
 	recoil = 1 // Even less than self-propelled bullets
 
 	muzzle_type = /obj/effect/projectile/laser/muzzle
@@ -63,7 +62,6 @@
 	icon_state = "heavylaser"
 	damage_types = list(BURN = 50)
 	armor_divisor = 1
-	style_damage = 60 //it's a slow firing beam weapon, this is probably fair.
 	recoil = 3
 
 	muzzle_type = /obj/effect/projectile/laser_heavy/muzzle
@@ -77,7 +75,6 @@
 	var/contractor = FALSE //Check if it's a contractor psychic beam
 	damage_types = list(PSY = 30)
 	armor_divisor = ARMOR_PEN_MAX
-	style_damage = 60 //It's magic brain beams, deal with it.
 	recoil = 2
 
 	muzzle_type = /obj/effect/projectile/psychic_laser_heavy/muzzle
@@ -195,7 +192,6 @@
 	damage_types = list(BURN = 60)
 	armor_divisor = 2
 	stutter = 3
-	style_damage = 70 //it's the laser AMR.
 	recoil = 10
 
 	muzzle_type = /obj/effect/projectile/xray/muzzle

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -19,7 +19,6 @@ There are important things regarding this file:
 	armor_divisor = 1
 	can_ricochet = TRUE
 	penetrating = 2
-	style_damage = 20
 	recoil = 3
 
 /obj/item/projectile/bullet/pistol/hv
@@ -161,7 +160,6 @@ There are important things regarding this file:
 	armor_divisor = 1
 	can_ricochet = TRUE
 	penetrating = 2
-	style_damage = 40
 	recoil = 6
 	wounding_mult = WOUNDING_WIDE
 
@@ -195,7 +193,6 @@ There are important things regarding this file:
 	armor_divisor = 3
 	penetrating = 2
 	step_delay = 0.8
-	style_damage = 70
 	recoil = 15 // Good luck shooting these from a revolver
 	wounding_mult = WOUNDING_EXTREME
 
@@ -248,7 +245,6 @@ There are important things regarding this file:
 	armor_divisor = 1
 	knockback = 1
 	step_delay = 1.1
-	style_damage = 25
 	recoil = 8
 	wounding_mult = WOUNDING_EXTREME
 
@@ -331,7 +327,6 @@ There are important things regarding this file:
 	embed = FALSE
 	can_ricochet = TRUE
 	recoil = 3
-	style_damage = 40
 	wounding_mult = WOUNDING_EXTREME
 
 /obj/item/projectile/bullet/bolt/on_hit(mob/living/target, def_zone = BP_CHEST)

--- a/code/modules/projectiles/projectile/force.dm
+++ b/code/modules/projectiles/projectile/force.dm
@@ -41,7 +41,6 @@
 	can_ricochet = FALSE
 	hitscan = TRUE
 	invisibility = 101	//Works like beams
-	style_damage = 101 // Shouldn't have gotten hit by an RPG
 
 	muzzle_type = /obj/effect/projectile/xray/muzzle
 	tracer_type = /obj/effect/projectile/xray/tracer

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -28,7 +28,6 @@
 	icon_state = "rocket"
 	damage_types = list(BRUTE = 60)
 	armor_divisor = 1
-	style_damage = 101 //single shot, incredibly powerful. If you get direct hit with this you deserve it, if you dodge the direct shot you're protected from the explosion.
 	check_armour = ARMOR_BOMB
 	penetrating = -5
 	recoil = 40

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1204,7 +1204,6 @@
 	cooked = TRUE
 	junk_food = TRUE
 	spawn_tags = SPAWN_TAG_JUNKFOOD
-	style_damage = 60
 	rarity_value = 20
 	taste_tag = list(SWEET_FOOD,FLOURY_FOOD)
 
@@ -1215,9 +1214,6 @@
 		SPAN_DANGER("\The [src.name] splats."),
 		SPAN_DANGER("You hear a splat.")
 	)
-	if(ishuman(hit_atom))
-		var/mob/living/carbon/human/depleted = hit_atom
-		depleted.slickness -= style_damage// did not do the confidence stuff as hitby proc handles that
 	qdel(src)
 
 /obj/item/reagent_containers/food/snacks/berryclafoutis

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -103,10 +103,18 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 	QDEL_LIST(breakdowns)
 	return ..()
 
+/datum/sanity/proc/get_style_multiplier()
+
+	if(owner)
+		var/multiplier = owner.style / MAX_HUMAN_STYLE / 3
+		return clamp(multiplier, 0, 0.3)
+
 /datum/sanity/proc/give_insight(value)
 	var/new_value = value
 	if(value > 0)
 		new_value = max(0, value * insight_gain_multiplier * GLOB.GLOBAL_INSIGHT_MOD)
+	var/multiplier = get_style_multiplier()
+	new_value += new_value * multiplier
 	insight = min(insight + new_value, max_insight)
 
 /datum/sanity/proc/give_resting(value)

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -107,7 +107,7 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 
 	if(owner)
 		var/multiplier = owner.style / MAX_HUMAN_STYLE / 3
-		return clamp(multiplier, 0, 0.3)
+		return clamp(multiplier, -0.15, 0.3)
 
 /datum/sanity/proc/give_insight(value)
 	var/new_value = value

--- a/code/modules/tables/flipping.dm
+++ b/code/modules/tables/flipping.dm
@@ -31,9 +31,6 @@
 		structure_shaken()
 
 	playsound(src,'sound/machines/Table_Fall.ogg',100,1)
-	if (ishuman(usr))
-		var/mob/living/carbon/human/stylish = usr
-		stylish.regen_slickness() // dramatic
 	return
 
 /obj/structure/table/proc/unflipping_check(var/direction)
@@ -72,9 +69,6 @@
 		to_chat(usr, SPAN_NOTICE("It won't budge."))
 		return
 	unflip()
-	if (ishuman(usr))
-		var/mob/living/carbon/human/depleted = usr
-		depleted.regen_slickness(-1)
 
 /obj/structure/table/proc/flip(var/direction)
 	if( !straight_table_check(turn(direction,90)) || !straight_table_check(turn(direction,-90)) )

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -116,12 +116,6 @@
 		if(user.a_intent == I_HURT)
 			if(prob(15))
 				target.Weaken(5)
-			if (ishuman(target))
-				var/mob/living/carbon/human/depleted = target
-				depleted.regen_slickness(-1)
-			if (ishuman(user))
-				var/mob/living/carbon/human/stylish = user
-				stylish.regen_slickness()
 			target.damage_through_armor(8, BRUTE, BP_HEAD, ARMOR_MELEE)
 			visible_message(SPAN_DANGER("[user] slams [target]'s face against \the [src]!"))
 			target.attack_log += "\[[time_stamp()]\] <font color='orange'>Has been slammed by [user.name] ([user.ckey] against \the [src])</font>"
@@ -146,14 +140,6 @@
 			to_chat(user, SPAN_DANGER("You need a better grip to do that!"))
 			return
 	else
-		if (ishuman(target))
-			var/mob/living/carbon/human/depleted = target
-			depleted.regen_slickness(-1)
-			depleted.confidence = FALSE
-			depleted.dodge_time = get_game_time()
-		if (ishuman(user))
-			var/mob/living/carbon/human/stylish = user
-			stylish.regen_slickness()
 		target.forceMove(loc)
 		target.Weaken(5)
 		visible_message(SPAN_DANGER("[user] puts [target] on \the [src]."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes all combat effects of style (dodging bullets,  explosion hopping ) , and all the vars that facilitated this
Style will now provide a maximum buff of 30% from any source of insight gain, and a maximum debuff of 15% from all source of gain.
## Why It's Good For The Game
Style has only facilitated full auto weapons being the meta , whilst all semi-auto weapons / bolts / shotguns were made seemingly useless outside of very few niche scenario. This aims to correct this.
Also style was a mechanic that when combined with typical speed powergaming (hyperzine + nuka cola + mechanical muscles) would result in near invincible people that would kill the entire crew (remember zimmer's moebius powergaming build as antag? that got him a ban after killing entire crews multiple rounds)
(Enough to say that even people wearing certain armors were still dodging bullets, and with humon's new accuracy system we get a lot of dodging by default)

## Testing
Ran locally , sanity ran fine and style is no more.

## Changelog
:cl:
del: Removed all ties of style with combat
add: Style now influences your insight gain , having max style will buff it by 30% , and falling below will debuff to a maximum of 15%
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
