### PR TITLE
Katana Fat Shaming

### DIFF
--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -206,7 +206,7 @@
 	item_state = "eutactic_katana"
 	toggleable = TRUE
 	max_upgrades = 1
-
+	w_class = ITEM_SIZE_HUGE
 	suitable_cell = /obj/item/cell/small
 
 	use_power_cost = 0.4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This changes the size of the Nano Katana from being "Normal" sized, to Huge.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently the Nano Katana is incredibly powerful while being unreasonably easy to store for it's capabilities. It starts at 30 damage _unpowered_, where as any other bladed weapon of it's size starts at 21 damage and without the armor penetration. It would fit into any satchel, tool belt, and even an engineering pouch or medium pouch. Which is insane, it's a non-telescopic **SWORD** that somehow fits in the same spot your wallet does.

It still fits on the Uniform, Belt, and Back slots.

This also gives it double-tact, like any other melee weapon of it's damage class. Weep.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![dreamseeker_XnKyIj3gK7](https://github.com/discordia-space/CEV-Eris/assets/11076040/2157f57f-c682-473e-b0e6-9f5586d29a9a)
[dreamseeker_Snv9navoBf.webm](https://github.com/discordia-space/CEV-Eris/assets/11076040/8cfcc570-67e0-45f0-9218-076d7d8a6556)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
balance: Balanced Nano Katana to fit it's damage class.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
