### PR TITLE
Last Tosshin Reference Eliminated

### DIFF
--- a/code/datums/autolathe/guns.dm
+++ b/code/datums/autolathe/guns.dm
@@ -152,6 +152,9 @@
 	name = "SA BR .20 \"Kovacs\""
 	build_path = /obj/item/gun/projectile/kovacs
 
+/datum/design/autolathe/gun/boltgun_fs
+	name = "FS BR .20 \"Kadmin\""
+	build_path = /obj/item/gun/projectile/boltgun/fs
 
 // .25 Rifles
 
@@ -172,10 +175,6 @@
 /datum/design/autolathe/gun/boltgun_serbian
 	name = "SA BR .30 \"Novakovic\""
 	build_path = /obj/item/gun/projectile/boltgun/serbian
-
-/datum/design/autolathe/gun/boltgun_fs
-	name = "FS BR .20 \"Tosshin\""
-	build_path = /obj/item/gun/projectile/boltgun/fs
 
 /datum/design/autolathe/gun/ak47
 	name = "Excelsior Car .30 Kalashnikov"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Found an antiquated reference to the Tosshin in guns.dm while stumbling along. Moved it to the proper caliber in the list, and renamed it to Kadmin, matching the ingame name.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Inconsistencies bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I added it to a disk and it was named Kadmin.
![TEMKEpzYkP](https://github.com/discordia-space/CEV-Eris/assets/11076040/65f0df0c-9a38-4f23-b341-8fb2a66d4cd2)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: fixed last Tosshin reference to Kadmin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
