### PR TITLE
Revert "Quickequip hotfix"

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -14,7 +14,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 	var/target_slot = get_quick_slot(I)
 	if(I.pre_equip(usr, target_slot))
 		return
-	if(!equip_to_slot_if_possible(I, target_slot, disable_warning = TRUE, redraw_mob = TRUE))
+	if(!I.try_transfer(target_slot, usr))
 		quick_equip_storage(I)
 	/*
 	if(!equip_to_appropriate_slot(I))


### PR DESCRIPTION
## About The Pull Request

Reverts discordia-space/CEV-Eris#8219

## Why It's Good For The Game

That hotfix caused clothing equip timer to be called twice, effectively doubling the time it takes to put something on, which is very inconvenient. Especially when it comes to armor.

## Testing

Launched local server with these changes, failed to reproduce the bug that hotfix claims to fix.

## Changelog
:cl:
Fix: Fixed clothing pre_equip() being called twice, doubling the time it takes to put something on.
/:cl: