### PR TITLE
Removes flash protection from Meson Optical Scanners

### DIFF
--- a/code/modules/clothing/glasses/meson.dm
+++ b/code/modules/clothing/glasses/meson.dm
@@ -5,7 +5,6 @@
 	item_state = "glasses"
 	vision_flags = SEE_TURFS
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
-	flash_protection = FLASH_PROTECTION_MAJOR
 	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
 	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	price_tag = 500


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the flash protection from Mesons
## Why It's Good For The Game
They're used for seeing all walls and the structure around. I do not see why they need to have this , ontop of the combat utility they have in maintenance (no speed debuff from poor sight + able to shoot at people from complete darkness) and their practical usage(seeing through walls)

## Testing
Ran it locally , tried to use optical mesons to stop a flashbang blind , did not work.
Technomancers are at large unaffected since their helmets and voidsuit helmets already have welding protection

## Changelog
:cl:
balance: Meson Optical Scanners no longer provide any flash protection.(from maximum protection to 0)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
