### PR TITLE
fix shield generator getting deleted when a certain weather event hits

### DIFF
--- a/code/__DEFINES/shields.dm
+++ b/code/__DEFINES/shields.dm
@@ -1,6 +1,7 @@
 #define SHIELD_DAMTYPE_PHYSICAL 1	// Physical damage - bullets, meteors, various hand objects - aka. "brute" damtype.
 #define SHIELD_DAMTYPE_EM 2			// Electromagnetic damage - Ion weaponry, stun beams, ...
 #define SHIELD_DAMTYPE_HEAT 3		// Heat damage - Lasers, fire
+#define SHIELD_DAMTYPE_SPECIAL 4    // Special for /datum/storyevent/harmonic_feedback (for now) but uses EM calculations otherwise because it makes sense to use it
 
 #define ENERGY_PER_HP (50 KILOWATTS)// Base amount energy that will be deducted from the generator's internal reserve per 1 HP of damage taken
 #define ENERGY_UPKEEP_PER_TILE 35	// Base upkeep per tile protected. Multiplied by various enabled shield modes. Without them the field does literally nothing.

--- a/code/game/gamemodes/events/space_weather.dm
+++ b/code/game/gamemodes/events/space_weather.dm
@@ -151,8 +151,8 @@
 /datum/event/harmonic_feedback/tick() //around two seconds
 	for(var/obj/machinery/power/shield_generator/G in GLOB.machines)
 		if(G.running != SHIELD_OFF)
-			G.take_damage(100, SHIELD_DAMTYPE_EM)
-
+			G.take_shield_damage(250, SHIELD_DAMTYPE_SPECIAL, "UNKNOWN") // ALRIGHT LISTEN WEATHER CAN LAST AT MAXIMUM 450 TICKS, AVERAGE AT 375 SHIELD HITS
+														 	// BY DEFAULT 1000 DAMAGE EQUALS 1 PERCENT, SO 0.25% * 375 = 93.75%, THIS WILL KNOCK SHIELDS OUT IF THEY'RE NOT AT FULL CAPACITY OR NOT CHARGING WELL
 /datum/storyevent/micro_debris
 	id = "micro_debris"
 	name = "micro debris field"

--- a/code/modules/modular_computers/file_system/programs/engineering/shield_control.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/shield_control.dm
@@ -1,9 +1,10 @@
 #define EVENT_DAMAGE_PHYSICAL 	0 //copied from shield_generator.dm
 #define EVENT_DAMAGE_EM 		1
 #define EVENT_DAMAGE_HEAT 		2
-#define EVENT_ENABLED 			3
-#define EVENT_DISABLED 			4
-#define EVENT_RECONFIGURED		5
+#define EVENT_DAMAGE_SPECIAL	3
+#define EVENT_ENABLED 			4
+#define EVENT_DISABLED 			5
+#define EVENT_RECONFIGURED		6
 
 /datum/computer_file/program/shield_control
 	filename = "shieldcontrol"
@@ -242,6 +243,7 @@
 #undef EVENT_DAMAGE_PHYSICAL
 #undef EVENT_DAMAGE_EM
 #undef EVENT_DAMAGE_HEAT
+#undef EVENT_DAMAGE_SPECIAL
 #undef EVENT_ENABLED
 #undef EVENT_DISABLED
 #undef EVENT_RECONFIGURED

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -731,8 +731,10 @@
 
 			if (origin_atom)
 				var/turf/T = get_turf(origin_atom)
-				if (T)
+				if(T)
 					logstring += " at [T.x],[T.y],[T.z]"
+				else
+					logstring += " -"
 
 			logstring += " Integrity [round(field_integrity())]%"
 

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -1,9 +1,11 @@
 #define EVENT_DAMAGE_PHYSICAL 	0
 #define EVENT_DAMAGE_EM 		1
 #define EVENT_DAMAGE_HEAT 		2
-#define EVENT_ENABLED 			3
-#define EVENT_DISABLED 			4
-#define EVENT_RECONFIGURED		5
+#define EVENT_DAMAGE_SPECIAL	3
+#define EVENT_ENABLED 			4
+#define EVENT_DISABLED 			5
+#define EVENT_RECONFIGURED		6
+
 /obj/machinery/power/shield_generator
 	name = "advanced shield generator"
 	desc = "A heavy-duty shield generator and capacitor, capable of generating energy shields at large distances."
@@ -485,6 +487,8 @@
 			energy_to_use *= 1 - (mitigation_em / 100)
 		if(SHIELD_DAMTYPE_HEAT)
 			energy_to_use *= 1 - (mitigation_heat / 100)
+		if(SHIELD_DAMTYPE_SPECIAL)
+			energy_to_use *= 1 - (mitigation_em / 100)
 
 	mitigation_em -= MITIGATION_HIT_LOSS
 	mitigation_heat -= MITIGATION_HIT_LOSS
@@ -498,6 +502,8 @@
 				mitigation_em += MITIGATION_HIT_LOSS + MITIGATION_HIT_GAIN
 			if(SHIELD_DAMTYPE_HEAT)
 				mitigation_heat += MITIGATION_HIT_LOSS + MITIGATION_HIT_GAIN
+			if(SHIELD_DAMTYPE_SPECIAL)
+				mitigation_em += MITIGATION_HIT_LOSS + MITIGATION_HIT_GAIN
 
 	mitigation_em = between(0, mitigation_em, mitigation_max)
 	mitigation_heat = between(0, mitigation_heat, mitigation_max)
@@ -512,6 +518,8 @@
 			log_event(EVENT_DAMAGE_EM, damager)
 		if(SHIELD_DAMTYPE_HEAT)
 			log_event(EVENT_DAMAGE_HEAT, damager)
+		if(SHIELD_DAMTYPE_SPECIAL)
+			log_event(EVENT_DAMAGE_SPECIAL, damager)
 
 	// Overload the shield, which will shut it down until we recharge above 5% again
 	if(current_energy < 0)
@@ -707,7 +715,7 @@
 /obj/machinery/power/shield_generator/proc/log_event(var/event_type, var/atom/origin_atom)
 	var/logstring = "[stationtime2text()]: "
 	switch (event_type)
-		if(EVENT_DAMAGE_PHYSICAL to EVENT_DAMAGE_HEAT)
+		if(EVENT_DAMAGE_PHYSICAL to EVENT_DAMAGE_SPECIAL)
 			switch (event_type)
 				if (EVENT_DAMAGE_PHYSICAL)
 					logstring += "Impact registered"
@@ -715,6 +723,8 @@
 					logstring += "EM Signature"
 				if (EVENT_DAMAGE_HEAT)
 					logstring += "Energy discharge"
+				if (EVENT_DAMAGE_SPECIAL)
+					logstring += "Gravitational wavefronts"
 				else
 					return
 
@@ -882,6 +892,7 @@
 #undef EVENT_DAMAGE_PHYSICAL
 #undef EVENT_DAMAGE_EM
 #undef EVENT_DAMAGE_HEAT
+#undef EVENT_DAMAGE_SPECIAL
 #undef EVENT_ENABLED
 #undef EVENT_DISABLED
 #undef EVENT_RECONFIGURED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes shield deleting on gravitational wavefronts anomaly, adds a special damtype for it reserved specifically for this event to make the reason why shields are getting damaged obvious. Adds a little spacer if there is no location for the damage in logging
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes weather event not REALLY mess shields up.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![изображение](https://github.com/discordia-space/CEV-Eris/assets/57810301/1b98dfeb-0c02-4ef1-928a-c310b78dd57f)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: Harmonic feedback surge anomaly weather event no longer physically deletes the shield generator, now instead properly damages it
add: special shield damage type reserved for harmonic feedback anomaly event used in shield generator logs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
