### PR TITLE
Suez Nerf

### DIFF
--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -35,9 +35,9 @@
 	icon_state = "stunrevolver"
 	item_state = "stunrevolver"
 	fire_sound = 'sound/weapons/Gunshot.ogg'
-	can_dual = TRUE
+	can_dual = FALSE
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
-	charge_cost = 50
+	charge_cost = 100
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6, MATERIAL_SILVER = 2)
 	price_tag = 1500
 	suitable_cell = /obj/item/cell/small
@@ -45,6 +45,7 @@
 	projectile_type = /obj/item/projectile/energy/electrode
 	init_recoil = HANDGUN_RECOIL(1)
 	serial_type = "NT"
+
 
 /obj/item/gun/energy/stunrevolver/moebius
 	name = "ML SP \"Suez\""	//Ersatz name


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Disabled the ability to dual wield (fire two at the same time while in harm intent) for stun revolvers, and increased the cost per shot from 50 to 100. Seems folk have caught on that dual wielding Suez, modifying the ever loving shit out of it, create department deleters. If this isn't enough, I'll revert it and look into making them unmodifiable, which will incredibly retard their potential.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cheap and easy ways to delete entire swaths of people might be fun for the person with the guns, but not everyone else.
![7y53gj](https://github.com/discordia-space/CEV-Eris/assets/11076040/b2e80948-36ab-405c-8495-a6e8c0df78bd)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Yepp it's a gun, it shoots and I can only shoot one at a time even on harm intent. I don't know what mods people use to make them into weapons of mass deletion intimately, so I can't recreate the carnage players have been doing.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
balance: Removed Stunrevolver Dual Wield, doubled energy cost.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
