### PR TITLE
[BOUNTY] Quick-equipped items go into open inventories

### DIFF
--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -118,6 +118,12 @@ var/list/_client_preferences_by_type
 	description ="Play jukebox music"
 	key = "SOUND_JUKEBOX"
 
+/datum/client_preference/play_jukebox/changed(var/mob/preference_mob, var/new_value)
+	if(new_value == GLOB.PREF_NO)
+		preference_mob.stop_all_music()
+	else
+		preference_mob.update_music()
+
 /datum/client_preference/play_local_tts
 	description ="Play local text-to-speech"
 	key = "TTS_VOLUME_LOCAL"
@@ -241,12 +247,6 @@ var/list/_client_preferences_by_type
 	description = "Enable gun crosshair"
 	key = "GUN_CURSOR"
 
-/datum/client_preference/play_jukebox/changed(var/mob/preference_mob, var/new_value)
-	if(new_value == GLOB.PREF_NO)
-		preference_mob.stop_all_music()
-	else
-		preference_mob.update_music()
-
 /datum/client_preference/stay_in_hotkey_mode
 	description = "Keep hotkeys on mob change"
 	key = "KEEP_HOTKEY_MODE"
@@ -269,6 +269,11 @@ var/list/_client_preferences_by_type
 	for (var/datum/tgui/tgui as anything in preference_mob?.tgui_open_uis)
 		// Force it to reload either way
 		tgui.update_static_data(preference_mob)
+
+/datum/client_preference/equip_open_inventory
+	description = "Quick-equip to open inventories"
+	key = "EQUIP_OPEN_INVENTORY"
+	default_value = GLOB.PREF_YES
 
 /********************
 * General Staff Preferences *

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -273,7 +273,7 @@ var/list/_client_preferences_by_type
 /datum/client_preference/equip_open_inventory
 	description = "Quick-equip stores items into open inventories"
 	key = "EQUIP_OPEN_INVENTORY"
-	default_value = GLOB.PREF_YES
+	default_value = GLOB.PREF_NO
 
 /********************
 * General Staff Preferences *

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -271,7 +271,7 @@ var/list/_client_preferences_by_type
 		tgui.update_static_data(preference_mob)
 
 /datum/client_preference/equip_open_inventory
-	description = "Quick-equip to open inventories"
+	description = "Quick-equip stores items into open inventories"
 	key = "EQUIP_OPEN_INVENTORY"
 	default_value = GLOB.PREF_YES
 

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -17,7 +17,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 	if(I.pre_equip(usr, target_slot))
 		return
 
-	if(s_active)
+	if((get_preference_value(/datum/client_preference/equip_open_inventory) == GLOB.PREF_YES) && s_active)
 		s_active.attackby(I, src)
 
 	if(!I.try_transfer(target_slot, usr))

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -11,9 +11,15 @@ This saves us from having to call add_fingerprint() any time something is put in
 	if(!I)
 		to_chat(src, SPAN_NOTICE("You are not holding anything to equip."))
 		return
+
+
 	var/target_slot = get_quick_slot(I)
 	if(I.pre_equip(usr, target_slot))
 		return
+
+	if(s_active)
+		s_active.attackby(I, src)
+
 	if(!I.try_transfer(target_slot, usr))
 		quick_equip_storage(I)
 	/*


### PR DESCRIPTION
## About The Pull Request

If you have an inventory open (e.g. a backpack) and you quick-equip, it goes into that inventory.

I could move this into a special preference, if that's desired.

## Why It's Good For The Game

Quality of life feature.

## Testing

Open your backpack
Quick-equip some boots
It goes into the backpack

Close your backpack
Quick-equip some boots
It goes onto your feet

## Changelog
:cl:
add: Quick-equipped items go into open inventories (e.g. an open backpack).
/:cl: