### PR TITLE
Mech equipment can now be used with an open hatch

### DIFF
--- a/code/modules/mechs/interface/screen_objects.dm
+++ b/code/modules/mechs/interface/screen_objects.dm
@@ -117,10 +117,6 @@
 
 /obj/screen/movable/exosuit/hardpoint/Click(var/location, var/control, var/params)
 	if(..() && owner && holding)
-		if(!owner.hatch_closed)
-			to_chat(usr, SPAN_WARNING("Error: Hardpoint interface disabled while [owner.body.hatch_descriptor] is open."))
-			return
-
 		var/modifiers = params2list(params)
 		if(modifiers["ctrl"])
 			if(owner.hardpoints_locked) to_chat(usr, SPAN_WARNING("Hardpoint ejection system is locked."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can now use mech equipment with an open hatch
## Why It's Good For The Game
QoL + approved by firefox

## Testing
Ran a local server , used a slayer mech and a light one, equipment functioned as expected.
## Changelog
:cl:
tweak: You can now use mech equipment with an open hatch
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
