### PR TITLE
Fixes 2 codebase sins

### DIFF
--- a/code/game/objects/items/_inventory.dm
+++ b/code/game/objects/items/_inventory.dm
@@ -159,13 +159,7 @@
 			on atom containerization
 
 		*/
-		forceMove(user)
-		H.legacy_equip_to_slot(src, target, TRUE)
-		equipped(user, target)
-		update_wear_icon(TRUE)
-		screen_loc = H.find_inv_position(target)
-		layer = ABOVE_HUD_LAYER
-		plane = ABOVE_HUD_PLANE
+		H.equip_to_slot(src, target, TRUE, FALSE)
 		if(H.client)
 			H.client.screen |= src
 		if(action_button_name)

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -256,9 +256,8 @@ var/list/flooring_types
 	if(!ishuman(M)|| M.incorporeal_move || !has_gravity(get_turf(M)))
 		return
 	if(MOVING_QUICKLY(M))
-		if(prob(5))
+		if(prob(5) && M.slip(null, 6))
 			M.adjustBruteLoss(5)
-			M.slip(null, 6)
 			playsound(M, 'sound/effects/bang.ogg', 50, 1)
 			to_chat(M, SPAN_WARNING("You tripped over!"))
 			return
@@ -284,7 +283,7 @@ var/list/flooring_types
 	space_smooth = SMOOTH_NONE
 	smooth_movable_atom = SMOOTH_NONE
 
-//Hull can upgrade to underplating
+//Hull can downgrade to underplating
 /decl/flooring/reinforced/plating/hull/can_build_floor(var/decl/flooring/newfloor)
 	return FALSE //Not allowed to build directly on hull, you must first remove it and then build on the underplating
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1482,7 +1482,7 @@ var/list/rank_prefix = list(\
 
 /mob/living/carbon/human/slip(var/slipped_on, stun_duration=8)
 	if((species.flags & NO_SLIP) || (shoes && (shoes.item_flags & NOSLIP)))
-		return 0
+		return FALSE
 	..(slipped_on,stun_duration)
 	regen_slickness(-3)
 	dodge_time = get_game_time()

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -14,8 +14,6 @@ This saves us from having to call add_fingerprint() any time something is put in
 	var/target_slot = get_quick_slot(I)
 	if(I.pre_equip(usr, target_slot))
 		return
-	if(isgun(I) && client.CH)
-		QDEL_NULL(client.CH)
 	if(!I.try_transfer(target_slot, usr))
 		quick_equip_storage(I)
 	/*
@@ -249,7 +247,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 		if(slot_r_hand)
 			return BP_R_ARM
 
-/mob/living/carbon/human/equip_to_slot(obj/item/W, slot, redraw_mob = 1)
+/mob/living/carbon/human/equip_to_slot(obj/item/W, slot, redraw_mob = 1, domove = TRUE)
 	SEND_SIGNAL_OLD(src, COMSING_HUMAN_EQUITP, W)
 	switch(slot)
 		if(slot_in_backpack)
@@ -264,7 +262,8 @@ This saves us from having to call add_fingerprint() any time something is put in
 		else
 			legacy_equip_to_slot(W, slot, redraw_mob)
 
-			W.forceMove(src)
+			if(domove)
+				W.forceMove(src)
 			W.equipped(src, slot)
 			W.update_wear_icon(redraw_mob)
 			W.screen_loc = find_inv_position(slot)
@@ -351,11 +350,15 @@ This saves us from having to call add_fingerprint() any time something is put in
 			src.r_store = W
 		if(slot_s_store)
 			src.s_store = W
+		if(slot_accessory_buffer)
+			if(src.wear_suit)
+				src.wear_suit.attackby(W, src)
+			return FALSE
 		else
 			to_chat(src, SPAN_DANGER("You are trying to eqip this item to an unsupported inventory slot. If possible, please write a ticket with steps to reproduce. Slot was: [slot]"))
 			return
 
-	return 1
+	return TRUE
 
 //Checks if a given slot can be accessed at this time, either to equip or unequip I
 /mob/living/carbon/human/slot_is_accessible(var/slot, var/obj/item/I, mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You no longer trip on plating if you can't slip.
Fixed quick-equip code further and also added support for quick-equipping accesories.
## Why It's Good For The Game
Fixes are always good.

## Testing
Tested localy , ran just fine with no-slips , quick-equip no longer gave funny error.
## Changelog
:cl:
fix: Fixed quick-equip not supporting holsters
fix: Fixed tripping on plating whilst having no slips.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
