### PR TITLE
Fix qdel of implants when slimed

### DIFF
--- a/code/modules/organs/external/subtypes/robotic.dm
+++ b/code/modules/organs/external/subtypes/robotic.dm
@@ -38,6 +38,10 @@
 /obj/item/organ/external/robotic/removed()
 	deactivate(emergency=TRUE)
 	..()
+	
+/obj/item/organ/external/robotic/dropped()
+	removed()
+	..()
 
 /obj/item/organ/external/robotic/setBleeding()
 	return FALSE

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -532,8 +532,11 @@
 /datum/reagent/toxin/slimetoxin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(H.species.name != SPECIES_SLIME)
+		if(H.species.name != SPECIES_SLIME && !H.isSynthetic()) //cannot transform if already a slime perosn or lack flesh to transform
 			to_chat(M, SPAN_DANGER("Your flesh rapidly mutates!"))
+			for(var/obj/item/W in H) //Check all items on the person
+				if(istype(W, /obj/item/organ/external/robotic)) //drop prosthetic limbs, you are a slime now. Implants will still stay on though
+					W.dropped()
 			H.set_species(SPECIES_SLIME)
 
 /datum/reagent/toxin/aslimetoxin
@@ -546,7 +549,11 @@
 
 /datum/reagent/toxin/aslimetoxin/affect_blood(mob/living/carbon/M, alien, effect_multiplier) // TODO: check if there's similar code anywhere else
 	var/cruciformed = FALSE
-	var/prosthetic = M.isSynthetic()
+	var/prosthetic = FALSE
+	var/mob/living/carbon/human/MH
+	if(istype(M, /mob/living/carbon/human)) //If it is human cast to human type for human procs
+		MH = M 
+		prosthetic = MH.isSynthetic()
 	if(HAS_TRANSFORMATION_MOVEMENT_HANDLER(M))
 		return
 	if(!prosthetic) //Check if is not FBP
@@ -577,7 +584,6 @@
 		else //if victim was cruciformed, gib the body instead of creating a slime. Deus saves
 			M.gib()
 	else
-		var/mob/living/carbon/human/MH = M //Because I don't know how to cast objects in BYOND
 		MH.vomit() //Otherwise the toxin spams as the body attempts to process it. Gets it out of the system quickly and we can stop trying to process this.
 
 /datum/reagent/other/xenomicrobes

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -545,29 +545,40 @@
 	color = "#13BC5E"
 
 /datum/reagent/toxin/aslimetoxin/affect_blood(mob/living/carbon/M, alien, effect_multiplier) // TODO: check if there's similar code anywhere else
+	var/cruciformed = FALSE
+	var/prosthetic = M.isSynthetic()
 	if(HAS_TRANSFORMATION_MOVEMENT_HANDLER(M))
 		return
-	to_chat(M, SPAN_DANGER("Your flesh rapidly mutates!"))
-	ADD_TRANSFORMATION_MOVEMENT_HANDLER(M)
-	M.canmove = 0
-	M.icon = null
-	M.overlays.Cut()
-	M.invisibility = 101
-	for(var/obj/item/W in M)
-		if(istype(W, /obj/item/implant)) //TODO: Carn. give implants a dropped() or something
-			qdel(W)
-			continue
-		W.layer = initial(W.layer)
-		W.loc = M.loc
-		W.dropped(M)
-	var/mob/living/carbon/slime/new_mob = new /mob/living/carbon/slime(M.loc)
-	new_mob.a_intent = "hurt"
-	new_mob.universal_speak = 1
-	if(M.mind)
-		M.mind.transfer_to(new_mob)
+	if(!prosthetic) //Check if is not FBP
+		to_chat(M, SPAN_DANGER("Your flesh rapidly mutates!"))
+		ADD_TRANSFORMATION_MOVEMENT_HANDLER(M)
+		M.canmove = 0
+		M.icon = null
+		M.overlays.Cut()
+		M.invisibility = 101
+		for(var/obj/item/W in M) //for every item in a entity including internal components and inventory
+			if(istype(W, /obj/item/implant) || istype(W, /obj/item/organ/external/robotic))  //Check if item is implant or prosthetic
+				if(istype(W, /obj/item/implant/core_implant/cruciform)) //If cruciform is present victim is gibbed instead of transformed
+					cruciformed = TRUE
+				W.dropped() //use the baseline dropped() 
+				continue
+			W.layer = initial(W.layer)
+			W.loc = M.loc
+			W.dropped(M)
+		if(!cruciformed) //If not cruciformed, get slimed
+			var/mob/living/carbon/slime/new_mob = new /mob/living/carbon/slime(M.loc)
+			new_mob.a_intent = "hurt"
+			new_mob.universal_speak = 1
+			if(M.mind)
+				M.mind.transfer_to(new_mob)
+			else
+				new_mob.key = M.key
+			qdel(M)
+		else //if victim was cruciformed, gib the body instead of creating a slime. Deus saves
+			M.gib()
 	else
-		new_mob.key = M.key
-	qdel(M)
+		var/mob/living/carbon/human/MH = M //Because I don't know how to cast objects in BYOND
+		MH.vomit() //Otherwise the toxin spams as the body attempts to process it. Gets it out of the system quickly and we can stop trying to process this.
 
 /datum/reagent/other/xenomicrobes
 	name = "Xenomicrobes"

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -532,12 +532,16 @@
 /datum/reagent/toxin/slimetoxin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
+		var/list/implants = list() //Create an empty list to store implants
 		if(H.species.name != SPECIES_SLIME && !H.isSynthetic()) //cannot transform if already a slime perosn or lack flesh to transform
-			to_chat(M, SPAN_DANGER("Your flesh rapidly mutates!"))
-			for(var/obj/item/W in H) //Check all items on the person
-				if(istype(W, /obj/item/organ/external/robotic)) //drop prosthetic limbs, you are a slime now. Implants will still stay on though
-					W.dropped()
-			H.set_species(SPECIES_SLIME)
+			if(istype(H.get_core_implant(), /obj/item/implant/core_implant/cruciform))
+				H.gib() //Deus saves
+			else
+				to_chat(M, SPAN_DANGER("Your flesh rapidly mutates!"))
+				for(var/obj/item/W in H) //Check all items on the person
+					if(istype(W, /obj/item/organ/external/robotic) || istype(W, /obj/item/implant)) //drop prosthetic limbs and implants, you are a slime now. 
+						W.dropped()
+				H.set_species(SPECIES_SLIME)
 
 /datum/reagent/toxin/aslimetoxin
 	name = "Advanced Mutation Toxin"

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -532,7 +532,6 @@
 /datum/reagent/toxin/slimetoxin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		var/list/implants = list() //Create an empty list to store implants
 		if(H.species.name != SPECIES_SLIME && !H.isSynthetic()) //cannot transform if already a slime perosn or lack flesh to transform
 			if(istype(H.get_core_implant(), /obj/item/implant/core_implant/cruciform))
 				H.gib() //Deus saves


### PR DESCRIPTION
Fixes the qdel effect on implants and prosthesis after processing advanced slime mutation toxin When processed all implants and prosthetic components are dropped FBPs just puke up the toxin.
Adds function that prosthetic limbs are dropped when transformed into a slime person, unless an FBP

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the TODO where implants and prosthetic external organs are deleted after being transformed by the advanced slime mutation toxin. All implants and prosthetic organs are dropped at the location of the transformation. 

- In cases where the victim has no organic parts (FBPs) they instead vomit up the contents of their stomach to reduce processing effects as quickly as possible.
- In the case of cruciform holders, the victim is gibbed but the cruciform drops with their soul intact so they can be revived.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Implants and prosthetic body parts are no longer lost to the void when a person is slimed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tested by

- Injecting a cruciformed human with advanced mutation toxin and then reviving them via the Clone pod to ensure that appearances were persisted
- Injecting an augmented human with either slime mutation or advanced slime mutation toxin and ensuring that all prosthetic limbs and organs dropped after the transformation
- Injecting a human with an excelsior implant with either regular or advanced slime mutation toxin and ensuring that the implant dropped after transformation
- Injecting a monkey
- Ingesting advanced mutation toxin as an FBP using Asters parts
- Ingesting advanced mutation toxin as an FBP using Moebius parts
- Ingesting advanced mutation toxin as an FBP using Homebrew parts

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
balance: FBPs can no longer be turned into grey slimes. Cruciformed humans are gibbed but not transformed.
fix: Implants and prosthetics are not deleted by transforming into a grey slime or a slimeperson. They will instead be dropped on the ground.
code: added a dropped() implementation for prosthetic limbs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
