### PR TITLE
add vscode configuration for prettier

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,33 @@
+{
+	"prettier.prettierPath": "./tgui/.yarn/sdks/prettier/index.js",
+	"typescript.tsdk": "./tgui/.yarn/sdks/typescipt/lib",
+	"typescript.enablePromptUseWorkspaceTsdk": true,
+	"[javascript]": {
+		"editor.rulers": [80],
+		"editor.defaultFormatter": "esbenp.prettier-vscode",
+		"editor.formatOnSave": true
+	},
+	"[javascriptreact]": {
+		"editor.rulers": [80],
+		"editor.defaultFormatter": "esbenp.prettier-vscode",
+		"editor.formatOnSave": true
+	},
+	"[typescript]": {
+		"editor.rulers": [80],
+		"editor.defaultFormatter": "esbenp.prettier-vscode",
+		"editor.formatOnSave": true
+	},
+	"[typescriptreact]": {
+		"editor.rulers": [80],
+		"editor.defaultFormatter": "esbenp.prettier-vscode",
+		"editor.formatOnSave": true
+	},
+	"[scss]": {
+		"editor.rulers": [80],
+		"editor.defaultFormatter": "esbenp.prettier-vscode",
+		"editor.formatOnSave": true
+	},
+	"files.associations": {
+		"*.dmi": "dmiEditor.dmiEditor"
+	}
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
 	"prettier.prettierPath": "./tgui/.yarn/sdks/prettier/index.js",
-	"typescript.tsdk": "./tgui/.yarn/sdks/typescipt/lib",
-	"typescript.enablePromptUseWorkspaceTsdk": true,
 	"[javascript]": {
 		"editor.rulers": [80],
 		"editor.defaultFormatter": "esbenp.prettier-vscode",


### PR DESCRIPTION
## About The Pull Request

Thanks to LetterN we have one of the most miserable TGUI ports i've ever seen, the one was removed four years ago was better. Anyway, prettier plugin for VSC is used on TG to format code, i use it in my personal projects too, but here, in this repo it didn't work 'cause one unnamed moron didn't configure it properly. I did it, please merge.

## Why It's Good For The Game

It's good for coders because this repo enforces to use prettier that is **broken by default**.

## Testing

Prettier for VSC **FINALLY** works as intended.
