### PR TITLE
Cruciform Internal Damage Hotfix

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -363,7 +363,7 @@
 		var/mob/living/carbon/human/M = H
 		var/obj/item/organ/external/E = M.organs_by_name[BP_CHEST]
 		for (var/i = 0; i < 5;i++)
-			E.take_damage(5, sharp = FALSE)
+			E.take_damage(5, BRUTE, sharp = FALSE)
 			//Deal 25 damage in five hits. Using multiple small hits mostly prevents internal damage
 
 		M.custom_pain("You feel the nails of the cruciform drive into your ribs!",1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gave cruciform implanting a damage type so it stops rupturing organs immediately, requiring surgery. Was unable to make a working log function for untyped damage to find more situations of this, and with my very limited time these past couple weeks I won't be able to figure it out in time. Good luck someone else.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugs bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
The Before.
![dreamseeker_hCYn3FLLjT](https://github.com/discordia-space/CEV-Eris/assets/11076040/d1302f43-c466-4e1e-9694-93ad7309b7c6)

The Now.
![U5ElJnNbg1](https://github.com/discordia-space/CEV-Eris/assets/11076040/25ccf715-547c-43a3-b0a8-9a96aa739f20)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: Cruciforms no longer emulate bone hurt juice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
