### PR TITLE
Egg Rebalance

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -181,6 +181,7 @@
 			qdel(src)
 
 var/const/MAX_CHICKENS = 50
+#define MEDIUM_CHICKENS 10
 var/global/chicken_count = 0
 
 /mob/living/simple_animal/chicken
@@ -247,8 +248,8 @@ var/global/chicken_count = 0
 		var/obj/item/reagent_containers/food/snacks/egg/E = new(get_turf(src))
 		E.pixel_x = rand(-6,6)
 		E.pixel_y = rand(-6,6)
-		if(chicken_count < MAX_CHICKENS)
-			START_PROCESSING(SSobj, E)
+		if(chicken_count < MEDIUM_CHICKENS || prob(clamp((100/MAX_CHICKENS)*(MAX_CHICKENS-chicken_count), 0, 100)))
+			START_PROCESSING(SSobj, E) // chicken threshold, then chicken ratio, then number of chickens to create
 
 
 /obj/item/reagent_containers/food/snacks/egg/var/amount_grown = 0

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -247,7 +247,7 @@ var/global/chicken_count = 0
 		var/obj/item/reagent_containers/food/snacks/egg/E = new(get_turf(src))
 		E.pixel_x = rand(-6,6)
 		E.pixel_y = rand(-6,6)
-		if(chicken_count < MAX_CHICKENS && prob(10))
+		if(chicken_count < MAX_CHICKENS)
 			START_PROCESSING(SSobj, E)
 
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -668,6 +668,7 @@
 	center_of_mass = list("x"=16, "y"=13)
 	preloaded_reagents = list("egg" = 3)
 	price_tag = 5
+	description_info = "Can have a flashlight used on it to determine if there is a chick inside."
 
 /obj/item/reagent_containers/food/snacks/egg/afterattack(obj/O as obj, mob/user as mob, proximity)
 	if(istype(O,/obj/machinery/microwave))
@@ -698,6 +699,20 @@
 			return
 		to_chat(user, SPAN_NOTICE("You color \the [src] [clr]"))
 		icon_state = "egg-[clr]"
+	else if (istype(W, /obj/item/device/lighting))
+		var/obj/item/device/lighting/light = W
+		if(!light.on)
+			to_chat(usr, SPAN_WARNING("[W] needs to be turned on to reveal the egg's insides."))
+			return
+		switch(amount_grown)
+			if(0 to 10)
+				to_chat(usr, SPAN_NOTICE("[src] appears to be a normal egg."))
+			if(10 to 50)
+				to_chat(usr, SPAN_NOTICE("[src] contains a spidery red mass."))
+			if(50 to 90)
+				to_chat(usr, SPAN_NOTICE("[src] contains a partially-grown chick."))
+			if(90 to 100)
+				to_chat(usr, SPAN_NOTICE("[src] contains a partially-grown chick.\nYou hear a faint tapping emanating from [src]."))
 	else
 		..()
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -699,22 +699,33 @@
 			return
 		to_chat(user, SPAN_NOTICE("You color \the [src] [clr]"))
 		icon_state = "egg-[clr]"
-	else if (istype(W, /obj/item/device/lighting))
-		var/obj/item/device/lighting/light = W
-		if(!light.on)
-			to_chat(usr, SPAN_WARNING("[W] needs to be turned on to reveal the egg's insides."))
-			return
-		switch(amount_grown)
-			if(0 to 10)
-				to_chat(usr, SPAN_NOTICE("[src] appears to be a normal egg."))
-			if(10 to 50)
-				to_chat(usr, SPAN_NOTICE("[src] contains a spidery red mass."))
-			if(50 to 90)
-				to_chat(usr, SPAN_NOTICE("[src] contains a partially-grown chick."))
-			if(90 to 100)
-				to_chat(usr, SPAN_NOTICE("[src] contains a partially-grown chick.\nYou hear a faint tapping emanating from [src]."))
 	else
-		..()
+		var/valid = FALSE
+		if (istype(W, /obj/item/device/lighting))
+			var/obj/item/device/lighting/light = W
+			if(!light.on)
+				to_chat(usr, SPAN_WARNING("[W] needs to be turned on to reveal the egg's insides."))
+				return
+			valid = TRUE
+
+		else if (istype(W, /obj/item/flame))
+			var/obj/item/flame/fire = W
+			if(!fire.lit)
+				to_chat(usr, SPAN_WARNING("[W] needs to be aflame to reveal the egg's insides."))
+				return
+			valid = TRUE
+		if(valid)
+			switch(amount_grown)
+				if(0 to 10)
+					to_chat(usr, SPAN_NOTICE("[src] appears to be a normal egg."))
+				if(10 to 50)
+					to_chat(usr, SPAN_NOTICE("[src] contains a spidery red mass."))
+				if(50 to 90)
+					to_chat(usr, SPAN_NOTICE("[src] contains a partially-grown chick."))
+				if(90 to 100)
+					to_chat(usr, SPAN_NOTICE("[src] contains a partially-grown chick.\nYou hear a faint tapping emanating from [src]."))
+		else
+			..()
 
 /obj/item/reagent_containers/food/snacks/egg/blue
 	icon_state = "egg-blue"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -723,7 +723,7 @@
 				if(50 to 90)
 					to_chat(usr, SPAN_NOTICE("[src] contains a partially-grown chick."))
 				if(90 to 100)
-					to_chat(usr, SPAN_NOTICE("[src] contains a partially-grown chick.\nYou hear a faint tapping emanating from [src]."))
+					to_chat(usr, SPAN_NOTICE("[src] contains a partially-grown chick.\nYou hear a faint tapping emanating from \the [src]."))
 		else
 			..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes the first few eggs start fertile, and after that eggs are less likely to be fertile depending on the number of chickens. This PR also adds a new "candling" mechanic which allows for progress monitoring of eggs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Farming Chickens is currently rather difficult, as only one in ten eggs can hatch, and it is invisible which are which; this PR solves those issues both by making eggs start more likely to hatch, and by making it possible to tell if eggs have begun to grow.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
spawned a chicken, fed it wheat, let the eggs hatch, used an unlit flare to fail to check the levels and used a lit flare on them to check the levels. After allowing flames to check the levels, used an unlit zippo to fail to check the levels and a lit zippo to check the levels.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
add: you can now use a flashlight or candle on an egg to see how grown it is.
tweak: chicken eggs now start guaranteed fertile and less of them are fertile the more chickens exist.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
