### PR TITLE
Brings robot movement speeds to date with human movement speeds.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -82,7 +82,7 @@
 	var/modtype = "Default"
 	var/lower_mod = 0
 	var/datum/effect/effect/system/ion_trail_follow/ion_trail = null
-	var/datum/effect/effect/system/spark_spread/spark_system//So they can initialize sparks whenever/N
+	var/datum/effect/effect/system/spark_spread/spark_system //So they can initialize sparks whenever/N
 	var/jeton = 0
 	var/killswitch = 0
 	var/killswitch_time = 60
@@ -90,7 +90,8 @@
 	var/weaponlock_time = 120
 	var/lawupdate = TRUE //Cyborgs will sync their laws with their AI by default
 	var/lockcharge //Used when locking down a borg to preserve cell charge
-	var/speed = 0.25
+	/// Humans get a -1 by default from any shoe.
+	var/speed = -1
 	var/scrambledcodes = 0 // Used to determine if a borg shows up on the robotics console.  Setting to one hides them.
 	var/tracking_entities = 0 //The number of known entities currently accessing the internal camera
 	var/braintype = "Cyborg"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -90,8 +90,8 @@
 	var/weaponlock_time = 120
 	var/lawupdate = TRUE //Cyborgs will sync their laws with their AI by default
 	var/lockcharge //Used when locking down a borg to preserve cell charge
-	/// Humans get a -1 by default from any shoe.
-	var/speed = -1
+	/// Humans get a -1 by default from any shoe. , robots had a 0.25 added by default.
+	var/speed = -0.75
 	var/scrambledcodes = 0 // Used to determine if a borg shows up on the robotics console.  Setting to one hides them.
 	var/tracking_entities = 0 //The number of known entities currently accessing the internal camera
 	var/braintype = "Cyborg"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the 0.25 speed debuff robots get and replaced with -0.75 speed buff
Humans get 3.5 movement delay (same as robots), but with a -1 added(from shoes.slowdown) that robots didn't have before. Robots actually got a 1.25 speed debuff (Which is massive)
## Why It's Good For The Game
Cyborgs are abysmally slow and being one is extremly boring.

## Testing
Ran it on local , borgs were  slower by humans overall , but NOT as overwhelmingly much as before.

## Changelog
:cl:
balance: Cyborgs  no longer get a 1.25 tally movespeed debuff, and are more on par with human movement speeds , but still with a 0.25 tally debuff.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
