### PR TITLE
Alternative shotgun change: damage up

### DIFF
--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -729,3 +729,4 @@
 	ammo_type = /obj/item/ammo_casing/antim
 	matter = list(MATERIAL_STEEL = 6)
 	max_ammo = 8
+	ammo_names = list(

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -729,4 +729,3 @@
 	ammo_type = /obj/item/ammo_casing/antim
 	matter = list(MATERIAL_STEEL = 6)
 	max_ammo = 8
-	ammo_names = list(

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -722,3 +722,10 @@
 
 /obj/item/ammo_magazine/m12/empty
 	initial_ammo = 0
+
+/obj/item/ammo_magazine/m12/antim
+	name = "ammo drum (.60)"
+	caliber = CAL_ANTIM
+	ammo_type = /obj/item/ammo_casing/antim
+	matter = list(MATERIAL_STEEL = 6)
+	max_ammo = 8

--- a/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
@@ -59,4 +59,4 @@
 	resultvars = list(/obj/item/gun/projectile/shotgun/bojevic)
 	gripvars = list(/obj/item/part/gun/modular/grip/serb)
 	mechanismvar = /obj/item/part/gun/modular/mechanism/autorifle // listen, its semi and full auto, not pump. makes sense
-	barrelvars = list(/obj/item/part/gun/modular/barrel/shotgun)
+	barrelvars = list(/obj/item/part/gun/modular/barrel/shotgun, /obj/item/part/gun/modular/barrel/antim)

--- a/code/modules/projectiles/guns/projectile/shotgun/bull.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/bull.dm
@@ -117,4 +117,4 @@
 	resultvars = list(/obj/item/gun/projectile/shotgun/bull)
 	gripvars = list(/obj/item/part/gun/modular/grip/rubber)
 	mechanismvar = /obj/item/part/gun/modular/mechanism/shotgun
-	barrelvars = list(/obj/item/part/gun/modular/barrel/shotgun)
+	barrelvars = list(/obj/item/part/gun/modular/barrel/shotgun, /obj/item/part/gun/modular/barrel/antim)

--- a/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
@@ -93,4 +93,4 @@
 	resultvars = list(/obj/item/gun/projectile/shotgun/doublebarrel)
 	gripvars = list(/obj/item/part/gun/modular/grip/wood)
 	mechanismvar = /obj/item/part/gun/modular/mechanism/shotgun
-	barrelvars = list(/obj/item/part/gun/modular/barrel/shotgun)
+	barrelvars = list(/obj/item/part/gun/modular/barrel/shotgun, /obj/item/part/gun/modular/barrel/antim)

--- a/code/modules/projectiles/guns/projectile/shotgun/gladstone.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/gladstone.dm
@@ -26,4 +26,4 @@
 	resultvars = list(/obj/item/gun/projectile/shotgun/pump/gladstone)
 	gripvars = list(/obj/item/part/gun/modular/grip/rubber)
 	mechanismvar = /obj/item/part/gun/modular/mechanism/shotgun
-	barrelvars = list(/obj/item/part/gun/modular/barrel/shotgun)
+	barrelvars = list(/obj/item/part/gun/modular/barrel/shotgun, /obj/item/part/gun/modular/barrel/antim)

--- a/code/modules/projectiles/guns/projectile/shotgun/pump.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/pump.dm
@@ -59,7 +59,7 @@
 	resultvars = list(/obj/item/gun/projectile/shotgun/pump)
 	gripvars = list(/obj/item/part/gun/modular/grip/wood)
 	mechanismvar = /obj/item/part/gun/modular/mechanism/shotgun
-	barrelvars = list(/obj/item/part/gun/modular/barrel/shotgun)
+	barrelvars = list(/obj/item/part/gun/modular/barrel/shotgun, /obj/item/part/gun/modular/barrel/antim)
 
 /obj/item/gun/projectile/shotgun/pump/sawn
 	name = "sawn-off FS SG \"Kammerer\""

--- a/code/modules/projectiles/guns/projectile/shotgun/regulator.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/regulator.dm
@@ -25,7 +25,7 @@
 	gripvars = list(/obj/item/part/gun/modular/grip/black, /obj/item/part/gun/modular/grip/rubber)
 	resultvars = list(/obj/item/gun/projectile/shotgun/pump/regulator, /obj/item/gun/projectile/shotgun/pump/regulator/army)
 	mechanismvar = /obj/item/part/gun/modular/mechanism/shotgun
-	barrelvars = list(/obj/item/part/gun/modular/barrel/shotgun)
+	barrelvars = list(/obj/item/part/gun/modular/barrel/shotgun, /obj/item/part/gun/modular/barrel/antim)
 
 /obj/item/gun/projectile/shotgun/pump/regulator/army
 	name = "NT SG \"Regulator M1000\""

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -45,7 +45,7 @@
 	resultvars = list(/obj/item/gun/projectile/heavysniper)
 	gripvars = list(/obj/item/part/gun/modular/grip/serb)
 	mechanismvar = /obj/item/part/gun/modular/mechanism/boltgun
-	barrelvars = list(/obj/item/part/gun/modular/barrel/antim, /obj/item/part/gun/modular/barrel/shotgun)
+	barrelvars = list(/obj/item/part/gun/modular/barrel/antim)
 
 /obj/item/gun/projectile/heavysniper/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -13,7 +13,7 @@
 	handle_casings = HOLD_CASINGS
 	load_method = SINGLE_CASING
 	max_shells = 1
-	damage_multiplier = 2
+	damage_multiplier = 1.8
 	proj_step_multiplier = 0 //so the PTR isn't useless as a sniper weapon
 	ammo_type = /obj/item/ammo_casing/antim
 	fire_sound = 'sound/weapons/guns/fire/sniper_fire.ogg'
@@ -45,7 +45,7 @@
 	resultvars = list(/obj/item/gun/projectile/heavysniper)
 	gripvars = list(/obj/item/part/gun/modular/grip/serb)
 	mechanismvar = /obj/item/part/gun/modular/mechanism/boltgun
-	barrelvars = list(/obj/item/part/gun/modular/barrel/antim)
+	barrelvars = list(/obj/item/part/gun/modular/barrel/antim, /obj/item/part/gun/modular/barrel/shotgun)
 
 /obj/item/gun/projectile/heavysniper/update_icon()
 	..()

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -249,7 +249,7 @@ There are important things regarding this file:
 	wounding_mult = WOUNDING_EXTREME
 
 /obj/item/projectile/bullet/shotgun/scrap
-	armor_divisor = 1.2
+	armor_divisor = 0.8
 	recoil = 10
 
 /obj/item/projectile/bullet/shotgun/beanbag

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -242,7 +242,7 @@ There are important things regarding this file:
 	name = "slug"
 	icon_state = "slug"
 	damage_types = list(BRUTE = 30)
-	armor_divisor = 1.5
+	armor_divisor = 1
 	knockback = 1
 	step_delay = 1.1
 	recoil = 10

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -241,15 +241,15 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/shotgun
 	name = "slug"
 	icon_state = "slug"
-	damage_types = list(BRUTE = 25)
-	armor_divisor = 1
+	damage_types = list(BRUTE = 30)
+	armor_divisor = 1.5
 	knockback = 1
 	step_delay = 1.1
 	recoil = 8
 	wounding_mult = WOUNDING_EXTREME
 
 /obj/item/projectile/bullet/shotgun/scrap
-	armor_divisor = 0.8
+	armor_divisor = 1.2
 	recoil = 10
 
 /obj/item/projectile/bullet/shotgun/beanbag
@@ -272,7 +272,7 @@ There are important things regarding this file:
 	knockback = 0
 
 /obj/item/projectile/bullet/shotgun/incendiary
-	damage_types = list(BRUTE = 38)
+	damage_types = list(BRUTE = 25)
 	knockback = 0
 
 	var/fire_stacks = 4
@@ -289,7 +289,7 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/pellet/shotgun
 	name = "shrapnel"
 	icon_state = "birdshot-1"
-	damage_types = list(BRUTE = 21)
+	damage_types = list(BRUTE = 25)
 	armor_divisor = 1
 	pellets = 6
 	range_step = 1

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -189,15 +189,15 @@ There are important things regarding this file:
 //Sniper rifles .60
 /obj/item/projectile/bullet/antim
 	name = ".60 caliber bullet"
-	damage_types = list(BRUTE = 18)
+	damage_types = list(BRUTE = 20)
 	armor_divisor = 3
 	penetrating = 2
 	step_delay = 0.8
-	recoil = 15 // Good luck shooting these from a revolver
+	recoil = 10 // on "par" with slugs. less damage but faster and pierces walls.
 	wounding_mult = WOUNDING_EXTREME
 
 /obj/item/projectile/bullet/antim/emp
-	damage_types = list(BRUTE = 16)
+	damage_types = list(BRUTE = 18)
 	armor_divisor = 2
 
 /obj/item/projectile/bullet/antim/emp/on_hit(atom/target, blocked = FALSE)
@@ -205,12 +205,12 @@ There are important things regarding this file:
 	empulse(target, 0, 0)
 
 /obj/item/projectile/bullet/antim/uranium
-	damage_types = list(BRUTE = 16)
+	damage_types = list(BRUTE = 18)
 	armor_divisor = 5
 	irradiate = 200
 
 /obj/item/projectile/bullet/antim/breach
-	damage_types = list(BRUTE = 16, HALLOSS = 20)
+	damage_types = list(BRUTE = 18, HALLOSS = 20)
 	armor_divisor = 2
 	penetrating = -5
 	nocap_structures = TRUE
@@ -235,7 +235,7 @@ There are important things regarding this file:
 
 /obj/item/projectile/bullet/antim/scrap
 	armor_divisor = 2
-	recoil = 20
+	recoil = 13
 
 //Shotguns .50
 /obj/item/projectile/bullet/shotgun
@@ -245,7 +245,7 @@ There are important things regarding this file:
 	armor_divisor = 1.5
 	knockback = 1
 	step_delay = 1.1
-	recoil = 8
+	recoil = 10
 	wounding_mult = WOUNDING_EXTREME
 
 /obj/item/projectile/bullet/shotgun/scrap
@@ -257,6 +257,7 @@ There are important things regarding this file:
 	icon_state = "buckshot"
 	check_armour = ARMOR_BULLET //neverforget
 	damage_types = list(BRUTE = 10, HALLOSS = 20)
+	recoil = 8 // should be weaker than lethal ammo
 	embed = FALSE
 	sharp = FALSE
 	wounding_mult = WOUNDING_WIDE
@@ -295,7 +296,7 @@ There are important things regarding this file:
 	range_step = 1
 	spread_step = 10
 	pellet_to_knockback_ratio = 2
-	recoil = 5
+	recoil = 7
 
 /obj/item/projectile/bullet/pellet/shotgun/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Shotgun ammo got a 20% damage increase
- slug 25 -> 30 damage, buck 21 -> 25 damage
- Slug recoil 8 -> 10
- buckshot recoil 5 -> 7
- .60 ammo got a tweak in accordance with the improved shotgun ammo. this didnt change .60 balance: base ammo is still a weaker slug in damage but has 0.8 step delay vs 1.1 and pierces walls easily. recoil adjusted to reflect the change
- AMR damage 2 -> 1.8. this makes it literally identical to before, no balance changes. it gets no extra recoil penalty with the .60 recoil buff because its single shot anyway. PLEASE NOTE: it could keep the 2x damage mult, it would do....not much more damage: 8 more damage compared what it does now (80 raw vs 72 raw, and 70 @15 armor vs 62 @15 armor)
- all shotguns can take .60 barrels. as stated above, .60 ammo is weaker damage wise but has better AP and bullet speed. this lets you tweak shotguns according to play style: close range, high damage, OR longer range, mediocre damage and wall piercing. Swapping barrels on the go is very slow, so you need to decide beforehand if cqc or long range. NOTE: makeshift shotgun already can take a .60 barrel. This was the intention behind the .60 change in #7547 
- ~~AMR can now take shotgun barrel.~~ in hindsight, no. would mean 105 damage hitscan slugs

alternative to #8194 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The issue: shotguns are CQC weapons but have no advantage in actual CQC due to automatic rifles, revolvers and bolt actions (with bayonets) being a thing.
The solution #8194 offers: remove the step delay malus from shotgun ammo = shotguns are no longer gimped to cqc, no other lethality change. still limited by ammo capacity and recoil
The solution this PR offers: improve the damage = shotguns are excellent damage sticks in cqc. still limited by slow bullets, ammo capacity, as well as slightly higher recoil than what they have now. .60 barrel swap for versatility 

DO NOTE: #8194 is a simpler change with fewer balance implications. it is smaller, but at the same time reduces the shotgun identity. It just makes them a normal gun. This PR is much more extensive in scope, and has to tweak more values as a consequence. I advise test merging because one thing is shooting at dummies in local host, another live playing.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

done. everything works, barrel swap works, no bugs

Putting some stats here to be more transparent

- .60 stats: 20 damage, 3 AP, 2x wound (40), 10 recoil
- .50 slug: 30 damage, 1 AP, 2x wound (60), 10 recoil
- .50 buck: 25 damage, 1 AP, 0.5 wound (12.5), 6 pellets, 7 recoil
- Double barrel with slug: 60 max damage, 30 damage @15 armor
- double barrel with buckshot: 75 max damage (if all pellets hit), 30 damage @15 armor (if all pellets hit)
- double barrel with .60: 40 max damage, 30 damage @15 armor


<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
balance: rebalanced shotgun ammo. more damage, more recoil
balance: .60 changed to keep up with shotgun ammo change
tweak: amr damage bonus changed in line with the .60 damage improvement. no actual balance change as a consequence
balance: shotguns can take .60 barrels
fix: fixed incendiary slugs having bugged damage. they do slightly less damage than normal slugs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
