### PR TITLE
fix calling parent proc for roachsign

### DIFF
--- a/code/game/objects/structures/roachsign.dm
+++ b/code/game/objects/structures/roachsign.dm
@@ -8,4 +8,5 @@
 	layer = SIGN_LAYER
 
 /obj/structure/roachsign/Initialize()
+	. = ..()
 	set_light(2, 2, "#82C2D8")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

make roachsign marked as initialized in atom subsystem log so no plane issue if mapped near open space

see this : https://github.com/discordia-space/CEV-Eris/pull/8307

## Testing

tested, planes are normal

## Changelog
:cl: Twomoon
fix: fixed roah sign parent proc magic
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
