### PR TITLE
Make resuscitator no longer work on synthetic hearts and work only on inject

### DIFF
--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -542,8 +542,10 @@
 	affects_dead = TRUE
 	reagent_type = "Medicine"
 
-/datum/reagent/resuscitator/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/resuscitator/affect_ingest(mob/living/carbon/M, var/alien, effect_multiplier)
+	return // since it's a "cardiac stimulant" it shouldn't really work unless injected
 
+/datum/reagent/resuscitator/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/internal/vital/heart/heart = H.random_organ_by_process(OP_HEART)
@@ -552,7 +554,8 @@
 			if(prob(30))
 				to_chat(H, SPAN_DANGER("Your heart feels like it's going to tear itself out of you!"))
 		if(H.stat == DEAD)
-			H.resuscitate()
+			if(!BP_IS_ROBOTIC(heart) // neither it should work on robotic hearts, chemistry n' stuff
+				H.resuscitate()
 
 /datum/reagent/resuscitator/overdose(mob/living/carbon/M, alien)
 	. = ..()

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -549,13 +549,14 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/internal/vital/heart/heart = H.random_organ_by_process(OP_HEART)
+		if(BP_IS_ROBOTIC(heart)) // neither it should work on robotic hearts, chemistry and stuf
+			return
 		if(heart)
 			heart.damage += 0.5
 			if(prob(30))
 				to_chat(H, SPAN_DANGER("Your heart feels like it's going to tear itself out of you!"))
 		if(H.stat == DEAD)
-			if(!BP_IS_ROBOTIC(heart) // neither it should work on robotic hearts, chemistry n' stuff
-				H.resuscitate()
+			H.resuscitate()
 
 /datum/reagent/resuscitator/overdose(mob/living/carbon/M, alien)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a `return` on `affect_ingest` for resuscitator and adds a check on if the heart is robotic, returns if that is true.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
In cool movies when main heroes need to "revive" someone they give him adrenaline - not with a pill but with an injection, which is incredibly cool and reviving people with a cardiac stimulant "pill" doesn't make sense to me.

I also do not think it should affect robotic hearts due to chemical incompatibility. Yes, this is a FBP nerf. And anyone else who takes a robotic heart.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

https://github.com/discordia-space/CEV-Eris/assets/57810301/0ed5a8ba-f35e-4c9b-bce8-5943e74bf28e


<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
balance: Resuscitator now needs to be injected to work
balance: Resuscitator no longer revives people with robotic hearts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
