### PR TITLE
Makes alcohol no longer be toxic by default

### DIFF
--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -1185,7 +1185,6 @@
 	SEND_SIGNAL_OLD(L, COMSIG_CARBON_HAPPY, src, MOB_DELETE_DRUG)
 
 /datum/reagent/alcohol/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
-	M.add_chemical_effect(CE_TOXIN, toxicity * (issmall(M) ? effect_multiplier * 2 : effect_multiplier))
 	M.add_chemical_effect(CE_PAINKILLER, max(35 - (strength / 2), 1))	//Vodka 32.5 painkiller, beer 15
 
 /datum/reagent/alcohol/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes alcohols no longer be toxic by default , Theres proper handling for it present in ethanol/affect_blood

## Why It's Good For The Game
Fixes a sip of vodka magically killing your liver instead of following old behaviour where you need to drink a lot in order to get your liver killed.

## Testing
Ran on local , liver didnt die after 3 bottle sips. Liver started taking damage after 1 full bottle.
## Changelog
:cl:
balance: Alcohols are no longer toxic by default. Toxicity is now handled as before in ethanol/affect_blood
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
