### PR TITLE
Mapping disk smartfridges

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -19900,16 +19900,7 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "aWV" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/material/plastic{
-	amount = 120
-	},
-/obj/item/stack/material/steel{
-	amount = 120
-	},
-/obj/item/stack/material/steel{
-	amount = 120
-	},
+/obj/machinery/smartfridge/disks,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/security/warden)
 "aWW" = (
@@ -21192,6 +21183,15 @@
 /obj/item/computer_hardware/hard_drive/portable/design/misc,
 /obj/item/computer_hardware/hard_drive/portable/design/security,
 /obj/item/reagent_containers/glass/beaker,
+/obj/item/stack/material/steel{
+	amount = 120
+	},
+/obj/item/stack/material/steel{
+	amount = 120
+	},
+/obj/item/stack/material/plastic{
+	amount = 120
+	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/security/warden)
 "aZH" = (
@@ -27448,6 +27448,7 @@
 /area/eris/rnd/lab)
 "bnd" = (
 /obj/machinery/light,
+/obj/machinery/smartfridge/disks,
 /turf/simulated/floor/tiled/dark,
 /area/eris/rnd/lab)
 "bne" = (
@@ -51967,9 +51968,12 @@
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/eris/maintenance/oldtele)
 "cvg" = (
-/obj/structure/table/standard,
-/obj/item/computer_hardware/hard_drive/portable/design/nonlethal_ammo,
-/obj/item/device/scanner/price,
+/obj/item/computer_hardware/hard_drive/portable/design/medical,
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/item/computer_hardware/hard_drive/portable/design/devices,
+/obj/item/computer_hardware/hard_drive/portable/design/tools,
+/obj/item/computer_hardware/hard_drive/portable/design/conveyors,
+/obj/machinery/smartfridge/disks,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/quartermaster/storage)
 "cvi" = (
@@ -54091,12 +54095,9 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/churchcorridor)
 "cAt" = (
+/obj/item/computer_hardware/hard_drive/portable/design/nonlethal_ammo,
+/obj/item/device/scanner/price,
 /obj/structure/table/standard,
-/obj/item/computer_hardware/hard_drive/portable/design/medical,
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/obj/item/computer_hardware/hard_drive/portable/design/devices,
-/obj/item/computer_hardware/hard_drive/portable/design/tools,
-/obj/item/computer_hardware/hard_drive/portable/design/conveyors,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/quartermaster/storage)
 "cAv" = (
@@ -58255,7 +58256,6 @@
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/command/exultant)
 "cKI" = (
-/obj/structure/table/rack,
 /obj/item/computer_hardware/hard_drive/portable/design/misc,
 /obj/item/computer_hardware/hard_drive/portable/design/tools,
 /obj/item/computer_hardware/hard_drive/portable/design/devices,
@@ -58263,6 +58263,7 @@
 /obj/item/computer_hardware/hard_drive/portable/design/conveyors,
 /obj/item/computer_hardware/hard_drive/portable/design/circuits,
 /obj/item/computer_hardware/hard_drive/portable/design/adv_tools,
+/obj/machinery/smartfridge/disks,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/engineering/breakroom)
 "cKJ" = (
@@ -84436,7 +84437,7 @@
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/research)
 "dXA" = (
-/obj/structure/table/standard,
+/obj/machinery/smartfridge/disks,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/storage/primary)
 "dXB" = (
@@ -104283,7 +104284,7 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/neotheology/storage)
 "qJx" = (
-/obj/structure/table/standard,
+/obj/machinery/smartfridge/disks,
 /turf/simulated/floor/tiled/white/golden,
 /area/eris/crew_quarters/kitchen_storage)
 "qKj" = (
@@ -105169,13 +105170,13 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
 "sPZ" = (
-/obj/structure/table/standard,
 /obj/item/computer_hardware/hard_drive/portable/design/nt_melee,
 /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter_clothes,
 /obj/item/device/radio/intercom{
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/machinery/smartfridge/disks,
 /turf/simulated/floor/tiled/white/golden,
 /area/eris/neotheology/bioprinter)
 "sRC" = (
@@ -169376,7 +169377,7 @@ aaB
 aSt
 aTa
 aSx
-aWV
+aTa
 aZG
 aUh
 aSG
@@ -169578,7 +169579,7 @@ aQC
 aaJ
 aTa
 aSy
-aTa
+aWV
 aTx
 aVa
 aSS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Finally mapping in disc smartfridges I added a year ago.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Convenient<sup>tm</sup> storage.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![cargo](https://github.com/discordia-space/CEV-Eris/assets/62264115/693b87d2-67fa-4078-97d0-aee0bf7ab78a)
![club](https://github.com/discordia-space/CEV-Eris/assets/62264115/d9f31d32-451e-435c-ac15-38147691433a)
![cruch](https://github.com/discordia-space/CEV-Eris/assets/62264115/52ce5e6f-8b60-4109-9f82-685a4cb33404)
![engi](https://github.com/discordia-space/CEV-Eris/assets/62264115/92328bec-674b-4c6f-a32e-b59a0acddde3)
![hammer](https://github.com/discordia-space/CEV-Eris/assets/62264115/67c723dd-e67f-4c27-aea1-e5d5ade1daaa)
![public](https://github.com/discordia-space/CEV-Eris/assets/62264115/7d62bd57-1cc5-4f3a-9b62-61f240a3d4d9)
![sci](https://github.com/discordia-space/CEV-Eris/assets/62264115/e87da683-4236-4dbd-b24f-2771c90e4804)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
add: Added disk smartfridge next to each lathe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
