### PR TITLE
Fixes catwalks being non-deconstructable

### DIFF
--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -171,7 +171,7 @@
 
 /obj/structure/catwalk/holo
 
-/obj/structure/catwalk/attackby(obj/item/I, mob/user)
+/obj/structure/catwalk/holo/attackby(obj/item/I, mob/user)
 	return
 
 /obj/item/stool/holostool


### PR DESCRIPTION
## About The Pull Request

A holodeck proc was wrongly defined, making catwalks undeconstructable. This PR fixes that.

## Why It's Good For The Game

Bugfix.

## Testing

Untested by author. Do not merge until tested.

## Changelog
:cl:
fix: fixes catwalks being indeconstructable
/:cl:
