### PR TITLE
Multistructure power requirement change

### DIFF
--- a/code/game/machinery/multistructure.dm
+++ b/code/game/machinery/multistructure.dm
@@ -50,7 +50,7 @@
 /datum/multistructure
 	var/list/structure = list()
 	var/list/elements = list()
-
+	var/use_power = TRUE // Does this machine need power to work?
 
 /datum/multistructure/Destroy()
 	disconnect_elements()
@@ -92,7 +92,7 @@
 
 /datum/multistructure/proc/is_operational()
 	for(var/obj/machinery/multistructure/part in elements)
-		if((part.stat & BROKEN) || (part.stat & EMPED) || (part.stat & NOPOWER))
+		if((part.stat & BROKEN) || (use_power ? (part.stat & EMPED) : FALSE) || (use_power ? (part.stat & NOPOWER) : FALSE))
 			return FALSE
 	return TRUE
 

--- a/code/modules/biomatter_manipulation/biogenerator.dm
+++ b/code/modules/biomatter_manipulation/biogenerator.dm
@@ -17,6 +17,7 @@
 
 	var/working = FALSE
 	var/last_output_power = 0		//used at UI
+	use_power = FALSE
 
 
 /datum/multistructure/biogenerator/init()

--- a/code/modules/biomatter_manipulation/bioreactor/bioreactor.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/bioreactor.dm
@@ -28,6 +28,7 @@
 	var/chamber_breached = FALSE
 	var/obj/effect/overlay/bioreactor_solution/solution
 
+	use_power = FALSE
 
 /datum/multistructure/bioreactor/connect_elements()
 	..()


### PR DESCRIPTION
## About The Pull Request

The bioreactor and biogenerator no longer require power to work, putting them inline with all other NeoTheology technology. (The biogenerator *produces* power, why did it need it to work?)

## Why It's Good For The Game

Bugfix good

## Testing

![image](https://github.com/discordia-space/CEV-Eris/assets/61586732/0619916a-4733-46ea-9481-ad18297eb96e)

## Changelog
:cl:
fix: bioreactor and biogenerator no longer need power
/:cl: