### PR TITLE
Makeshift Voidsuit Pockets

### DIFF
--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -422,6 +422,37 @@
 	siemens_coefficient = 0.8
 	helmet = /obj/item/clothing/head/space/void/riggedvoidsuit
 	spawn_blacklisted = TRUE
+	item_flags = DRAG_AND_DROP_UNEQUIP|EQUIP_SOUNDS
+	var/obj/item/storage/internal/pockets
+
+/obj/item/clothing/suit/space/void/riggedvoidsuit/New()
+	..()
+	pockets = new/obj/item/storage/internal(src)
+	pockets.storage_slots = 3	//three slots
+	pockets.max_w_class = ITEM_SIZE_SMALL		//fit only pocket sized items
+	pockets.max_storage_space = 4
+
+/obj/item/clothing/suit/space/void/riggedvoidsuit/Destroy()
+	QDEL_NULL(pockets)
+	. = ..()
+
+/obj/item/clothing/suit/space/void/riggedvoidsuit/attack_hand(mob/user)
+	if ((is_worn() || is_held()) && !pockets.handle_attack_hand(user))
+		return TRUE
+	..(user)
+
+/obj/item/clothing/suit/space/void/riggedvoidsuit/MouseDrop(obj/over_object)
+	if(pockets.handle_mousedrop(usr, over_object))
+		return TRUE
+	..(over_object)
+
+/obj/item/clothing/suit/space/void/riggedvoidsuit/attackby(obj/item/W, mob/user)
+	..()
+	pockets.attackby(W, user)
+
+/obj/item/clothing/suit/space/void/riggedvoidsuit/emp_act(severity)
+	pockets.emp_act(severity)
+	..()
 
 //NT
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makeshift voidsuit has 3 pockets for small items now, exactly like the scav armor
This means to take it off you have to click drag.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Voidsuit is a weak one so giving it storage doesn't feel unbalanced, and I imagine if you're making a voidsuit from scratch with your hands you would add storage options.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

- Launched test
- Crafted voidsuit
- Put 3 small items in it
- Checked voidsuit was able to be taken off

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: Makeshift voidsuit has 3 pockets like Scav Armor now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
