### PR TITLE
Un-shadow-nerfs armored coats.

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -130,7 +130,7 @@
 		rad = 0
 	)
 	price_tag = 600
-	slowdown = MEDIUM_SLOWDOWN
+	slowdown = 0.1
 	valid_accessory_slots = list("armband","decor")
 	restricted_accessory_slots = list("armband")
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -130,7 +130,7 @@
 		rad = 0
 	)
 	price_tag = 600
-	slowdown = 0.1
+	slowdown = LIGHT_SLOWDOWN
 	valid_accessory_slots = list("armband","decor")
 	restricted_accessory_slots = list("armband")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Humon modified their slowdown in his recoil tweak PR without mentioning it, shadow balance changes at it again ruining my playthroughs..

## Why It's Good For The Game
Many vagabonds will now be able to enjoy the armored coats they order from the guild.

## Testing

Tested locally
## Changelog
:cl:
balance: Returned armored coats to the same slowdown as armored vests.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
