### PR TITLE
Fix intercoms being added to player inventory after exiting cryo

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -496,12 +496,7 @@
 	return
 
 /obj/machinery/cryopod/relaymove(var/mob/user)
-	..()
-	//set_occupant(null, FALSE)
-	go_out()
-	for(var/obj/item/thing in contents)
-		thing.forceMove(loc)
-		user.equip_to_appropriate_slot(thing)
+	eject()
 
 
 /obj/machinery/cryopod/proc/go_out()


### PR DESCRIPTION
## About The Pull Request

What it says on the tin.

## Why It's Good For The Game

Fixes good.

## Testing

Spawned in a cryopod, found an intercom in a suit storage slot.
Made a fix.
Spawned in a cryopod again, found no intercom in a suit storage slot.

## Changelog
:cl:
fix: Intercoms being added to player inventory on exiting a cryopod
/:cl:
