### PR TITLE
Metabolism changes

### DIFF
--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -31,9 +31,6 @@
 
 #define REAGENTS_OVERDOSE 30
 
-#define REAGENTS_MIN_EFFECT_MULTIPLIER 0.2
-#define REAGENTS_MAX_EFFECT_MULTIPLIER 2.5
-
 #define CHEM_SYNTH_ENERGY 3000 // How much energy does it take to synthesize 1 unit of chemical, in Joules.
 
 #define CE_STABLE			"stabilization"		// Inaprovaline

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -85,6 +85,7 @@
 					blood_max += W.damage * WOUND_BLEED_MULTIPLIER
 		if (temp.open)
 			blood_max += OPEN_ORGAN_BLEED_AMOUNT  //Yer stomach is cut open
+		blood_max *= get_organ_efficiency(OP_HEART) //Hey check out how hard I can bleed
 
 	// bloodclotting slows bleeding
 	if(chem_effects[CE_BLOODCLOT])

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -69,20 +69,12 @@
 		return consumed_amount_human(M, alien,location) // Since humans should scale off livers , hearts and stomachs
 	var/removed = metabolism
 	if(location == CHEM_INGEST)
-		if(ingest_met)
-			removed = ingest_met
-		else
-			removed = removed/2
+		removed = ingest_met ? ingest_met : removed * 0.5
 	if(touch_met && (location == CHEM_TOUCH))
-		removed = touch_met
-	// on half of overdose, chemicals will start be metabolized faster,
-	// also blood circulation affects chemical strength (meaining if target has low blood volume or has something that lowers blood circulation chemicals will be consumed less and effect will diminished)
-	if(location == CHEM_BLOOD)
-		if(!constant_metabolism)
-			if(overdose)
-				removed = CLAMP(metabolism * volume/(overdose/2) * M.get_blood_circulation()/100, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
-			else
-				removed = CLAMP(metabolism * volume/(REAGENTS_OVERDOSE/2) * M.get_blood_circulation()/100, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
+		removed = touch_met ? touch_met : removed * 0.5
+	// The faster the blood circulation, the faster the reagents process. Blood volume affects blood circulation as well, leading to diminished effects.
+	if(!constant_metabolism && (location == CHEM_BLOOD || location == CHEM_INGEST))
+		removed = CLAMP(metabolism * M.get_blood_circulation()/100, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
 	removed = max(round(removed, 0.01), 0.01)
 	removed = min(removed, volume)
 

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -101,7 +101,7 @@
 
 	// The faster the blood circulation, the faster the reagents process. Blood volume affects blood circulation as well, leading to diminished effects.
 	if(!constant_metabolism && (location == CHEM_BLOOD || location == CHEM_INGEST))
-		removed = CLAMP(removed * M.get_blood_circulation()/100, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
+		removed = CLAMP(removed * consumer.get_blood_circulation()/100, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
 
 	removed = max(round(removed, 0.01), 0.01)
 	removed = min(removed, volume)

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -66,15 +66,19 @@
 
 /datum/reagent/proc/consumed_amount(mob/living/carbon/M, alien, location)
 	if(ishuman(M))
-		return consumed_amount_human(M, alien,location) // Since humans should scale off livers , hearts and stomachs
+		return consumed_amount_human(M, alien,location) // Humans have additional metabolism changes based on their organs.
+
 	var/removed = metabolism
+
 	if(location == CHEM_INGEST)
 		removed = ingest_met ? ingest_met : removed * 0.5
 	if(touch_met && (location == CHEM_TOUCH))
 		removed = touch_met ? touch_met : removed * 0.5
+
 	// The faster the blood circulation, the faster the reagents process. Blood volume affects blood circulation as well, leading to diminished effects.
 	if(!constant_metabolism && (location == CHEM_BLOOD || location == CHEM_INGEST))
 		removed = CLAMP(metabolism * M.get_blood_circulation()/100, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
+
 	removed = max(round(removed, 0.01), 0.01)
 	removed = min(removed, volume)
 
@@ -82,23 +86,19 @@
 
 /datum/reagent/proc/consumed_amount_human(mob/living/carbon/human/consumer, alien, location)
 	var/removed = metabolism
+
 	if(location == CHEM_INGEST)
 		var/calculated_buff = ((consumer.get_organ_efficiency(OP_LIVER) + consumer.get_organ_efficiency(OP_HEART) + consumer.get_organ_efficiency(OP_STOMACH)) / 3) / 100
-		if(ingest_met)
-			removed = ingest_met * calculated_buff
-		else
-			removed = (metabolism / 2) * calculated_buff
-	if(touch_met && (location == CHEM_TOUCH))
-		removed = touch_met // This doesn't get a buff , there is no organ that can count for this , really.
-	// on half of overdose, chemicals will start be metabolized faster,
-	// also blood circulation affects chemical strength (meaining if target has low blood volume or has something that lowers blood circulation chemicals will be consumed less and effect will diminished)
+		removed = ingest_met ? ingest_met : removed * 0.5
+	if(touch_met && location == CHEM_TOUCH)
+		removed = touch_met // This isn't affected by any internal organs.
 	if(location == CHEM_BLOOD)
 		var/calculated_buff = ((consumer.get_organ_efficiency(OP_LIVER) + consumer.get_organ_efficiency(OP_HEART) * 2) / 3) / 100
-		if(!constant_metabolism)
-			if(overdose)
-				removed = CLAMP(metabolism * volume/(overdose/2) * consumer.get_blood_circulation()/100 * calculated_buff, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
-			else
-				removed = CLAMP(metabolism * volume/(REAGENTS_OVERDOSE/2) * consumer.get_blood_circulation()/100 * calculated_buff, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
+
+	// The faster the blood circulation, the faster the reagents process. Blood volume affects blood circulation as well, leading to diminished effects.
+	if(!constant_metabolism && (location == CHEM_BLOOD || location == CHEM_INGEST))
+		removed = CLAMP(metabolism * M.get_blood_circulation()/100, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
+
 	removed = max(round(removed, 0.01), 0.01)
 	removed = min(removed, volume)
 

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -70,15 +70,17 @@
 
 	var/removed = metabolism
 
-	if(location == CHEM_INGEST)
-		removed = ingest_met ? ingest_met : removed * 0.5
-	if(touch_met && (location == CHEM_TOUCH))
-		removed = touch_met ? touch_met : removed * 0.5
+	switch(location)
+		if(CHEM_INGEST)
+			removed = ingest_met ? ingest_met : removed * 0.5
+		if(CHEM_TOUCH)
+			removed = touch_met ? touch_met : removed
 
 	// The faster the blood circulation, the faster the reagents process. Blood volume affects blood circulation as well, leading to diminished effects.
 	if(!constant_metabolism && (location == CHEM_BLOOD || location == CHEM_INGEST))
-		removed = CLAMP(metabolism * M.get_blood_circulation()/100, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
+		removed *= M.get_blood_circulation()/100
 
+	removed = CLAMP(removed, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
 	removed = CLAMP(removed, 0, volume)
 
 	return removed
@@ -100,10 +102,10 @@
 
 	// The faster the blood circulation, the faster the reagents process. Blood volume affects blood circulation as well, leading to diminished effects.
 	if(!constant_metabolism && (location == CHEM_BLOOD || location == CHEM_INGEST))
-		removed = CLAMP(removed * consumer.get_blood_circulation()/100, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
+		removed *= consumer.get_blood_circulation()/100
 
-	removed = max(round(removed, 0.01), 0.01)
-	removed = min(removed, volume)
+	removed = CLAMP(removed, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
+	removed = CLAMP(removed, 0, volume)
 
 	return removed
 

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -80,7 +80,6 @@
 	if(!constant_metabolism && (location == CHEM_BLOOD || location == CHEM_INGEST))
 		removed *= M.get_blood_circulation()/100
 
-	removed = CLAMP(removed, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
 	removed = CLAMP(removed, 0, volume)
 
 	return removed
@@ -104,7 +103,6 @@
 	if(!constant_metabolism && (location == CHEM_BLOOD || location == CHEM_INGEST))
 		removed *= consumer.get_blood_circulation()/100
 
-	removed = CLAMP(removed, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
 	removed = CLAMP(removed, 0, volume)
 
 	return removed

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -79,8 +79,7 @@
 	if(!constant_metabolism && (location == CHEM_BLOOD || location == CHEM_INGEST))
 		removed = CLAMP(metabolism * M.get_blood_circulation()/100, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
 
-	removed = max(round(removed, 0.01), 0.01)
-	removed = min(removed, volume)
+	removed = CLAMP(removed, 0, volume)
 
 	return removed
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes the volume of a reagent irrelevant when calculating how quickly it should metabolize. Previously, it was taking the overdose threshold into account and the math for that was based on volume, leading to cases where even though the metabolization rates were accounted for, the reagents wouldn't run out at the same time. This only applies to the bloodstream.

It also makes blood circulation affect ingested reagents, since reagents from the stomach end up in the bloodstream anyways and the absorption of reagents from the colon is assisted by blood flow to the area as well.

Also, I removed a safety check that caused reagents with a metabolism of 0 to still metabolize and synaptizine to metabolize twice as fast while in the stomach. Reaching 0 is practically impossible, not to mention managing to do it triggers a check in metabolization code that skips reagent effects entirely.

I've also removed REAGENTS_MIN_EFFECT_MULTIPLIER and REAGENTS_MAX_EFFECT_MULTIPLIER as they're not actually needed. Why? Because reagents in the stomach work just fine and they aren't clamped by these whatsoever.

Also, loads of code refactoring in the modified procs, reading them no longer gives you brain damage.

Bleeding is now affected by heart efficiency. Like, a lot.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It makes metabolization code easier to read and fixes seemingly correct reagent ratios not running out at the same time.

It also doesn't make much sense for a reagent to be processed faster if there's more of it gameplay-wise, overdoses on their own are intended to be the only reason to avoid taking lots of the same reagent.

Also, high and low metabolisms both carry significant upsides and downsides. Since these pretty much balance out, limiting them seems irrelevant considering how insane this codebase is by nature.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Caused no abnormalities in a few basic tests. I can't really test everything since this has very high edge-case potential, make sure to TM it first as people may find unwanted exploits like infinite healing or something.

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
balance: Chemicals no longer take their volume into account when processing. This should lead to far more predictable reagent behaviour.
balance: Removed all limits on reagent metabolization modifiers. This means giving yourself 10 hearts is even funnier now.
add: Having a highly efficient heart may cause elevated bleeding, exercise caution.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
