### PR TITLE
Club Showcase Now Includes Food

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -970,15 +970,15 @@
 	auto_price = FALSE
 
 /obj/machinery/vending/drink_showcase
-	name = "Club Cocktail Showcase"
-	desc = "A vending machine to showcase cocktails."
+	name = "Club Showcase"
+	desc = "A vending machine to showcase cocktails and meals."
 	icon_state = "showcase"
 	var/icon_fill = "showcase-fill"
 	vend_delay = 15
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 	vendor_department = DEPARTMENT_CIVILIAN
 	custom_vendor = TRUE
-	can_stock = list(/obj/item/reagent_containers/glass, /obj/item/reagent_containers/food/drinks, /obj/item/reagent_containers/food/condiment)
+	can_stock = list(/obj/item/reagent_containers/glass, /obj/item/reagent_containers/food)
 
 /obj/machinery/vending/drink_showcase/update_icon()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Club showcase now includes food.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People constantly break into the club to eat raw meat off the floor like animals. Worker decides to go take a piss, and within two minutes the door is broken in, the microwave is destroyed, and all the meat was eaten. Raisins litter the floor. The vagabond opens fire on the club worker immediately for being caught stealing 12credits worth of food. Really just a bad time.

This at least lets the club load up the vendor with more than drinks. They can mass produce cheap easy meals and put them into the showcase as a sort of snack vendor, as currently none exist. Hopefully this'll be used to reduce the number of club break ins that drive club players away from actually playing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![7ZStJDFtVT](https://github.com/discordia-space/CEV-Eris/assets/11076040/eac36606-6c38-4f99-96ab-2a2a0cbb974a)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: tweaked Club Showcase to allow whole food items as well as drinks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
