### PR TITLE
Standardize Agrolyte's Pain Relief Litany

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/agrolyte.dm
+++ b/code/modules/core_implant/cruciform/rituals/agrolyte.dm
@@ -60,7 +60,7 @@
 		fail("[T.name]\'s mutated flesh rejects your will.", user, C)
 		return FALSE
 
-	to_chat(T, SPAN_NOTICE("You feel better as your pain eases, although still lightheaded.."))
+	to_chat(T, SPAN_NOTICE("You feel better as your pain eases, although still lightheaded."))
 	to_chat(user, SPAN_NOTICE("You ease the pain of [T.name]."))
 
 	T.reagents.add_reagent("deusblessing", 15)

--- a/code/modules/core_implant/cruciform/rituals/agrolyte.dm
+++ b/code/modules/core_implant/cruciform/rituals/agrolyte.dm
@@ -47,7 +47,7 @@
 /datum/ritual/cruciform/agrolyte/mercy
 	name = "Hand of mercy"
 	phrase = "Non est verus dolor."
-	desc = "Relieves the pain of a person in front of you."
+	desc = "Relieves the pain of a person in front of you. More impactful than one applies to oneself."
 	power = 5
 
 /datum/ritual/cruciform/agrolyte/mercy/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/C)
@@ -60,10 +60,10 @@
 		fail("[T.name]\'s mutated flesh rejects your will.", user, C)
 		return FALSE
 
-	to_chat(T, SPAN_NOTICE("You feel slightly better as your pain eases."))
+	to_chat(T, SPAN_NOTICE("You feel better as your pain eases, although still lightheaded.."))
 	to_chat(user, SPAN_NOTICE("You ease the pain of [T.name]."))
 
-	T.add_chemical_effect(CE_PAINKILLER, 15)  // painkiller effect to target
+	T.reagents.add_reagent("deusblessing", 15)
 
 	return TRUE
 

--- a/code/modules/core_implant/cruciform/rituals/agrolyte.dm
+++ b/code/modules/core_implant/cruciform/rituals/agrolyte.dm
@@ -47,7 +47,7 @@
 /datum/ritual/cruciform/agrolyte/mercy
 	name = "Hand of mercy"
 	phrase = "Non est verus dolor."
-	desc = "Relieves the pain of a person in front of you. More impactful than one applies to oneself."
+	desc = "Relieves the pain of a person in front of you. More impactful than the Relief litany applied to oneself."
 	power = 5
 
 /datum/ritual/cruciform/agrolyte/mercy/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/C)

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -279,6 +279,12 @@
 	if(prob(3 - (2 * M.stats.getMult(STAT_TGH))))
 		M.Stun(3)
 
+/datum/reagent/medicine/tramadol/holy
+	id = "deusblessing"
+	overdose = REAGENTS_OVERDOSE * 3
+	scannable = 0
+	nerve_system_accumulations = 0
+
 /datum/reagent/medicine/oxycodone
 	name = "Oxycodone"
 	id = "oxycodone"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changed Agrolyte's pain litany to match personal pain litany, but better. Where as personal is a holy version of paracetamol, Agrolyte has a holy version of Tramadol.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When the Personal pain relief litany was changed from a solid Chemical_Effect number to a metabolized reagent, the Agrolyte's were left in the dust. This brings them up to par, being more capable of relieving the pain of others than they can themselves.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
The new reagent in the bloodstream.
![dreamseeker_xFAnFUB8gM](https://github.com/discordia-space/CEV-Eris/assets/11076040/3900a97e-fe8c-4126-a771-12ec6ec60ab8)
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: NT Agrolyte's Pain Relief for others is now also a reagent, more powerful than the personal pain relief.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
