### PR TITLE
blacklists the unfunny dead meme mask from spawning

### DIFF
--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -599,6 +599,7 @@
 	)
 	price_tag = 1997
 
+//	spawn_tags = SPAWN_TAG_ODDITY
 	spawn_blacklisted = TRUE
 
 /obj/item/clothing/mask/gas/big_shot/equipped(mob/living/carbon/human/user, slot)

--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -599,7 +599,7 @@
 	)
 	price_tag = 1997
 
-//	spawn_tags = SPAWN_TAG_ODDITY
+	spawn_tags = SPAWN_TAG_ODDITY
 	spawn_blacklisted = TRUE
 
 /obj/item/clothing/mask/gas/big_shot/equipped(mob/living/carbon/human/user, slot)

--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -599,7 +599,7 @@
 	)
 	price_tag = 1997
 
-	spawn_tags = SPAWN_TAG_ODDITY
+	spawn_blacklisted = TRUE
 
 /obj/item/clothing/mask/gas/big_shot/equipped(mob/living/carbon/human/user, slot)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This pull request disables the spawning of the bigshot mask. it can now only be obtained via admin intervention
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
if we are going to ban or warn people for breaking the atmosphere, meming and spamming on comms. this mask referencing a dead meme that adds a large amount of text to your messages gets annoying fast, especially with tts. runs counter to that policy as it does all of those things and more. it is also buggy and its effects dont get properly removed when its taken off.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
i compiled and loaded in, then ran a search to see if any of the masks had spawned. there were 0 results
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
del: Bigshot mask no longer spawns naturally
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
