### PR TITLE
Advanced and normal slime mutation toxins no longer instantly convert people

### DIFF
--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -591,6 +591,7 @@
 				if(20)
 					to_chat(M, SPAN_DANGER("Your skin starts burning from water!"))
 					M.adjustHalLoss(10)
+					M.visible_message("Emanates clouds of steam as the water from their skin starts boiling! ", range = 7)
 					var/datum/effect/effect/system/smoke_spread/smoke = new()
 					smoke.set_up(3, 0 , get_turf(M), FALSE)
 					smoke.start()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You need 10 units and 40 seconds to convert someone to a slime person
You need 15 units and 60 seconds to covnert someone to a slime
The process is now done with messages ,warning the target of the transformation progress.


## Why It's Good For The Game
Insta-transformations are cringe overall.
## Testing
Tested locally , works  fine.

## Changelog
:cl:
balance: Slime mutation toxin now needs 10 units and 40 seconds to convert
balance: Advanced slime mutation toxin now needs 15 units and 60 seconds to convert.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
