### PR TITLE
Exosuit Drill Reports Ore

### DIFF
--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -402,7 +402,7 @@
 								for(var/obj/item/ore/ore in range(T,1))
 									if(get_dir(owner,ore)&owner.dir)
 										ore.Move(ore_box)
-
+								to_chat(user, SPAN_NOTICE("The drill automatically loaded the ore into the ore box."))
 					playsound(src, 'sound/weapons/rapidslice.ogg', 50, 1)
 
 			else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
With an ore box loaded to an Exosuit's Clamp, the Drill now reports that the ore it exposes is automatically loaded into the ore box.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I promised money to shady people to redo exosuits entirely thinking exosuit drills were fundamentally broken cuz I never saw ore drop when I was using it, just to realize the next day that it's because exosuit drills were automatically searching for stored ore boxes to load the ore into.

Adding the message will let idiots like me know that the drill works and where the ore is going.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
[dreamseeker_3cu3uT1a1f.webm](https://github.com/discordia-space/CEV-Eris/assets/11076040/71b23099-4132-41fd-b889-266505b2d16b)
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
add: Added Exosuit Drill message to report ore deposited into Clamp's ore box.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
