### PR TITLE
Remote observation is now a T4 mutation , not T2

### DIFF
--- a/code/__DEFINES/mutations.dm
+++ b/code/__DEFINES/mutations.dm
@@ -8,7 +8,6 @@
 
 #define MUTATION_LESSER_HEALING		/datum/mutation/t2/healing_factor
 #define MUTATION_REMOTESAY			/datum/mutation/t2/remotesay
-#define MUTATION_REMOTESEE			/datum/mutation/t2/remoteobserve
 #define MUTATION_FORCESAY			/datum/mutation/t2/forcespeak
 #define MUTATION_NOPRINTS			/datum/mutation/t2/noprints
 #define MUTATION_ROACH_PHEROMONES	/datum/mutation/t2/roach_pheromones
@@ -27,6 +26,7 @@
 #define MUTATION_XRAY				/datum/mutation/t4/xray
 #define MUTATION_PHAZING			/datum/mutation/t4/phazing
 #define MUTATION_MORPH				/datum/mutation/t4/morph
+#define MUTATION_REMOTESEE			/datum/mutation/t4/remoteobserve
 
 // Sdisabilities. // TODO: To be replaced with status effects -- KIROV
 #define BLIND 0x1

--- a/code/modules/genetics/mutations_T2.dm
+++ b/code/modules/genetics/mutations_T2.dm
@@ -21,20 +21,6 @@
 	if(..())
 		user.verbs -= /mob/living/carbon/human/proc/remotesay
 
-
-/datum/mutation/t2/remoteobserve
-	name = "Remote observation"
-	desc = "Allows you to look through the eyes of other people."
-
-/datum/mutation/t2/remoteobserve/imprint(mob/living/carbon/user)
-	if(..())
-		user.verbs += /mob/living/carbon/human/proc/remoteobserve
-
-/datum/mutation/t2/remoteobserve/cleanse(mob/living/carbon/user)
-	if(..())
-		user.verbs -= /mob/living/carbon/human/proc/remoteobserve
-
-
 /datum/mutation/t2/forcespeak
 	name = "Force speak"
 	desc = "Allows you to force other person in line of sight to speak."

--- a/code/modules/genetics/mutations_T4.dm
+++ b/code/modules/genetics/mutations_T4.dm
@@ -3,6 +3,20 @@
 	tier_string = "Aurelien"
 	NSA_load = 0
 
+/datum/mutation/t4/remoteobserve
+	name = "Remote observation"
+	desc = "Allows you to look through the eyes of other people."
+	NSA_load = 20
+
+/datum/mutation/t4/remoteobserve/imprint(mob/living/carbon/user)
+	if(..())
+		user.verbs += /mob/living/carbon/human/proc/remoteobserve
+
+/datum/mutation/t4/remoteobserve/cleanse(mob/living/carbon/user)
+	if(..())
+		user.verbs -= /mob/living/carbon/human/proc/remoteobserve
+
+
 /datum/mutation/t4/godblood
 	name = "God Blood"
 	desc = "Suppresses cruciform, allowing to have any implant or organ, as well as mutations."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes remote observation a T4 mutation , from T2
Adds a NSA load of 20 to remote observation

## Why It's Good For The Game
Just like the remote-sight breakdown , this ability has the vast power of instantly exposing any antagonist without any viable counter
It also fucks over excelciors more often then every other antag and ruins buildup

## Testing
Gave myself the mutation , got NSA.

## Changelog
:cl:
balance: Remote observation is now a T4 mutation, from T2 , and now also gives 20 NSA.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
