### PR TITLE
Make forcing events logged

### DIFF
--- a/code/game/gamemodes/storyteller_print.dm
+++ b/code/game/gamemodes/storyteller_print.dm
@@ -258,7 +258,7 @@
 
 				var/result = evt.create(href_list["severity"])
 				if (result)
-					message_admins("Event \"[evt.id]\" was successfully force spawned by [key_name(usr)]")
+					log_and_message_admins("Event \"[evt.id]\" was successfully force spawned by [key_name(usr)]")
 				else
 					message_admins("[key_name(usr)] failed to force spawn \"[evt.id]\".")
 			if(href_list["ev_debug"] && usr && usr.client)


### PR DESCRIPTION
Logging, security, I dunno how many teleports *someone* spawned *that one* round. I'd like to. I can't test it because of how logging works clientside, so I just opted in to make a change on web.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
important things logging = good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
can't
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
admin: When an admin forces an event it's now logged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
