### PR TITLE
Pulling something adds fingerprints

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -795,6 +795,10 @@ default behaviour is:
 	if (!AM || !usr || src==AM || !isturf(src.loc))	//if there's no person pulling OR the person is pulling themself OR the object being pulled is inside something: abort!
 		return
 
+	if(isobj(AM)) // even if we fail all the checks assume they touched the thing
+		AM.add_fingerprint(usr)
+		message_admins("[AM] now has [usr] fingeprints because he pulled it.")
+
 	if (AM.anchored)
 		to_chat(src, "<span class='warning'>It won't budge!</span>")
 		return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -797,7 +797,6 @@ default behaviour is:
 
 	if(isobj(AM)) // even if we fail all the checks assume they touched the thing
 		AM.add_fingerprint(usr)
-		message_admins("[AM] now has [usr] fingeprints because he pulled it.")
 
 	if (AM.anchored)
 		to_chat(src, "<span class='warning'>It won't budge!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds an `add_fingerprint` proc after an `ifobj` check after earlier sanity checks - even if you fail trying to pull an item you logically touched it. `ifobj` check is there because in normal gameplay only objects get fingerprints
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sorry I don't have that image where an assistant carries two toolboxes and pulls a corpse using his buttcheeks with "this is realistic" caption. It makes sense for you to leave fingerprints on objects you try to drag.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

https://github.com/discordia-space/CEV-Eris/assets/57810301/7881e978-7662-408f-aeef-15f3ec1c5c2d


<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
add: You now leave fingerprints on objects you (try to) pull.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
