### PR TITLE
Remove "department-specific" prosthetics

### DIFF
--- a/code/modules/organs/body_modifications.dm
+++ b/code/modules/organs/body_modifications.dm
@@ -42,7 +42,6 @@ var/global/list/modifications_types = list(
 	var/nature = MODIFICATION_ORGANIC
 	var/hascolor = FALSE
 	var/allow_nt = TRUE
-	var/list/department_specific = ALL_DEPARTMENTS
 
 /datum/body_modification/proc/get_mob_icon(organ, color="#ffffff", gender = MALE, species)	//Use in setup character only
 	return new/icon('icons/mob/human.dmi', "blank")
@@ -62,24 +61,6 @@ var/global/list/modifications_types = list(
 		if(parent.nature > nature)
 			to_chat(usr, "[name] can't be attached to [parent.name]")
 			return FALSE
-
-	if(department_specific.len)
-		if(H && H.mind)
-			var/department = H.mind.assigned_job.department
-			if(!department)
-				return FALSE
-			else if(!department_specific.Find(department))
-				to_chat(usr, "This body-mod does not match your chosen department.")
-				return FALSE
-		else if(P)
-			var/datum/job/J
-			if(ASSISTANT_TITLE in P.job_low)
-				J = SSjob.GetJob(ASSISTANT_TITLE)
-			else
-				J = SSjob.GetJob(P.job_high)
-			if(!J || !department_specific.Find(J.department))
-				to_chat(usr, "This body-mod does not match your highest-priority department.")
-				return FALSE
 
 	if(!allow_nt && H?.get_core_implant(/obj/item/implant/core_implant/cruciform))
 		to_chat(usr, "Your cruciform prevents you from using this modification.")
@@ -166,14 +147,12 @@ var/global/list/modifications_types = list(
 	id = "prosthesis_technomancer"
 	replace_limb = /obj/item/organ/external/robotic/technomancer
 	body_parts = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_CHEST, BP_GROIN, BP_HEAD)
-	department_specific = list(DEPARTMENT_ENGINEERING)
 	icon = 'icons/mob/human_races/cyberlimbs/technomancer.dmi'
 
 /datum/body_modification/limb/prosthesis/moebius
 	id = "prosthesis_moebius"
 	replace_limb = /obj/item/organ/external/robotic/moebius
 	body_parts = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_CHEST, BP_GROIN, BP_HEAD)
-	department_specific = list(DEPARTMENT_MEDICAL, DEPARTMENT_SCIENCE)
 	icon = 'icons/mob/human_races/cyberlimbs/moebius.dmi'
 
 /datum/body_modification/limb/prosthesis/makeshift


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Remove department_specific var and "This body-mod does not match your highest-priority departmen"
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It *still* spams the shit out of chat. All prosthetics available there are same stat-wise I see no point in not letting people take all of them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Ran the server, could select all prosthetics, chat was clear.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: Everyone can select *truly* any prosthetic now in character setup.
fix: Fixed chat spam ("This body-mod does not match your chosen department").
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
