### PR TITLE
Nanite changes

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -95,6 +95,7 @@
 #define COMSIG_HUMAN_HEALTH "human_health"					   //from human/updatehealth()
 #define COMSIG_HUMAN_SANITY "human_sanity"						//from /datum/sanity/proc/onLife()
 #define COMSIG_HUMAN_INSTALL_IMPLANT "human_install_implant"
+#define COMSIG_HUMAN_MECH_REPAIR "human_mech_repair"			//from /datum/component/internal_wound/Process()
 // /datum/species signals
 
 // /obj signals

--- a/code/modules/organs/internal/internal_wounds/_internal_wound.dm
+++ b/code/modules/organs/internal/internal_wounds/_internal_wound.dm
@@ -106,6 +106,8 @@
 		if(treatment_threshold && owner_ce[chem_effect] >= treatment_threshold)
 			owner_ce[chem_effect] -= treatment_threshold
 			treatment(FALSE)
+			if(chem_effect == CE_MECH_REPAIR)
+				SEND_SIGNAL(H, COMSIG_HUMAN_MECH_REPAIR)
 			return
 
 	// Spread once
@@ -236,7 +238,7 @@
 				if(!islist(H.internal_organs_by_efficiency[process]))
 					H.internal_organs_by_efficiency[process] = list()
 				H.internal_organs_by_efficiency[process] |= O
-	
+
 	if(organ_efficiency_multiplier)
 		for(var/organ in O.organ_efficiency)
 			O.organ_efficiency[organ] = round(O.organ_efficiency[organ] * (1 + organ_efficiency_multiplier), 1)

--- a/code/modules/organs/internal/internal_wounds/robotic.dm
+++ b/code/modules/organs/internal/internal_wounds/robotic.dm
@@ -33,7 +33,7 @@
 /datum/component/internal_wound/robotic/sharp
 	treatments_item = list(/obj/item/stack/nanopaste = 1)
 	treatments_tool = list(QUALITY_SEALING = FAILCHANCE_NORMAL)
-	treatments_chem = list(CE_MECH_REPAIR = 1)
+	treatments_chem = list(CE_MECH_REPAIR = 0.8)
 	severity = 0
 	severity_max = 5
 	hal_damage = IWOUND_INSIGNIFICANT_DAMAGE
@@ -59,7 +59,7 @@
 /datum/component/internal_wound/robotic/edge
 	treatments_item = list(/obj/item/stack/cable_coil = 5, /obj/item/stack/nanopaste = 1)
 	treatments_tool = list(QUALITY_CLAMPING = FAILCHANCE_NORMAL)
-	treatments_chem = list(CE_MECH_REPAIR = 1)
+	treatments_chem = list(CE_MECH_REPAIR = 0.8)
 	severity = 0
 	severity_max = 5
 	hal_damage = IWOUND_INSIGNIFICANT_DAMAGE
@@ -85,7 +85,7 @@
 /datum/component/internal_wound/robotic/emp_burn
 	treatments_item = list(/obj/item/stack/cable_coil = 5, /obj/item/stack/nanopaste = 1)
 	treatments_tool = list(QUALITY_PULSING = FAILCHANCE_NORMAL)
-	treatments_chem = list(CE_MECH_REPAIR = 1.5)
+	treatments_chem = list(CE_MECH_REPAIR = 1)
 	severity = 0
 	severity_max = 5
 	next_wound = /datum/component/internal_wound/robotic/overheat
@@ -139,7 +139,7 @@
 // Other wounds
 /datum/component/internal_wound/robotic/corrosion
 	treatments_item = list(/obj/item/stack/nanopaste = 2)
-	treatments_chem = list(CE_MECH_ACID = 1.5, CE_MECH_REPAIR = 0.8)	// sulphiric + hydrochloric acid or poly acid
+	treatments_chem = list(CE_MECH_ACID = 1.5, CE_MECH_REPAIR = 0.3)	// sulphiric + hydrochloric acid or poly acid
 	scar = /datum/component/internal_wound/robotic/blunt	// Cleaning corrosion involves removing material
 	severity = 0
 	severity_max = 4
@@ -155,7 +155,7 @@
 	name = "plastic deformation"
 	treatments_item = list(/obj/item/stack/nanopaste = 5)
 	treatments_tool = list(QUALITY_WELDING = FAILCHANCE_NORMAL)
-	treatments_chem = list(CE_MECH_REPAIR = 1.5)
+	treatments_chem = list(CE_MECH_REPAIR = 1)
 	severity = 4
 	severity_max = 4
 	hal_damage = IWOUND_INSIGNIFICANT_DAMAGE

--- a/code/modules/organs/internal/internal_wounds/robotic.dm
+++ b/code/modules/organs/internal/internal_wounds/robotic.dm
@@ -7,7 +7,7 @@
 /datum/component/internal_wound/robotic/blunt
 	treatments_item = list(/obj/item/stack/nanopaste = 1)
 	treatments_tool = list(QUALITY_HAMMERING = FAILCHANCE_NORMAL)
-	treatments_chem = list(CE_MECH_REPAIR = 0.55)		// repair nanites + 3 metals OR repair nanite OD + a metal
+	treatments_chem = list(CE_MECH_REPAIR = 0.5)
 	severity = 0
 	severity_max = 5
 	hal_damage = IWOUND_INSIGNIFICANT_DAMAGE
@@ -33,7 +33,7 @@
 /datum/component/internal_wound/robotic/sharp
 	treatments_item = list(/obj/item/stack/nanopaste = 1)
 	treatments_tool = list(QUALITY_SEALING = FAILCHANCE_NORMAL)
-	treatments_chem = list(CE_MECH_REPAIR = 0.85)		// repair nanites + 6 metals OR repair nanite OD + 7 metals
+	treatments_chem = list(CE_MECH_REPAIR = 1)
 	severity = 0
 	severity_max = 5
 	hal_damage = IWOUND_INSIGNIFICANT_DAMAGE
@@ -59,7 +59,7 @@
 /datum/component/internal_wound/robotic/edge
 	treatments_item = list(/obj/item/stack/cable_coil = 5, /obj/item/stack/nanopaste = 1)
 	treatments_tool = list(QUALITY_CLAMPING = FAILCHANCE_NORMAL)
-	treatments_chem = list(CE_MECH_REPAIR = 0.85)
+	treatments_chem = list(CE_MECH_REPAIR = 1)
 	severity = 0
 	severity_max = 5
 	hal_damage = IWOUND_INSIGNIFICANT_DAMAGE
@@ -85,7 +85,7 @@
 /datum/component/internal_wound/robotic/emp_burn
 	treatments_item = list(/obj/item/stack/cable_coil = 5, /obj/item/stack/nanopaste = 1)
 	treatments_tool = list(QUALITY_PULSING = FAILCHANCE_NORMAL)
-	treatments_chem = list(CE_MECH_REPAIR = 0.95)	// repair nanite OD + all metals
+	treatments_chem = list(CE_MECH_REPAIR = 1.5)
 	severity = 0
 	severity_max = 5
 	next_wound = /datum/component/internal_wound/robotic/overheat
@@ -139,7 +139,7 @@
 // Other wounds
 /datum/component/internal_wound/robotic/corrosion
 	treatments_item = list(/obj/item/stack/nanopaste = 2)
-	treatments_chem = list(CE_MECH_ACID = 1.5)	// sulphiric + hydrochloric acid or poly acid
+	treatments_chem = list(CE_MECH_ACID = 1.5, CE_MECH_REPAIR = 0.8)	// sulphiric + hydrochloric acid or poly acid
 	scar = /datum/component/internal_wound/robotic/blunt	// Cleaning corrosion involves removing material
 	severity = 0
 	severity_max = 4
@@ -155,7 +155,7 @@
 	name = "plastic deformation"
 	treatments_item = list(/obj/item/stack/nanopaste = 5)
 	treatments_tool = list(QUALITY_WELDING = FAILCHANCE_NORMAL)
-	treatments_chem = list(CE_MECH_REPAIR = 0.95)	// repair nanite OD + all metals
+	treatments_chem = list(CE_MECH_REPAIR = 1.5)
 	severity = 4
 	severity_max = 4
 	hal_damage = IWOUND_INSIGNIFICANT_DAMAGE

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -28,9 +28,6 @@
 /datum/reagent/metal
 	reagent_type = "Metal"
 
-/datum/reagent/metal/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
-	M.add_chemical_effect(CE_MECH_REPAIR, 0.05)	// Makes metals useful and stackable for FBPs
-
 /datum/reagent/metal/aluminum
 	name = "Aluminum"
 	id = "aluminum"

--- a/code/modules/reagents/reagents/nanites.dm
+++ b/code/modules/reagents/reagents/nanites.dm
@@ -292,9 +292,9 @@
 		M.add_chemical_effect(CE_DYNAMICFINGERS, uni_identity)
 
 /datum/reagent/nanites/repair
-	name = "repair nanites"
+	name = "Mechanites"
 	description = "Microscopic construction robots programmed to repair internal components."
-	id = "fbp_repair"
+	id = "repair"
 
 	var/repair_strength = 0
 

--- a/code/modules/reagents/reagents/nanites.dm
+++ b/code/modules/reagents/reagents/nanites.dm
@@ -42,7 +42,7 @@
 		return TRUE
 
 /datum/reagent/nanites/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
-	holder.trans_to_mob(M, 0.5, id) // Nanites are programmed to enter the bloodstream from the stomach.
+	holder.trans_to_mob(M, 0.5, id) // Nanites are programmed to enter the bloodstream from the stomach on their own.
 
 /datum/reagent/nanites/capped
 	name = "Raw Industrial Nanobots"

--- a/code/modules/reagents/reagents/nanites.dm
+++ b/code/modules/reagents/reagents/nanites.dm
@@ -42,7 +42,7 @@
 		return TRUE
 
 /datum/reagent/nanites/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
-	holder.trans_to_mob(M, 0.5, id) // Nanites are programmed to enter the bloodstream from the stomach on their own.
+	holder.trans_to_mob(M, 0.5, id) // Nanites are programmed to enter the bloodstream from the stomach.
 
 /datum/reagent/nanites/capped
 	name = "Raw Industrial Nanobots"

--- a/code/modules/reagents/reagents/nanites.dm
+++ b/code/modules/reagents/reagents/nanites.dm
@@ -298,11 +298,22 @@
 
 	var/repair_strength = 0
 
+/datum/reagent/nanites/repair/proc/on_wound_repaired(mob/living/carbon/human/H)
+	SIGNAL_HANDLER
+
+	repair_strength = H.chem_effects[CE_MECH_REPAIR] // Resets the repair strength to the remaining strength after treating a wound.
+
+/datum/reagent/nanites/repair/on_mob_add(mob/living/L)
+	RegisterSignal(L, COMSIG_HUMAN_MECH_REPAIR, PROC_REF(on_wound_repaired))
+
 /datum/reagent/nanites/repair/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(!..())
 		return
 	M.add_chemical_effect(CE_MECH_REPAIR, repair_strength)
 	repair_strength += 0.1 * effect_multiplier // Based on treatment thresholds specific to each wound type.
+
+/datum/reagent/nanites/repair/on_mob_delete(mob/living/L)
+	UnregisterSignal(L, COMSIG_HUMAN_MECH_REPAIR)
 
 /* Uncomment when CE_MECH_REPLENISH has a use
 // "Blood" restore

--- a/code/modules/reagents/reagents/nanites.dm
+++ b/code/modules/reagents/reagents/nanites.dm
@@ -42,7 +42,7 @@
 		return TRUE
 
 /datum/reagent/nanites/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
-	holder.trans_to_mob(M, 0.5 * effect_multiplier, id) // Nanites are programmed to enter the bloodstream from the stomach.
+	holder.trans_to_mob(M, 0.5, id) // Nanites are programmed to enter the bloodstream from the stomach.
 
 /datum/reagent/nanites/capped
 	name = "Raw Industrial Nanobots"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes nanites do things a lot differently. Especially affects repair nanites.

Nanites will now work when ingested via moving into the bloodstream on their own. This means nanites that previously only worked on non-fbps work on fbps and ones that only worked on fbps work on non-fbps. You can also use them as pills now, them being restricted to blood was undocumented as well, but now it's not as much of an issue.

Repair nanites, now "mechanites" no longer work based on a convoluted system of adding metals together with the nanites in specific ratios to fix different types of wounds... even writing this makes my brain hurt. Not to mention the total lack of in-game documentation.

They instead work over time, requiring an overall specific amount per wound healed. The amount required in units matches exactly with the CE_MECH_REPAIR amount listed for each wound type. This makes comprehending it a lot easier. I've also made them able to fix corrosion.

Resetting the repair strength counter is done via a signal sent by the wounds when they are fixed by CE_MECH_REPAIR. This is a neat and efficient way of doing it.

I've also improved a few descriptions in slight ways and removed the weird fbp subtype as it's no longer needed and caused some annoying side-effects, such as them not being affected by metabolism modifiers. They also no longer bypass the need to be in the bloodstream, as nanites can now simply navigate to the bloodstream from the stomach.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It makes undocumented shitcode chems actually good, not to mention making "repair nanites" less prone to turning you invincible to all wounds, which is unbalanced as hell. I bet others have been confused by nanites not working as expected as well and this PR aims to address all of that.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

TBD, going to gauge the responses first.

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
balance: All nanites work properly now, whether you take them via ingestion or injection. Repair nanites, now "mechanites", can affect non-fbps and don't require a convoluted mess of metal reagents to function.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
