### PR TITLE
frag grenade shell wall bug resolution

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -471,9 +471,13 @@
 	else
 		passthrough = (A.bullet_act(src, def_zone) == PROJECTILE_CONTINUE) //backwards compatibility
 		if(isturf(A))
-			for(var/obj/O in A)
+			if(QDELETED(src)) // we don't want bombs to explode once for every time bullet_act is called
+				on_impact(A)
+				invisibility = 101
+				return TRUE // see that next line? it can overload the server.
+			for(var/obj/O in A) // if src's bullet act spawns more objs, the list will increase,
 				if(O.density)
-					O.bullet_act(src)
+					O.bullet_act(src) // causing exponential growth due to the spawned obj spawning itself
 			for(var/mob/living/M in A)
 				attack_mob(M)
 

--- a/code/modules/projectiles/projectile/projectilegrenades.dm
+++ b/code/modules/projectiles/projectile/projectilegrenades.dm
@@ -21,7 +21,8 @@
 	grenade_effect(target)
 
 /obj/item/projectile/bullet/grenade/proc/grenade_effect(target)
-	return
+	qdel(src) // DO NOT ALLOW SRC TO SURVIVE THIS
+	SHOULD_CALL_PARENT(TRUE)
 
 /obj/item/projectile/bullet/grenade/blast
 	name = "blast shell"
@@ -30,6 +31,7 @@
 
 /obj/item/projectile/bullet/grenade/blast/grenade_effect(target)
 	explosion(get_turf(target), explosion_power, explosion_falloff)
+	. = ..()
 
 /obj/item/projectile/bullet/grenade/heatwave
 	name = "heatwave shell"
@@ -40,7 +42,8 @@
 	var/fire_stacks = TRUE
 
 /obj/item/projectile/bullet/grenade/heatwave/grenade_effect(target)
-    heatwave(target, heavy_range, weak_range, heat_damage, fire_stacks, penetration)
+	heatwave(target, heavy_range, weak_range, heat_damage, fire_stacks, penetration)
+	. = ..()
 
 /obj/item/projectile/bullet/grenade/frag
 	name = "frag shell"
@@ -66,6 +69,7 @@
 /obj/item/projectile/bullet/grenade/frag/grenade_effect(target)
 	fragment_explosion(target, range, f_type, f_amount, f_damage, f_step, same_turf_hit_chance)
 	explosion(get_turf(target), 60, 40)
+	. = ..()
 
 /obj/item/projectile/bullet/grenade/frag/sting/weak
 	name = "sting shell"
@@ -80,6 +84,7 @@
 
 /obj/item/projectile/bullet/grenade/emp/grenade_effect(target)
 	empulse(target, heavy_emp_range, light_emp_range)
+	. = ..()
 
 /obj/item/projectile/bullet/grenade/emp/low_yield
 	heavy_emp_range = 4
@@ -94,6 +99,7 @@
 /obj/item/projectile/bullet/grenade/handgrenade/grenade_effect(target)
 	var/obj/item/grenade/G = new hand_gren(src)
 	G.prime()
+	. = ..()
 
 /obj/item/projectile/bullet/grenade/handgrenade/teargas    // Because why not
 	name = "cs shell"


### PR DESCRIPTION
grenade shells now universally qdel self on activation

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
this PR solves frag grenade shells overloading the server upon bump on wall.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
the server being overloaded is bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
fired all grenade shell types at walls, including frags, with expected results for each.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
fix: fixed grenade shell wall bump bug
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
