### PR TITLE
Fixes KS23 crafting

### DIFF
--- a/code/modules/projectiles/guns/projectile/shotgun/ks23.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/ks23.dm
@@ -19,3 +19,13 @@
 	saw_off = FALSE
 	spawn_blacklisted = TRUE
 	serial_type = "Excelsior"
+	gun_parts = list(/obj/item/part/gun/frame/ks = 1, /obj/item/part/gun/modular/grip/excel = 1, /obj/item/part/gun/modular/mechanism/shotgun = 1, /obj/item/part/gun/modular/barrel/shotgun = 1)
+
+/obj/item/part/gun/frame/ks
+	name = "KS-23 frame"
+	desc = "A KS-23 shotgun frame. A prolitarian's favorite."
+	icon_state = "frame_shotgun"
+	resultvars = list(/obj/item/gun/projectile/shotgun/pump/ks)
+	gripvars = list(/obj/item/part/gun/modular/grip/excel)
+	mechanismvar = /obj/item/part/gun/modular/mechanism/shotgun
+	barrelvars = list(/obj/item/part/gun/modular/barrel/shotgun)


### PR DESCRIPTION
## About The Pull Request

In simple words: KS23 didn't had it's own frame and was giving you Kammer frame upon dissembling which you couldn't assemble in KS23 in the last place.

## Why It's Good For The Game

Die, roachlings, die!

## Testing

I spawned KS23, brake it down, got the correct frame, then reassembled it and got the right shotgun

![image](https://github.com/discordia-space/CEV-Eris/assets/71145590/a1fc6b10-6da1-495e-af4f-fece7b07c196)
![image](https://github.com/discordia-space/CEV-Eris/assets/71145590/f43da684-8a67-4ac0-87d9-61aab7cf61fd)

## Changelog
:cl: Evie7056
fix: fixed KS23 crafting and uncrafting
/:cl:

