### PR TITLE
Hotfix for sticking weapon click handlers

### DIFF
--- a/code/game/objects/items/_inventory.dm
+++ b/code/game/objects/items/_inventory.dm
@@ -152,7 +152,7 @@
 			return FALSE
 		if(!H.can_equip(src, target, FALSE, FALSE, FALSE))
 			return FALSE
-		H.remove_from_mob(src, drop = FALSE)
+		H.remove_from_mob(src, FALSE)
 		/*
 			Copied from human equip_to_slot
 			Separate since its needed to prevent double-signals being sent

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -139,10 +139,11 @@
 	O.layer = initial(O.layer)
 	O.set_plane(initial(O.plane))
 	O.screen_loc = null
-	if(istype(O, /obj/item) && drop)
+	if(isitem(O))
 		var/obj/item/I = O
-		I.forceMove(get_turf(src), MOVED_DROP)
 		I.dropped(src)
+		if(drop && !QDELING(O))
+			I.forceMove(get_turf(src), MOVED_DROP)
 	return TRUE
 
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -119,6 +119,8 @@
 		..()
 
 
+
+
 /obj/item/gun/attackby(obj/item/I, mob/living/user, params)
 	var/tool_type = I.get_tool_type(user, list(QUALITY_BOLT_TURNING, serial_type ? QUALITY_HAMMERING : null), src)
 	switch(tool_type)
@@ -215,7 +217,7 @@
 		if(wield_state && wielded)//Because most of the time the "normal" icon state is held in one hand. This could be expanded to be less hacky in the future.
 			item_state_slots[slot_l_hand_str] = "lefthand"  + wield_state
 			item_state_slots[slot_r_hand_str] = "righthand" + wield_state
-			
+
 		else
 			item_state_slots[slot_l_hand_str] = "lefthand"  + state
 			item_state_slots[slot_r_hand_str] = "righthand" + state


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I forgor to push this to the AI jamming PR

## Why It's Good For The Game
bug less

## Testing

Tested ingame , no more sticking weapon hud actions.

## Changelog
:cl:
fix: Fixed gun actions and click handlers sticking when using quick-equip.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
