### PR TITLE
Brace rework

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -1935,7 +1935,6 @@
 #include "code\modules\mob\living\carbon\human\human_movement.dm"
 #include "code\modules\mob\living\carbon\human\human_organs.dm"
 #include "code\modules\mob\living\carbon\human\human_powers.dm"
-#include "code\modules\mob\living\carbon\human\human_recoil.dm"
 #include "code\modules\mob\living\carbon\human\human_species.dm"
 #include "code\modules\mob\living\carbon\human\inventory.dm"
 #include "code\modules\mob\living\carbon\human\life.dm"

--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -99,10 +99,11 @@
 
 #define VIG_OVERCHARGE_GEN 0.05
 
-#define EMBEDDED_RECOIL(x)     list(1.3 *x, 0  *x, 0  *x )
-#define HANDGUN_RECOIL(x)      list(1.15*x, 0.1*x, 0.6*x )
-#define SMG_RECOIL(x)          list(1   *x, 0.2*x, 1.2*x )
-#define CARBINE_RECOIL(x)      list(0.85*x, 0.3*x, 1.8*x )
-#define RIFLE_RECOIL(x)        list(0.7 *x, 0.4*x, 2.4*x )
-#define LMG_RECOIL(x)          list(0.55*x, 0.5*x, 3*x   )
-#define HMG_RECOIL(x)          list(0.4 *x, 0.6*x, 3.6*x )
+// Base recoil - Offset while moving - Recoil from being one-handed
+#define EMBEDDED_RECOIL(x)     list(1.3 *x, 0, 0  *x )
+#define HANDGUN_RECOIL(x)      list(1.15*x, 2, 0.6*x )
+#define SMG_RECOIL(x)          list(1   *x, 4, 1.2*x )
+#define CARBINE_RECOIL(x)      list(0.85*x, 6, 1.8*x )
+#define RIFLE_RECOIL(x)        list(0.7 *x, 8, 2.4*x )
+#define LMG_RECOIL(x)          list(0.55*x, 10, 3*x   )
+#define HMG_RECOIL(x)          list(0.4 *x, 12, 3.6*x )

--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -100,10 +100,10 @@
 #define VIG_OVERCHARGE_GEN 0.05
 
 // Base recoil - Offset while moving - Recoil from being one-handed
-#define EMBEDDED_RECOIL(x)     list(1.3 *x,  1, 0  *x )
-#define HANDGUN_RECOIL(x)      list(1.2 *x,  2, 0.6*x )
-#define SMG_RECOIL(x)          list(1   *x,  3, 1.2*x )
-#define CARBINE_RECOIL(x)      list(0.9 *x,  4, 1.8*x )
+#define EMBEDDED_RECOIL(x)     list(1.3 *x,  3, 0  *x )
+#define HANDGUN_RECOIL(x)      list(1.2 *x,3.5, 0.6*x )
+#define SMG_RECOIL(x)          list(1   *x,  4, 1.2*x )
+#define CARBINE_RECOIL(x)      list(0.9 *x,4.5, 1.8*x )
 #define RIFLE_RECOIL(x)        list(0.8 *x,  5, 2.4*x )
-#define LMG_RECOIL(x)          list(0.7 *x, 10, 3*x   )
-#define HMG_RECOIL(x)          list(0.6 *x, 20, 3.6*x )
+#define LMG_RECOIL(x)          list(0.7 *x,  8, 3*x   )
+#define HMG_RECOIL(x)          list(0.6 *x, 12, 3.6*x )

--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -70,21 +70,21 @@
 #define FULL_AUTO_600		list(mode_name = "full auto",  mode_desc = "600 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 2  , icon="auto")
 #define FULL_AUTO_800		list(mode_name = "fuller auto",  mode_desc = "800 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 1.6, icon="auto")
 
-#define SEMI_AUTO_300	list(mode_name = "semiauto",  mode_desc = "Fire as fast as you can pull the trigger", burst=1, fire_delay=4, move_delay=null, icon="semi")
+#define SEMI_AUTO_300	list(mode_name = "semiauto",  mode_desc = "Fire as fast as you can pull the trigger", burst=1, fire_delay=4, icon="semi")
 
 //Cog firemode
-#define BURST_2_BEAM		list(mode_name="2-beam bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, move_delay=2, icon="burst")
+#define BURST_2_BEAM		list(mode_name="2-beam bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, icon="burst")
 
-#define BURST_2_ROUND			list(mode_name="2-round bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, move_delay=2, icon="burst")
-#define BURST_3_ROUND			list(mode_name="3-round bursts", mode_desc = "Short, controlled bursts", burst=3, fire_delay=null, move_delay=4, icon="burst")
-#define BURST_3_ROUND_RAPID		list(mode_name=" High-delay Rapid 3-round bursts", mode_desc = "Short, fast bursts with a higher delay between bursts", burst=3, fire_delay=15, move_delay=4, icon="auto", burst_delay = 0.5)
-#define BURST_3_ROUND_DAMAGE	list(mode_name="3-round bursts", mode_desc = "Short, controlled bursts", burst=3, fire_delay=null, move_delay=4, icon="burst")
-#define BURST_5_ROUND			list(mode_name="5-round bursts", mode_desc = "Short, controlled bursts", burst=5, fire_delay=null, move_delay=6, icon="burst")
-#define BURST_8_ROUND			list(mode_name="8-round bursts", mode_desc = "Short, uncontrolled bursts", burst=8, fire_delay=null, move_delay=8, icon="burst")
+#define BURST_2_ROUND			list(mode_name="2-round bursts", mode_desc = "Short, controlled bursts", burst=2, fire_delay=null, icon="burst")
+#define BURST_3_ROUND			list(mode_name="3-round bursts", mode_desc = "Short, controlled bursts", burst=3, fire_delay=null, icon="burst")
+#define BURST_3_ROUND_RAPID		list(mode_name=" High-delay Rapid 3-round bursts", mode_desc = "Short, fast bursts with a higher delay between bursts", burst=3, fire_delay=15, icon="auto", burst_delay = 0.5)
+#define BURST_3_ROUND_DAMAGE	list(mode_name="3-round bursts", mode_desc = "Short, controlled bursts", burst=3, fire_delay=null, icon="burst")
+#define BURST_5_ROUND			list(mode_name="5-round bursts", mode_desc = "Short, controlled bursts", burst=5, fire_delay=null, icon="burst")
+#define BURST_8_ROUND			list(mode_name="8-round bursts", mode_desc = "Short, uncontrolled bursts", burst=8, fire_delay=null, icon="burst")
 
 //SMG rapid
-#define BURST_3_ROUND_SMG	list(mode_name=" High-delay Rapid 3-round bursts", mode_desc = "Short, fast bursts with a short recovery time between bursts to allow the barrel to cool", burst=3, fire_delay=12, move_delay=3, icon="auto", burst_delay = 1.4)
-#define BURST_6_ROUND_SMG	list(mode_name=" High-delay Rapid 6-round bursts", mode_desc = "Long, fast bursts with a long recovery time between bursts to allow the barrel to cool", burst=6, fire_delay=25, move_delay=5, icon="auto", burst_delay = 1.4)
+#define BURST_3_ROUND_SMG	list(mode_name=" High-delay Rapid 3-round bursts", mode_desc = "Short, fast bursts with a short recovery time between bursts to allow the barrel to cool", burst=3, fire_delay=12, icon="auto", burst_delay = 1.4)
+#define BURST_6_ROUND_SMG	list(mode_name=" High-delay Rapid 6-round bursts", mode_desc = "Long, fast bursts with a long recovery time between bursts to allow the barrel to cool", burst=6, fire_delay=25, icon="auto", burst_delay = 1.4)
 
 #define WEAPON_NORMAL		list(mode_name="standard", burst =1, icon="semi")
 #define WEAPON_CHARGE		list(mode_name="charge mode", mode_desc="Hold down the trigger, and let loose a more powerful shot", mode_type = /datum/firemode/charge, icon="charge")

--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -100,10 +100,10 @@
 #define VIG_OVERCHARGE_GEN 0.05
 
 // Base recoil - Offset while moving - Recoil from being one-handed
-#define EMBEDDED_RECOIL(x)     list(1.3 *x, 0, 0  *x )
-#define HANDGUN_RECOIL(x)      list(1.15*x, 2, 0.6*x )
-#define SMG_RECOIL(x)          list(1   *x, 4, 1.2*x )
-#define CARBINE_RECOIL(x)      list(0.85*x, 6, 1.8*x )
-#define RIFLE_RECOIL(x)        list(0.7 *x, 8, 2.4*x )
-#define LMG_RECOIL(x)          list(0.55*x, 10, 3*x   )
-#define HMG_RECOIL(x)          list(0.4 *x, 12, 3.6*x )
+#define EMBEDDED_RECOIL(x)     list(1.3 *x,  1, 0  *x )
+#define HANDGUN_RECOIL(x)      list(1.2 *x,  2, 0.6*x )
+#define SMG_RECOIL(x)          list(1   *x,  3, 1.2*x )
+#define CARBINE_RECOIL(x)      list(0.9 *x,  4, 1.8*x )
+#define RIFLE_RECOIL(x)        list(0.8 *x,  5, 2.4*x )
+#define LMG_RECOIL(x)          list(0.7 *x, 10, 3*x   )
+#define HMG_RECOIL(x)          list(0.6 *x, 20, 3.6*x )

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -296,8 +296,6 @@
 	var/old_turf = get_turf(mob)
 	step(mob, direction)
 
-	if(!MOVING_DELIBERATELY(mob))
-		mob.handle_movement_recoil()
 	mob.add_momentum(direction)
 	// Something with pulling things
 	var/extra_delay = HandleGrabs(direction, old_turf)

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -311,6 +311,8 @@
 	*/
 	mob.moving = FALSE
 
+	mob.update_cursor()
+
 /datum/movement_handler/mob/movement/MayMove(var/mob/mover)
 	return IS_SELF(mover) &&  mob.moving ? MOVEMENT_STOP : MOVEMENT_PROCEED
 

--- a/code/datums/recoil.dm
+++ b/code/datums/recoil.dm
@@ -46,7 +46,7 @@
 
 // Better for nanoUI data
 /datum/recoil/proc/getFancyList()
-	return list("Recoil Buildup" = recoil_buildup, "Unbraced Penalty" = brace_penalty, "Onehanding Penalty" = one_hand_penalty)
+	return list("Recoil Buildup" = recoil_buildup, "Movement Penalty" = brace_penalty, "Onehanded Penalty" = one_hand_penalty)
 
 /datum/recoil/proc/attachRecoil(datum/recoil/AA)
 	return getRecoil(recoil_buildup+AA.recoil_buildup, brace_penalty+AA.brace_penalty, one_hand_penalty+AA.one_hand_penalty)

--- a/code/datums/recoil.dm
+++ b/code/datums/recoil.dm
@@ -4,7 +4,6 @@
 #define RECOIL_BASE "recoil_buildup"
 #define RECOIL_TWOHAND "brace_penalty"
 #define RECOIL_ONEHAND "one_hand_penalty"
-#define RECOIL_BRACE_LEVEL "brace_penalty_level"
 #define RECOIL_ONEHAND_LEVEL "one_hand_penalty_level"
 
 /proc/getRecoil(recoil_buildup = 0, brace_penalty = 0, one_hand_penalty = 0)
@@ -17,7 +16,6 @@
 	var/brace_penalty
 	var/one_hand_penalty
 
-	var/brace_penalty_level = 0
 	var/one_hand_penalty_level = 0
 
 /datum/recoil/New(_recoil_buildup = 0, _brace_penalty = 0, _one_hand_penalty = 0)
@@ -25,7 +23,6 @@
 	brace_penalty = _brace_penalty
 	one_hand_penalty = _one_hand_penalty
 	if(recoil_buildup)
-		brace_penalty_level = brace_penalty / recoil_buildup
 		one_hand_penalty_level = one_hand_penalty / (recoil_buildup + brace_penalty)
 	tag = RECOILID
 
@@ -38,7 +35,7 @@
 	return getRecoil(recoil_buildup * _recoil_buildup, brace_penalty * _brace_penalty, one_hand_penalty * _one_hand_penalty)
 
 /datum/recoil/proc/modifyAllRatings(modifier = 1)
-	return getRecoil(recoil_buildup * modifier, brace_penalty * modifier, one_hand_penalty * modifier) // Set to multiply due to nature of recoil
+	return getRecoil(recoil_buildup * modifier, one_hand_penalty * modifier) // Set to multiply due to nature of recoil
 
 /datum/recoil/proc/getRating(rating)
 	return vars[rating]

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -84,10 +84,6 @@ for reference:
 	return material
 
 /obj/structure/barricade/attackby(obj/item/W as obj, mob/user as mob)
-	if(user.a_intent == I_HELP && istype(W, /obj/item/gun))
-		var/obj/item/gun/G = W
-		G.gun_brace(user, src)
-		return
 	if(istype(W, /obj/item/stack))
 		var/obj/item/stack/D = W
 		if(D.get_material_name() != material.name)
@@ -215,15 +211,6 @@ for reference:
 	icon_state = "barrier[locked]"
 
 /obj/machinery/deployable/barrier/attackby(obj/item/W, mob/user)
-
-	if(user.a_intent == I_HELP && istype(W, /obj/item/gun))
-		var/obj/item/gun/G = W
-		if(anchored == TRUE) //Just makes sure we're not bracing on movable cover
-			G.gun_brace(user, src)
-			return
-		else
-			to_chat(user, SPAN_NOTICE("You can't brace your weapon - the [src] is not anchored down."))
-		return
 
 	if(W.GetIdCard())
 		if(allowed(user))

--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -362,7 +362,7 @@
 	if(weapon_upgrades[GUN_UPGRADE_FOREGRIP])
 		G.braceable = 0
 	if(weapon_upgrades[GUN_UPGRADE_BIPOD])
-		G.braceable = 2
+		G.braceable += GUN_UPGRADE_BIPOD
 	if(weapon_upgrades[GUN_UPGRADE_EXPLODE])
 		G.rigged = 2
 	if(weapon_upgrades[GUN_UPGRADE_ZOOM])

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -138,6 +138,7 @@
 	)
 	I.weapon_upgrades = list(
 		GUN_UPGRADE_RECOIL = 0.9,
+		GUN_UPGRADE_FOREGRIP
 	)
 	I.gun_loc_tag = GUN_UNDERBARREL
 

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -70,14 +70,6 @@
 		reinforce_girder()
 
 /obj/structure/girder/attackby(obj/item/I, mob/user)
-	if(user.a_intent == I_HELP && istype(I, /obj/item/gun))
-		var/obj/item/gun/G = I
-		if(anchored == TRUE) //Just makes sure we're not bracing on movable cover
-			G.gun_brace(user, src)
-			return
-		else
-			to_chat(user, SPAN_NOTICE("You can't brace your weapon - the [src] is not anchored down."))
-		return
 
 	//Attempting to damage girders
 	//This supercedes all construction, deconstruction and similar actions. So change your intent out of harm if you don't want to smack it

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -94,16 +94,6 @@
 	take_damage(damage * 0.2)
 
 /obj/structure/grille/attackby(obj/item/I, mob/user)
-
-	if(user.a_intent == I_HELP && istype(I, /obj/item/gun))
-		var/obj/item/gun/G = I
-		if(anchored == TRUE) //Just makes sure we're not bracing on movable cover
-			G.gun_brace(user, src)
-			return
-		else
-			to_chat(user, SPAN_NOTICE("You can't brace your weapon - the [src] is not anchored down."))
-		return
-
 	var/list/usable_qualities = list(QUALITY_WIRE_CUTTING)
 	if(anchored)
 		usable_qualities.Add(QUALITY_SCREW_DRIVING)

--- a/code/game/objects/structures/low_wall.dm
+++ b/code/game/objects/structures/low_wall.dm
@@ -447,11 +447,6 @@
 		if (user.unEquip(I, src.loc))
 			set_pixel_click_offset(I, params)
 			return
-	//Gun bracing
-	if(!(locate(/obj/structure/window) in loc) && user.a_intent == I_HELP && istype(I, /obj/item/gun))
-		var/obj/item/gun/G = I
-		G.gun_brace(user, src) //.../modules/projectiles/gun.dm
-		return
 	//Hitting the wall with stuff
 	if(!istype(I,/obj/item/rcd) && !istype(I, /obj/item/reagent_containers))
 		if(!I.force)

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -26,7 +26,6 @@
 	init_recoil = LMG_RECOIL(1)
 	matter = list()
 	cell_type = /obj/item/cell/medium/mech
-	init_offset = 10 // Pew pew in all directions
 
 /obj/item/mech_equipment/mounted_system/taser/ion
 	name = "mounted ion rifle"

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -131,7 +131,7 @@
 	restrict_safety = TRUE
 	twohanded = FALSE
 	init_firemodes = list(
-		list(mode_name="spit fire",  burst=5, burst_delay=0.8, move_delay=5, one_hand_penalty=15, icon="burst")
+		list(mode_name="spit fire",  burst=5, burst_delay=0.8, one_hand_penalty=15, icon="burst")
 		)
 	spawn_tags = null
 	matter = list()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -23,10 +23,19 @@
 		tally += 1
 
 	if(recoil)
-		var/obj/item/gun/G = get_active_hand()
-		if(istype(G))
-			var/datum/recoil/R = G.recoil
-			tally += CLAMP(round(recoil) / (60 / R.getRating(RECOIL_TWOHAND)), 0, 8) // Scales with the size of the gun - bigger guns slow you more
+		var/obj/item/gun/GA = get_active_hand()
+		var/obj/item/gun/GI = get_inactive_hand()
+
+		var/brace_recoil = 0
+		if(istype(GA))
+			var/datum/recoil/R = GA.recoil
+			brace_recoil = R.getRating(RECOIL_TWOHAND)
+		if(istype(GI))
+			var/datum/recoil/R = GI.recoil
+			brace_recoil = max(brace_recoil, R.getRating(RECOIL_TWOHAND))
+
+		if(brace_recoil)
+			tally += CLAMP(round(recoil) / (60 / brace_recoil), 0, 8) // Scales with the size of the gun - bigger guns slow you more
 		else
 			tally += CLAMP(round(recoil) / 20, 0, 8) // Lowest possible while holding a gun
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -23,7 +23,11 @@
 		tally += 1
 
 	if(recoil)
-		tally += CLAMP(round(recoil) / 15, 0, 4) // Max of 60 recoil for a net 4 slowdown
+		var/obj/item/gun/G = get_active_hand()
+		if(istype(G))
+			tally += CLAMP(round(recoil) / (60 / recoil.getRating(RECOIL_TWOHAND)), 0, 8) // Scales with the size of the gun - bigger guns slow you more
+		else
+			tally += CLAMP(round(recoil) / 20, 0, 8) // Lowest possible while holding a gun
 
 	var/obj/item/implant/core_implant/cruciform/C = get_core_implant(/obj/item/implant/core_implant/cruciform)
 	if(C && C.active)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -25,7 +25,8 @@
 	if(recoil)
 		var/obj/item/gun/G = get_active_hand()
 		if(istype(G))
-			tally += CLAMP(round(recoil) / (60 / recoil.getRating(RECOIL_TWOHAND)), 0, 8) // Scales with the size of the gun - bigger guns slow you more
+			var/datum/recoil/R = G.recoil
+			tally += CLAMP(round(recoil) / (60 / R.getRating(RECOIL_TWOHAND)), 0, 8) // Scales with the size of the gun - bigger guns slow you more
 		else
 			tally += CLAMP(round(recoil) / 20, 0, 8) // Lowest possible while holding a gun
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -22,6 +22,9 @@
 	if(blocking)
 		tally += 1
 
+	if(recoil)
+		tally += CLAMP(round(recoil) / 15, 0, 4) // Max of 60 recoil for a net 4 slowdown
+
 	var/obj/item/implant/core_implant/cruciform/C = get_core_implant(/obj/item/implant/core_implant/cruciform)
 	if(C && C.active)
 		var/obj/item/cruciform_upgrade/upgrade = C.upgrade

--- a/code/modules/mob/living/carbon/human/human_recoil.dm
+++ b/code/modules/mob/living/carbon/human/human_recoil.dm
@@ -1,9 +1,0 @@
-/mob/living/carbon/human/handle_movement_recoil()
-	deltimer(recoil_reduction_timer)
-
-	var/base_recoil = 1
-	var/suit_stiffness = 0
-	var/uniform_stiffness = 0
-	base_recoil += suit_stiffness + suit_stiffness * uniform_stiffness // Wearing it under actual armor, or anything too thick is extremely uncomfortable.
-
-	add_recoil(base_recoil)

--- a/code/modules/mob/living/living_recoil.dm
+++ b/code/modules/mob/living/living_recoil.dm
@@ -43,8 +43,13 @@
 	else
 		deltimer(recoil_reduction_timer)
 
-/mob/living/proc/update_cursor(var/obj/item/gun/G)
-	if(get_preference_value(/datum/client_preference/gun_cursor) != GLOB.PREF_YES || !(istype(get_active_hand(), /obj/item/gun) || recoil > 0))
+//This doesn't really belong here, but it doesn't belong anywhere else either
+/mob/proc/update_cursor()
+	return
+
+/mob/living/update_cursor()
+	var/obj/item/gun/G = get_active_hand()
+	if(get_preference_value(/datum/client_preference/gun_cursor) != GLOB.PREF_YES || (!istype(G, /obj/item/gun) || G.safety))
 		remove_cursor()
 		return
 	if(client)

--- a/code/modules/mob/living/living_recoil.dm
+++ b/code/modules/mob/living/living_recoil.dm
@@ -49,7 +49,7 @@
 		return
 	if(client)
 		client.mouse_pointer_icon = initial(client.mouse_pointer_icon)
-		var/offset = round(calculate_offset(G.init_offset_with_brace()) * 0.8)
+		var/offset = round(calculate_offset(G.init_offset_with_brace(src)) * 0.8)
 		var/icon/base = find_cursor_icon('icons/obj/gun_cursors/standard/standard.dmi', offset)
 		ASSERT(isicon(base))
 		client.mouse_pointer_icon = base

--- a/code/modules/mob/living/living_recoil.dm
+++ b/code/modules/mob/living/living_recoil.dm
@@ -7,9 +7,6 @@
 	deltimer(recoil_reduction_timer)
 	add_recoil(recoil_buildup)
 
-mob/proc/handle_movement_recoil() // Used in movement/mob.dm
-	return // Ghosts and roaches have no movement recoil
-
 /mob/living/proc/add_recoil(var/recoil_buildup)
 	if(recoil_buildup)
 		recoil += recoil_buildup
@@ -32,6 +29,7 @@ mob/proc/handle_movement_recoil() // Used in movement/mob.dm
 		offset += recoil
 	offset = round(offset)
 	offset = CLAMP(offset, 0, MAX_ACCURACY_OFFSET)
+
 	return offset
 
 //Called after setting recoil

--- a/code/modules/mob/living/simple_animal/hostile/stranger.dm
+++ b/code/modules/mob/living/simple_animal/hostile/stranger.dm
@@ -133,8 +133,8 @@
 	spawn_blacklisted = TRUE
 
 	init_firemodes = list(
-		list(mode_name="XhddhrdJkJ", mode_desc="uDsfMdPQkm", burst=1, projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/pulse.ogg', fire_delay=15, move_delay=null, charge_cost=9, icon="destroy", projectile_color = "#FFFFFF"),
-		list(mode_name="bP6hfnj3Js", mode_desc="AhG8GjobYa", burst=3, projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/pulse.ogg', fire_delay=5, move_delay=4, charge_cost=11, icon="vaporize", projectile_color = "#FFFFFF")
+		list(mode_name="XhddhrdJkJ", mode_desc="uDsfMdPQkm", burst=1, projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/pulse.ogg', fire_delay=15, charge_cost=9, icon="destroy", projectile_color = "#FFFFFF"),
+		list(mode_name="bP6hfnj3Js", mode_desc="AhG8GjobYa", burst=3, projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/pulse.ogg', fire_delay=5, charge_cost=11, icon="vaporize", projectile_color = "#FFFFFF")
 	)
 
 /obj/item/gun/energy/plasma/stranger/update_icon(ignore_inhands)

--- a/code/modules/projectiles/dynamic_cursor.dm
+++ b/code/modules/projectiles/dynamic_cursor.dm
@@ -3,7 +3,7 @@
 /obj/item/gun/equipped(mob/living/H)
 	. = ..()
 	if(is_held() && !safety)
-		H.update_cursor(src)
+		H.update_cursor()
 	else
 		H.remove_cursor()
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -40,7 +40,7 @@
 	var/burst = 1
 	var/fire_delay = 6 	//delay after shooting before the gun can be used again
 	var/burst_delay = 2	//delay between shots, if firing in bursts
-	var/move_delay = 1
+	var/move_delay = 0
 	var/fire_sound = 'sound/weapons/Gunshot.ogg'
 	var/rigged = FALSE
 	var/fire_sound_text = "gunshot"
@@ -445,7 +445,7 @@
 		next_fire_time = world.time + fire_delay < GUN_MINIMUM_FIRETIME ? GUN_MINIMUM_FIRETIME : fire_delay
 		user.setClickCooldown(fire_delay)
 
-	// user.set_move_cooldown(move_delay) Removed for testing. Uncomment to reenable move delay from firing guns.
+	user.set_move_cooldown(move_delay)
 	if(muzzle_flash)
 		set_light(0)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -445,7 +445,7 @@
 		next_fire_time = world.time + fire_delay < GUN_MINIMUM_FIRETIME ? GUN_MINIMUM_FIRETIME : fire_delay
 		user.setClickCooldown(fire_delay)
 
-	user.set_move_cooldown(move_delay)
+	user.set_move_cooldown(abs(move_delay))
 	if(muzzle_flash)
 		set_light(0)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -445,7 +445,7 @@
 		next_fire_time = world.time + fire_delay < GUN_MINIMUM_FIRETIME ? GUN_MINIMUM_FIRETIME : fire_delay
 		user.setClickCooldown(fire_delay)
 
-	user.set_move_cooldown(move_delay)
+	// user.set_move_cooldown(move_delay) Removed for testing. Uncomment to reenable move delay from firing guns.
 	if(muzzle_flash)
 		set_light(0)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -48,7 +48,7 @@
 	var/datum/recoil/recoil // Reference to the recoil datum in datum/recoil.dm
 	var/list/init_recoil = list(0, 0, 0) // For updating weapon mods
 
-	var/braceable = 0 // Offset reduction based on whether the gun is braced
+	var/braceable = 1 // Offset reduction based on whether the gun is braced
 
 	var/list/gun_parts = list(/obj/item/part/gun = 1 ,/obj/item/stack/material/steel = 4)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -804,7 +804,7 @@
 	if(safety)
 		user.remove_cursor()
 	else
-		user.update_cursor(src)
+		user.update_cursor()
 
 /obj/item/gun/proc/toggle_carry_state(mob/living/user)
 	inversed_carry = !inversed_carry
@@ -898,7 +898,7 @@
 					"name" = i,
 					"value" = recoilList[i]
 					))
-				total_recoil += recoilList[i]
+				total_recoil += i == "Movement Penalty" ? recoilList[i] / 10 : recoilList[i] / 10
 		data["recoil_info"] = recoil_vals
 
 	data["total_recoil"] = total_recoil

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -596,7 +596,7 @@
 	var/offset = init_offset
 
 	var/datum/movement_handler/mob/delay/delay = user.GetMovementHandler(/datum/movement_handler/mob/delay)
-	if(delay)
+	if(delay && (world.time < delay.next_move))
 		offset += recoil.getRating(RECOIL_TWOHAND)
 	else if(braceable)
 		offset -= braceable // With a bipod, you can negate most of your recoil

--- a/code/modules/projectiles/guns/launcher/projectile_grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/projectile_grenade_launcher.dm
@@ -22,6 +22,7 @@
 	price_tag = 3000
 	gun_parts = list(/obj/item/part/gun = 2, /obj/item/part/gun/modular/grip/wood = 1, /obj/item/part/gun/modular/mechanism/shotgun = 1)
 	serial_type = "NT"
+	move_delay = 3
 
 /obj/item/gun/projectile/shotgun/pump/grenade/update_icon()
 	wielded_item_state = "_doble"

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -26,8 +26,8 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_BIPOD = TRUE,
-		GUN_UPGRADE_RECOIL = 1.2
+		GUN_UPGRADE_BIPOD = 5,
+		GUN_UPGRADE_OFFSET = 2
 		)
 	I.gun_loc_tag = GUN_UNDERBARREL
 

--- a/code/modules/projectiles/guns/projectile/automatic/lmg.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/lmg.dm
@@ -21,7 +21,7 @@
 	reload_sound = 'sound/weapons/guns/interact/lmg_magin.ogg'
 	cocked_sound = 'sound/weapons/guns/interact/lmg_cock.ogg'
 	fire_sound = 'sound/weapons/guns/fire/lmg_fire.ogg'
-	init_recoil = LMG_RECOIL(0.5)
+	init_recoil = LMG_RECOIL(1)
 	damage_multiplier = 1.3
 	penetration_multiplier = -0.1
 	twohanded = TRUE
@@ -122,9 +122,9 @@
 	icon_base = "tk"
 	icon_state = "tkclosed-empty"
 	item_state = "tkclosedmag"
-	init_recoil = LMG_RECOIL(0.3)
+	init_recoil = LMG_RECOIL(1)
 	damage_multiplier = 1.2
-	penetration_multiplier = 0.3
+	penetration_multiplier = -0.1
 
 	spawn_blacklisted = FALSE
 	gun_parts = list(/obj/item/part/gun/frame/tk = 1, /obj/item/part/gun/modular/grip/rubber = 1, /obj/item/part/gun/modular/mechanism/machinegun = 1, /obj/item/part/gun/modular/barrel/clrifle = 1)

--- a/code/modules/projectiles/guns/projectile/automatic/lmg.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/lmg.dm
@@ -28,7 +28,6 @@
 	spawn_blacklisted = TRUE
 	rarity_value = 80
 	slowdown_hold = 0.5
-	init_offset = 10 // Countered by bracing it
 	gun_parts = list(/obj/item/part/gun = 1 ,/obj/item/stack/material/plasteel = 4)
 
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/automatic/maxim.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/maxim.dm
@@ -27,10 +27,10 @@
 	penetration_multiplier = -0.2
 	burst_delay = 0.8
 	init_firemodes = list(
-		list(mode_name = "full auto",  mode_desc="800 rounds per minute", mode_type = /datum/firemode/automatic, fire_delay=2.4, icon="auto", move_delay=5),
-		list(mode_name="short bursts", mode_desc="dakka", burst=5, fire_delay=null, move_delay=5,  icon="burst"),
-		list(mode_name="long bursts", mode_desc="Dakka", burst=8, fire_delay=null, move_delay=7,  icon="burst"),
-		list(mode_name="suppressing fire", mode_desc="DAKKA", burst=16, fire_delay=null, move_delay=13,  icon="burst")
+		list(mode_name = "full auto",  mode_desc="800 rounds per minute", mode_type = /datum/firemode/automatic, fire_delay=2.4, icon="auto"),
+		list(mode_name="short bursts", mode_desc="dakka", burst=5, fire_delay=null, icon="burst"),
+		list(mode_name="long bursts", mode_desc="Dakka", burst=8, fire_delay=null, icon="burst"),
+		list(mode_name="suppressing fire", mode_desc="DAKKA", burst=16, fire_delay=null, icon="burst")
 		)
 	twohanded = TRUE
 	spawn_blacklisted = TRUE

--- a/code/modules/projectiles/guns/projectile/automatic/motherfucker.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/motherfucker.dm
@@ -20,7 +20,7 @@
 	init_recoil = LMG_RECOIL(1)
 	burst_delay = 0
 	burst = 6
-	init_offset = 14 //awful accuracy
+	init_offset = 4 //awful accuracy
 	init_firemodes = list(
 		list(mode_name="6-round bursts", burst=6, fire_delay=null, move_delay=7, icon="burst"),
 		)

--- a/code/modules/projectiles/guns/projectile/automatic/motherfucker.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/motherfucker.dm
@@ -22,7 +22,7 @@
 	burst = 6
 	init_offset = 4 //awful accuracy
 	init_firemodes = list(
-		list(mode_name="6-round bursts", burst=6, fire_delay=null, move_delay=7, icon="burst"),
+		list(mode_name="6-round bursts", burst=6, fire_delay=null, move_delay=3, icon="burst"),
 		)
 	spawn_tags = SPAWN_TAG_GUN_HANDMADE
 	var/recentpumpmsg = 0

--- a/code/modules/projectiles/guns/projectile/automatic/z8.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/z8.dm
@@ -28,7 +28,7 @@
 	init_firemodes = list(
 		SEMI_AUTO_300,
 		BURST_3_ROUND,
-		list(mode_name="fire grenades", mode_desc="Unlocks the underbarrel grenade launcher", burst=null, fire_delay=null, move_delay=null,  icon="grenade", use_launcher=1)
+		list(mode_name="fire grenades", mode_desc="Unlocks the underbarrel grenade launcher", burst=null, fire_delay=null, icon="grenade", use_launcher=1)
 		)
 
 	var/obj/item/gun/projectile/shotgun/pump/grenade/underslung/launcher

--- a/code/modules/projectiles/guns/projectile/other/RPG.dm
+++ b/code/modules/projectiles/guns/projectile/other/RPG.dm
@@ -27,6 +27,7 @@
 	wield_delay = 1 SECOND
 	wield_delay_factor = 0.8 // 80 vig
 	serial_type = "SA"
+	move_delay = 5
 
 /obj/item/gun/projectile/rpg/update_icon()
 	. = ..()

--- a/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
@@ -17,8 +17,8 @@
 	penetration_multiplier = 0
 	init_recoil = HANDGUN_RECOIL(0.9)
 	init_firemodes = list(
-		list(mode_name="semiauto", mode_desc="Fire almost as fast as you can pull the trigger", burst=1, fire_delay=1.2, move_delay=null, 				icon="semi"),
-		list(mode_name="2-round bursts", mode_desc="Not quite the Mozambique method", burst=2, fire_delay=0.2, move_delay=4,    	icon="burst"),
+		list(mode_name="semiauto", mode_desc="Fire almost as fast as you can pull the trigger", burst=1, fire_delay=1.2, icon="semi"),
+		list(mode_name="2-round bursts", mode_desc="Not quite the Mozambique method", burst=2, fire_delay=0.2, icon="burst"),
 		)
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE

--- a/code/modules/projectiles/guns/projectile/shotgun/bull.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/bull.dm
@@ -24,7 +24,6 @@
 	fire_delay = 4
 	bulletinsert_sound = 'sound/weapons/guns/interact/shotgun_insert.ogg'
 	fire_sound = 'sound/weapons/guns/fire/shotgunp_fire.ogg'
-	move_delay = null
 	init_firemodes = list(
 		list(mode_name="Single-fire", mode_desc="Send Vagabonds flying back several paces", burst=1, icon="semi"),
 		list(mode_name="Both Barrels", mode_desc="Give them the side-by-side", burst=2, icon="burst"),

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -37,6 +37,7 @@
 	serial_type = "SA"
 	action_button_name = "Switch zoom level"
 	action_button_proc = "switch_zoom"
+	move_delay = 3
 
 /obj/item/part/gun/frame/heavysniper
 	name = "Hristov frame"

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -164,11 +164,6 @@
 		break_to_parts()
 		return
 
-	if(user.a_intent == I_HELP && istype(W, /obj/item/gun))
-		var/obj/item/gun/G = W
-		G.gun_brace(user, src)
-		return
-
 	if(can_plate && !material)
 		to_chat(user, SPAN_WARNING("There's nothing to put \the [W] on! Try adding plating to \the [src] first."))
 		return

--- a/nano/templates/weapon_stats.tmpl
+++ b/nano/templates/weapon_stats.tmpl
@@ -59,7 +59,7 @@
 						{{:value.name}}
 					</div>
 					<div class="itemContent">
-						{{:helper.displayBar(value.value, 0, data.total_recoil, value.value <= 0.5 ? 'good' : value.value <= 1.5 ? 'average' : 'bad', value.value + ' degrees')}}
+						{{:helper.displayBar(value.name == "Movement Penalty" ? value.value / 10 : value.value, 0, data.total_recoil, (value.name == "Movement Penalty" ? value.value / 10 : value.value) <= 0.5 ? 'good' : (value.name == "Movement Penalty" ? value.value / 10 : value.value) <= 1.5 ? 'average' : 'bad', (value.name == "Movement Penalty" ? value.value / 10 : value.value) + ' degrees')}}
 					</div>
 				{{/for}}
 				<br>


### PR DESCRIPTION
## About The Pull Request

Removes Kegdo brace, implements stationary bracing.

Recoil is massively reduced while shooting without movement, scaling with the size of your gun.
Recoil provides a slowdown, but guns no longer stun your movement.

Bipods now activate when stationary.

Includes balance patch to Takeshi as it made such an easily avaliable item way too powerful out-of-the-box.

## Why It's Good For The Game

More accuracy, more combat depth.

## Testing

I shot a variety of guns, ran around while holding them. Worked fine.

Major balance changes, live testing required.

## Changelog
:cl:
del: Removed bracing on tables
fix: Foregrip gives foregrip modifier
balance: Standing still improves accuracy when shooting, especially with larger guns
del: Removed recoil gained from movement
balance: Shooting guns no longer stuns your movement
balance: Recoil provides a scaling slowdown
balance: Takeshi stats nerfed, LMG recoil increased
/:cl: