### PR TITLE
Increase shrapnel removal damage.

### DIFF
--- a/code/modules/surgery/organic.dm
+++ b/code/modules/surgery/organic.dm
@@ -392,7 +392,7 @@
 	)
 	var/obj/item/shrapnel = locate(/obj/item/material/shard/shrapnel) in organ.implants //will succeed regardless
 	organ.remove_item(shrapnel, user, FALSE)
-	organ.take_damage(tool.force * 1.2, sharp=TRUE)
+	organ.take_damage(tool.force * 1, sharp=TRUE)
 
 //Cauterizing a wound to stop bleeding
 /datum/surgery_step/close_wounds

--- a/code/modules/surgery/organic.dm
+++ b/code/modules/surgery/organic.dm
@@ -383,7 +383,7 @@
 	)
 	var/obj/item/shrapnel = locate(/obj/item/material/shard/shrapnel) in organ.implants
 	organ.remove_item(shrapnel, user, FALSE)
-	organ.take_damage(tool.force, 0, sharp=TRUE) //So it's a bad idea to remove shrapnel with a chainsaw
+	organ.take_damage(tool.force * 0.5, 0, sharp=TRUE) //So it's a bad idea to remove shrapnel with a chainsaw
 
 /datum/surgery_step/remove_shrapnel/fail_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
 	user.visible_message(

--- a/code/modules/surgery/organic.dm
+++ b/code/modules/surgery/organic.dm
@@ -383,7 +383,7 @@
 	)
 	var/obj/item/shrapnel = locate(/obj/item/material/shard/shrapnel) in organ.implants
 	organ.remove_item(shrapnel, user, FALSE)
-	organ.take_damage(tool.force * 0.1, 0, sharp=TRUE) //So it's a bad idea to remove shrapnel with a chainsaw
+	organ.take_damage(tool.force, 0, sharp=TRUE) //So it's a bad idea to remove shrapnel with a chainsaw
 
 /datum/surgery_step/remove_shrapnel/fail_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
 	user.visible_message(
@@ -392,7 +392,7 @@
 	)
 	var/obj/item/shrapnel = locate(/obj/item/material/shard/shrapnel) in organ.implants //will succeed regardless
 	organ.remove_item(shrapnel, user, FALSE)
-	organ.take_damage(tool.force * 0.3, sharp=TRUE)
+	organ.take_damage(tool.force * 1.2, sharp=TRUE)
 
 //Cauterizing a wound to stop bleeding
 /datum/surgery_step/close_wounds


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases shrapnel removal damage multiplier from 0.1 to 1
Fail multiplier increased from 0.3 to 1.2

## Why It's Good For The Game
Katana with 50 melle damage dealt a whopping 5 brute on shrapnel removal, and 15 on fail.
We also have throwing knifes/kitchen knifes with abysmally low damage for removing shrapnel with minimal risk.


## Testing
Tested locally , shrap removal ran fine.

## Changelog
:cl:
balance: Shrapnel removal multiplier changed from 0.1 on succes to 1 , and from 0.3 to 1.2 on fail
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
