### PR TITLE
Revert "Removes home system and faction fields from the crew records program as they were always showing up empty"

### DIFF
--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -199,6 +199,8 @@ FIELD_SHORT("Fingerprint", fingerprint, access_security, access_security)
 
 // EMPLOYMENT RECORDS
 FIELD_LONG("Employment Record", emplRecord, access_heads, access_heads)
+FIELD_SHORT("Home System", homeSystem, access_heads, access_change_ids)
+FIELD_SHORT("Faction", faction, access_heads, access_heads)
 FIELD_LONG("Qualifications", skillset, access_heads, access_heads)
 
 // ANTAG RECORDS


### PR DESCRIPTION
Reverts discordia-space/CEV-Eris#7642
Improve do not remove