### PR TITLE
Riot Shield Hotkey Modification (WIP)

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -84,6 +84,7 @@
 // /mob/living/carbon/human signals
 #define COMSIG_HUMAN_ACTIONINTENT_CHANGE "action_intent_change"
 #define COMSIG_HUMAN_WALKINTENT_CHANGE "walk_intent_change"
+#define COMSIG_HUMAN_BLOCKINTENT_CHANGE "block_intent_change"
 #define COMSIG_EMPTY_POCKETS "human_empty_pockets"
 #define COMSIG_HUMAN_SAY "human_say"							//from mob/living/carbon/human/say(): (message)
 #define COMSIG_HUMAN_ROBOTIC_MODIFICATION "human_robotic_modification"


### PR DESCRIPTION
**Still heavily work in progress. Will have commit notes up top as I figure shit out. I am like 85% just chewing my keyboard and praying for results. Help in optimization or just getting it to fukken work is appreciated. Kinda out of my depth.**

TODOS:

1. Replace walking being the determining factor to determine if a shield is raised or not.
2. Ensure that blocking with a shield slows down the user as much as previously (as though they were walking)
3. Prevent "parry" attacks that blocking currently has associated with it with inhand items, shield shouldn't parry, this isn't dark souls
4. Blocking disengages when struck, ensure blocking with shield doesn't drop shield/blocking state

-Began changing walking intents into determinations of blocking or not blocking. Currently compiles, but changing blocking state doesn't update status properly.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Are you like me, and annoyed every time you want to use your big ass hunk of metal to shield yourself, but you gotta drag your stupid ass mouse all the way to the bottom of the screen, interrupting your bashies, just to click the walk/run toggle like a pleb? Or are you a gentleman who put in ALL THAT EFFORT into making a client-side macro for the Walk/Run verbs?

Well I'm here to tell you that I'm about to make all that effort null and void! Congratulations loser, we're adapting!

Introducing BLOCKING/SHIELDING INTEGRATION! They'll be one in the same! Without a shield, you can defend yourself with the F key. Now with a shield, it's the same button! You ain't gotta drag that mouse away from your target anymore, you can keep donkey konging all over that motherfucker more easily while making sure your ass isn't turned into the grass you should've touched.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Using one hotkey that one can internally recognize as the "oh shit I don't wanna die" button work both with and without Helps You Die Slower equipment is good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
