### PR TITLE
Fix accessories being added to pockets

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -98,5 +98,6 @@
 	..(over_object)
 
 /obj/item/clothing/suit/space/medicus/attackby(obj/item/W, mob/user)
+	if(!istype(W, /obj/item/clothing/accessory)) // Do not put accessories into pockets
+		pockets.attackby(W, user)
 	..()
-	pockets.attackby(W, user)

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -447,8 +447,9 @@
 	..(over_object)
 
 /obj/item/clothing/suit/space/void/riggedvoidsuit/attackby(obj/item/W, mob/user)
+	if(!istype(W, /obj/item/clothing/accessory)) // Do not put accessories into pockets
+		pockets.attackby(W, user)
 	..()
-	pockets.attackby(W, user)
 
 /obj/item/clothing/suit/space/void/riggedvoidsuit/emp_act(severity)
 	pockets.emp_act(severity)

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -26,8 +26,9 @@
 	..(over_object)
 
 /obj/item/clothing/suit/storage/attackby(obj/item/W, mob/user)
+	if(!istype(W, /obj/item/clothing/accessory)) // Do not put accessories into pockets
+		pockets.attackby(W, user)
 	..()
-	pockets.attackby(W, user)
 
 /obj/item/clothing/suit/storage/emp_act(severity)
 	pockets.emp_act(severity)


### PR DESCRIPTION
## About The Pull Request

Accessories added to suits with pockets no longer take up space in pockets.

## Why It's Good For The Game

Bugfix good.

## Testing

Before:

![image](https://github.com/discordia-space/CEV-Eris/assets/65828539/4590538e-e39f-445b-8b1a-804d0a453290)

After:

![image](https://github.com/discordia-space/CEV-Eris/assets/65828539/a2e0e061-d50f-4931-91ee-081204c67ee8)

## Changelog
:cl:
fix: Fixed accessories added to suits with pockets taking up space in said pockets.
/:cl: