### PR TITLE
Adjust Evac Voting Values

### DIFF
--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -158,7 +158,7 @@
 	name = "Initiate Bluespace Jump"
 	question = "Do you want to initiate a bluespace jump and restart the round?"
 	time = 120
-	minimum_win_percentage = 0.6
+	minimum_win_percentage = 0.55
 	cooldown = 20 MINUTES
 	next_vote = 90 MINUTES //Minimum round length before it can be called for the first time
 	choice_types = list()
@@ -166,12 +166,12 @@
 
 /*To prevent abuse and rule-by-salt, the evac vote weights each player's vote based on a few parameters
 	If you are alive and have been for a while, then you have the normal 1 vote
-	If you are dead, or just spawned, you get only 0.3 votes
-	If you are an antag or a head of staff, you get 2 votes
+	If you are dead, or just spawned, you get only 0.5 votes
+	If you are an antag or a head of staff, you get 1.5 votes
 */
-#define VOTE_WEIGHT_LOW	0.3
+#define VOTE_WEIGHT_LOW	0.5
 #define VOTE_WEIGHT_NORMAL	1
-#define VOTE_WEIGHT_HIGH	2
+#define VOTE_WEIGHT_HIGH	1.5
 #define MINIMUM_VOTE_LIFETIME	15 MINUTES
 /datum/poll/evac
 	choice_types = list(/datum/vote_choice/evac, /datum/vote_choice/noevac)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Getting folks to stick around as ghosts (either to wait for the next round, or to become a ghost antag, or just observe) is difficult with round duration averages passing the four hour mark. So I gave ghosts lightly more power, and Command/Antags slightly less power.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
During rounds where something actually happens, there's usually a big ol' firefight between two factions, a bunch of people die. Sometimes there isn't even an antag involved. The round hit it's climax for most players, many of them dying. Many of the players are satisfied, the story ridden to it's conclusion.

Problem is, that one MEO who hasn't left RnD and that one carrion who has been deep maint diving for 3 hours voted NO to Evac, so now the 13 players who are dead have to sit there and watch these two numbskulls do absolutely nothing because they decided to not participate with other players and just play solo minecraft.

13 dead players is 3.9 voting strength. The MEO and one carrion is 4 voting strength. So two players overcame 13 dead players. And that's at a simple 50/50 split. If we actually take the 60% majority needed to leave into consideration, there would need to be over 18 dead players to out-vote TWO PEOPLE. This is simply madness. It isn't "salt vote" or "ided" at that point. Especially since command staff, once dead, then have a .3 vote regardless.

This isn't the american voting system. Players are players, regardless of whether they're a ghost or not. They deserve to have more of a say.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![dreamseeker_puneV4Gkwo](https://github.com/discordia-space/CEV-Eris/assets/11076040/1ea05579-f085-4e54-9b67-6ece175f67f7)
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: Increased dead vote
tweak: Decreased Command/Antag vote
tweak: Balanced Majority Value to 55%
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
