### PR TITLE
Give artists some starting money and starting materials

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -91,7 +91,7 @@
 	selection_color = "#dddddd"
 	also_known_languages = list(LANGUAGE_CYRILLIC = 10, LANGUAGE_JIVE = 40, LANGUAGE_MONKEY = 20)
 	access = list(access_bar, access_kitchen, access_maint_tunnels, access_artist, access_theatre)
-
+	initial_balance = 600
 	outfit_type = /decl/hierarchy/outfit/job/service/artist
 	wage = WAGE_NONE //They should get paid by the club owner, otherwise you know what to do.
 	stat_modifiers = list(

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -51877,6 +51877,22 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/structure/table/standard,
+/obj/item/stack/material/plasteel{
+	amount = 20
+	},
+/obj/item/stack/material/steel{
+	amount = 20
+	},
+/obj/item/stack/material/glass{
+	amount = 20
+	},
+/obj/item/stack/material/plastic{
+	amount = 20
+	},
+/obj/item/stack/material/wood{
+	amount = 20
+	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/crew_quarters/artistoffice)
 "cuK" = (

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -51237,13 +51237,21 @@
 	},
 /obj/item/paper_bin,
 /obj/machinery/button/remote/blast_door{
-	id = "maint_hatch_conference_2";
-	name = "Maintenance Hatch Control";
+	id = "artist_office_east";
+	name = "Starboard Hatch Control";
 	pixel_x = -24;
+	pixel_y = -6;
 	req_access = null
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "artist_office_west";
+	name = "Port Hatch Control";
+	pixel_x = -24;
+	pixel_y = 6;
+	req_access = null
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/eris/crew_quarters/artistoffice)
@@ -103205,6 +103213,22 @@
 /obj/machinery/smartfridge/kitchen,
 /turf/simulated/floor/plating,
 /area/eris/crew_quarters/kitchen)
+"kAg" = (
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/blast/regular/open{
+	id = "ClubTotalLockdown";
+	layer = 2.6;
+	name = "Club Total Lockdown"
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	id = "artist_office_east";
+	layer = 3.3;
+	name = "Maintenance Hatch"
+	},
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/artistoffice)
 "kAt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -105274,7 +105298,7 @@
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
-	id = "maint_hatch_conference_2";
+	id = "artist_office_west";
 	layer = 3.3;
 	name = "Maintenance Hatch"
 	},
@@ -168174,8 +168198,8 @@ cxA
 erj
 erj
 erj
-pSP
-pSP
+kAg
+kAg
 erj
 tCA
 dFo

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -51885,22 +51885,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/table/standard,
-/obj/item/stack/material/plasteel{
-	amount = 20
-	},
-/obj/item/stack/material/steel{
-	amount = 20
-	},
-/obj/item/stack/material/glass{
-	amount = 20
-	},
-/obj/item/stack/material/plastic{
-	amount = 20
-	},
-/obj/item/stack/material/wood{
-	amount = 20
-	},
+/obj/structure/flora/pottedplant/random,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/crew_quarters/artistoffice)
 "cuK" = (
@@ -104333,9 +104318,24 @@
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/clownoffice)
 "npf" = (
-/obj/structure/flora/pottedplant/random,
 /obj/machinery/camera/network/third_section{
 	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/stack/material/wood{
+	amount = 20
+	},
+/obj/item/stack/material/plastic{
+	amount = 20
+	},
+/obj/item/stack/material/glass{
+	amount = 20
+	},
+/obj/item/stack/material/plasteel{
+	amount = 20
+	},
+/obj/item/stack/material/steel{
+	amount = 20
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/eris/crew_quarters/artistoffice)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Give club artists some starting money on their account (600, a bit less than club workers) and a few sheets of material (20 of wood, plastic, glass, steel, plasteel) to bootstrap their art shop.

Materials are stored on a table on a table that has been added to artist office.

Also add a button to be able to close west/east hatches independently in artist office.

## Why It's Good For The Game

Provide artists with a kickstart to help them since they currently have no money nor material at round start.

## Testing

- Spawned as artist after roundstart, checked my account and saw money on it (840 and 900 the two times I spawned, I guess there is a random multiplier applied).
- Checked that the two buttons were working
- Checked that the materials were on the table in correct amounts

![image](https://user-images.githubusercontent.com/64754494/236633209-5ebf44a1-377d-4afb-ace6-0d61287d6cbd.png)


## Changelog
:cl: Hyperio
add: Give artists some starting money and starting materials
add: Artist office now has two buttons to control independently the west/east hatches
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
