### PR TITLE
Fix Plant Gene Application

### DIFF
--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -265,18 +265,17 @@
 			// Uses best of BIO and COG
 			stat_multiplier = min(usr.stats.getMult(STAT_BIO, STAT_LEVEL_GODLIKE), usr.stats.getMult(STAT_COG, STAT_LEVEL_GODLIKE))
 
+		seed.modified += round(rand(30, 50) * stat_multiplier)
 		if(!isnull(plant_controller.seeds[seed.seed.name]))
 			seed.seed = seed.seed.diverge(1)
 			seed.seed_type = seed.seed.name
 			seed.update_seed()
 
-		if(prob(seed.modified * stat_multiplier))
+		if(seed.modified >= 100)
 			failed_task = TRUE
 			seed.modified = 100
 
 		seed.seed.apply_gene(loaded_gene)
-		seed.modified += round(rand(10, 15) * stat_multiplier)
-		seed.modified = max(seed.modified, 100)
 
 		start_task()
 		return 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Up until now, applying genes to plants was a one gene per generation thing, forcing long trivial repetitions of seed, splice, plant, clip, repeat. I noticed that the Gene Splicing machine did have code that was supposed to have this be BIO/COG (higher wins) random chance between 5 and 15 percent affliction, instead of immediately going from 0-100%. I have cleaned it up, and fixed it so that it works as originally intended, but with only a max of four genes per generation, which is way more than enough.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes gene splicing machine work as intended, makes arduous unrewarding effort a bit faster.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
[dreamseeker_Noa79MM3Tu.webm](https://github.com/discordia-space/CEV-Eris/assets/11076040/99b13e4f-8b8b-4b10-a8b7-6acf193023bf)
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: Plant Gene splicing machine can apply multiple genes per seed, as code originally implied.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
