### PR TITLE
Moebius hard-difficulty update.

### DIFF
--- a/code/modules/research/experiment.dm
+++ b/code/modules/research/experiment.dm
@@ -23,6 +23,7 @@ GLOBAL_LIST_EMPTY(explosion_watcher_list)
 	var/list/saved_autopsy_weapons = list()
 	var/list/saved_symptoms = list()
 	var/list/saved_slimecores = list()
+	var/list/saved_object_types = list() // type = decon_count
 
 	// Special point amount for autopsy weapons
 	var/static/list/special_weapons = list(
@@ -58,6 +59,11 @@ GLOBAL_LIST_EMPTY(explosion_watcher_list)
 	var/has_new_tech = FALSE
 	var/is_board = istype(I, /obj/item/electronics/circuitboard)
 
+	// No research value for what has been deconstructed already
+	if(I.type in saved_object_types)
+		// has to be 1 else division by 0
+		return 1
+
 	for(var/T in temp_tech)
 		if(tech_points[T])
 			if(ignoreRepeat)
@@ -84,6 +90,9 @@ GLOBAL_LIST_EMPTY(explosion_watcher_list)
 
 		if(!(temp_tech[T] in saved_tech_levels[T]))
 			saved_tech_levels[T] += temp_tech[T]
+
+	if(!(I.type in saved_object_types))
+		saved_object_types += I.type
 
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes it so you can no longer deconstruct the exact same objects for any meaningfull amount of points

## Why It's Good For The Game
One of the most cited complaints in Dchat is from moebius powergamers getting hyperspeed and full body augmentations 20 minutes into the round due to how easy research is to cheese in its current state , the entire mechanism requiring trade or exploration can be bypassed by printing a telecomms ansible 20 times (which gives 400 points even if it was deconstructed before) effectively letting people research all the tech nodes quite fast.
This change will make it so moebius is far more willing to deal for research items (be that disks , guns , or covert tech) or even steal for them.. (This also allows further PR's to buff moebius research since it should no longer be so easy to do completly)


## Testing
Ran locally and tested  with the RD console.
## Changelog
:cl:
balance: Desctructive analyzer and handheld analyzers no longer receive any points from deconstructing the same objects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
