### PR TITLE
Fixes holoposters turning invisible

### DIFF
--- a/code/game/machinery/holoposter.dm
+++ b/code/game/machinery/holoposter.dm
@@ -49,8 +49,13 @@
 	if(stat & (NOPOWER))
 		return
 	if (istype(W, /obj/item/tool/multitool))
+		var/selected_icon_state
 		playsound(user.loc, 'sound/items/multitool_pulse.ogg', 60, 1)
-		icon_state = input("Available Posters", "Holographic Poster") as null|anything in  postertypes + "random"
+		selected_icon_state = input("Available Posters", "Holographic Poster") as null|anything in  postertypes + "random"
+		if(!selected_icon_state)
+			return
+		else
+			icon_state = selected_icon_state
 		if(icon_state == "random")
 			stat &= ~BROKEN
 			icon_forced = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #7627 by checking if the value returned by the input() proc is null (meaning that the user cancelled the action),
and only setting the icon state if it isn't.

Also, I've been thinking about converting this to tgui to learn how to convert UIs properly, yah or nah?
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix good 👍 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Clicked a holoposter with a multitool, tested all default options, as well as random and cancelled the action.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chasu
fix: Holoposters no longer turn invisible after multitool interaction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
