### PR TITLE
Fix missing keyword args for linter

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -38,7 +38,7 @@
 		brainmob = null
 	. = ..()
 
-/obj/item/organ/internal/vital/brain/take_damage(amount, damage_type = BRUTE, wounding_multiplier = 1, sharp = FALSE, edge = FALSE, silent = FALSE)
+/obj/item/organ/internal/vital/brain/take_damage(amount, damage_type = BRUTE, wounding_multiplier = 1, silent = FALSE, sharp = FALSE, edge = FALSE)
 	if(!damage_type || status & ORGAN_DEAD)
 		return
 

--- a/code/modules/organs/internal/bones.dm
+++ b/code/modules/organs/internal/bones.dm
@@ -17,7 +17,7 @@
 /obj/item/organ/internal/bone/die()
 	return
 
-/obj/item/organ/internal/bone/take_damage()
+/obj/item/organ/internal/bone/take_damage(amount, damage_type = BRUTE, wounding_multiplier = 1, sharp = FALSE, edge = FALSE, silent = FALSE)
 	if(damage > (min_broken_damage * ORGAN_HEALTH_MULTIPLIER) && !(status & ORGAN_BROKEN))
 		fracture()
 	. = ..()

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -204,7 +204,7 @@
 	W.time_inflicted = world.time
 
 //Note: external organs have their own version of this proc
-/obj/item/organ/take_damage(amount, damage_type, wounding_multiplier = 1, silent, sharp = FALSE, edge = FALSE)
+/obj/item/organ/take_damage(amount, damage_type, wounding_multiplier = 1, silent = FALSE, sharp = FALSE, edge = FALSE)
 	if(!BP_IS_ROBOTIC(src))
 		//only show this if the organ is not robotic
 		if(owner && parent && amount > 0 && !silent)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -204,7 +204,7 @@
 	W.time_inflicted = world.time
 
 //Note: external organs have their own version of this proc
-/obj/item/organ/take_damage(amount, damage_type, wounding_multiplier = 1, silent)
+/obj/item/organ/take_damage(amount, damage_type, wounding_multiplier = 1, silent, sharp = FALSE, edge = FALSE)
 	if(!BP_IS_ROBOTIC(src))
 		//only show this if the organ is not robotic
 		if(owner && parent && amount > 0 && !silent)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Add keywords to `bone/take_damage` to fix linter complaining about that.

## Changelog
:cl: Hyperio
fix: Fix missing keyword args for linter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
