### PR TITLE
Leg tally fix

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -351,8 +351,8 @@
 	if(status & ORGAN_SPLINTED)
 		. += 0.5
 
-	var/muscle_eff = owner.get_specific_organ_efficiency(OP_MUSCLE, organ_tag)
-	var/nerve_eff = max(owner.get_specific_organ_efficiency(OP_NERVE, organ_tag),1)
+	var/muscle_eff = max(owner.get_specific_organ_efficiency(OP_MUSCLE, organ_tag), 50)
+	var/nerve_eff = max(owner.get_specific_organ_efficiency(OP_NERVE, organ_tag), 100)
 	muscle_eff = (muscle_eff/100) - (muscle_eff/nerve_eff) //Need more nerves to control those new muscles
 	if(muscle_eff)
 		. -= 0.6 * muscle_eff / (muscle_eff + 0.4) // Diminishing returns with a hard cap of 0.6 and soft cap of 0.5


### PR DESCRIPTION
## About The Pull Request

The limits were wrong, which allow a destroyed nerve to provide unlimited speedboost. This fixes it by setting the minimum nerve efficiency at 100, and muscle efficiency at 50.

## Why It's Good For The Game

Bugfix.

## Testing

Ran around ingame

## Changelog
:cl:
fix: no more unlimited speed from wrecked nerves
/:cl: