### PR TITLE
Siliconomy Part 1.1

### DIFF
--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -229,6 +229,8 @@
 		/obj/item/newspaper,
 		/obj/item/pen,
 		/obj/item/stamp,
+		/obj/item/packageWrap,
+		/obj/item/device/destTagger,
 		/obj/item/smallDelivery
 		)
 

--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -223,9 +223,13 @@
 		/obj/item/clipboard,
 		/obj/item/paper,
 		/obj/item/paper_bundle,
+		/obj/item/paper_bin,
 		/obj/item/card/id,
 		/obj/item/book,
-		/obj/item/newspaper
+		/obj/item/newspaper,
+		/obj/item/pen,
+		/obj/item/stamp,
+		/obj/item/smallDelivery
 		)
 
 /obj/item/gripper/research //A general usage gripper, used for toxins/robotics/xenobio/etc
@@ -299,6 +303,7 @@
 		/obj/item/electronics/circuitboard/broken,
 		/obj/item/clothing/mask/smokable/cigarette,
 		/obj/item/spacecash,
+		/obj/item/device/eftpos,
 		///obj/item/reagent_containers/cooking_container //Part of cooking overhaul, not yet ported
 		)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I forgot about the EFTPOS in my previous Silicon Economy PR. This adds the ability to pick it up, which is vital to interacting with it.

While I was at it, I expanded the list of items the Clerical gripper can hold, as it was previously missing Pens, Stamps, Paper Bin (haven't figured out how to make it actually pick up paper out of it), the Destination Tagger, Package Wrap, and Small Parcels. All these seemed to be clerical type stuff.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
EFTPOS needed to be in-hand to set the transaction. The clerical gripper was just because I was already there and looking at it. I confirmed I could pick up the items, albeit I couldn't actually write on paper, nor take paper out of the bin. Probably why they were missing, but I'll figure that out eventually. No one noticed because no one uses service borg.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![image](https://user-images.githubusercontent.com/11076040/233509778-d971da45-11f4-4612-a4c4-89a64f6354af.png)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
add: Added EFTPOS to Service Gripper list
add: Added pen, stamp, package wrap, destination tagger, and small parcels to Clerical Gripper
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
