### PR TITLE
Mines start anchored

### DIFF
--- a/code/game/objects/items/weapons/mine.dm
+++ b/code/game/objects/items/weapons/mine.dm
@@ -49,6 +49,7 @@
 
 /obj/item/mine/old/armed
 	armed = TRUE
+	anchored = TRUE
 	deployed = TRUE
 	rarity_value = 55
 	spawn_frequency = 10
@@ -66,6 +67,7 @@
 
 /obj/item/mine/improv/armed
 	armed = TRUE
+	anchored = TRUE
 	deployed = TRUE
 	rarity_value = 44
 	spawn_frequency = 10
@@ -96,13 +98,13 @@
 	if(!armed)
 		user.visible_message(
 			SPAN_DANGER("[user] starts to deploy \the [src]."),
-			SPAN_DANGER("you begin deploying \the [src]!")
+			SPAN_DANGER("You begin deploying \the [src]!")
 			)
 
 		if (do_after(user, 25))
 			user.visible_message(
 				SPAN_DANGER("[user] has deployed \the [src]."),
-				SPAN_DANGER("you have deployed \the [src]!")
+				SPAN_DANGER("You have deployed \the [src]!")
 				)
 
 			deployed = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds `anchored = TRUE` to roundstart armed mines. Also fixes a minor typo in mine deployment text
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![изображение](https://github.com/discordia-space/CEV-Eris/assets/57810301/337e777d-82c0-45f8-bf8a-f7990813d7bd)
Thank you Silverwolves for bringing this to my attention and specifically reporting this in #junkyard (/s)
You're not supposed to be able to drag mines around.
I thought of adding an unique interaction where they just explode into your face if you try to drag them, but it's too much work and launch is soon
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing


https://github.com/discordia-space/CEV-Eris/assets/57810301/cda97023-0108-48e5-bfeb-666dd3a8864d


## Changelog
:cl:
fix: Roundstart mines can no longer be pulled around.
spellcheck: Fixed a typo in mine deployment message.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
