### PR TITLE
Remove Godblood Excel Interaction

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/excelsior.dm
+++ b/code/game/objects/items/weapons/implant/implants/excelsior.dm
@@ -83,11 +83,6 @@
 	if(!wearer || !wearer.mind)
 		return
 
-	// Mutant with resistance to mind control still can use an implant, albeit not fully
-	if(get_active_mutation(target, MUTATION_GODBLOOD))
-		target.verbs.Add(/datum/faction/excelsior/proc/communicate_verb)
-		return
-
 	if(!F)
 		to_chat(target, SPAN_WARNING("You feel nothing."))
 
@@ -106,7 +101,7 @@
 		if(A.id == antag_id)
 			A.remove_antagonist()
 	wearer.visible_message(SPAN_DANGER("As \the [src] is removed from \the [wearer]..."))
-	if(prob(66) && !get_active_mutation(wearer, MUTATION_GODBLOOD))
+	if(prob(66))
 		wearer.visible_message(SPAN_DANGER("\The [wearer]'s [part.name] violently explodes from within!"))
 		wearer.adjustBrainLoss(200)
 		part.droplimb(FALSE, DROPLIMB_BLUNT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Some dingbat thought Godblood created "A mutant with mind control resistance", and wrote in non-cruciformed Godbloods being able to get free Excel comms for laughs. That isn't how Godblood works at all, it simply removes the restrictions a cruciform places on the bearer, it has no advantages outside of this.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More lore accurate, one less discrepancy to mislead players about particular weirder aspects of the world. Also why the fuck get free team antag comms? Man worked hard to get you into a corner and implant you, give him that comrade.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tried testing it on a godblooded cruciformed person, didn't work at all, as expected the cruciform still blocked the implanting.
![dreamseeker_p5Nk4PXz6Y](https://github.com/discordia-space/CEV-Eris/assets/11076040/627f81c5-1807-4772-83bc-b9e1c7550df3)

Tried testing on non-cruciformed godblooded person, worked as expected.
![dreamseeker_2xQ2UQXt7z](https://github.com/discordia-space/CEV-Eris/assets/11076040/f70a96b5-9d58-40b0-9c76-af890a06db3d)

Also the description as featured on the UI, I had to spawn like 40 different bodies to finally get the mutation because I'm dumb and don't know how to apply mutations via Variable Viewer.
![5CrZI0k2r4](https://github.com/discordia-space/CEV-Eris/assets/11076040/4897b000-5b82-4b93-b0b8-6c64b5226fbe)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
del: Godblood giving free Excel comms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
