### PR TITLE
A pack of dice is no longer a pill bottle

### DIFF
--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -87,7 +87,7 @@ RSF
 			product = new /obj/item/pen()
 			used_energy = 50
 		if(5)
-			product = new /obj/item/storage/pill_bottle/dice()
+			product = new /obj/item/storage/box/dice()
 			used_energy = 200
 
 	to_chat(user, "Dispensing [product ? product : "product"]...")

--- a/code/game/objects/items/weapons/storage/misc.dm
+++ b/code/game/objects/items/weapons/storage/misc.dm
@@ -1,11 +1,11 @@
-/obj/item/storage/pill_bottle/dice
+/obj/item/storage/box/dice
 	name = "pack of dice"
 	desc = "A small container with dice inside."
 	spawn_tags = SPAWN_TAG_ITEM
 	prespawned_content_type = /obj/item/dice/d20
 	prespawned_content_amount = 1
 
-/obj/item/storage/pill_bottle/dice/populate_contents()
+/obj/item/storage/box/dice/populate_contents()
 	for(var/i in 1 to prespawned_content_amount)
 		new prespawned_content_type(src)
 	new /obj/item/dice(src)

--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -22,7 +22,7 @@
 
 /datum/gear/dice
 	display_name = "dice pack"
-	path = /obj/item/storage/pill_bottle/dice
+	path = /obj/item/storage/box/dice
 
 /datum/gear/cards
 	display_name = "deck of cards"


### PR DESCRIPTION
## About The Pull Request

Pack of dice is not a pill bottle.

## Why It's Good For The Game

Bug bad.

## Testing

It spawns properly in a box now.

## Changelog
:cl:
fix: pack of dice is no longer a pill bottle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
