### PR TITLE
Buffs excelciors

### DIFF
--- a/code/datums/contract.dm
+++ b/code/datums/contract.dm
@@ -346,7 +346,7 @@ GLOBAL_LIST_INIT(excel_item_targets,list(
 			to_chat(user, SPAN_NOTICE("Mandate completed: [name] ([reward] energy, [E.time2minutes(E.mandate_increase)] minutes have been added to the detection countdown timer.)"))
 		else
 			to_chat(user, SPAN_NOTICE("Mandate completed: [name] ([reward] energy)"))
-	
+
 	for (var/obj/machinery/complant_teleporter/t in excelsior_teleporters)
 		t.update_nano_data()
 
@@ -377,7 +377,7 @@ GLOBAL_LIST_INIT(excel_item_targets,list(
 	reward = 1200
 	var/datum/mind/target_mind
 	var/cruciform_check = FALSE
-	var/desc_text = "by stuffing them alive in the teleporter" // Text for the end of desc, a bit hacky
+	var/desc_text = "by stuffing them alive in the teleporter. We will provide reinforcements for the completion of this objective." // Text for the end of desc, a bit hacky
 	var/command_bias = 15 //Bonus chance for targeting heads and IH
 
 /datum/antag_contract/excel/targeted/New()

--- a/code/game/machinery/excelsior/ex_teleporter.dm
+++ b/code/game/machinery/excelsior/ex_teleporter.dm
@@ -25,7 +25,7 @@ var/global/excelsior_last_draft = 0
 	var/mob/current_user
 	var/time_until_scan
 
-	var/reinforcements_delay = 20 MINUTES
+	var/reinforcements_delay = 5 MINUTES
 	var/reinforcements_cost = 2000
 
 	var/list/nanoui_data = list()			// Additional data for NanoUI use
@@ -351,7 +351,7 @@ var/global/excelsior_last_draft = 0
 		to_chat(user, SPAN_WARNING("Not enough energy."))
 		return
 	if(world.time < (excelsior_last_draft + reinforcements_delay))
-		to_chat(user, SPAN_WARNING("You can call only one conscript for 20 minutes."))
+		to_chat(user, SPAN_WARNING("You can call only one conscript for 5 minutes."))
 		return
 	if(excelsior_conscripts <= 0)
 		to_chat(user, SPAN_WARNING("They have nobody to send to you."))
@@ -373,12 +373,16 @@ var/global/excelsior_last_draft = 0
 	var/mob/living/carbon/human/conscript = new /mob/living/carbon/human(loc)
 	conscript.ckey = candidate.ckey
 	make_antagonist(conscript.mind, ROLE_EXCELSIOR_REV)
-	conscript.stats.setStat(STAT_TGH, 10)
-	conscript.stats.setStat(STAT_VIG, 10)
+	conscript.stats.setStat(STAT_TGH, 30)
+	conscript.stats.setStat(STAT_VIG, 30)
+	conscript.stats.setStat(STAT_ROB, 30)
+	conscript.stats.setStat(STAT_MEC, 10)
+	conscript.stats.setStat(STAT_BIO, 10)
 	conscript.equip_to_appropriate_slot(new /obj/item/clothing/under/excelsior())
 	conscript.equip_to_appropriate_slot(new /obj/item/clothing/shoes/workboots())
 	conscript.equip_to_appropriate_slot(new /obj/item/device/radio/headset())
 	conscript.equip_to_appropriate_slot(new /obj/item/storage/backpack/satchel())
+	conscript.equip_to_appropriate_slot(new /obj/item/melee/baton/excelbaton())
 	var/obj/item/card/id/card = new(conscript)
 	conscript.set_id_info(card)
 	card.assignment = "Excelsior Conscript"

--- a/code/game/machinery/excelsior/ex_teleporter.dm
+++ b/code/game/machinery/excelsior/ex_teleporter.dm
@@ -351,7 +351,7 @@ var/global/excelsior_last_draft = 0
 		to_chat(user, SPAN_WARNING("Not enough energy."))
 		return
 	if(world.time < (excelsior_last_draft + reinforcements_delay))
-		to_chat(user, SPAN_WARNING("You can call only one conscript for [reinforcements_delay/MINUTES] minutes."))
+		to_chat(user, SPAN_WARNING("You can call only one conscript for [reinforcements_delay / 600] minutes."))
 		return
 	if(excelsior_conscripts <= 0)
 		to_chat(user, SPAN_WARNING("They have nobody to send to you."))

--- a/code/game/machinery/excelsior/ex_teleporter.dm
+++ b/code/game/machinery/excelsior/ex_teleporter.dm
@@ -351,7 +351,7 @@ var/global/excelsior_last_draft = 0
 		to_chat(user, SPAN_WARNING("Not enough energy."))
 		return
 	if(world.time < (excelsior_last_draft + reinforcements_delay))
-		to_chat(user, SPAN_WARNING("You can call only one conscript for 5 minutes."))
+		to_chat(user, SPAN_WARNING("You can call only one conscript for [reinforcements_delay] minutes."))
 		return
 	if(excelsior_conscripts <= 0)
 		to_chat(user, SPAN_WARNING("They have nobody to send to you."))

--- a/code/game/machinery/excelsior/ex_teleporter.dm
+++ b/code/game/machinery/excelsior/ex_teleporter.dm
@@ -351,7 +351,7 @@ var/global/excelsior_last_draft = 0
 		to_chat(user, SPAN_WARNING("Not enough energy."))
 		return
 	if(world.time < (excelsior_last_draft + reinforcements_delay))
-		to_chat(user, SPAN_WARNING("You can call only one conscript for [reinforcements_delay] minutes."))
+		to_chat(user, SPAN_WARNING("You can call only one conscript for [reinforcements_delay/MINUTES] minutes."))
 		return
 	if(excelsior_conscripts <= 0)
 		to_chat(user, SPAN_WARNING("They have nobody to send to you."))

--- a/code/game/machinery/excelsior/ex_turret.dm
+++ b/code/game/machinery/excelsior/ex_turret.dm
@@ -16,7 +16,7 @@
 	var/ammo_max = 96
 	var/working_range = 30 // how far this turret operates from excelsior teleporter
 	var/burst_lenght = 8
-	health = 60
+	health = 300
 	shot_delay = 0
 
 /obj/machinery/porta_turret/excelsior/proc/has_power_source_nearby()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the excel turret health from 60 to 300
Excelsior conscripts now get 30 rob , vig , tgh and 10 mec and bio
Excelsior conscripts now also spawn with a excel stunbaton
Excelsior conscript timer reduced to 5 minutes
The excel target contract specifies that doing it gives available conscripts

## Why It's Good For The Game
A average .30 bullet mag with  each bullet dealing 15 damage will still deal 450 damage to a turret. As they are now , they are far too weak , being taken in 2-3 shots by any attacker.
Conscripts were severely underused and also weak when called, the fact that barely anyone knows that the kidnapping contracts also give conscripts added onto this issue.
I reduced the timer because i don't see a point in having it at 20 minutes.
## Testing
Ran locally , kidnapped a command member , called a conscript , spawned with stunbaton and better stats.
Turret took 10-ish .30 bullets to take out , instead of 2.
## Changelog
:cl:
balance: Excel turret health buffed from 60 to 300
balance: Excelsior conscripts now start with 30 points in rob , vig and TGH, and 10 in mec and bio
balance: Excelsior conscripts now start with a stunbaton
balance: Excelsior reinforcement delay reduced from 20 minutes to 5
fix: Excel kidnapping contract now mentions giving reinforcements for its completion.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
