### PR TITLE
Not-so-hot fix for agrolyte perk

### DIFF
--- a/code/game/objects/items/devices/scanners/scanners.dm
+++ b/code/game/objects/items/devices/scanners/scanners.dm
@@ -52,8 +52,9 @@
 		return
 	if (!user.IsAdvancedToolUser())
 		return
-	if(!cell_use_check(charge_per_use, user))
-		return
+	if(!is_virtual)
+		if(!cell_use_check(charge_per_use, user))
+			return
 	return TRUE
 
 /obj/item/device/scanner/proc/is_valid_scan_target(atom/O)


### PR DESCRIPTION
## About The Pull Request
Added a check for virtual scanners to ignore cells. Universal sollution!

## Why It's Good For The Game
Agrolytes won't loose their faith battery, hail the Lord Protector!

## Testing

Run the server with upstream code and my agrolyte compitely burned out after 20 glanses
Run the server with changed code and I can stare at grass for hours!
Also checked other scanners (from med and two plant scans) - all works and requires charge

## Changelog
:cl:
fix: fixed agrolyte perk requiring cell charge
/:cl: