### PR TITLE
Plasmacutterfix

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -43,7 +43,7 @@
 /obj/item/projectile/beam/cutter/proc/pass_check(var/turf/simulated/mineral/M)
 var/mineral_passes = 5
 if(mineral_passes = 0);
-return list(null, FALSE) // the projectile stops
+	return list(null, FALSE) // the projectile stops
 		var/mineral_destroyed = on_impact(M.GetDrilled)
 	return list(PROJECTILE_CONTINUE, mineral_destroyed) // the projectile tunnels deeper
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -40,10 +40,17 @@
 	tracer_type = /obj/effect/projectile/laser/plasmacutter/tracer
 	impact_type = /obj/effect/projectile/laser/plasmacutter/impact
 
+/obj/item/projectile/beam/cutter/proc/pass_check(var/turf/simulated/mineral/M)
+var/mineral_passes = 5
+if(mineral_passes = 0);
+return list(null, FALSE) // the projectile stops
+		var/mineral_destroyed = on_impact(M.GetDrilled)
+	return list(PROJECTILE_CONTINUE, mineral_destroyed) // the projectile tunnels deeper
+
 /obj/item/projectile/beam/cutter/on_impact(var/atom/A)
 	if(istype(A, /turf/simulated/mineral))
 		var/turf/simulated/mineral/M = A
-		M.GetDrilled(5)
+		M.GetDrilled(1)
 	.=..()
 
 /obj/item/projectile/beam/practice


### PR DESCRIPTION


## About The Pull Request

WIP DO NOT MERGE, This requests borrows some Aurora code to add the functionality of a multi tile passthrough for ores. this will allow the plasma cutter to be actually useful in mass cutting lots of ores at the same time instead of just being one shot at a time for each tile. 

## Why It's Good For The Game

It will make mining more efficient and make it more worth it to trade with moebius for better parts. 
## Testing

No tests as of yet. I'm still trying to get the code to work, honestly could use some help reviewing it and working things out
## Changelog
:cl:
add: New function to plasma cutter. cuts through multiple rock tiles. pending further updates to ore clamp functionality and autopickup of ores to allow the cutter to be more useful. maybe rebalance to plasma cutter energy cost. 
/:cl:


