### PR TITLE
Fix altar not accepting cruciform upgrades

### DIFF
--- a/code/modules/core_implant/cruciform/machinery/altar.dm
+++ b/code/modules/core_implant/cruciform/machinery/altar.dm
@@ -15,7 +15,7 @@
 	available_slots += list(list("offset" = list("x" = 8 , "y" = -3), "item" = null))
 	..()
 /obj/machinery/optable/altar/attackby(obj/item/I, mob/user)
-	if(!istype(I) || !(I.type in acceptable_items))
+	if(!istype(I) || !is_type_in_list(I, acceptable_items))
 		return
 
 	item_cleanup()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it possible to place cruciform upgrade on the altar.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![изображение](https://user-images.githubusercontent.com/62264115/233856594-d31ac760-e133-4d20-bc4f-b5c960817bf3.png)
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: fixed altar not allowing cruciform upgrades to be placed on it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
