### PR TITLE
Grenade shell multi-explosion bugfix

### DIFF
--- a/code/modules/projectiles/projectile/projectilegrenades.dm
+++ b/code/modules/projectiles/projectile/projectilegrenades.dm
@@ -18,7 +18,9 @@
 		..()
 
 /obj/item/projectile/bullet/grenade/on_hit(atom/target)	//Allows us to cause different effects for each grenade shell on hit
+	..()
 	grenade_effect(target)
+	qdel(src)
 
 /obj/item/projectile/bullet/grenade/proc/grenade_effect(target)
 	return


### PR DESCRIPTION
## About The Pull Request

Grenade shells due to SSExplosion's new behaviour no longer delete themselves on detonation. This PR fixes it.

## Why It's Good For The Game

Bugfix

## Testing

Pending

## Changelog
:cl:
fix: grenade shells no longer explode infinite times when hitting something
/:cl: