### PR TITLE
no more step delay

### DIFF
--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -244,7 +244,7 @@ There are important things regarding this file:
 	damage_types = list(BRUTE = 25)
 	armor_divisor = 1
 	knockback = 1
-	step_delay = 1.1
+	step_delay = 1
 	recoil = 8
 	wounding_mult = WOUNDING_EXTREME
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Removes the shotgun step delay, meaning shotgun projectiles are as fast as all other bullets
## Why It's Good For The Game
The fact shells are slowers has always been terrible, just awful design option. There has never been a reason why that should be a thing. Is it the high damage? well revolvers also have really high damage too, but their bullets aren't slow. Hell, the AMR has hitscan and yet hits harder than a double barrel, and through walls.

It really is a relic of old times that is, imo, thoroughly obsolete. No, you cant even use realism as an argument. A 12ga slug is faster than non-hotloaded 9mm rounds, so technically .35 should have slower bullets, not .50

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
The gun shoots.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
balance: shotgun shells are no longer inexplicably slower than other bullets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
