### PR TITLE
Raises GYM tickets price from 50 to 200

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1939,7 +1939,7 @@
 		)
 
 	prices = list(
-		/obj/item/gym_ticket = 50,
+		/obj/item/gym_ticket = 200,
 		/obj/item/tool/hammer/dumbbell = 90,
 		/obj/item/reagent_containers/food/drinks/protein_shake = 150,//a total ripoff
 		/obj/item/reagent_containers/food/drinks/energy = 200,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Raises the GYM tickets price from 50 to 200

## Why It's Good For The Game
The machines give between 15 and 20 points for the wanted combat stat, which is the amount which a overwhelming-upper high oddity would give. It being available for just 50 credits really doesn't stimulate any vaga-economy , so this should help with better motivating vagabonds (and anyone in general) to do jobs.

## Testing
Ran a test locally , vendor showed the price as 200 creds

## Changelog
:cl:
balance: Gym tickets now cost 200 credits , up from 50 credits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
