### PR TITLE
Fix downstream grenade duping bug

### DIFF
--- a/code/modules/projectiles/projectile/projectilegrenades.dm
+++ b/code/modules/projectiles/projectile/projectilegrenades.dm
@@ -12,13 +12,18 @@
 
 /obj/item/projectile/bullet/grenade/Move()	//Makes grenade shells cause their effect when they arrive at their target turf
 	if(get_turf(src) == get_turf(original))
+		if(QDELETED(src)) return
+
 		grenade_effect(get_turf(src))
 		qdel(src)
 	else
 		..()
 
 /obj/item/projectile/bullet/grenade/on_hit(atom/target)	//Allows us to cause different effects for each grenade shell on hit
+	if(QDELETED(src)) return
+
 	grenade_effect(target)
+	qdel(src)
 
 /obj/item/projectile/bullet/grenade/proc/grenade_effect(target)
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This fix the bug as of 1 year ago on Eris where firing a grenade launcher at certain angle into wall lead to server crashing and duping. 

Can't replicate this anymore on current Eris code but replicated it downstream while porting it over on old code. This happen if you fire a grenade launcher at certain angle between two walls.

Can't go wrong with not firing grenade effect when qdeleted.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevent possible crash

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

- Spawned living/carbon/human

- Fired 12 rounds of frag and stings into the wall. Nothing wrong 
- Also tested downstream

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: Fixed a possible crash / lagfest when grenade launcher are fired at certain angles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
