### PR TITLE
The long awaited speed nerf(and fix?!?!)

### DIFF
--- a/code/game/objects/items/devices/organ_module/passive/muscle.dm
+++ b/code/game/objects/items/devices/organ_module/passive/muscle.dm
@@ -25,3 +25,4 @@
 	E.tally -= 0.3
 	boosting = TRUE
 
+

--- a/code/game/objects/items/devices/organ_module/passive/muscle.dm
+++ b/code/game/objects/items/devices/organ_module/passive/muscle.dm
@@ -6,23 +6,25 @@
 	var/boosting = FALSE
 
 /obj/item/organ_module/muscle/onInstall(obj/item/organ/external/E)
-	E.tally -= 0.25
-	boosting = TRUE
+	if(E.owner)
+		E.owner.tally -= 0.25
+		boosting = TRUE
 
 /obj/item/organ_module/muscle/onRemove(obj/item/organ/external/E)
-	E.tally += 0.25
+	E.owner.tally += 0.25
 	boosting = FALSE
 
 /obj/item/organ_module/muscle/emp_act(severity)
 	if(boosting)
-		E.tally += 0.3
+		E.owner.tally += 0.3
 		// worst case scenario , 5  seconds of debuff
 		boosting = FALSE
-		addtimer(CALLBACK(src, PROC_REF(reboot), 5 SECONDS / severity ))
+		addtimer(CALLBACK(src, PROC_REF(reboot), E.owner, 5 SECONDS / severity ))
 
 
-/obj/item/organ_module/muscle/proc/reboot()
-	E.tally -= 0.3
-	boosting = TRUE
+/obj/item/organ_module/muscle/proc/reboot(mob/living/carbon/human/the_debuffed)
+	if(the_debuffed)
+		the_debuffed.tally -= 0.3
+		boosting = TRUE
 
 

--- a/code/game/objects/items/devices/organ_module/passive/muscle.dm
+++ b/code/game/objects/items/devices/organ_module/passive/muscle.dm
@@ -15,11 +15,11 @@
 	boosting = FALSE
 
 /obj/item/organ_module/muscle/emp_act(severity)
-	if(boosting)
-		E.owner.tally += 0.3
+	if(isorgan(loc))
+		loc:owner:tally += 0.3
 		// worst case scenario , 5  seconds of debuff
 		boosting = FALSE
-		addtimer(CALLBACK(src, PROC_REF(reboot), E.owner, 5 SECONDS / severity ))
+		addtimer(CALLBACK(src, PROC_REF(reboot), loc:owner, 5 SECONDS / severity ))
 
 
 /obj/item/organ_module/muscle/proc/reboot(mob/living/carbon/human/the_debuffed)

--- a/code/game/objects/items/devices/organ_module/passive/muscle.dm
+++ b/code/game/objects/items/devices/organ_module/passive/muscle.dm
@@ -3,9 +3,25 @@
 	desc = "A set of mechanical muscles designed to be implanted into legs, increasing the efficacy of your legs."
 	allowed_organs = list(BP_R_LEG, BP_L_LEG)
 	icon_state = "muscle"
+	var/boosting = FALSE
 
-/obj/item/organ_module/muscule/onInstall(obj/item/organ/external/E)
+/obj/item/organ_module/muscle/onInstall(obj/item/organ/external/E)
 	E.tally -= 0.25
+	boosting = TRUE
 
-/obj/item/organ_module/muscule/onRemove(obj/item/organ/external/E)
+/obj/item/organ_module/muscle/onRemove(obj/item/organ/external/E)
 	E.tally += 0.25
+	boosting = FALSE
+
+/obj/item/organ_module/muscle/emp_act(severity)
+	if(boosting)
+		E.tally += 0.3
+		// worst case scenario , 5  seconds of debuff
+		boosting = FALSE
+		addtimer(CALLBACK(src, PROC_REF(reboot), 5 SECONDS / severity ))
+
+
+/obj/item/organ_module/muscle/proc/reboot()
+	E.tally -= 0.3
+	boosting = TRUE
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
FIxes Mechanical muscles not providing a tally buff
Added a EMP interaction that removes the speed debuff for 5 / 2.5 / 1.3 seconds for severity 1/2/3
## Why It's Good For The Game
1)They never worked (it was all a mental trick)
2)Counterable speed gaming.
## Testing
Ran locally , i actually had a speed buff..

## Changelog
:cl:
fix: Fixed mechanical muscles not increasing speed
balance: Added a EMP interaction to mechanical muscles ,that removes their speed buff and gives an additonal 0.25 slowdown for 5/2.5/1.3 seconds for severities 1/2/3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
