### PR TITLE
Flashbangs now affect recoil and robustness

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -42,6 +42,7 @@
 		H.flash(3, FALSE , TRUE , TRUE, 15)
 	else
 		M.flash(5, FALSE, TRUE , TRUE)
+	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_ADEPT, 10 SECONDS, "flashbang")
 	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_ADEPT, 10 SECONDS, "flashbang")
 	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_ADEPT, 10 SECONDS, "flashbang")
 	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_ADEPT, 10 SECONDS, "flashbang")
@@ -129,16 +130,20 @@
 		var/obj/item/organ/internal/eyes/E = H.random_organ_by_process(OP_EYES)
 		if (E && E.damage >= E.min_bruised_damage)
 			to_chat(M, SPAN_DANGER("Your eyes start to burn badly!"))
+		H.add_recoil(300 - ear_safety * 100)
 	if (M.ear_damage >= 15)
 		to_chat(M, SPAN_DANGER("Your ears start to ring badly!"))
 	else
 		if (M.ear_damage >= 5)
 			to_chat(M, SPAN_DANGER("Your ears start to ring!"))
+
 	if(stat_reduction)
+		M.stats.addTempStat(STAT_ROB, stat_def, 10 SECONDS, "flashbang")
 		M.stats.addTempStat(STAT_VIG, stat_def, 10 SECONDS, "flashbang")
 		M.stats.addTempStat(STAT_COG, stat_def, 10 SECONDS, "flashbang")
 		M.stats.addTempStat(STAT_BIO, stat_def, 10 SECONDS, "flashbang")
 		M.stats.addTempStat(STAT_MEC, stat_def, 10 SECONDS, "flashbang")
+
 	M.update_icons()
 
 /obj/item/grenade/flashbang/nt


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Flashbangs now add a stat debuff to robustness, and also affect recoil(Adds 300 - ear_safety * 100 recoil)
## Why It's Good For The Game
Flashbangs see rare use as a non-lethal combat gadget , most predominantly to everyone still seeing after they're used and still being able to aim perfectly.This is more so aimed at letting people close the distance or using flashbangs to prevent enemy fire from hitting them with  max accuracy.

## Testing
Ran a server on local as SGT, flashbangs gave me recoil and a good debuff to my robustness.
## Changelog
:cl:
balance: Flashbangs now give 300 recoil , reduced by 100 for each ear safety level(max is 3)
balance: Flashbangs now also reduce the robustness tstat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
