### PR TITLE
Add Mining Satchels and Ore Boxes to Trade Ships

### DIFF
--- a/code/modules/trade/datums/trade_stations_presets/1-common/asterstradecapital.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/asterstradecapital.dm
@@ -53,7 +53,9 @@
 		"Mining Gear" = list(
 			/obj/machinery/mining/deep_drill,
 			/obj/item/tool/pickaxe,
-			/obj/item/tool/pickaxe/excavation
+			/obj/item/tool/pickaxe/excavation,
+			/obj/item/storage/bag/ore,
+			/obj/structure/ore_box
 		),
 		"Toys" = list(
 			/obj/item/toy/balloon = good_data("Water Balloon", list(1, 50), null),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Motherfucking Art keeps opening every single motherfucking miner locker to take all the motherfucking mining satchels because of the motherfucking caverns won't let you drag in an motherfucking ore crate motherfucker I am 
### PISSED

What If **I** wanted a locker to hide my antag items huh? What if I wanted my own locker **I** could lock so I could shove my motherfucking lunch in there huh? You son of a bitch I will
### BEAT YOUR MOTHERFUCKING ASS
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There is now a way to get more mining satchels. There was previously no way to get more.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![oyDBewjdID](https://github.com/discordia-space/CEV-Eris/assets/11076040/dfd65451-3422-4d40-8c6e-1b0369d5e5cc)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
add: Added Mining Satchel and Ore Crate to Asters' trade ship.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
