### PR TITLE
SM now comes in crates

### DIFF
--- a/code/controllers/subsystems/trade.dm
+++ b/code/controllers/subsystems/trade.dm
@@ -446,7 +446,7 @@ SUBSYSTEM_DEF(trade)
 	var/obj/structure/closet/secure_closet/personal/trade/C
 	var/count_of_all = collect_counts_from(shopList)
 	var/price_for_all = collect_price_for_list(shopList)
-	if((isnum(count_of_all) && count_of_all > 1) || shopList.Find("/obj/machinery/power/supermatter") > -1)
+	if((isnum(count_of_all) && count_of_all > 1) || shopList.Find("/obj/machinery/power/supermatter") > 0)
 		C = senderBeacon.drop(/obj/structure/closet/secure_closet/personal/trade)
 		if(is_order)
 			C.locked = TRUE

--- a/code/controllers/subsystems/trade.dm
+++ b/code/controllers/subsystems/trade.dm
@@ -446,7 +446,7 @@ SUBSYSTEM_DEF(trade)
 	var/obj/structure/closet/secure_closet/personal/trade/C
 	var/count_of_all = collect_counts_from(shopList)
 	var/price_for_all = collect_price_for_list(shopList)
-	if(isnum(count_of_all) && count_of_all > 1)
+	if((isnum(count_of_all) && count_of_all > 1) || shopList.Find("/obj/machinery/power/supermatter") > -1)
 		C = senderBeacon.drop(/obj/structure/closet/secure_closet/personal/trade)
 		if(is_order)
 			C.locked = TRUE


### PR DESCRIPTION
Per issue #7994, quick check for SM shard and crates the order if SM is present in order

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Per issue #7994, QoL change to put the SM from the Zayra in a crate. We do want guild techs, even if it is funny when they run into the SM they ordered.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Minor QoL fix so people aren't upset about dusting themselves by accident.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Tested by ordering a single SM from Zayra
Tested by ordering an SM with other items from Zayra
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: added a check to creating an order from the trade beacon so that orders containing an SM shard are crated on spawn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
