### PR TITLE
Quickfix for pickaxe stats pickaxes too fast

### DIFF
--- a/code/game/objects/items/weapons/tools/pickaxe.dm
+++ b/code/game/objects/items/weapons/tools/pickaxe.dm
@@ -12,7 +12,7 @@
 	matter = list(MATERIAL_STEEL = 6)
 	tool_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_PRYING = 20) //So it still shares its switch off quality despite not yet being used.
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_PRYING = 20)
-	switched_on_qualities = list(QUALITY_DIGGING = 45, QUALITY_PRYING = 20)
+	switched_on_qualities = list(QUALITY_DIGGING = 30, QUALITY_PRYING = 20)
 	toggleable = TRUE
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 	attack_verb = list("hit", "pierced", "sliced", "attacked")
@@ -55,7 +55,7 @@
 	switched_on_force = WEAPON_FORCE_ROBUST
 	tool_qualities = list(QUALITY_EXCAVATION = 15, QUALITY_PRYING = 25)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 15, QUALITY_PRYING = 25)
-	switched_on_qualities = list(QUALITY_DIGGING = 50, QUALITY_PRYING = 20)
+	switched_on_qualities = list(QUALITY_DIGGING = 35, QUALITY_PRYING = 20)
 	glow_color = COLOR_BLUE_LIGHT
 	degradation = 0.6
 	workspeed = 1.4
@@ -73,7 +73,7 @@
 	matter = list(MATERIAL_STEEL = 6, MATERIAL_PLASTIC = 2)
 	tool_qualities = list(QUALITY_EXCAVATION = 10)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10)
-	switched_on_qualities = list(QUALITY_DIGGING = 50)
+	switched_on_qualities = list(QUALITY_DIGGING = 35)
 	origin_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	degradation = 0.7
 	use_power_cost = 0.4
@@ -89,7 +89,7 @@
 	matter = list(MATERIAL_STEEL = 7, MATERIAL_PLATINUM = 2)
 	tool_qualities = list(QUALITY_EXCAVATION = 10)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10)
-	switched_on_qualities = list(QUALITY_DIGGING = 55)
+	switched_on_qualities = list(QUALITY_DIGGING = 40)
 	origin_tech = list(TECH_MATERIAL = 4, TECH_POWER = 2, TECH_ENGINEERING = 3)
 	degradation = 0.6
 	workspeed = 1.8
@@ -106,7 +106,7 @@
 	item_state = "jackhammer"
 	tool_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 10)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 10)
-	switched_on_qualities = list(QUALITY_DIGGING = 55, QUALITY_DRILLING = 10)
+	switched_on_qualities = list(QUALITY_DIGGING = 40, QUALITY_DRILLING = 10)
 	matter = list(MATERIAL_STEEL = 8, MATERIAL_PLASTIC = 2)
 	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	degradation = 0.7
@@ -121,7 +121,7 @@
 	icon_state = "one_star_drill"
 	tool_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 10)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 10)
-	switched_on_qualities = list(QUALITY_DIGGING = 60, QUALITY_DRILLING = 10)
+	switched_on_qualities = list(QUALITY_DIGGING = 45, QUALITY_DRILLING = 10)
 	matter = list(MATERIAL_STEEL = 8, MATERIAL_PLATINUM = 2)
 	origin_tech = list(TECH_MATERIAL = 4, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	degradation = 0.6
@@ -141,7 +141,7 @@
 	force = WEAPON_FORCE_DANGEROUS * 1.15
 	tool_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 20)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 20)
-	switched_on_qualities = list(QUALITY_DIGGING = 60, QUALITY_DRILLING = 20)
+	switched_on_qualities = list(QUALITY_DIGGING = 45, QUALITY_DRILLING = 20)
 	matter = list(MATERIAL_STEEL = 8, MATERIAL_PLASTEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_DIAMOND = 1)
 	origin_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 5)
 	max_upgrades = 4

--- a/code/game/objects/items/weapons/tools/shovel.dm
+++ b/code/game/objects/items/weapons/tools/shovel.dm
@@ -14,14 +14,14 @@
 	hitsound = 'sound/weapons/melee/blunthit.ogg'
 	sharp = FALSE
 	edge = TRUE
-	tool_qualities = list(QUALITY_SHOVELING = 30, QUALITY_DIGGING = 30, QUALITY_EXCAVATION = 10, QUALITY_HAMMERING = 10)
+	tool_qualities = list(QUALITY_SHOVELING = 30, QUALITY_DIGGING = 25, QUALITY_EXCAVATION = 10, QUALITY_HAMMERING = 10)
 	rarity_value = 9.6
 
 /obj/item/tool/shovel/improvised
 	name = "junk shovel"
 	desc = "A large but fragile tool for moving dirt and rock, made by hand. Has more than enough space for tool mods to make it better."
 	icon_state = "impro_shovel"
-	tool_qualities = list(QUALITY_SHOVELING = 25, QUALITY_DIGGING = 25, QUALITY_EXCAVATION = 10, QUALITY_HAMMERING = 10)
+	tool_qualities = list(QUALITY_SHOVELING = 25, QUALITY_DIGGING = 20, QUALITY_EXCAVATION = 10, QUALITY_HAMMERING = 10)
 	degradation = 1.5
 	max_upgrades = 5 //all makeshift tools get more mods to make them actually viable for mid-late game
 	rarity_value = 5
@@ -36,7 +36,7 @@
 	throwforce = WEAPON_FORCE_HARMLESS
 	w_class = ITEM_SIZE_SMALL
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 1)
-	tool_qualities = list(QUALITY_SHOVELING = 20, QUALITY_DIGGING = 20, QUALITY_EXCAVATION = 10,QUALITY_HAMMERING = 10)
+	tool_qualities = list(QUALITY_SHOVELING = 20, QUALITY_DIGGING = 15, QUALITY_EXCAVATION = 10,QUALITY_HAMMERING = 10)
 	max_upgrades = 2
 	rarity_value = 19.2
 
@@ -49,7 +49,7 @@
 	throwforce = WEAPON_FORCE_WEAK
 	w_class = ITEM_SIZE_NORMAL
 	matter = list(MATERIAL_PLASTEEL = 6,  MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 1)
-	tool_qualities = list(QUALITY_SHOVELING = 60, QUALITY_DIGGING = 40, QUALITY_EXCAVATION = 20, QUALITY_HAMMERING = 15)
+	tool_qualities = list(QUALITY_SHOVELING = 60, QUALITY_DIGGING = 30, QUALITY_EXCAVATION = 20, QUALITY_HAMMERING = 15)
 	use_power_cost = 0.8
 	degradation = 0.7
 	max_upgrades = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes some stats for drills and shovels so they work slightly slower

## Why It's Good For The Game

instant drilling wasn't intended, turns out stats have a lot more impact than expected

## Testing
It should be a bit slower now while still being fast

## Changelog
:cl:
Balance:Tool stats. 
/:cl:

