### PR TITLE
Adds Carbon pill bottles

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -69,6 +69,9 @@
 	new /obj/item/reagent_containers/pill/antitox(src)
 	new /obj/item/reagent_containers/pill/antitox(src)
 	new /obj/item/reagent_containers/pill/antitox(src)
+	new /obj/item/reagent_containers/pill/carbon(src)
+	new /obj/item/reagent_containers/pill/carbon(src)
+	new /obj/item/reagent_containers/pill/carbon(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector(src)
 	new /obj/item/device/scanner/health(src)
 
@@ -194,6 +197,8 @@
 	new /obj/item/stack/medical/advanced/ointment/nt(src)
 	new /obj/item/reagent_containers/syringe/large/antitoxin(src)
 	new /obj/item/reagent_containers/syringe/large/dexalin_plus(src)
+	new /obj/item/reagent_containers/pill/carbon(src)
+	new /obj/item/reagent_containers/pill/carbon(src)
 
 /obj/item/storage/firstaid/nt/update_icon()
 	if(!contents.len)
@@ -251,6 +256,11 @@
 	name = "bottle of Dylovene pills"
 	desc = "Contains pills used to treat toxic substances in the blood."
 	prespawned_content_type = /obj/item/reagent_containers/pill/dylovene
+
+/obj/item/storage/pill_bottle/carbon
+	name = "bottle of Carbon pills"
+	desc = "Contains pills used to purge stomach contents"
+	prespawned_content_type = /obj/item/reagent_containers/pill/carbon
 
 /obj/item/storage/pill_bottle/inaprovaline
 	name = "bottle of Inaprovaline pills"

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -259,7 +259,7 @@
 
 /obj/item/storage/pill_bottle/carbon
 	name = "bottle of Carbon pills"
-	desc = "Contains pills used to purge stomach contents"
+	desc = "Contains pills used to purge stomach contents."
 	prespawned_content_type = /obj/item/reagent_containers/pill/carbon
 
 /obj/item/storage/pill_bottle/inaprovaline

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -192,6 +192,11 @@
 	icon_state = "pill13"
 	preloaded_reagents = list("anti_toxin" = 15)
 
+/obj/item/reagent_containers/pill/carbon
+	name = "Carbon pill"
+	desc = "A pill of activated charcoal, used to purge stomach contents."
+	icon_state = "pill9"
+	preloaded_reagents = list("carbon" = 15)
 
 /obj/item/reagent_containers/pill/inaprovaline
 	name = "Inaprovaline pill"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds carbon pills + carbon pill bottles
adds carbon pills to the anti-toxin kit and to NT med kit

## Why It's Good For The Game
Anti-toxins kit should also include  a basic way of purging stomach contents.
## Testing
ran a local test , kits spawned with carbon pills.


## Changelog
:cl:
add: Added carbon pills to the anti-toxin kit and NT medkit,
add: Added a new pill bottle , carbon pill bottle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
