### PR TITLE
Lock church lockers

### DIFF
--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -80,7 +80,7 @@
 	selection_color = "#ecd37d"
 	also_known_languages = list(LANGUAGE_LATIN = 100)
 	security_clearance = CLEARANCE_COMMON
-	cruciform_access = list(access_morgue, access_crematorium, access_maint_tunnels, access_hydroponics)
+	cruciform_access = list(access_nt_acolyte, access_morgue, access_crematorium, access_maint_tunnels, access_hydroponics, access_nt_custodian)
 	wage = WAGE_PROFESSIONAL // The money of the soul is faith, and cold hard cash
 	outfit_type = /decl/hierarchy/outfit/job/church/acolyte
 
@@ -172,7 +172,7 @@
 	//alt_titles = list("Custodian","Sanitation Technician")
 	also_known_languages = list(LANGUAGE_LATIN = 100)
 	security_clearance = CLEARANCE_COMMON
-	cruciform_access = list(access_janitor, access_maint_tunnels, access_morgue, access_crematorium)
+	cruciform_access = list(access_nt_custodian, access_janitor, access_maint_tunnels, access_morgue, access_crematorium)
 	wage = WAGE_LABOUR_HAZARD // The money of the soul is faith, and cold hard cash
 	outfit_type = /decl/hierarchy/outfit/job/church/janitor
 

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -3,8 +3,6 @@
  *		Club Manager
  *      Club Worker
  *		Janitor
- *		Custodian
- *		Acolyte
  */
 
 /*
@@ -81,70 +79,3 @@
 	new /obj/item/soap/nanotrasen(src)
 	new /obj/item/storage/pouch/small_generic(src) // Because I feel like poor janitor gets it bad.
 	new /obj/item/tool/knife/dagger/nt(src)
-
-/obj/structure/closet/custodial
-	name = "custodial closet"
-	desc = "A storage unit for purifying clothes and gear."
-	icon_state = "custodian"
-
-/obj/structure/closet/custodial/populate_contents()
-	if(prob(25))
-		new /obj/item/storage/backpack/neotheology(src)
-	else if(prob(25))
-		new /obj/item/storage/backpack/sport/neotheology(src)
-	else
-		new /obj/item/storage/backpack/satchel/neotheology(src)
-	new /obj/item/clothing/under/rank/church(src)
-	new /obj/item/storage/belt/utility/neotheology(src)
-	new /obj/item/device/radio/headset/church(src)
-	new /obj/item/clothing/gloves/thick(src)
-	new /obj/item/clothing/suit/armor/custodian(src)
-	new /obj/item/clothing/head/armor/custodian(src)
-	//new /obj/item/clothing/head/soft/purple(src)
-	//new /obj/item/clothing/head/beret/purple(src)
-	new /obj/item/device/lighting/toggleable/flashlight(src)
-	new /obj/item/gun/matter/launcher/nt_sprayer(src)
-	new /obj/item/caution(src)
-	new /obj/item/caution(src)
-	new /obj/item/caution(src)
-	new /obj/item/caution(src)
-	new /obj/item/device/lightreplacer(src)
-	new /obj/item/storage/bag/trash(src)
-	new /obj/item/clothing/shoes/galoshes(src)
-	new /obj/item/mop(src)
-	new /obj/item/clothing/under/rank/church/sport(src)
-	new /obj/item/clothing/suit/storage/neotheosports(src)
-	new /obj/item/soap/nanotrasen(src)
-	new /obj/item/storage/pouch/small_generic(src) // Because I feel like poor janitor gets it bad.
-	new /obj/item/cell/small/neotheology(src)
-	new /obj/item/cell/small/neotheology(src)
-	new /obj/item/tool/knife/dagger/nt(src)
-	new /obj/item/holyvacuum(src)
-	new /obj/item/clothing/shoes/jackboots/neotheology(src)
-/obj/structure/closet/acolyte
-	name = "acolyte closet"
-	desc = "A closet for those that work with the machines of god."
-	icon_state = "acolyte"
-
-/obj/structure/closet/acolyte/populate_contents()
-	if(prob(25))
-		new /obj/item/storage/backpack/neotheology(src)
-	else if(prob(25))
-		new /obj/item/storage/backpack/sport/neotheology(src)
-	else
-		new /obj/item/storage/backpack/satchel/neotheology(src)
-	new /obj/item/clothing/under/rank/acolyte(src)
-	new /obj/item/clothing/suit/storage/neotheology_jacket(src)
-	new /obj/item/storage/belt/tactical/neotheology(src)
-	new /obj/item/clothing/mask/gas(src)
-	new /obj/item/device/radio/headset/church(src)
-	new /obj/item/clothing/gloves/thick(src)
-	new /obj/item/clothing/under/rank/church/sport(src)
-	new /obj/item/clothing/suit/storage/neotheosports(src)
-	new /obj/item/clothing/head/armor/acolyte(src)
-	new /obj/item/clothing/suit/armor/acolyte(src)
-	new /obj/item/cell/small/neotheology(src)
-	new /obj/item/storage/pouch/holster/belt/sheath(src)
-	new /obj/item/tool/sword/nt/shortsword(src)
-	new /obj/item/tool/knife/dagger/nt(src)
-	new /obj/item/clothing/shoes/reinforced(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
@@ -31,3 +31,106 @@
 	new /obj/item/tool/sword/nt/longsword(src)
 	new /obj/item/tool/knife/dagger/nt(src)
 	new /obj/item/storage/box/ids(src)
+
+
+/obj/structure/closet/secure_closet/acolyte
+	name = "acolyte closet"
+	desc = "A closet for those that work with the machines of god."
+	req_access = list(access_nt_acolyte)
+	icon_state = "acolyte"
+
+/obj/structure/closet/secure_closet/acolyte/populate_contents()
+	if(prob(25))
+		new /obj/item/storage/backpack/neotheology(src)
+	else if(prob(25))
+		new /obj/item/storage/backpack/sport/neotheology(src)
+	else
+		new /obj/item/storage/backpack/satchel/neotheology(src)
+	new /obj/item/clothing/under/rank/acolyte(src)
+	new /obj/item/clothing/suit/storage/neotheology_jacket(src)
+	new /obj/item/storage/belt/tactical/neotheology(src)
+	new /obj/item/clothing/mask/gas(src)
+	new /obj/item/device/radio/headset/church(src)
+	new /obj/item/clothing/gloves/thick(src)
+	new /obj/item/clothing/under/rank/church/sport(src)
+	new /obj/item/clothing/suit/storage/neotheosports(src)
+	new /obj/item/clothing/head/armor/acolyte(src)
+	new /obj/item/clothing/suit/armor/acolyte(src)
+	new /obj/item/cell/small/neotheology(src)
+	new /obj/item/storage/pouch/holster/belt/sheath(src)
+	new /obj/item/tool/sword/nt/shortsword(src)
+	new /obj/item/tool/knife/dagger/nt(src)
+	new /obj/item/clothing/shoes/reinforced(src)
+
+
+/obj/structure/closet/secure_closet/custodial
+	name = "custodial closet"
+	desc = "A storage unit for purifying clothes and gear."
+	req_access = list(access_nt_custodian)
+	icon_state = "custodian"
+
+/obj/structure/closet/secure_closet/custodial/populate_contents()
+	if(prob(25))
+		new /obj/item/storage/backpack/neotheology(src)
+	else if(prob(25))
+		new /obj/item/storage/backpack/sport/neotheology(src)
+	else
+		new /obj/item/storage/backpack/satchel/neotheology(src)
+	new /obj/item/clothing/under/rank/church(src)
+	new /obj/item/storage/belt/utility/neotheology(src)
+	new /obj/item/device/radio/headset/church(src)
+	new /obj/item/clothing/gloves/thick(src)
+	new /obj/item/clothing/suit/armor/custodian(src)
+	new /obj/item/clothing/head/armor/custodian(src)
+	//new /obj/item/clothing/head/soft/purple(src)
+	//new /obj/item/clothing/head/beret/purple(src)
+	new /obj/item/device/lighting/toggleable/flashlight(src)
+	new /obj/item/gun/matter/launcher/nt_sprayer(src)
+	new /obj/item/caution(src)
+	new /obj/item/caution(src)
+	new /obj/item/caution(src)
+	new /obj/item/caution(src)
+	new /obj/item/device/lightreplacer(src)
+	new /obj/item/storage/bag/trash(src)
+	new /obj/item/clothing/shoes/galoshes(src)
+	new /obj/item/mop(src)
+	new /obj/item/clothing/under/rank/church/sport(src)
+	new /obj/item/clothing/suit/storage/neotheosports(src)
+	new /obj/item/soap/nanotrasen(src)
+	new /obj/item/storage/pouch/small_generic(src) // Because I feel like poor janitor gets it bad.
+	new /obj/item/cell/small/neotheology(src)
+	new /obj/item/cell/small/neotheology(src)
+	new /obj/item/tool/knife/dagger/nt(src)
+	new /obj/item/holyvacuum(src)
+	new /obj/item/clothing/shoes/jackboots/neotheology(src)
+
+
+/obj/structure/closet/secure_closet/agrolyte
+	name = "agrolyte's locker"
+	req_access = list(access_hydroponics)
+	icon_state = "agrolyte"
+
+/obj/structure/closet/secure_closet/agrolyte/populate_contents()
+	if(prob(25))
+		new /obj/item/storage/backpack/neotheology(src)
+	else if(prob(25))
+		new /obj/item/storage/backpack/sport/neotheology(src)
+	else
+		new /obj/item/storage/backpack/satchel/neotheology(src)
+	new /obj/item/clothing/suit/apron(src)
+	new /obj/item/storage/belt/utility/neotheology(src)
+	new /obj/item/storage/bag/produce(src)
+	new /obj/item/clothing/under/rank/hydroponics(src)
+	new /obj/item/device/scanner/plant(src)
+	new /obj/item/device/radio/headset/church(src)
+	new /obj/item/clothing/mask/bandana/botany(src)
+	new /obj/item/tool/minihoe(src)
+	new /obj/item/tool/hatchet(src)
+	new /obj/item/tool/wirecutters(src)
+	new /obj/item/clothing/under/rank/church/sport(src)
+	new /obj/item/clothing/suit/storage/neotheosports(src)
+	new /obj/item/reagent_containers/spray/plantbgone(src)
+	new /obj/item/clothing/suit/armor/agrolyte(src)
+	new /obj/item/clothing/head/armor/agrolyte(src)
+	new /obj/item/clothing/gloves/botanic_leather(src)
+	new /obj/item/clothing/shoes/reinforced(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -27,34 +27,3 @@
 	name = "gardener's locker"
 	req_access = list(access_hydroponics)
 	access_occupy = list()
-
-/obj/structure/closet/secure_closet/personal/agrolyte
-	name = "agrolyte's locker"
-	req_access = list(access_hydroponics)
-	access_occupy = list(access_hydroponics)
-	icon_state = "agrolyte"
-
-/obj/structure/closet/secure_closet/personal/agrolyte/populate_contents()
-	if(prob(25))
-		new /obj/item/storage/backpack/neotheology(src)
-	else if(prob(25))
-		new /obj/item/storage/backpack/sport/neotheology(src)
-	else
-		new /obj/item/storage/backpack/satchel/neotheology(src)
-	new /obj/item/clothing/suit/apron(src)
-	new /obj/item/storage/belt/utility/neotheology(src)
-	new /obj/item/storage/bag/produce(src)
-	new /obj/item/clothing/under/rank/hydroponics(src)
-	new /obj/item/device/scanner/plant(src)
-	new /obj/item/device/radio/headset/church(src)
-	new /obj/item/clothing/mask/bandana/botany(src)
-	new /obj/item/tool/minihoe(src)
-	new /obj/item/tool/hatchet(src)
-	new /obj/item/tool/wirecutters(src)
-	new /obj/item/clothing/under/rank/church/sport(src)
-	new /obj/item/clothing/suit/storage/neotheosports(src)
-	new /obj/item/reagent_containers/spray/plantbgone(src)
-	new /obj/item/clothing/suit/armor/agrolyte(src)
-	new /obj/item/clothing/head/armor/agrolyte(src)
-	new /obj/item/clothing/gloves/botanic_leather(src)
-	new /obj/item/clothing/shoes/reinforced(src)

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -41604,7 +41604,7 @@
 /area/eris/maintenance/section3deck3port)
 "bUK" = (
 /obj/item/reagent_containers/spray/cleaner,
-/obj/structure/closet/custodial,
+/obj/structure/closet/secure_closet/custodial,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/crew_quarters/janitor)
 "bUL" = (
@@ -100157,10 +100157,10 @@
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section3deck4port)
 "hbk" = (
-/obj/structure/closet/acolyte,
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
+/obj/structure/closet/secure_closet/acolyte,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/neotheology/churchbarracks)
 "hbQ" = (
@@ -100325,10 +100325,10 @@
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/security/exerooms)
 "hug" = (
-/obj/structure/closet/acolyte,
 /obj/machinery/camera/network/third_section{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/acolyte,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/neotheology/churchbarracks)
 "huE" = (
@@ -101573,10 +101573,10 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/medical/chemstor)
 "koc" = (
-/obj/structure/closet/acolyte,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/acolyte,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/neotheology/churchbarracks)
 "ksh" = (
@@ -104838,10 +104838,10 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
 "sNY" = (
-/obj/structure/closet/acolyte,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/acolyte,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/neotheology/churchbarracks)
 "sOb" = (
@@ -106996,7 +106996,7 @@
 /turf/simulated/wall/r_wall,
 /area/eris/neotheology/chapel)
 "yll" = (
-/obj/structure/closet/secure_closet/personal/agrolyte,
+/obj/structure/closet/secure_closet/agrolyte,
 /turf/simulated/floor/grass,
 /area/eris/crew_quarters/hydroponics)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds lock to acolyte's and custodian's lockers.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency, I guess? Agrolyte's locker has a lock, why not the other two?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Locked, unlocked, opened, closed
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: acolyte's locker and custodian's locker now lockable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
