### PR TITLE
Mining Speed Buff PR

### DIFF
--- a/code/game/objects/items/weapons/tools/pickaxe.dm
+++ b/code/game/objects/items/weapons/tools/pickaxe.dm
@@ -12,7 +12,7 @@
 	matter = list(MATERIAL_STEEL = 6)
 	tool_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_PRYING = 20) //So it still shares its switch off quality despite not yet being used.
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_PRYING = 20)
-	switched_on_qualities = list(QUALITY_DIGGING = 30, QUALITY_PRYING = 20)
+	switched_on_qualities = list(QUALITY_DIGGING = 35, QUALITY_PRYING = 20)
 	toggleable = TRUE
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 	attack_verb = list("hit", "pierced", "sliced", "attacked")
@@ -55,10 +55,10 @@
 	switched_on_force = WEAPON_FORCE_ROBUST
 	tool_qualities = list(QUALITY_EXCAVATION = 15, QUALITY_PRYING = 25)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 15, QUALITY_PRYING = 25)
-	switched_on_qualities = list(QUALITY_DIGGING = 40, QUALITY_PRYING = 20)
+	switched_on_qualities = list(QUALITY_DIGGING = 45, QUALITY_PRYING = 20)
 	glow_color = COLOR_BLUE_LIGHT
 	degradation = 0.6
-	workspeed = 1.2
+	workspeed = 1.4
 	use_power_cost = 0
 	spawn_blacklisted = TRUE
 	rarity_value = 10
@@ -73,7 +73,7 @@
 	matter = list(MATERIAL_STEEL = 6, MATERIAL_PLASTIC = 2)
 	tool_qualities = list(QUALITY_EXCAVATION = 10)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10)
-	switched_on_qualities = list(QUALITY_DIGGING = 35)
+	switched_on_qualities = list(QUALITY_DIGGING = 40)
 	origin_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	degradation = 0.7
 	use_power_cost = 0.4
@@ -89,10 +89,10 @@
 	matter = list(MATERIAL_STEEL = 7, MATERIAL_PLATINUM = 2)
 	tool_qualities = list(QUALITY_EXCAVATION = 10)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10)
-	switched_on_qualities = list(QUALITY_DIGGING = 35)
+	switched_on_qualities = list(QUALITY_DIGGING = 55)
 	origin_tech = list(TECH_MATERIAL = 4, TECH_POWER = 2, TECH_ENGINEERING = 3)
 	degradation = 0.6
-	workspeed = 1.7
+	workspeed = 1.8
 	max_upgrades = 2
 	use_power_cost = 0.6
 	spawn_blacklisted = TRUE
@@ -106,7 +106,7 @@
 	item_state = "jackhammer"
 	tool_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 10)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 10)
-	switched_on_qualities = list(QUALITY_DIGGING = 40, QUALITY_DRILLING = 10)
+	switched_on_qualities = list(QUALITY_DIGGING = 50, QUALITY_DRILLING = 10)
 	matter = list(MATERIAL_STEEL = 8, MATERIAL_PLASTIC = 2)
 	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	degradation = 0.7
@@ -121,11 +121,11 @@
 	icon_state = "one_star_drill"
 	tool_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 10)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 10)
-	switched_on_qualities = list(QUALITY_DIGGING = 40, QUALITY_DRILLING = 10)
+	switched_on_qualities = list(QUALITY_DIGGING = 65, QUALITY_DRILLING = 10)
 	matter = list(MATERIAL_STEEL = 8, MATERIAL_PLATINUM = 2)
 	origin_tech = list(TECH_MATERIAL = 4, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	degradation = 0.6
-	workspeed = 1.7
+	workspeed = 1.9
 	max_upgrades = 2
 	use_fuel_cost = 0.10
 	max_fuel = 90
@@ -141,7 +141,7 @@
 	force = WEAPON_FORCE_DANGEROUS * 1.15
 	tool_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 20)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 20)
-	switched_on_qualities = list(QUALITY_DIGGING = 50, QUALITY_DRILLING = 20)
+	switched_on_qualities = list(QUALITY_DIGGING = 60, QUALITY_DRILLING = 20)
 	matter = list(MATERIAL_STEEL = 8, MATERIAL_PLASTEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_DIAMOND = 1)
 	origin_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 5)
 	max_upgrades = 4

--- a/code/game/objects/items/weapons/tools/pickaxe.dm
+++ b/code/game/objects/items/weapons/tools/pickaxe.dm
@@ -12,7 +12,7 @@
 	matter = list(MATERIAL_STEEL = 6)
 	tool_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_PRYING = 20) //So it still shares its switch off quality despite not yet being used.
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_PRYING = 20)
-	switched_on_qualities = list(QUALITY_DIGGING = 35, QUALITY_PRYING = 20)
+	switched_on_qualities = list(QUALITY_DIGGING = 45, QUALITY_PRYING = 20)
 	toggleable = TRUE
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 	attack_verb = list("hit", "pierced", "sliced", "attacked")
@@ -55,7 +55,7 @@
 	switched_on_force = WEAPON_FORCE_ROBUST
 	tool_qualities = list(QUALITY_EXCAVATION = 15, QUALITY_PRYING = 25)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 15, QUALITY_PRYING = 25)
-	switched_on_qualities = list(QUALITY_DIGGING = 45, QUALITY_PRYING = 20)
+	switched_on_qualities = list(QUALITY_DIGGING = 50, QUALITY_PRYING = 20)
 	glow_color = COLOR_BLUE_LIGHT
 	degradation = 0.6
 	workspeed = 1.4
@@ -73,7 +73,7 @@
 	matter = list(MATERIAL_STEEL = 6, MATERIAL_PLASTIC = 2)
 	tool_qualities = list(QUALITY_EXCAVATION = 10)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10)
-	switched_on_qualities = list(QUALITY_DIGGING = 40)
+	switched_on_qualities = list(QUALITY_DIGGING = 50)
 	origin_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	degradation = 0.7
 	use_power_cost = 0.4
@@ -106,7 +106,7 @@
 	item_state = "jackhammer"
 	tool_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 10)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 10)
-	switched_on_qualities = list(QUALITY_DIGGING = 50, QUALITY_DRILLING = 10)
+	switched_on_qualities = list(QUALITY_DIGGING = 55, QUALITY_DRILLING = 10)
 	matter = list(MATERIAL_STEEL = 8, MATERIAL_PLASTIC = 2)
 	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	degradation = 0.7
@@ -121,7 +121,7 @@
 	icon_state = "one_star_drill"
 	tool_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 10)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 10)
-	switched_on_qualities = list(QUALITY_DIGGING = 65, QUALITY_DRILLING = 10)
+	switched_on_qualities = list(QUALITY_DIGGING = 60, QUALITY_DRILLING = 10)
 	matter = list(MATERIAL_STEEL = 8, MATERIAL_PLATINUM = 2)
 	origin_tech = list(TECH_MATERIAL = 4, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	degradation = 0.6

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -273,7 +273,7 @@
 /obj/item/material/drill_head/Initialize()
 	. = ..()
 
-	//durability = 2 * (material ? material.integrity : 1)
+	//durability = 3 * (material ? material.integrity : 1)
 
 /obj/item/material/drill_head/Created(var/creator)
 	ApplyDurability()
@@ -292,7 +292,7 @@
 
 
 /obj/item/material/drill_head/verb/ApplyDurability()
-	durability = 2 * (material ? material.integrity : 1)
+	durability = 3 * (material ? material.integrity : 1)
 
 /obj/item/mech_equipment/drill
 	name = "drill"
@@ -355,10 +355,10 @@
 			var/T = target.loc
 
 			//Better materials = faster drill! //
-			var/delay = 30
+			var/delay = 20
 			switch (drill_head.material.hardness) // It's either default (steel), plasteel or diamond
-				if(80) delay = 15
-				if(100) delay = 10
+				if(80) delay = 10
+				if(100) delay = 5
 			owner.setClickCooldown(delay) //Don't spamclick!
 			if(do_after(owner, delay, target) && drill_head)
 				if(src == owner.selected_system)
@@ -383,7 +383,7 @@
 						for(var/turf/simulated/floor/asteroid/M in range(target,1))
 							if(get_dir(owner,M)&owner.dir)
 								M.gets_dug()
-								drill_head.durability -= 1
+								drill_head.durability -= 0.1
 					else if(target.loc == T)
 						target.ex_act(2)
 						drill_head.durability -= 1

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -124,7 +124,7 @@
 	light_range = 3
 
 	var/obj/machinery/mineral/console = null
-	var/sheets_per_tick = 10
+	var/sheets_per_tick = 20
 	var/list/ores_processing
 	var/list/ores_stored
 	var/static/list/alloy_data

--- a/code/modules/mining/machine_unloading.dm
+++ b/code/modules/mining/machine_unloading.dm
@@ -7,7 +7,7 @@
 	icon_state = "unloader"
 	density = TRUE
 	anchored = TRUE
-	var/unload_amt = 10
+	var/unload_amt = 20
 	var/input_dir = null
 	var/output_dir = null
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -125,7 +125,7 @@
 			var/excavation_amount = input("How deep are you going to dig?", "Excavation depth", 0)
 			if(excavation_amount)
 				to_chat(user, SPAN_NOTICE("You start exacavating [src]."))
-				if(I.use_tool(user, src, WORKTIME_SLOW, tool_type, FAILCHANCE_NORMAL, required_stat = STAT_COG))
+				if(I.use_tool(user, src, WORKTIME_NORMAL, tool_type, FAILCHANCE_NORMAL, required_stat = STAT_COG))
 					to_chat(user, SPAN_NOTICE("You finish excavating [src]."))
 					excavation_level += excavation_amount
 					GetDrilled(0)
@@ -134,7 +134,7 @@
 
 		if(QUALITY_DIGGING)
 			to_chat(user, SPAN_NOTICE("You start digging the [src]."))
-			if(I.use_tool(user, src, WORKTIME_NORMAL, tool_type, FAILCHANCE_VERY_EASY, required_stat = STAT_ROB))
+			if(I.use_tool(user, src, WORKTIME_FAST, tool_type, FAILCHANCE_VERY_EASY, required_stat = STAT_ROB))
 				to_chat(user, SPAN_NOTICE("You finish digging the [src]."))
 				GetDrilled(0)
 			return
@@ -238,7 +238,7 @@
 		if (dug)
 			to_chat(user, SPAN_WARNING("This area has already been dug"))
 			return
-		if(I.use_tool(user, src, WORKTIME_NORMAL, QUALITY_DIGGING, FAILCHANCE_EASY, required_stat = STAT_ROB))
+		if(I.use_tool(user, src, WORKTIME_FAST, QUALITY_DIGGING, FAILCHANCE_EASY, required_stat = STAT_ROB))
 			to_chat(user, SPAN_NOTICE("You dug a hole."))
 			gets_dug()
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -44,7 +44,7 @@
 /obj/item/projectile/beam/cutter/on_impact(var/atom/A)
 	if(istype(A, /turf/simulated/mineral))
 		var/turf/simulated/mineral/M = A
-		M.GetDrilled(1)
+		M.GetDrilled(5)
 	.=..()
 
 /obj/item/projectile/beam/practice


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR rebalances lots of aspects of mining, it changes the general drill speed of asteroid turf, updates the statistics for the pickaxes upgrading them to a faster speed, and updates stats for mech drills to make them more powerful: Drill's heads are more durable and drilling sand only gives 1/10th the degradation of the drill. Plasma cutter mech attachment now pierces multiple tiles per blast.  

## Why It's Good For The Game

These changes are to speed up the gameplay for mining and increasing value for mining drills beyond just being good for selling on the beacon. One star tools are put above their counterparts and on par with tools 1 tier above them combined with their original speed, which makes using them much more worth it. The mech is underwhelming to say the least. its way to clunky and its tools are relatively bad at collecting resources; with these updates to the drills and plasma cutter it should make mining mechs a serious force to be reckoned with and not just something that has no use. I considered just bringing up the stats for all drills up to like 80 each or something. but that isn't the most effective, so I just changed turf dig speed to fast. Basically this makes mining far more fast paced. And while this may compete slightly with Golem mining, I think the easy variety of the giant drill offers competition against the ability to drill fast, it also makes using a hand drill in general more tolerable. 


tl;dr: speed up hand drills to make them tolerable. hopefully if this works people will actually buy materials from the guild instead of just having it all bought from the trade beacon by the captain or given by the eye of the protector. if we have miners they should actually have some use. btw I'm gonna try and port the auto-pick up options from other servers like mechs and pouches on TG have....that'll be fun to figure out. 
## Testing

I drilled the rocks with the drills. everything appeared in order. 

## Changelog
:cl:
Balance: changed drill stats all across the board
tweak: overall turf dig speed
balance: Mech drill effectiveness
Balance:Mech plasma cutter effectiveness
/:cl:

