### PR TITLE
Rework E-armblade

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -240,6 +240,7 @@
 			spawn(1) if(src) qdel(src)
 
 /obj/item/melee/energy/blade/organ_module //just to make sure that blade doesnt delet itself
+	w_class = ITEM_SIZE_SMALL //Same as other armblades, it shouldn't be a bulky item requiring double-tact
 	cleanup = FALSE
 	init_procees = FALSE
 

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -240,7 +240,7 @@
 			spawn(1) if(src) qdel(src)
 
 /obj/item/melee/energy/blade/organ_module //just to make sure that blade doesnt delet itself
-	w_class = ITEM_SIZE_SMALL //Same as other armblades, it shouldn't be a bulky item requiring double-tact
+	no_double_tact = TRUE //Retains BULKY defensive capabilities like parrying while blocking while being fast as other armblades
 	cleanup = FALSE
 	init_procees = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Directly removes Double Tact from the Energy Armblade cybernetic without sacrificing it's BULKY size, which has defensive capabilities while using the BLOCK hotkey.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Why should a quick e-shank require two clicks? It does 6 more damage than the wrist shank (a makeshift item) but has zero modifiability. The wrist shank does more damage with a single mod, without double tact. At the very least, such an item that isn't modifiable should have more advantages than something assembled from actual junk.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled, launched, swung my energy armblade into floor tiles without double tact.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
balance: Removed Double Tact from the Energy Armblade cybernetic.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
