### PR TITLE
Correct name on Uniform Crate

### DIFF
--- a/code/game/objects/items/weapons/storage/deferred.dm
+++ b/code/game/objects/items/weapons/storage/deferred.dm
@@ -320,7 +320,7 @@
 	/obj/item/storage/fancy/cigarettes = 1)
 
 /obj/item/storage/deferred/crate/german_uniform
-	name = "german uniform crate"
+	name = "oberthian uniform crate"
 	desc = "A moderately sized crate full of clothes."
 	icon_state = "germancrate_deferred"
 	initial_contents = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Previously was named "German Uniform Crate". Is now named Oberthian Uniform Crate.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Although the items are referenced as german in-code, all the garments display names as Oberthian in-game.

And because the internet can't handle germany existing without cosplaying as bad decisions.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I mean I can REALLY make a video for this if you'd like. It'll be like an infomercial.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: Corrected name of THE uniform crate to accurately represent inworld lore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
