### PR TITLE
Nerf adrenaline effects, remove Nomad cigs from loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -164,8 +164,7 @@
 	var/cigarettes_type = list(
 		"Space Cigarettes"			=	/obj/item/storage/fancy/cigarettes,
 		"DromedaryCo Cigarettes"	=	/obj/item/storage/fancy/cigarettes/dromedaryco,
-		"AcmeCo Cigarettes"			=	/obj/item/storage/fancy/cigarettes/killthroat,
-		"Nomads Cigarettes"			=	/obj/item/storage/fancy/cigarettes/homeless
+		"AcmeCo Cigarettes"			=	/obj/item/storage/fancy/cigarettes/killthroat
 	)
 	gear_tweaks += new/datum/gear_tweak/path(cigarettes_type)
 

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -201,8 +201,7 @@
 	withdrawal_threshold = 30
 
 /datum/reagent/adrenaline/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
-	M.SetParalysis(0)
-	M.SetWeakened(0)
+	M.add_chemical_effect(CE_PAINKILLER, 15)
 	M.stats.addTempStat(STAT_TGH, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "adrenaline")
 	M.add_chemical_effect(CE_TOXIN, 3)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes nomad cigarettes packets from loadout and removes Weakened(0)/Paralysis(0) from Adrenaline reagent, replaces it with (CE_PAINKILLER, 15)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Why adrenaline is OP:
- Nomads have adrenaline, they can be taken in loadout
- Very simple recipe (blood and dexalin)
- Laughable NSA (5)
- Completely negates stuns (Weakened(0)/Paralysis(0)

How with changes outlined above it's completely different, but still good:
- Still gives 25 TGH
- Still has 5 NSA
- Weak painkiller effect (inaprovaline)
- Abundance

Also having simply better cigarettes in loadout (Nomads) compared to others is no bueno, I removed them too.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![изображение](https://github.com/discordia-space/CEV-Eris/assets/57810301/9a8c6714-2149-4aad-a87a-2b43ff337f4e)
![изображение](https://github.com/discordia-space/CEV-Eris/assets/57810301/c052d5a4-458f-4daa-a954-bce486112acd)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
del: Nomad cigarette packet is removed from loadout but can still be obtained in-game
balance: Instead of removing paralysis/weakened Adrenaline now has weak painkiller effect (same as inaprovaline).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
