### PR TITLE
The long awaited proper fix for SSchunks tracking going wrong

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -499,6 +499,7 @@
 	/// Why isn't it just eject ? because it somehow breaks SSchunks. ForceMoving out of these does not get registered properly
 	/// The mob does NOT have a LOC when it gets done by eject() , but this way it does for its forceMove() when we call go_out() from here
 	/// I dont know why it is this way , blame Byond ? - SPCR 2023
+	/// I figured it out... its because it used to remove the mob to eject from its contents before actually ejecting them , causing their loc to be null..
 	if(occupant)
 		var/list/items_to_give = contents
 		items_to_give -= announce

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -495,8 +495,17 @@
 
 	return
 
-/obj/machinery/cryopod/relaymove(var/mob/user)
-	eject()
+/obj/machinery/cryopod/relaymove(mob/user)
+	/// Why isn't it just eject ? because it somehow breaks SSchunks. ForceMoving out of these does not get registered properly
+	/// The mob does NOT have a LOC when it gets done by eject() , but this way it does for its forceMove() when we call go_out() from here
+	/// I dont know why it is this way , blame Byond ? - SPCR 2023
+	if(occupant)
+		var/list/items_to_give = contents
+		items_to_give -= announce
+		for(var/obj/item/W in items_to_give)
+			W.forceMove(get_turf(src))
+			occupant.equip_to_appropriate_slot(W) // Items are now ejected. Tries to put them items on the occupant so they don't leave them behind
+		go_out()
 
 
 /obj/machinery/cryopod/proc/go_out()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR fixes SSchunks tracking failing for everyone spawning from cryopods(and as thus not being targeted by roaches)
Root of the issue is still unknown , i just tried something and it didnt happen anymore on local so i guess thats it

Edit : I figured out the root , cryogenics would create a list of stuff to eject and remove the mob and radio from it , causing their location to get set to null (hence , confusing SSchunks on where the mob really is and as thus never updating properly from it)

## Why It's Good For The Game
Roaches no longer ignore cryogenically stored people

## Testing 
Ran on local

## Changelog
:cl:
fix: Fixed SSchunk tracking going wrong for everyone waking out of cryo pods.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
