### PR TITLE
Adds crafting recipes back for armor parts

### DIFF
--- a/code/datums/craft/craft_designs.dm
+++ b/code/datums/craft/craft_designs.dm
@@ -350,3 +350,15 @@ Based on /datum/design of \code\datums\autolathe\autolathe_datums.dm
 	name = "\"Sermak\" rifle frame"
 	build_path = /obj/item/gun/projectile/automatic/modular/ak/makeshift
 	minimum_quality = 0
+
+// misc
+/datum/design/makeshift/stock_frame
+	name = "stock frame"
+	build_path = /obj/item/part/gun/modular/stock
+
+/datum/design/makeshift/armor_part
+	name = "armor part"
+	build_path = /obj/item/part/armor
+	minimum_quality = 0
+	// I dunno, it kinda meant to be affordable and a comodity since all amor you make with it is medicore.
+	// Probably could be changed to +1 but the average vaga would need to upgrade the lath at least with t2


### PR DESCRIPTION
## About The Pull Request

Tittle. Now you can craft armor parts on crafting bench as you used to be before UI update. Also adds modular stock there, since it's a bit silly that you need to scavenge a sermak to obtain one.

## Why It's Good For The Game

Armor parts crafting was a feature missed after a modular guns V2. That would allow Vaga in armor made from crafted parts more common. Also, kinda brings back an old trading route for Guild. Now, armor parts are actually a comodity it meant to be for 500 credits (it's current price).

Also, for the stocks... welp, just fixes a small oversight and gives a bit more convenience for the players. 

## Testing

recipes spawn correctly in their tab and are very craftable

## Changelog
:cl:
add: recipe for stock frame on crafting station
tweak: armor parts are craftable once again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
