### PR TITLE
Fixes Roundstart walls looking damaged

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -60,7 +60,7 @@
 		var/overlayCount = 16
 		var/alpha_inc = 256 / overlayCount
 
-		for(var/i = 1; i <= overlayCount; i++)
+		for(var/i = 0; i <= overlayCount; i++)
 			var/image/img = image(icon = 'icons/turf/walls.dmi', icon_state = "overlay_damage")
 			img.blend_mode = BLEND_MULTIPLY
 			img.alpha = (i * alpha_inc) - 1


### PR DESCRIPTION
makes the alpha start at invisible

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
this fixes walls having damage overlays (looking damaged) roundstart.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
walls now look like they are supposed to
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
i compiled, then stared at a wall closely and noticed no damage overlay
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: fixed walls looking damaged roundstart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
