### PR TITLE
No Trash Nun

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -41,6 +41,7 @@
 	item_state = "nt_habithat_visor"
 	desc = "Protective helmet meant more to safeguard against disease, retrofit to also be spaceworthy."
 	style = STYLE_HIGH //Very low defenses, but looks better than a normal spacesuit
+	spawn_blacklisted = TRUE
 	matter = list(MATERIAL_BIOMATTER = 15, MATERIAL_PLASTIC = 5, MATERIAL_STEEL = 5)
 
 /obj/item/clothing/suit/space/medicus
@@ -49,6 +50,7 @@
 	item_state = "nt_habit"
 	desc = "Protective robes meant more to safeguard against disease, retrofit to also be spaceworthy. Has pockets for medical convenience."
 	style = STYLE_HIGH //Very low defenses, but looks better than a normal spacesuit
+	spawn_blacklisted = TRUE
 	slowdown = LIGHT_SLOWDOWN
 	matter = list(MATERIAL_BIOMATTER = 25, MATERIAL_PLASTIC = 10, MATERIAL_STEEL = 10)
 	item_flags = DRAG_AND_DROP_UNEQUIP|STOPPRESSUREDAMAGE|THICKMATERIAL|AIRTIGHT|COVER_PREVENT_MANIPULATION


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Medicus Robes were not intended to spawn in maint. The space suit I built it off of, the helmet is already blacklisted, but the suit wasn't, and I didn't realize that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The only thing worse than a vagabond, is a vagabond cosplaying as a nun. Begone, thot.

But no really it's a hotfix.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled, tested locally, and I looked into a single clothing trash pile and no nun came at me with a gun. Mission successful.
![dreamseeker_JSNh2clbJe](https://github.com/discordia-space/CEV-Eris/assets/11076040/3fa4d15f-9fcc-4b83-9b18-4e8ecec3f114)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: Removed unintended trash catholics.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
