### PR TITLE
Quickequip hotfix

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -14,8 +14,6 @@ This saves us from having to call add_fingerprint() any time something is put in
 	var/target_slot = get_quick_slot(I)
 	if(I.pre_equip(usr, target_slot))
 		return
-	//if(!I.try_transfer(target_slot, usr))
-	//	quick_equip_storage(I)
 	if(!equip_to_slot_if_possible(I, target_slot, disable_warning = TRUE, redraw_mob = TRUE))
 		quick_equip_storage(I)
 	/*

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -14,7 +14,9 @@ This saves us from having to call add_fingerprint() any time something is put in
 	var/target_slot = get_quick_slot(I)
 	if(I.pre_equip(usr, target_slot))
 		return
-	if(!I.try_transfer(target_slot, usr))
+	//if(!I.try_transfer(target_slot, usr))
+	//	quick_equip_storage(I)
+	if(!equip_to_slot_if_possible(I, target_slot, disable_warning = TRUE, redraw_mob = TRUE))
 		quick_equip_storage(I)
 	/*
 	if(!equip_to_appropriate_slot(I))


### PR DESCRIPTION
## About The Pull Request

Makes quickequip unscope the player. Unforeseen consequences can be possible, but are quite unlikely.

## Why It's Good For The Game

Fixes a goofy bug.

## Testing

Attempted to equip and unequip Tosshin, both scoped and unscoped. Worked as intended, could not fire the gun and the scope did not stay on when the Tosshin was put in the suit slot or back.

## Changelog
:cl:
fix: "e" to quickequip no longer allows firing guns from within storage
/:cl: