### PR TITLE
Excelsior revamp part 1

### DIFF
--- a/code/datums/autolathe/biomatter.dm
+++ b/code/datums/autolathe/biomatter.dm
@@ -30,6 +30,13 @@
 	name = "Robust Harvestt"
 	build_path = /obj/item/reagent_containers/glass/fertilizer/rh
 	materials = list(MATERIAL_BIOMATTER = 7.5)
+
+//Excel print only
+/datum/design/bioprinter/readeat
+	name = "MRE"
+	build_path = /obj/item/reagent_containers/food/snacks/mre
+	materials = list(MATERIAL_BIOMATTER = 25)
+
 //[/NUTRIMENTS]
 
 //[CLOTHES, ARMOR AND ACCESORIES]

--- a/code/game/antagonist/station/revolutionary/excel_faction.dm
+++ b/code/game/antagonist/station/revolutionary/excel_faction.dm
@@ -85,7 +85,8 @@
 
 	var/obj/item/storage/deferred/stash/sack/stash = new
 
-	new /obj/item/computer_hardware/hard_drive/portable/design(stash)
+	new /obj/item/storage/box/data_disk(stash)
+	new /obj/item/storage/box/excel_parts(stash)
 	new /obj/item/computer_hardware/hard_drive/portable/design/excelsior/core(stash)
 	new /obj/item/computer_hardware/hard_drive/portable/design/excelsior/weapons(stash)
 	new /obj/item/electronics/circuitboard/excelsiorautolathe(stash)

--- a/code/game/machinery/excelsior/ex_teleporter.dm
+++ b/code/game/machinery/excelsior/ex_teleporter.dm
@@ -53,7 +53,10 @@ var/global/excelsior_last_draft = 0
 		/obj/item/stock_parts/manipulator/excelsior = 350,
 		/obj/item/stock_parts/micro_laser/excelsior = 350,
 		/obj/item/stock_parts/matter_bin/excelsior = 350,
-		/obj/item/clothing/under/excelsior = 50,
+		/obj/item/clothing/under/excelsior = 75,
+		/obj/item/computer_hardware/hard_drive/portable/design/excelsior/frheal = 100,
+		/obj/item/gun/projectile/boltgun = 125,
+		/obj/item/ammo_magazine/sllrifle = 25,
 		/obj/item/electronics/circuitboard/excelsior_teleporter = 500,
 		/obj/item/electronics/circuitboard/excelsiorautolathe = 150,
 		/obj/item/electronics/circuitboard/excelsiorreconstructor = 150,
@@ -390,6 +393,9 @@ var/global/excelsior_last_draft = 0
 	card.update_name()
 	conscript.equip_to_appropriate_slot(card)
 	conscript.update_inv_wear_id()
+
+//Later I'm going to add 3 new roles for excelsior conscripts with increasing energy cost, the roles are such; Mekhanik, Medik, and Commissar
+//They will have specialized skills, spawn with some medical,engineering, or for the commissar just cool looking clothes. I will not code these roles until I can make sprites for them.
 
 /obj/machinery/complant_teleporter/proc/reinforcements_check()
 	if(excelsior_conscripts <= 0)

--- a/code/game/objects/items/weapons/design_disks/excelsior.dm
+++ b/code/game/objects/items/weapons/design_disks/excelsior.dm
@@ -196,3 +196,17 @@
 		/datum/design/autolathe/ammo/shotgun_beanbag,
 		/datum/design/autolathe/ammo/shotgun_pellet
 	)
+
+//means of recuperation will be later supplimented with a new excelsior advanced healing kits with their own sprites, for the meantime it will contain just basic healing gear and a food item
+/obj/item/computer_hardware/hard_drive/portable/design/excelsior/frheal
+	disk_name = "Excelsior Means of Recuperation"
+	desc = {"The back has a machine etching:\n \
+	\"The health of the worker is essential to the success of the revolution\""}
+	spawn_blacklisted = TRUE
+	license = -1
+	designs = list(
+		/datum/design/bioprinter/medical/bruise,
+		/datum/design/bioprinter/medical/splints,
+		/datum/design/bioprinter/medical/ointment,
+		/datum/design/bioprinter/readeat
+	)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -594,8 +594,16 @@
 	item_state = "packet_njoy_blue"
 	prespawned_content_type = /obj/item/storage/pill_bottle/njoy/blue
 
-/obj/item/storage/box/njoy/green
-	name = "green Njoy packet"
-	icon_state = "packet_njoy_green"
-	item_state = "packet_njoy_green"
-	prespawned_content_type = /obj/item/storage/pill_bottle/njoy/green
+/obj/item/storage/box/excel_parts
+	name = "Excelsior Means of Foundation"
+	desc = "Much like a factory, a revolution needs a firm foundation; this one is yours."
+	spawn_blacklisted = TRUE
+	var/list/things2spawn = list(
+		/obj/item/stock_parts/manipulator/excelsior
+		/obj/item/stock_parts/manipulator/excelsior
+		/obj/item/stock_parts/manipulator/excelsior
+		/obj/item/stock_parts/matter_bin/excelsior
+		/obj/item/stock_parts/matter_bin/excelsior
+		/obj/item/stock_parts/matter_bin/excelsior
+	)
+

--- a/code/game/objects/items/weapons/tools/pickaxe.dm
+++ b/code/game/objects/items/weapons/tools/pickaxe.dm
@@ -12,7 +12,7 @@
 	matter = list(MATERIAL_STEEL = 6)
 	tool_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_PRYING = 20) //So it still shares its switch off quality despite not yet being used.
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_PRYING = 20)
-	switched_on_qualities = list(QUALITY_DIGGING = 45, QUALITY_PRYING = 20)
+	switched_on_qualities = list(QUALITY_DIGGING = 30, QUALITY_PRYING = 20)
 	toggleable = TRUE
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 	attack_verb = list("hit", "pierced", "sliced", "attacked")
@@ -55,7 +55,7 @@
 	switched_on_force = WEAPON_FORCE_ROBUST
 	tool_qualities = list(QUALITY_EXCAVATION = 15, QUALITY_PRYING = 25)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 15, QUALITY_PRYING = 25)
-	switched_on_qualities = list(QUALITY_DIGGING = 50, QUALITY_PRYING = 20)
+	switched_on_qualities = list(QUALITY_DIGGING = 35, QUALITY_PRYING = 20)
 	glow_color = COLOR_BLUE_LIGHT
 	degradation = 0.6
 	workspeed = 1.4
@@ -73,7 +73,7 @@
 	matter = list(MATERIAL_STEEL = 6, MATERIAL_PLASTIC = 2)
 	tool_qualities = list(QUALITY_EXCAVATION = 10)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10)
-	switched_on_qualities = list(QUALITY_DIGGING = 50)
+	switched_on_qualities = list(QUALITY_DIGGING = 35)
 	origin_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	degradation = 0.7
 	use_power_cost = 0.4
@@ -89,7 +89,7 @@
 	matter = list(MATERIAL_STEEL = 7, MATERIAL_PLATINUM = 2)
 	tool_qualities = list(QUALITY_EXCAVATION = 10)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10)
-	switched_on_qualities = list(QUALITY_DIGGING = 55)
+	switched_on_qualities = list(QUALITY_DIGGING = 40)
 	origin_tech = list(TECH_MATERIAL = 4, TECH_POWER = 2, TECH_ENGINEERING = 3)
 	degradation = 0.6
 	workspeed = 1.8
@@ -106,7 +106,7 @@
 	item_state = "jackhammer"
 	tool_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 10)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 10)
-	switched_on_qualities = list(QUALITY_DIGGING = 55, QUALITY_DRILLING = 10)
+	switched_on_qualities = list(QUALITY_DIGGING = 40, QUALITY_DRILLING = 10)
 	matter = list(MATERIAL_STEEL = 8, MATERIAL_PLASTIC = 2)
 	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	degradation = 0.7
@@ -121,7 +121,7 @@
 	icon_state = "one_star_drill"
 	tool_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 10)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 10)
-	switched_on_qualities = list(QUALITY_DIGGING = 60, QUALITY_DRILLING = 10)
+	switched_on_qualities = list(QUALITY_DIGGING = 45, QUALITY_DRILLING = 10)
 	matter = list(MATERIAL_STEEL = 8, MATERIAL_PLATINUM = 2)
 	origin_tech = list(TECH_MATERIAL = 4, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	degradation = 0.6
@@ -141,7 +141,7 @@
 	force = WEAPON_FORCE_DANGEROUS * 1.15
 	tool_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 20)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 20)
-	switched_on_qualities = list(QUALITY_DIGGING = 60, QUALITY_DRILLING = 20)
+	switched_on_qualities = list(QUALITY_DIGGING = 45, QUALITY_DRILLING = 20)
 	matter = list(MATERIAL_STEEL = 8, MATERIAL_PLASTEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_DIAMOND = 1)
 	origin_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 5)
 	max_upgrades = 4

--- a/code/game/objects/items/weapons/tools/shovel.dm
+++ b/code/game/objects/items/weapons/tools/shovel.dm
@@ -14,14 +14,14 @@
 	hitsound = 'sound/weapons/melee/blunthit.ogg'
 	sharp = FALSE
 	edge = TRUE
-	tool_qualities = list(QUALITY_SHOVELING = 30, QUALITY_DIGGING = 30, QUALITY_EXCAVATION = 10, QUALITY_HAMMERING = 10)
+	tool_qualities = list(QUALITY_SHOVELING = 30, QUALITY_DIGGING = 25, QUALITY_EXCAVATION = 10, QUALITY_HAMMERING = 10)
 	rarity_value = 9.6
 
 /obj/item/tool/shovel/improvised
 	name = "junk shovel"
 	desc = "A large but fragile tool for moving dirt and rock, made by hand. Has more than enough space for tool mods to make it better."
 	icon_state = "impro_shovel"
-	tool_qualities = list(QUALITY_SHOVELING = 25, QUALITY_DIGGING = 25, QUALITY_EXCAVATION = 10, QUALITY_HAMMERING = 10)
+	tool_qualities = list(QUALITY_SHOVELING = 25, QUALITY_DIGGING = 20, QUALITY_EXCAVATION = 10, QUALITY_HAMMERING = 10)
 	degradation = 1.5
 	max_upgrades = 5 //all makeshift tools get more mods to make them actually viable for mid-late game
 	rarity_value = 5
@@ -36,7 +36,7 @@
 	throwforce = WEAPON_FORCE_HARMLESS
 	w_class = ITEM_SIZE_SMALL
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 1)
-	tool_qualities = list(QUALITY_SHOVELING = 20, QUALITY_DIGGING = 20, QUALITY_EXCAVATION = 10,QUALITY_HAMMERING = 10)
+	tool_qualities = list(QUALITY_SHOVELING = 20, QUALITY_DIGGING = 15, QUALITY_EXCAVATION = 10,QUALITY_HAMMERING = 10)
 	max_upgrades = 2
 	rarity_value = 19.2
 
@@ -49,7 +49,7 @@
 	throwforce = WEAPON_FORCE_WEAK
 	w_class = ITEM_SIZE_NORMAL
 	matter = list(MATERIAL_PLASTEEL = 6,  MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 1)
-	tool_qualities = list(QUALITY_SHOVELING = 60, QUALITY_DIGGING = 40, QUALITY_EXCAVATION = 20, QUALITY_HAMMERING = 15)
+	tool_qualities = list(QUALITY_SHOVELING = 60, QUALITY_DIGGING = 30, QUALITY_EXCAVATION = 20, QUALITY_HAMMERING = 15)
 	use_power_cost = 0.8
 	degradation = 0.7
 	max_upgrades = 4

--- a/code/modules/clothing/spacesuits/void/excelsior.dm
+++ b/code/modules/clothing/spacesuits/void/excelsior.dm
@@ -67,7 +67,7 @@
 		hud.forceMove(src)
 
 /obj/item/clothing/suit/space/void/excelsior
-	name = "Excelsior armor"
+	name = "Mothballed Excelsior armor"
 	desc = "An ancient space suit design, remade with advanced materials. Provides good protection, especially against energy discharges, while remaining surprisingly flexible."
 	icon_state = "soviet_skaf"
 	item_state = "soviet_skaf"
@@ -90,5 +90,58 @@
 		MATERIAL_PLASTEEL = 5
 	)
 	helmet = /obj/item/clothing/head/space/void/excelsior
+	spawn_blacklisted = TRUE
+	slowdown = MEDIUM_SLOWDOWN
+
+/obj/item/clothing/head/space/void/excelsior_mothball
+	name = "Mothballed Excelsior helmet"
+	desc = "A deceptively well armored space helmet. This one is degraded and has had its hud torn out."
+	icon_state = "cosmo"
+	item_state = "cosmo"
+
+	//Worse excel armor without a hud ingrained, its for the radio stash
+	matter = list(
+		MATERIAL_PLASTIC = 20,
+		MATERIAL_GLASS = 10,
+		MATERIAL_PLASTEEL = 3
+	)
+
+	armor = list(
+		melee = 10,
+		bullet = 10,
+		energy = 11,
+		bomb = 25,
+		bio = 100,
+		rad = 75
+	)
+	siemens_coefficient = 0
+	species_restricted = list(SPECIES_HUMAN)
+	light_overlay = "helmet_light_green"
+	price_tag = 300
+
+/obj/item/clothing/suit/space/void/excelsior_mothball
+	name = "Mothballed Excelsior armor"
+	desc = "An ancient space suit design, remade with advanced materials. Provides good protection, especially against energy discharges, while remaining surprisingly flexible."
+	icon_state = "soviet_skaf"
+	item_state = "soviet_skaf"
+	slowdown = 0.2
+	w_class = ITEM_SIZE_NORMAL
+	armor = list(
+		melee = 10,
+		bullet = 10,
+		energy = 11,
+		bomb = 25,
+		bio = 100,
+		rad = 75
+	)
+	siemens_coefficient = 0 //Shockproof!
+	breach_threshold = 6
+	resilience = 0.08
+	matter = list(
+		MATERIAL_PLASTIC = 30,
+		MATERIAL_STEEL = 10,
+		MATERIAL_PLASTEEL = 5
+	)
+	helmet = /obj/item/clothing/head/space/void/excelsior_mothball
 	spawn_blacklisted = TRUE
 	slowdown = MEDIUM_SLOWDOWN

--- a/code/modules/clothing/under/excelsior.dm
+++ b/code/modules/clothing/under/excelsior.dm
@@ -1,10 +1,18 @@
 /obj/item/clothing/under/excelsior
 	name = "random excelsior jumpsuit"
-	desc = "Excelsior jumpsuit designed to boost morale and spread the revolution"
+	desc = "Reject decadent capitalist 'fashion' embrace true revolutionary style!"
 	icon_state = "excelsior_white"
 	item_state = "bl_suit"
 	has_sensor = 0
 	spawn_blacklisted = TRUE
+		armor = list(
+		melee = 2,
+		bullet = 2,
+		energy = 3,
+		bomb = 0,
+		bio = 5,
+		rad = 10
+	)
 
 /obj/item/clothing/under/excelsior/Initialize(mapload, ...)
 	. = ..()

--- a/code/modules/stashes/stash_types/excelsior.dm
+++ b/code/modules/stashes/stash_types/excelsior.dm
@@ -8,11 +8,11 @@
 	loot_type = "Excelsior"
 	nonmaint_reroll = 100
 	contents_list_base = list(/obj/item/electronics/circuitboard/excelsiorautolathe = 1,
-	 /obj/item/implanter/excelsior/broken = 2)
+	/obj/item/implanter/excelsior/broken = 2)
 
 	contents_list_random = list(/obj/item/implantcase/excelsior/broken = 70,
 	/obj/item/implantcase/excelsior/broken = 40,
-	/obj/item/clothing/suit/space/void/excelsior = 70,
+	/obj/item/clothing/suit/space/void/excelsior_mothball = 70,
 	/obj/item/gun/projectile/automatic/modular/ak/excelsior = 30,
 	/obj/item/gun/projectile/automatic/modular/ak/excelsior = 30,
 	/obj/item/ammo_magazine/lrifle = 50,


### PR DESCRIPTION


## About The Pull Request

Basically I added some designs, made a new disk, changed the stash excel armor to a mothballed version that is less effective, added a box of excel stock parts to speed up excelsior early gameplay, added boltgun and ammo to excel teleporter for relatively cheap for an easy way to get a relatively below average rifle, also encourages using the mosin, excel clothing has some armor to encourage its usage. The new disk that contains some bandages and a MRE as a design, excels tend to starve, and while reliance on the ship is good, food can be a bit of a hinderance to the revolution(slow down antag gameplay and bore the crew).

## Why It's Good For The Game

Excels could use a bit of extra supplies while I figure out how to actually best revamp them. This will upgrade some excel functions and encourage excels to utilize their armor instead of just dressing like the rest of the crew. The goal of these changes is slightly aesthetic, but is also to speed up the excels capturing and converting without giving a blatant OP upgrade. 
## Testing

Testing will occur soon. 

## Changelog
ADD:MEANS OF RECUPERATION
Balance:Excel jumpsuit armored
balance: Excel armor stash is now mothball armor
add: Excel stock parts box
balance: mosin and ammo added to the teleporter.
Balance:more stuff will be added soon, PR work in progress.
/:cl:

