### PR TITLE
Wire splicing magnetizes to the nearest wire if it doesn't spawn on one

### DIFF
--- a/code/game/objects/structures/wire_splicing.dm
+++ b/code/game/objects/structures/wire_splicing.dm
@@ -58,7 +58,7 @@
 				best_score = turf_score
 				candidates.Cut()
 
-			candidates.Add(src)
+			candidates.Add(T)
 
 		//No nearby cables? Cancel
 		if (!candidates.len)


### PR DESCRIPTION
## About The Pull Request

I was porting wire splices to Yogstation when I noticed that the spawn code that dynamically moves around the splice to different locations has been broken for 6 years (since they were introduced).

It spawns itself and then looks for valid locations in range to move to if it's not on a wire. However, it would only ever add itself to the candidates list, which obviously never moved it. I didn't even see any area where it wasn't placed directly onto a wire, so this entire chunk of code might not even be needed.

## Why It's Good For The Game

I'm not sure if this is good for the game. Just fixing bugs.

## Testing

Here's a picture from Yogstation of it working (all spawned under my ghost): 
![image](https://user-images.githubusercontent.com/5091394/232644989-e4f0da2f-dba3-47db-8724-38ef9755dc67.png)

## Changelog
:cl:
fix: fixes wire splicing not looking around them for valid spawn positions
/:cl:
