### PR TITLE
Drugs call parent on affect_ingest(), removes duplicate definition of affect_blood()

### DIFF
--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -66,7 +66,7 @@
 
 /datum/reagent/proc/consumed_amount(mob/living/carbon/M, alien, location)
 	if(ishuman(M))
-		return consumed_amount_human(M, alien,location) // Since humans should scale off livers , hearts and stomachs
+		return consumed_amount_human(M, alien,location) // Humans have additional metabolism changes based on their organs.
 	var/removed = metabolism
 	if(location == CHEM_INGEST)
 		if(ingest_met)
@@ -75,14 +75,9 @@
 			removed = removed/2
 	if(touch_met && (location == CHEM_TOUCH))
 		removed = touch_met
-	// on half of overdose, chemicals will start be metabolized faster,
-	// also blood circulation affects chemical strength (meaining if target has low blood volume or has something that lowers blood circulation chemicals will be consumed less and effect will diminished)
-	if(location == CHEM_BLOOD)
-		if(!constant_metabolism)
-			if(overdose)
-				removed = CLAMP(metabolism * volume/(overdose/2) * M.get_blood_circulation()/100, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
-			else
-				removed = CLAMP(metabolism * volume/(REAGENTS_OVERDOSE/2) * M.get_blood_circulation()/100, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
+	// The faster the blood circulation, the faster the reagents process and the higher the effect multiplier. Blood volume affects blood circulation as well, leading to diminished effects.
+	if(!constant_metabolism)
+		removed = CLAMP(metabolism * M.get_blood_circulation()/100, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
 	removed = max(round(removed, 0.01), 0.01)
 	removed = min(removed, volume)
 
@@ -97,16 +92,12 @@
 		else
 			removed = (metabolism / 2) * calculated_buff
 	if(touch_met && (location == CHEM_TOUCH))
-		removed = touch_met // This doesn't get a buff , there is no organ that can count for this , really.
-	// on half of overdose, chemicals will start be metabolized faster,
-	// also blood circulation affects chemical strength (meaining if target has low blood volume or has something that lowers blood circulation chemicals will be consumed less and effect will diminished)
+		removed = touch_met // This doesn't get any buffs as no organ really applies to it.
+	// The faster the blood circulation, the faster the reagents process and the higher the effect multiplier. Blood volume affects blood circulation as well, leading to diminished effects.
 	if(location == CHEM_BLOOD)
 		var/calculated_buff = ((consumer.get_organ_efficiency(OP_LIVER) + consumer.get_organ_efficiency(OP_HEART) * 2) / 3) / 100
-		if(!constant_metabolism)
-			if(overdose)
-				removed = CLAMP(metabolism * volume/(overdose/2) * consumer.get_blood_circulation()/100 * calculated_buff, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
-			else
-				removed = CLAMP(metabolism * volume/(REAGENTS_OVERDOSE/2) * consumer.get_blood_circulation()/100 * calculated_buff, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
+	if(!constant_metabolism)
+		removed = CLAMP(metabolism * consumer.get_blood_circulation()/100 * calculated_buff, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
 	removed = max(round(removed, 0.01), 0.01)
 	removed = min(removed, volume)
 

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -66,7 +66,7 @@
 
 /datum/reagent/proc/consumed_amount(mob/living/carbon/M, alien, location)
 	if(ishuman(M))
-		return consumed_amount_human(M, alien,location) // Humans have additional metabolism changes based on their organs.
+		return consumed_amount_human(M, alien,location) // Since humans should scale off livers , hearts and stomachs
 	var/removed = metabolism
 	if(location == CHEM_INGEST)
 		if(ingest_met)
@@ -75,9 +75,14 @@
 			removed = removed/2
 	if(touch_met && (location == CHEM_TOUCH))
 		removed = touch_met
-	// The faster the blood circulation, the faster the reagents process and the higher the effect multiplier. Blood volume affects blood circulation as well, leading to diminished effects.
-	if(!constant_metabolism)
-		removed = CLAMP(metabolism * M.get_blood_circulation()/100, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
+	// on half of overdose, chemicals will start be metabolized faster,
+	// also blood circulation affects chemical strength (meaining if target has low blood volume or has something that lowers blood circulation chemicals will be consumed less and effect will diminished)
+	if(location == CHEM_BLOOD)
+		if(!constant_metabolism)
+			if(overdose)
+				removed = CLAMP(metabolism * volume/(overdose/2) * M.get_blood_circulation()/100, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
+			else
+				removed = CLAMP(metabolism * volume/(REAGENTS_OVERDOSE/2) * M.get_blood_circulation()/100, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
 	removed = max(round(removed, 0.01), 0.01)
 	removed = min(removed, volume)
 
@@ -92,12 +97,16 @@
 		else
 			removed = (metabolism / 2) * calculated_buff
 	if(touch_met && (location == CHEM_TOUCH))
-		removed = touch_met // This doesn't get any buffs as no organ really applies to it.
-	// The faster the blood circulation, the faster the reagents process and the higher the effect multiplier. Blood volume affects blood circulation as well, leading to diminished effects.
+		removed = touch_met // This doesn't get a buff , there is no organ that can count for this , really.
+	// on half of overdose, chemicals will start be metabolized faster,
+	// also blood circulation affects chemical strength (meaining if target has low blood volume or has something that lowers blood circulation chemicals will be consumed less and effect will diminished)
 	if(location == CHEM_BLOOD)
 		var/calculated_buff = ((consumer.get_organ_efficiency(OP_LIVER) + consumer.get_organ_efficiency(OP_HEART) * 2) / 3) / 100
-	if(!constant_metabolism)
-		removed = CLAMP(metabolism * consumer.get_blood_circulation()/100 * calculated_buff, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
+		if(!constant_metabolism)
+			if(overdose)
+				removed = CLAMP(metabolism * volume/(overdose/2) * consumer.get_blood_circulation()/100 * calculated_buff, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
+			else
+				removed = CLAMP(metabolism * volume/(REAGENTS_OVERDOSE/2) * consumer.get_blood_circulation()/100 * calculated_buff, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
 	removed = max(round(removed, 0.01), 0.01)
 	removed = min(removed, volume)
 

--- a/code/modules/reagents/reagents/drugs.dm
+++ b/code/modules/reagents/reagents/drugs.dm
@@ -13,13 +13,8 @@
 		H.sanity.onDrug(src, effect_multiplier)
 	SEND_SIGNAL_OLD(M, COMSIG_CARBON_HAPPY, src, ON_MOB_DRUG)
 
-/datum/reagent/drug/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
-	if(sanity_gain && ishuman(M))
-		var/mob/living/carbon/human/H = M
-		H.sanity.onDrug(src, effect_multiplier)
-	SEND_SIGNAL_OLD(M, COMSIG_CARBON_HAPPY, src, ON_MOB_DRUG)
-
 /datum/reagent/drug/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
+	..()
 	if(sanity_gain && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		H.sanity.onDrug(src, effect_multiplier)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I started wondering why hyperzine doesn't work on ingest, well, here's why.

/drug/affect_ingest() was not calling parent, meaning the affect_blood() called in /reagent/affect_ingest() was not getting called.

There was also a duplicate definition of affect_blood() for whatever reason, so I removed that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes a long-standing bug (3 years) and removes an useless piece of code.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiles, no other testing done.
This can't cause any new bugs.
...don't quote me on that.

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: Drugs work properly on ingest.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
