### PR TITLE
Borer infest fix

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -60,7 +60,7 @@
 	if(!M || !Adjacent(M) || !iscarbon(M))
 		return
 
-	if((ishuman(M) && isMonkey(M)) && (!M.mind || !M.client))
+	if((ishuman(M) && !M.isMonkey()) && (!M.mind || !M.client))
 		to_chat(src, SPAN_WARNING("Host's body is in a state of hibernation, you are afraid to be crushed when they roll over in their sleep!"))
 		return
 	if(M.has_brain_worms())

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -60,7 +60,7 @@
 	if(!M || !Adjacent(M) || !iscarbon(M))
 		return
 
-	if(ishuman(M) && (!M.mind || !M.client))
+	if((ishuman(M) && isMonkey(M)) && (!M.mind || !M.client))
 		to_chat(src, SPAN_WARNING("Host's body is in a state of hibernation, you are afraid to be crushed when they roll over in their sleep!"))
 		return
 	if(M.has_brain_worms())


### PR DESCRIPTION
## About The Pull Request
Added check for being a monkey. That's about it
## Why It's Good For The Game
Expands worm roleplay variety? IDK, we just forgot to add this check and now it's working as it was intended
## Testing

- Confirming bug
Spawned a monkey and tried infesting it - fail. Issue confirmed
- Resolving issues
Dug into infest code and added check for monkey next to check for human
- Checking if issue is solved
Spawned monkey, stunned it, crawled inside
Double check. Spawned monkey and crawled inside without stun in case it was depended on stunning target
Success in both cases. Issue resolved!

## Changelog
:cl:
fix: Fixed borer not being able to infest monkeys
/:cl:
