### PR TITLE
Makes Blitzshell a fun role

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/blitzshell.dm
+++ b/code/modules/mob/living/silicon/robot/drone/blitzshell.dm
@@ -10,6 +10,7 @@
 	station_drone = FALSE
 	eyecolor = null
 	ai_access = FALSE
+	local_transmit = 0 // Give these fellas at least the bare MINIMUM of RP capacity.
 
 /mob/living/silicon/robot/drone/blitzshell/updatename()
 	real_name = "\"Blitzshell\" assault drone ([rand(100,999)])"

--- a/code/modules/mob/living/silicon/robot/drone/blitzshell.dm
+++ b/code/modules/mob/living/silicon/robot/drone/blitzshell.dm
@@ -27,6 +27,7 @@
 	remove_language(LANGUAGE_ROBOT)
 	remove_language(LANGUAGE_DRONE)
 	add_language(LANGUAGE_BLITZ, 1)
+	add_language(LANGUAGE_GERMAN, 1) // Oberth drone. Give these fellas at least the bare MINIMUM of RP capacity.
 	UnlinkSelf()
 
 /mob/living/silicon/robot/drone/blitzshell/GetIdCard()


### PR DESCRIPTION
## About The Pull Request

Gives Blitzshell language

## Why It's Good For The Game

Makes playing Blitzshell a viable way to have fun

## Testing

Tested locally, blitz could speak. Blitz language is no longer "Transmit" however, which might cause problems in blitz to blitz comms. (Not that it matters considering blitz are generally lone-ops)

## Changelog
:cl:
tweak: blitz speaks language
/:cl: