### PR TITLE
Nerfs nuka cola, hyperzine, and leg augmentation

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -354,8 +354,8 @@
 	var/muscle_eff = owner.get_specific_organ_efficiency(OP_MUSCLE, organ_tag)
 	var/nerve_eff = max(owner.get_specific_organ_efficiency(OP_NERVE, organ_tag),1)
 	muscle_eff = (muscle_eff/100) - (muscle_eff/nerve_eff) //Need more nerves to control those new muscles
-	. += max(-(muscle_eff), MAX_MUSCLE_SPEED)
-
+	if(muscle_eff)
+		. += 0.6 * muscle_eff / (muscle_eff + 0.4) // Diminishing returns with a hard cap of 0.6 and soft cap of 0.5
 	. += tally
 
 /obj/item/organ/external/proc/is_nerve_struck()

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -355,7 +355,7 @@
 	var/nerve_eff = max(owner.get_specific_organ_efficiency(OP_NERVE, organ_tag),1)
 	muscle_eff = (muscle_eff/100) - (muscle_eff/nerve_eff) //Need more nerves to control those new muscles
 	if(muscle_eff)
-		. += 0.6 * muscle_eff / (muscle_eff + 0.4) // Diminishing returns with a hard cap of 0.6 and soft cap of 0.5
+		. -= 0.6 * muscle_eff / (muscle_eff + 0.4) // Diminishing returns with a hard cap of 0.6 and soft cap of 0.5
 	. += tally
 
 /obj/item/organ/external/proc/is_nerve_struck()

--- a/code/modules/reagents/reagents/drugs.dm
+++ b/code/modules/reagents/reagents/drugs.dm
@@ -246,7 +246,7 @@
 	..()
 	if(prob(5))
 		M.emote(pick("twitch", "blink_r", "shiver"))
-	M.add_chemical_effect(CE_SPEEDBOOST, 0.6)
+	M.add_chemical_effect(CE_SPEEDBOOST, 0.5)
 	M.add_chemical_effect(CE_PULSE, 2)
 
 /datum/reagent/drug/hyperzine/withdrawal_act(mob/living/carbon/M)

--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -936,11 +936,12 @@
 
 /datum/reagent/drink/nuka_cola/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
 	..()
-	M.add_chemical_effect(CE_SPEEDBOOST, 0.8)
+	M.add_chemical_effect(CE_SPEEDBOOST, 0.6)
 	M.make_jittery(20 * effect_multiplier)
 	M.druggy = max(M.druggy, 30 * effect_multiplier)
 	M.dizziness += 5 * effect_multiplier
 	M.drowsyness = 0
+	M.apply_effect(0.5 * effect_multiplier, IRRADIATE, 0)
 
 /datum/reagent/drink/grenadine
 	name = "Grenadine Syrup"


### PR DESCRIPTION
## About The Pull Request

Reduces the effectiveness of nuka cola and hyperzine, makes nuka cola irradiate the consumer.

Muscle/nerve efficiency now gives diminishing returns, requiring significantly more effort for significantly less payout.
Little effort gives more payout than it used to, however.

## Why It's Good For The Game

Chems were overpowered, nuka cola was regularly exploited to gain an unfair advantage.
Diminishing augmentation good for the lowly consumer, bad for the powergamer.

Nerfs requested by Fox.

## Testing

Augmented character walked visibly faster when modded, but felt slower than it used to.

## Changelog
:cl:
tweak: nuka cola irradiates you
balance: nuka cola, hyperzine nerfed
balance: augmenting your leg with more muscle gives diminishing returns
/:cl: