### PR TITLE
Crew Morale Rework (WIP)

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -143,6 +143,24 @@ avoid code duplication. This includes items that may sometimes act as a standard
 			QDEL_IN(S, 2 SECONDS)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 
+/obj/item/proc/spin_attack(mob/user)
+	var/turf/G //Ground Zero, where the user is
+	G = get_turf(user)
+	
+	var/buffer_zone //Define the area around the user to attack
+	buffer_zone = get_step(G, alldirs)
+	
+	var/obj/effect/effect/melee/swing/S = new() //Enact the swing on the defined attack area
+	S.dir = buffer_zone
+	user.visible_message(SPAN_DANGER("[user] spins \his [src] in a circle"))
+	playsound(loc, 'sound/effects/swoosh.ogg', 50, 1, -1)
+	
+	var/dmg_modifier = 0.5 //Decide damage applied to targets in attack area
+	dmg_modifier = tileattack(user, buffer_zone, modifier = 1)
+	tileattack(user, buffer_zone, modifier = dmg_modifier)
+	QDEL_IN(S, 2 SECONDS)
+	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+
 /atom/proc/attackby(obj/item/W, mob/user, params)
 	return
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -144,22 +144,39 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 
 /obj/item/proc/spin_attack(mob/user)
-	var/turf/G //Ground Zero, where the user is
-	G = get_turf(user)
+	var/free_space = TRUE // If there are walls or structures around us, we are hindered.
+	for(var/turf/T in range(1, user.loc))
+		if(istype(T, /turf/simulated/wall))
+			free_space = FALSE
+	if(!free_space)
+		to_chat(user, SPAN_WARNING("There isn't enough space to do this."))
+		return
+	if(free_space)
+		visible_message(SPAN_DANGER("[user] pivots, spinning their [src] around!"))
+	var/bufferzone
+	bufferzone = range(1, user.loc)
+	for(var/mob/living/L in bufferzone)
+		L.attackby(src, user)
+	tileattack(user, bufferzone)
+	sleep(1)
 	
-	var/buffer_zone //Define the area around the user to attack
-	buffer_zone = get_step(G, alldirs)
-	
-	var/obj/effect/effect/melee/swing/S = new() //Enact the swing on the defined attack area
-	S.dir = buffer_zone
-	user.visible_message(SPAN_DANGER("[user] spins \his [src] in a circle"))
-	playsound(loc, 'sound/effects/swoosh.ogg', 50, 1, -1)
-	
-	var/dmg_modifier = 0.5 //Decide damage applied to targets in attack area
-	dmg_modifier = tileattack(user, buffer_zone, modifier = 1)
-	tileattack(user, buffer_zone, modifier = dmg_modifier)
-	QDEL_IN(S, 2 SECONDS)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+
+//	var/spin = 2 //adjustable, the amount of tiles checked - 10 - X
+//	var/dir = user.dir // Defines the direction the user is facing
+//	if(dir & NORTH || dir & SOUTH)
+//		dir = turn(dir, 90)
+//	var/_turf //Defines the turf the user is facing
+//	while(spin < 10 && src) //we SPEEEN
+//		if((spin % 2) == 0)
+//			dir = turn(dir, 90)
+//			_turf = get_step(user, dir)
+//		spin++
+//		while(user.set_dir(dir))
+//			for(var/mob/living/L in _turf)
+//				L.attackby(src, user)
+//			swing_attack(_turf, user)
+//		sleep(1)
+
 
 /atom/proc/attackby(obj/item/W, mob/user, params)
 	return

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -535,7 +535,7 @@ var/global/list/items_blood_overlay_by_type = list()
 					unEquip(inhand_grab)
 		else
 			to_chat(src, SPAN_WARNING("You do not have a firm enough grip to forcibly spin [inhand_grab.affecting]."))
-
+	
 	else if (I && !I.abstract && I.mob_can_unequip(src, get_active_hand_slot())) // being unable to unequip normally means
 		I.SpinAnimation(5,1) // that the item is stuck on or in, and so cannot spin
 		external_recoil(50)

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -92,6 +92,8 @@
 	desc = "A saintly-looking whip that can be extended for more pain."
 	icon_state = "nt_scourge"
 	item_state = "nt_scourge"
+	extended_reach = FALSE
+	forced_broad_strike = FALSE
 	force = WEAPON_FORCE_ROBUST
 	var/force_extended = WEAPON_FORCE_PAINFUL
 	armor_divisor = ARMOR_PEN_EXTREME
@@ -115,6 +117,8 @@
 
 /obj/item/tool/sword/nt/scourge/proc/extend()
 	extended = TRUE
+	extended_reach = TRUE
+	forced_broad_strike = TRUE
 	force += (force_extended - initial(force))
 	armor_divisor += (armor_divisor_extended - initial(armor_divisor))
 	agony += (agony_extended - initial(agony))
@@ -124,6 +128,8 @@
 
 /obj/item/tool/sword/nt/scourge/proc/unextend()
 	extended = FALSE
+	extended_reach = FALSE
+	forced_broad_strike = FALSE
 	w_class = initial(w_class)
 	agony = initial(agony)
 	slot_flags = initial(slot_flags)
@@ -144,6 +150,10 @@
 		var/mob/living/carbon/human/O = target
 		target.stun_effect_act(stun, agony, hit_zone, src)
 		O.say(pick("OH", "LORD", "MERCY", "SPARE", "ME", "HAVE", "PLEASE"))
+
+/obj/item/tool/sword/nt/scourge/hand_spin(mob/living/carbon/caller)
+	if(extended)
+		spin_attack(caller)
 
 /obj/item/tool/sword/nt/spear
 	name = "NT Pilum"


### PR DESCRIPTION
**Gave Scourge's whip mode extended reach, forced broad stroke, and tested to assure working as intended. Began prep work for a Spin_Attack proc it and other whips will use.**

**TODO: Finish Spin_Attack proc, currently works with verb, defines area kinda, plays sound, but doesn't strike targets in zone nor play swing effect.**
**TODO: Give similar whip reach to the chain of command, and Spin_Attack**
**TODO: Make sure the Scourge doesn't make individuals struck scream more from the multiple hits of forced_broad_strike**

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hello, you! You look important, don't you. You're probably someone's boss! And you look like someone who needs a little help getting YOUR help to do the helping, am I right? I know I'm right. I got just the thing for you.

It's beatings! Now available in extendo-mode! Take your favored whip or whip-like, hit the extendo-mode button, and you can slap someone silly without having to get close enough to appreciate all the ugly features riddling their face like inner city neglected infrastructure!

Pick up your Helper's Helper, today!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Whips, and whip like items, should feel like whips. Part of that is reach, and swiping motions for lacerations. So I've added reach to the only two whips I know about, the Scourge and the Chain of Command. The Scourge, being a hybrid weapon, only has it when extended, which increases it's size to Bulky. This Bulkiness means that, extended, it isn't super useful to use alongside a shield, as you retain double-tact without two-handing it.

The Chain of Command is the Grade A posterchild of overbearing administration trying to squeeze more blood out of the rock that is their workforce, and should act a similar way.

The new Spin_Attack proc will allow items like whips, and future things I hope to add, to affect the immediate vicinity of the user in a small AoE, affecting only adjacent tiles in all cardinal directions. In the case of whips, swift cuts for anyone near by and a little breathing room.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Scourge Extended Reach and Forced Broad Strike operate as intended.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
