### PR TITLE
Add anonymous vote starting, make BSJ vote anonymous by default

### DIFF
--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -56,7 +56,7 @@ SUBSYSTEM_DEF(vote)
 	vote_start_time = world.time
 
 	var/text = "[poll.name] vote started by [(poll.starter_anonymous) ? "Iriska" : "[poll.initiator]"]."
-		log_vote(text)
+	log_vote(text)
 	to_chat(world, {"<font color='purple'><b>[text]</b>\nType <b>vote</b> or click <a href='?src=\ref[src]'>here</a> to place your votes. <br>You have [poll.time] seconds to vote.</font>"})
 	sound_to(world, sound('sound/ambience/alarm4.ogg', repeat = 0, wait = 0, volume = 50, channel = GLOB.vote_sound_channel))
 

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -55,8 +55,8 @@ SUBSYSTEM_DEF(vote)
 
 	vote_start_time = world.time
 
-	var/text = "[poll.name] vote started by [poll.initiator]."
-	log_vote(text)
+	var/text = "[poll.name] vote started by [(poll.starter_anonymous) ? "Iriska" : "[poll.initiator]"]."
+		log_vote(text)
 	to_chat(world, {"<font color='purple'><b>[text]</b>\nType <b>vote</b> or click <a href='?src=\ref[src]'>here</a> to place your votes. <br>You have [poll.time] seconds to vote.</font>"})
 	sound_to(world, sound('sound/ambience/alarm4.ogg', repeat = 0, wait = 0, volume = 50, channel = GLOB.vote_sound_channel))
 
@@ -87,7 +87,15 @@ SUBSYSTEM_DEF(vote)
 	if(active_vote)
 		data += "<h2>Vote: '[active_vote.question]'</h2>"
 		data += "Time Left: [active_vote.time - get_vote_time()] s<br>"
-		data += "Started by: <b>[active_vote.initiator]</b><hr>"
+
+		if(active_vote.starter_anonymous)
+			data += "Started by: <b>Iriska</b>"
+			if(admin)
+				data += " <i>Initiator: <b>[active_vote.initiator]</b></i>"
+			data += "<hr>"
+		else
+			data += "Started by: <b>[active_vote.initiator]</b><hr>"
+
 
 		if(active_vote.multiple_votes)
 			data += "You can vote multiple choices.<br>"

--- a/code/controllers/subsystems/voting/poll.dm
+++ b/code/controllers/subsystems/voting/poll.dm
@@ -10,6 +10,7 @@
 	var/multiple_votes = FALSE
 	var/can_revote = TRUE	//Can voters change their mind?
 	var/can_unvote = FALSE
+	var/starter_anonymous = FALSE   // Do we hide starters name? Admins will still see through this.
 
 	var/see_votes = TRUE	//Can voters see choices votes count?
 

--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -306,8 +306,8 @@
 	if(alert("Should the voters see another voters votes?","Custom vote","Yes","No") == "No")
 		see_votes = FALSE
 
-	if(alert("Should the voters be able to see who initiated the vote? If you're the only admin and not stealthmining, it will be very obvious!","Custom vote","Yes","No") == "Yes")
-		starter_anonymous = TRUE
+	if(alert("Should the voters be able to see who initiated the vote? If you're the only admin and not stealthmining, it will be very obvious!","Custom vote","Yes","No") == "No")
+		starter_anonymous = FALSE
 
 	if(alert("Are you sure you want to continue?","Custom vote","Yes","No") == "No")
 		choices.Cut()

--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -157,6 +157,7 @@
 /datum/poll/evac
 	name = "Initiate Bluespace Jump"
 	question = "Do you want to initiate a bluespace jump and restart the round?"
+	starter_anonymous = TRUE	// For "some" reason people go mad over this particular vote.
 	time = 120
 	minimum_win_percentage = 0.6
 	cooldown = 20 MINUTES
@@ -304,6 +305,9 @@
 
 	if(alert("Should the voters see another voters votes?","Custom vote","Yes","No") == "No")
 		see_votes = FALSE
+
+	if(alert("Should the voters be able to see who initiated the vote? If you're the only admin and not stealthmining, it will be very obvious!","Custom vote","Yes","No") == "Yes")
+		starter_anonymous = TRUE
 
 	if(alert("Are you sure you want to continue?","Custom vote","Yes","No") == "No")
 		choices.Cut()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds `starter_anonymous` variable to votes, that hides vote starter ckey from players, both in chat and vote interface. Admins are able to see it. Adds it to BSJ vote by default. Replacement name is Iriska.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
To prevent harrasment of players who call for BSJ vote when other players don't want to leave yet. If you really don't want to leave, then just press No.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![изображение](https://github.com/discordia-space/CEV-Eris/assets/57810301/6e9db62d-276c-491d-95b5-fb02bea0187b)
![изображение](https://github.com/discordia-space/CEV-Eris/assets/57810301/f450a3bf-5046-4c2e-8424-c4ef7942fae5)
![изображение](https://github.com/discordia-space/CEV-Eris/assets/57810301/4a2c5d35-b271-4149-9393-f56a82cf699f)
![изображение](https://github.com/discordia-space/CEV-Eris/assets/57810301/a5cbb00f-8cdc-47be-a0a6-e29cf313c7a9)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: Bluespace Jump vote starters are now anonymous.
code: Votes now support anonymous starters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
