### PR TITLE
Borer fixes + rebalance

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -55,7 +55,7 @@
 					switch(to_remove)
 						if("cell")
 							if(cell)
-								to_chat(user, "You detatch \the [cell] from \the [src]'s battery mount.")
+								to_chat(user, "You detach \the [cell] from \the [src]'s battery mount.")
 								for(var/obj/item/rig_module/module in installed_modules)
 									module.deactivate()
 								user.put_in_hands(cell)

--- a/code/modules/clothing/spacesuits/rig/rig_modules.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_modules.dm
@@ -59,7 +59,7 @@
 	mod.holder = null
 
 	if (user)
-		to_chat(user, "You detatch \the [mod] from \the [src].")
+		to_chat(user, "You detach \the [mod] from \the [src].")
 
 	mod.uninstalled(src, user)
 	if (delete)

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -241,7 +241,7 @@
 				tank.forceMove(get_turf(src))
 				src.tank = null
 			else if(choice == boots)
-				to_chat(user, "You detatch \the [boots] from \the [src]'s boot mounts.")
+				to_chat(user, "You detach \the [boots] from \the [src]'s boot mounts.")
 				boots.forceMove(get_turf(src))
 				src.boots = null
 		else

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -137,7 +137,7 @@
 	if(!(owner.status_flags & REBUILDING_ORGANS))
 		var/mob/living/simple_animal/borer/borer = owner.get_brain_worms()
 		if(borer)
-			borer.detatch() //Should remove borer if the brain is removed - RR
+			borer.detach() //Should remove borer if the brain is removed - RR
 
 		var/obj/item/organ/internal/carrion/core/C = owner.random_organ_by_process(BP_SPCORE)
 		if(C)

--- a/code/modules/mob/living/carbon/carbon_powers.dm
+++ b/code/modules/mob/living/carbon/carbon_powers.dm
@@ -60,7 +60,11 @@
 		visible_message("\red <B>[src] heaves violently, expelling a rush of vomit and a wriggling, sluglike creature!</B>")
 		B.chemicals -= reproduce_cost
 		B.has_reproduced = 1
-		B.borer_add_exp(10)
+		if(istype(B.host, /mob/living/carbon/human/) && !B.host.isMonkey())// this is a mess but host's var grabs "[human_name] (mob/living/carbon/human/)"
+			B.borer_add_exp(25)
+		else
+			to_chat(src, SPAN_WARNING("You do not have anything to learn from this host. Find a human!"))
+
 
 		new /obj/effect/decal/cleanable/vomit(get_turf(src))
 		playsound(loc, 'sound/effects/splat.ogg', 50, 1)

--- a/code/modules/mob/living/carbon/carbon_powers.dm
+++ b/code/modules/mob/living/carbon/carbon_powers.dm
@@ -1,4 +1,6 @@
 //Brain slug proc for voluntary removal of control.
+
+ //Problem: I DONT KNOW WHY, BUT BORER ONCE PICKED THIS FILE'S ABILITIES ONCE IT INFESTED INTO MONKEY, IN MOST CASES IT PICKED borer_powers.dm. If you solve this, delete this note pls (and delete it if i'm wrong and stupid)
 /mob/living/carbon/proc/release_control()
 
 	set category = "Abilities"
@@ -49,14 +51,14 @@
 	set desc = "Spawn several young."
 
 	var/mob/living/simple_animal/borer/B = get_brain_worms()
-
+	var/reproduce_cost = (round(B.max_chemicals_inhost * 0.75))
 	if(!B)
 		return
 
-	if(B.chemicals >= 100)
+	if(B.chemicals >= reproduce_cost)
 		to_chat(src, "\red <B>Your host twitches and quivers as you rapidly excrete a larva from your sluglike body.</B>")
 		visible_message("\red <B>[src] heaves violently, expelling a rush of vomit and a wriggling, sluglike creature!</B>")
-		B.chemicals -= 100
+		B.chemicals -= reproduce_cost
 		B.has_reproduced = 1
 		B.borer_add_exp(10)
 
@@ -65,5 +67,5 @@
 		new /mob/living/simple_animal/borer(get_turf(src))
 
 	else
-		to_chat(src, "You do not have enough chemicals stored to reproduce.")
+		to_chat(src, "You do not have enough chemicals stored to reproduce. (You need [reproduce_cost]).")
 		return

--- a/code/modules/mob/living/carbon/carbon_powers.dm
+++ b/code/modules/mob/living/carbon/carbon_powers.dm
@@ -1,6 +1,6 @@
-//Brain slug proc for voluntary removal of control.
 
- //Problem: I DONT KNOW WHY, BUT BORER ONCE PICKED THIS FILE'S ABILITIES ONCE IT INFESTED INTO MONKEY, IN MOST CASES IT PICKED borer_powers.dm. If you solve this, delete this note pls (and delete it if i'm wrong and stupid)
+//FILE: Borer gets powers from this one once he Assumes Control
+//Brain slug proc for voluntary removal of control.
 /mob/living/carbon/proc/release_control()
 
 	set category = "Abilities"
@@ -12,7 +12,7 @@
 	if(B && B.host_brain)
 		to_chat(src, "\red <B>You withdraw your probosci, releasing control of [B.host_brain]</B>")
 
-		B.detatch()
+		B.detach()
 
 		verbs |= /mob/living/carbon/human/proc/commune
 		verbs |= /mob/living/carbon/human/proc/psychic_whisper

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -29,6 +29,9 @@
 	pass_flags = PASSTABLE
 	universal_understand = 1
 	faction = "borers"
+	can_pull_size = ITEM_SIZE_TINY
+	can_pull_mobs = MOB_PULL_NONE
+	density = FALSE
 
 	var/borer_level = 0
 	var/borer_exp = 0
@@ -43,6 +46,7 @@
 	var/docile = FALSE                      // Sugar can stop borers from acting.
 	var/has_reproduced
 	var/roundstart
+	var/invisibility_cost = 5
 
 	// Abilities borer can use when outside the host
 	var/list/abilities_standalone = list(
@@ -150,9 +154,11 @@
 		chemicals++
 
 /mob/living/simple_animal/borer/proc/process_invisibility()
-	if(invisibility == TRUE)
-		chemicals -= 1
-		if(chemicals <= 2)
+	if(invisibility)
+		chemicals -= invisibility_cost
+		if(chemicals <= max_chemicals/2 && (max_chemicals/2) - invisibility_cost <= chemicals)
+			to_chat(src, to_chat(src, "\red <B>Your invisibility will run out soon!</B>"))
+		if(chemicals <= invisibility_cost + 1)
 			invisible() // Disable invisibility
 			chemicals = 0
 

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -91,7 +91,7 @@
 		var/obj/item/organ/external/head = H.get_organ(BP_HEAD)
 		head.implants.Remove(src) // This should be safe.
 	if(controlling)
-		detatch()
+		detach()
 	return ..()
 
 /mob/living/simple_animal/borer/Login()
@@ -166,7 +166,7 @@
 	to_chat(host, SPAN_DANGER("You feel your control over your host suddenly stop."))
 	update_abilities()
 	spawn(1)
-		detatch()
+		detach()
 
 /mob/living/simple_animal/borer/proc/process_host()
 	if(host && !stat)
@@ -223,7 +223,7 @@
 			stat("Host health", host.stat == DEAD ? "Deceased" : host.health)
 			stat("Host brain damage", host.getBrainLoss())
 
-/mob/living/simple_animal/borer/proc/detatch()
+/mob/living/simple_animal/borer/proc/detach()
 
 	if(!host || !controlling) return
 
@@ -363,7 +363,7 @@
 		alpha = 255
 		invisibility = 0
 	if(controlling || host)
-		detatch()
+		detach()
 		leave_host()
 
 /mob/living/simple_animal/borer/update_sight()

--- a/code/modules/mob/living/simple_animal/borer/borer_captive.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_captive.dm
@@ -59,10 +59,10 @@
 		var/mob/living/simple_animal/borer/B = src.loc
 		var/mob/living/captive_brain/H = src
 
-		to_chat(H, SPAN_DANGER("You begin doggedly resisting the parasite's control (this will take approximately sixty seconds)."))
+		to_chat(H, SPAN_DANGER("You begin doggedly resisting the parasite's control (this will take approximately thirty seconds)."))
 		to_chat(B.host, SPAN_DANGER("You feel the captive mind of [src] begin to resist your control."))
 
-		spawn(rand(200,250)+B.host.brainloss)
+		spawn(rand(250,300)+B.host.brainloss)
 			if(!B || !B.controlling) return
 
 			B.host.adjustBrainLoss(rand(0.1,0.5))

--- a/code/modules/mob/living/simple_animal/borer/borer_captive.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_captive.dm
@@ -62,7 +62,7 @@
 		to_chat(H, SPAN_DANGER("You begin doggedly resisting the parasite's control (this will take approximately thirty seconds)."))
 		to_chat(B.host, SPAN_DANGER("You feel the captive mind of [src] begin to resist your control."))
 
-		spawn(rand(250,300)+B.host.brainloss)
+		spawn(rand(25 SECONDS, 30 SECONDS)+B.host.brainloss)
 			if(!B || !B.controlling) return
 
 			B.host.adjustBrainLoss(rand(0.1,0.5))

--- a/code/modules/mob/living/simple_animal/borer/borer_captive.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_captive.dm
@@ -68,7 +68,7 @@
 			B.host.adjustBrainLoss(rand(0.1,0.5))
 			to_chat(H, SPAN_DANGER("With an immense exertion of will, you regain control of your body!"))
 			to_chat(B.host, SPAN_DANGER("You feel control of the host brain ripped from your grasp, and retract your probosci before the wild neural impulses can damage you."))
-			B.detatch()
+			B.detach()
 			verbs |= /mob/living/carbon/human/proc/commune
 			verbs |= /mob/living/carbon/human/proc/psychic_whisper
 			verbs |= /mob/living/carbon/proc/spawn_larvae

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -237,8 +237,8 @@
 	if(stat)
 		return
 
-	if(world.time - used_dominate < 600) // a two minutes cooldown.
-		to_chat(src, "\red <B>You cannot use that ability again so soon. It will be ready in [(600 - (world.time - used_dominate))/10] seconds.")
+	if(world.time - used_dominate < 1 MINUTE) // a one minutes cooldown.
+		to_chat(src, "\red <B>You cannot use that ability again so soon. It will be ready in [(1 MINUTE - (world.time - used_dominate))/ (1 SECOND)] seconds.")
 		return
 
 	if(is_ventcrawling)

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -30,7 +30,7 @@
 				to_chat(host, SPAN_DANGER("As though waking from a dream, you shake off the insidious mind control of the brain worm. Your thoughts are your own again."))
 			to_chat(host, SPAN_DANGER("Something slimy wiggles out of your ear and plops to the ground!"))
 
-		detatch()
+		detach()
 		leave_host()
 
 /mob/living/simple_animal/borer/proc/infest()
@@ -60,9 +60,9 @@
 	if(!M || !Adjacent(M) || !iscarbon(M))
 		return
 
-	if(ishuman(M) && (!M.mind || !M.client))
-		to_chat(src, SPAN_WARNING("Host's body is in a hybernation state, you are afraid to be crushed when they roll over in their sleep!"))
-		return
+	//if(ishuman(M) && (!M.mind || !M.client))
+//		to_chat(src, SPAN_WARNING("Host's body is in a hybernation state, you are afraid to be crushed when they roll over in their sleep!"))
+//		return
 	if(M.has_brain_worms())
 		to_chat(src, SPAN_WARNING("You cannot infest someone who is already infested!"))
 		return

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -262,8 +262,8 @@
 
 	var/mob/living/carbon/M = input(src,"Who do you wish to dominate?") in null|choices
 
-	if(world.time - used_dominate < 600)
-		to_chat(src, "\red <B>You cannot use that ability again so soon. It will be ready in [(600 - (world.time - used_dominate))/10] seconds.")
+	if(world.time - used_dominate < 1 MINUTE)
+		to_chat(src, "\red <B>You cannot use that ability again so soon. It will be ready in [(1 MINUTE - (world.time - used_dominate))/ (1 SECOND)] seconds.")
 		return
 
 	if(!M || !Adjacent(M)) return

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -312,7 +312,7 @@
 
 	to_chat(src, SPAN_NOTICE("You begin delicately adjusting your connection to the host brain. This will take some time..."))
 
-	spawn(300+(host.brainloss*5))
+	spawn(30 SECONDS + (host.brainloss * 5))
 
 		if(!host || !src || controlling)
 			return

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -540,8 +540,8 @@
 	if(stat)
 		return
 
-	if(world.time - used_dominate < 600)
-		to_chat(src, "\red <B>You cannot use that ability again so soon. It will be ready in [(600 - (world.time - used_dominate))/10] seconds.</B>")
+	if(world.time - used_dominate < 1 MINUTE)
+		to_chat(src, "\red <B>You cannot use that ability again so soon. It will be ready in [(1 MINUTE - (world.time - used_dominate))/ (1 SECOND)] seconds.</B>")
 		return
 
 	if(host)

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -60,6 +60,9 @@
 	if(!M || !Adjacent(M) || !iscarbon(M))
 		return
 
+	if(ishuman(M) && (!M.mind || !M.client))
+		to_chat(src, SPAN_WARNING("Host's body is in a hybernation state, you are afraid to be crushed when they roll over in their sleep!"))
+		return
 	if(M.has_brain_worms())
 		to_chat(src, SPAN_WARNING("You cannot infest someone who is already infested!"))
 		return
@@ -234,8 +237,8 @@
 	if(stat)
 		return
 
-	if(world.time - used_dominate < 150)
-		to_chat(src, SPAN_WARNING("You cannot use that ability again so soon."))
+	if(world.time - used_dominate < 600) // a two minutes cooldown.
+		to_chat(src, "\red <B>You cannot use that ability again so soon. It will be ready in [(600 - (world.time - used_dominate))/10] seconds.")
 		return
 
 	if(is_ventcrawling)
@@ -259,8 +262,8 @@
 
 	var/mob/living/carbon/M = input(src,"Who do you wish to dominate?") in null|choices
 
-	if(world.time - used_dominate < 150)
-		to_chat(src, SPAN_WARNING("You cannot use that ability again so soon."))
+	if(world.time - used_dominate < 600)
+		to_chat(src, "\red <B>You cannot use that ability again so soon. It will be ready in [(600 - (world.time - used_dominate))/10] seconds.")
 		return
 
 	if(!M || !Adjacent(M)) return
@@ -275,6 +278,9 @@
 		to_chat(src, "You cannot paralyze someone who is already infested!")
 		return
 
+	if(invisibility)
+		invisible() //removes invisibility on using paralyze
+		to_chat(src, SPAN_NOTICE("You become visible again."))
 	to_chat(src, SPAN_WARNING("You focus your psychic lance on [M] and freeze their limbs with a wave of terrible dread."))
 	to_chat(M, SPAN_DANGER("You feel a creeping, horrible sense of dread come over you, freezing your limbs and setting your heart racing."))
 	var/duration = 10 + (borer_level*2)
@@ -534,8 +540,8 @@
 	if(stat)
 		return
 
-	if(world.time - used_dominate < 150)
-		to_chat(src, "\red <B>You cannot use that ability again so soon.</B>")
+	if(world.time - used_dominate < 600)
+		to_chat(src, "\red <B>You cannot use that ability again so soon. It will be ready in [(600 - (world.time - used_dominate))/10] seconds.</B>")
 		return
 
 	if(host)
@@ -581,14 +587,18 @@
 	if(stat)
 		return
 
+	if(docile)
+		to_chat(src, SPAN_DANGER("You are feeling far too docile to do that."))
+		return
+
 	if(!host)
 		to_chat(src, "\red <B>You cannot do this without a host.</B>")
 		return
-
-	if(chemicals >= 100)
+	var/reproduce_cost = (round(max_chemicals_inhost * 0.75)) // literally max chems but 75% of it
+	if(chemicals >= reproduce_cost)
 		to_chat(host, "\red <B>Your host twitches and quivers as you rapidly excrete a larva from your sluglike body.</B>")
 		visible_message("\red <B>[host.name] heaves violently, expelling a rush of vomit and a wriggling, sluglike creature!</B>")
-		chemicals -= 100
+		chemicals -= reproduce_cost
 		has_reproduced = TRUE
 		borer_add_exp(10)
 
@@ -597,7 +607,7 @@
 		new /mob/living/simple_animal/borer(get_turf(host))
 
 	else
-		to_chat(src, SPAN_NOTICE("You do not have enough chemicals stored to reproduce."))
+		to_chat(src, SPAN_NOTICE("You do not have enough chemicals stored to reproduce. (You need [reproduce_cost])."))
 		return
 
 /mob/living/simple_animal/borer/proc/commune()

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -61,7 +61,7 @@
 		return
 
 	if(ishuman(M) && (!M.mind || !M.client))
-		to_chat(src, SPAN_WARNING("Host's body is in a hybernation state, you are afraid to be crushed when they roll over in their sleep!"))
+		to_chat(src, SPAN_WARNING("Host's body is in a state of hibernation, you are afraid to be crushed when they roll over in their sleep!"))
 		return
 	if(M.has_brain_worms())
 		to_chat(src, SPAN_WARNING("You cannot infest someone who is already infested!"))

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -310,9 +310,9 @@
 		to_chat(src, SPAN_WARNING("You can't control a dead host."))
 		return
 
-	to_chat(src, SPAN_NOTICE("You begin delicately adjusting your connection to the host brain..."))
+	to_chat(src, SPAN_NOTICE("You begin delicately adjusting your connection to the host brain. This will take some time..."))
 
-	spawn(100+(host.brainloss*5))
+	spawn(300+(host.brainloss*5))
 
 		if(!host || !src || controlling)
 			return
@@ -598,9 +598,12 @@
 	if(chemicals >= reproduce_cost)
 		to_chat(host, "\red <B>Your host twitches and quivers as you rapidly excrete a larva from your sluglike body.</B>")
 		visible_message("\red <B>[host.name] heaves violently, expelling a rush of vomit and a wriggling, sluglike creature!</B>")
-		chemicals -= reproduce_cost
 		has_reproduced = TRUE
-		borer_add_exp(10)
+		chemicals -= reproduce_cost
+		if(istype(host, /mob/living/carbon/human/) && !host.isMonkey())
+			borer_add_exp(25)
+		else
+			to_chat(src, SPAN_WARNING("You do not have anything to learn from this host. Find a human!"))
 
 		new /obj/effect/decal/cleanable/vomit(get_turf(host))
 		playsound(loc, 'sound/effects/splat.ogg', 50, 1)

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -56,13 +56,13 @@
 
 	var/mob/living/carbon/M = input(src,"Who do you wish to infest?") in null|choices
 
-	// non-humanoids disabled due to not working.
+	 //non-humanoids disabled due to not working.
 	if(!M || !Adjacent(M) || !iscarbon(M))
 		return
 
-	//if(ishuman(M) && (!M.mind || !M.client))
-//		to_chat(src, SPAN_WARNING("Host's body is in a hybernation state, you are afraid to be crushed when they roll over in their sleep!"))
-//		return
+	if(ishuman(M) && (!M.mind || !M.client))
+		to_chat(src, SPAN_WARNING("Host's body is in a hybernation state, you are afraid to be crushed when they roll over in their sleep!"))
+		return
 	if(M.has_brain_worms())
 		to_chat(src, SPAN_WARNING("You cannot infest someone who is already infested!"))
 		return

--- a/code/modules/organs/external/dismemberment.dm
+++ b/code/modules/organs/external/dismemberment.dm
@@ -92,6 +92,11 @@
 
 			for(var/obj/item/I in src)
 				if(I.w_class <= ITEM_SIZE_SMALL)
+					if(istype(I, /mob/living/simple_animal/borer/))
+						var/mob/living/simple_animal/borer/B = target
+						B.detatch()
+						B.leave_host()
+						continue
 					qdel(I)
 					continue
 				I.forceMove(get_turf(src))

--- a/code/modules/organs/external/dismemberment.dm
+++ b/code/modules/organs/external/dismemberment.dm
@@ -54,8 +54,7 @@
 		dir = 2
 
 	switch(disintegrate)
-		if(DROPLIMB_EDGE, DROPLIMB_EDGE_BURN)
-			compile_icon()
+		if(DROPLIMB_EDGE, DROPLIMB_EDGE_BURN) //TODO: IF head cut off, borer actions "stay" in body, camera will be on cut off head, will not be able to be detach. Too Bad!
 			add_blood(victim)
 			var/matrix/M = matrix()
 			M.Turn(rand(180))
@@ -90,13 +89,15 @@
 				I.forceMove(get_turf(src))
 				I.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),30)
 
+			for(var/mob/living/I in src) // check for mobs inside you... yeah
+				if(istype(I, /mob/living/simple_animal/borer/))
+					var/mob/living/simple_animal/borer/B = I
+					B.detach()
+					B.leave_host()
+					I.forceMove(get_turf(src))
+					I.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),30)
 			for(var/obj/item/I in src)
 				if(I.w_class <= ITEM_SIZE_SMALL)
-					if(istype(I, /mob/living/simple_animal/borer/))
-						var/mob/living/simple_animal/borer/B = target
-						B.detatch()
-						B.leave_host()
-						continue
 					qdel(I)
 					continue
 				I.forceMove(get_turf(src))

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -61,7 +61,7 @@
 		/obj/item/organ/internal/carrion/core/proc/carrion_transform,
 		/obj/item/organ/internal/carrion/core/proc/EvolutionMenu,
 		/obj/item/organ/internal/carrion/core/proc/carrion_fakedeath,
-		/obj/item/organ/internal/carrion/core/proc/detatch,
+		/obj/item/organ/internal/carrion/core/proc/detach,
 		/obj/item/organ/internal/carrion/core/proc/make_spider,
 		/obj/item/organ/internal/carrion/core/proc/spider_menu
 	)
@@ -213,9 +213,9 @@
 		EvolutionMenu()
 	..()
 
-/obj/item/organ/internal/carrion/core/proc/detatch()
+/obj/item/organ/internal/carrion/core/proc/detach()
 	set category = "Carrion"
-	set name = "Detatch"
+	set name = "Detach"
 
 	if(owner.status_flags & FAKEDEATH)
 		to_chat(owner, SPAN_WARNING("We are regenerating our body!"))

--- a/code/modules/surgery/organic.dm
+++ b/code/modules/surgery/organic.dm
@@ -312,7 +312,7 @@
 /datum/surgery_step/remove_item/end_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool, atom/movable/target)
 	if(istype(target, /mob/living/simple_animal/borer))
 		var/mob/living/simple_animal/borer/B = target
-		B.detatch()
+		B.detach()
 		B.leave_host()
 	user.visible_message(
 		SPAN_NOTICE("[user] extracts something out of [organ.get_surgery_name()] with \the [tool]."),

--- a/code/modules/surgery/organic.dm
+++ b/code/modules/surgery/organic.dm
@@ -310,6 +310,10 @@
 	organ.owner_custom_pain("The pain in your [organ.name] is living hell!", 1)
 
 /datum/surgery_step/remove_item/end_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool, atom/movable/target)
+	if(istype(target, /mob/living/simple_animal/borer))
+		var/mob/living/simple_animal/borer/B = target
+		B.detatch()
+		B.leave_host()
 	user.visible_message(
 		SPAN_NOTICE("[user] extracts something out of [organ.get_surgery_name()] with \the [tool]."),
 		SPAN_NOTICE("You extract [target] out of [organ.get_surgery_name()] with \the [tool].")

--- a/code/modules/surgery/robotic.dm
+++ b/code/modules/surgery/robotic.dm
@@ -96,7 +96,7 @@
 /datum/surgery_step/robotic/remove_item/end_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool, atom/movable/target)
 	if(istype(target, /mob/living/simple_animal/borer)) // the fact that you wrench out a borer like a bolt is fucking stupid and funny
 		var/mob/living/simple_animal/borer/B = target
-		B.detatch()
+		B.detach()
 		B.leave_host()
 	user.visible_message(
 		SPAN_NOTICE("[user] extracts something out of [organ.get_surgery_name()] with \the [tool]."),

--- a/code/modules/surgery/robotic.dm
+++ b/code/modules/surgery/robotic.dm
@@ -94,6 +94,10 @@
 	)
 
 /datum/surgery_step/robotic/remove_item/end_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool, atom/movable/target)
+	if(istype(target, /mob/living/simple_animal/borer)) // the fact that you wrench out a borer like a bolt is fucking stupid and funny
+		var/mob/living/simple_animal/borer/B = target
+		B.detatch()
+		B.leave_host()
 	user.visible_message(
 		SPAN_NOTICE("[user] extracts something out of [organ.get_surgery_name()] with \the [tool]."),
 		SPAN_NOTICE("You extract [target] out of [organ.get_surgery_name()] with \the [tool].")

--- a/code/modules/tips_and_tricks/roles.dm
+++ b/code/modules/tips_and_tricks/roles.dm
@@ -45,5 +45,5 @@
 
 /tipsAndTricks/roles/borerLang
     roles_list = list(/datum/antagonist/borer)
-    tipText = "As a borer, reading host's mind will teach you the languages host knows. For every language you learn you get more experience."
+    tipText = "As a borer, reading a host's mind will teach you the languages they know. For every language you learn you get more experience."
 

--- a/code/modules/tips_and_tricks/roles.dm
+++ b/code/modules/tips_and_tricks/roles.dm
@@ -42,3 +42,8 @@
 /tipsAndTricks/roles/carrionsurgery
     roles_list = list(/datum/antagonist/carrion)
     tipText = "As a carrion, you have greatly increased control over your body - if you want to perform self-surgery, you can do it standing up."
+
+/tipsAndTricks/roles/borerLang
+    roles_list = list(/datum/antagonist/borer)
+    tipText = "As a borer, reading host's mind will teach you the languages host knows. For every language you learn you get more experience."
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Borer bug fixes. Such as: 
Borer's abilities will not think it's inside the host when surgically removed.
Borer invisibility now correctly processes chemicals.
If host's head is gibbed (not cut off), borer will not die and will drop out.
Borer cannot pull big things, such as humans and closets anymore
You cannot bump-walk into borer anymore, he is smol!!!


Borer rebalance:
Borer's invisibility cost has been slightly increased.
Borer cooldowns for both paralyze and invisibility increased to 60 seconds.
Borer paralyze will now put borer out of invisibility.
Borer cannot occupy humans that SSD'd.
Borer doesn't get exp from reproducing in mobs that are not humans, though still can do that
Borer now takes 30 seconds to take control of the human instead of 10.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Other fixes:
All "detaTch" in code is now "detach"
Ackshually, resisting a host takes approx 30 seconds, not 60!!! :nerd: (text changed)
Borer tip added. Duh...
## Why It's Good For The Game

Borer had bugs (ex. infinite invisibility), plus was easy to troll people with paralyze spam in invisibility, instead of actually infesting them and doing spooky wormy things. Too Bad!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Tested absolutely everything several times.

## Changelog
:cl:
balance: Borer's abilities were rebalanced.
balance: Borer will now become visible once it paralyzes a human.
balance: Borer cannot use Infest on SSD human's bodies.
fix: Borer's properties such as ability to pull humans and bump into mobs were changed.
fix: Borer's invisibility now uses chemicals when it's invisible.
fix: Borer will not bug out once the host's head was gibbed.
balance: Borer's Assume Control will now take 30 seconds to kick in instead of 10.
spellcheck: Human resisting borer will now know that they need 30 seconds to resist, not 60.
spellcheck: "detatch" in code and texts is now "detach".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->