### PR TITLE
Revert "Leather satchels are stylish"

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -324,10 +324,8 @@
 
 /obj/item/storage/backpack/satchel/leather
 	name = "leather satchel"
-	desc = "A fancy satchel made with fine leather. While fancy, it has less storage space than most other satchels."
+	desc = "A fancy satchel made with fine leather."
 	icon_state = "satchel_leather"
-	max_storage_space = DEFAULT_HUGE_STORAGE * 0.5 // 20 instead of 28
-	style = STYLE_LOW // Sacrificing storage space is stylish
 
 /obj/item/storage/backpack/satchel/leather/withwallet
 	rarity_value = 4.16


### PR DESCRIPTION
## About The Pull Request

Revert of "Leather satchels are stylish" PR.

## Why It's Good For The Game

Since style no longer affects combat, it became much less valuable and I think no longer warrants reduction of leather satchel's storage capacity.
+1 style is hardly beneficial now, but reduced capacity on already small storage is a big deal.
I (as well as some other players) prefer this satchel for it's appearance, but by choosing it we're put at a disadvantage for effectively no gain. Probably shouldn't be that way.

## Testing
Tested. This fine.
![image](https://github.com/discordia-space/CEV-Eris/assets/66647116/9673df1e-3d84-4595-9847-cf5742b0cca8)
![image](https://github.com/discordia-space/CEV-Eris/assets/66647116/41e150e1-d31b-4bcf-9381-504d15a6e58c)
![image](https://github.com/discordia-space/CEV-Eris/assets/66647116/371dfdd2-9108-4ca6-800f-a18a6171376f)
## Changelog
🆑 
balance: Returned storage capacity to leather satchel
/🆑