### PR TITLE
Wall becomes stronger

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -8,7 +8,7 @@
 	var/list/resources
 	var/seismic_activity = 1  // SEISMIC_MIN
 
-	var/thermite = 0
+	var/thermite = FALSE
 	oxygen = MOLES_O2STANDARD
 	nitrogen = MOLES_N2STANDARD
 	var/to_be_destroyed = 0 //Used for fire, if a melting temperature was reached, it will be destroyed

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -149,14 +149,14 @@
 					return
 			if(isnull(construction_stage) || !reinf_material)
 				to_chat(user, SPAN_NOTICE("You begin removing the outer plating..."))
-				if(I.use_tool(user, src, WORKTIME_LONG, tool_type, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
+				if(I.use_tool(user, src, WORKTIME_LONG * material.heat_resistance, tool_type, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
 					to_chat(user, SPAN_NOTICE("You remove the outer plating."))
 					dismantle_wall()
 					user.visible_message(SPAN_WARNING("The wall was torn open by [user]!"))
 					return
 			if(construction_stage == 4)
 				to_chat(user, SPAN_NOTICE("You begin removing the outer plating..."))
-				if(I.use_tool(user, src, WORKTIME_NORMAL, tool_type, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
+				if(I.use_tool(user, src, WORKTIME_NORMAL * material.heat_resistance, tool_type, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
 					construction_stage = 3
 					update_icon()
 					to_chat(user, SPAN_NOTICE("You press firmly on the cover, dislodging it."))

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -149,14 +149,14 @@
 					return
 			if(isnull(construction_stage) || !reinf_material)
 				to_chat(user, SPAN_NOTICE("You begin removing the outer plating..."))
-				if(I.use_tool(user, src, WORKTIME_LONG * material.heat_resistance, tool_type, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
+				if(I.use_tool(user, src, WORKTIME_SLOW * material.heat_resistance, tool_type, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
 					to_chat(user, SPAN_NOTICE("You remove the outer plating."))
 					dismantle_wall()
 					user.visible_message(SPAN_WARNING("The wall was torn open by [user]!"))
 					return
 			if(construction_stage == 4)
 				to_chat(user, SPAN_NOTICE("You begin removing the outer plating..."))
-				if(I.use_tool(user, src, WORKTIME_NORMAL * material.heat_resistance, tool_type, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
+				if(I.use_tool(user, src, WORKTIME_SLOW * material.heat_resistance, tool_type, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
 					construction_stage = 3
 					update_icon()
 					to_chat(user, SPAN_NOTICE("You press firmly on the cover, dislodging it."))

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -232,7 +232,7 @@
 		var/attackforce = I.force*I.structure_damage_factor
 		var/dam_threshhold = material.integrity
 		if(reinf_material)
-			dam_threshhold = CEILING(max(dam_threshhold,reinf_material.integrity) * 0.5, 1)
+			dam_threshhold += reinf_material.integrity * 0.5
 		var/dam_prob = material.hardness * 1.4
 		if (locate(/obj/effect/overlay/wallrot) in src)
 			dam_prob *= 0.5 //Rot makes reinforced walls breakable

--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -1,9 +1,22 @@
+/turf/simulated/wall/steelr_wall
+	icon_state = "rgeneric"
+	description_info = "Can be deconstructed by following these steps \n Use a cutting tool on the wall \n Use a screw-driving tool on the wall \n Use a welder \n Use a wrench \n Use a welder \n Pry off the outer shell"
+
+/turf/simulated/wall/steelr_wall/New(var/newloc)
+	..(newloc, MATERIAL_STEEL, MATERIAL_STEEL) //2strong
 /turf/simulated/wall/r_wall
 	icon_state = "rgeneric"
 	description_info = "Can be deconstructed by following these steps \n Use a cutting tool on the wall \n Use a screw-driving tool on the wall \n Use a welder \n Use a wrench \n Use a welder \n Pry off the outer shell"
 
 /turf/simulated/wall/r_wall/New(var/newloc)
 	..(newloc, MATERIAL_PLASTEEL, MATERIAL_PLASTEEL) //3strong
+
+/turf/simulated/wall/v_wall
+	icon_state = "rgeneric"
+	description_info = "Can be deconstructed by following these steps \n Use a cutting tool on the wall \n Use a screw-driving tool on the wall \n Use a welder for some minutes \n Use a wrench \n Use a welder \n Pry off the outer shell"
+
+/turf/simulated/wall/v_wall/New(var/newloc)
+	..(newloc, MATERIAL_OSMIUM, MATERIAL_OSMIUM) //4strong
 
 /turf/simulated/wall/cult
 	icon_state = "cult"
@@ -87,6 +100,8 @@
 
 /turf/simulated/wall/iron/New(var/newloc)
 	..(newloc,MATERIAL_IRON)
+/turf/simulated/wall/plasteel/New(var/newloc)
+	..(newloc, MATERIAL_PLASTEEL)
 /turf/simulated/wall/uranium/New(var/newloc)
 	..(newloc,MATERIAL_URANIUM)
 /turf/simulated/wall/diamond/New(var/newloc)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -327,7 +327,7 @@
 /turf/simulated/wall/take_damage(damage)
 	if(locate(/obj/effect/overlay/wallrot) in src)
 		damage *= 10
-	. = health - damage < 0 ? damage - (damage - health) : damage
+	. = min(health, damage)
 	health -= damage
 	if(health <= 0)
 		var/leftover = abs(health)
@@ -398,15 +398,20 @@
 	O.anchored = TRUE
 	O.density = TRUE
 	O.layer = 5
+	
+	thermite = FALSE
+	take_damage((material.integrity*2.5) / material.heat_resistance) // thermite overkills steel immediately but not plasteel
 
-	src.ChangeTurf(/turf/simulated/floor/plating)
+	if(istype(src, /turf/simulated/floor))
+		var/turf/simulated/floor/F = src
+		F.burn_tile()
+		F.icon_state = "wall_thermite"
+		to_chat(user, SPAN_WARNING("The thermite starts melting the wall away."))
+	else
+		to_chat(user, SPAN_WARNING("The thermite starts melting through the wall."))
 
-	var/turf/simulated/floor/F = src
-	F.burn_tile()
-	F.icon_state = "wall_thermite"
-	to_chat(user, SPAN_WARNING("The thermite starts melting through the wall."))
 
-	spawn(100)
+	spawn(10 SECONDS)
 		if(O)
 			qdel(O)
 //	F.sd_LumReset()		//TODO: ~Carn

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -578,6 +578,7 @@ var/list/name_to_material
 /material/osmium
 	name = MATERIAL_OSMIUM
 	stack_type = /obj/item/stack/material/osmium
+	integrity = 480 // might as well.
 	icon_colour = "#9999FF"
 	stack_origin_tech = list(TECH_MATERIAL = 5)
 	heat_resistance = 10 // osmium is REALLY dense and high melting point.

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -108,6 +108,7 @@ var/list/name_to_material
 	var/radioactivity            // Radiation var. Used in wall and object processing to irradiate surroundings.
 	var/ignition_point           // K, point at which the material catches on fire.
 	var/melting_point = 1800     // K, walls will take damage if they're next to a fire hotter than this
+	var/heat_resistance = 1 	 // divisor, walls resist thermite and welding based on this
 	var/integrity = 150          // General-use HP value for products.
 	var/opacity = 1              // Is the material transparent? 0.5< makes transparent walls/doors.
 	var/explosion_resistance = 5 // Only used by walls currently.
@@ -336,6 +337,7 @@ var/list/name_to_material
 	shard_type = SHARD_STONE_PIECE
 	weight = 22
 	hardness = 55
+	heat_resistance = 8
 	door_icon_base = "stone"
 	sheet_singular_name = "brick"
 	sheet_plural_name = "bricks"
@@ -374,6 +376,7 @@ var/list/name_to_material
 	icon_reinf = "reinf_over"
 	icon_colour = PLASTEEL_COLOUR//"#777777"
 	explosion_resistance = 25
+	heat_resistance = 3
 	hardness = 80
 	weight = 23
 	stack_origin_tech = list(TECH_MATERIAL = 2)
@@ -384,6 +387,7 @@ var/list/name_to_material
 	stack_type = null
 	icon_base = "metal"
 	weight = 20
+	heat_resistance = 4
 	hardness = 90
 	door_icon_base = "metal"
 	icon_colour = "#D1E6E3"
@@ -576,6 +580,8 @@ var/list/name_to_material
 	stack_type = /obj/item/stack/material/osmium
 	icon_colour = "#9999FF"
 	stack_origin_tech = list(TECH_MATERIAL = 5)
+	heat_resistance = 10 // osmium is REALLY dense and high melting point.
+	melting_point = T0C+3025
 	weight = 90
 	hardness = 90
 	sheet_singular_name = "ingot"
@@ -640,6 +646,7 @@ var/list/name_to_material
 	shard_type = SHARD_SPLINTER
 	shard_can_repair = 0 // you can't weld splinters back into planks
 	hardness = 15
+	heat_resistance = 0.5 // not good
 	weight = 18
 	melting_point = T0C+300 //okay, not melting in this case, but hot enough to destroy wood
 	ignition_point = T0C+288
@@ -665,6 +672,7 @@ var/list/name_to_material
 	icon_base = "solid"
 	icon_reinf = "reinf_over"
 	icon_colour = "#AAAAAA"
+	heat_resistance = 0.25 // very bad
 	hardness = 1
 	weight = 1
 	ignition_point = T0C+232 //"the temperature at which book-paper catches fire, and burns." close enough
@@ -677,6 +685,7 @@ var/list/name_to_material
 	name = MATERIAL_CLOTH
 	stack_origin_tech = list(TECH_MATERIAL = 2)
 	door_icon_base = "wood"
+	heat_resistance = 0.25 // very bad
 	ignition_point = T0C+232
 	melting_point = T0C+300
 	flags = MATERIAL_PADDING

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -194,7 +194,7 @@
 	if(volume >= 5)
 		if(istype(T, /turf/simulated/wall))
 			var/turf/simulated/wall/W = T
-			W.thermite = 1
+			W.thermite = TRUE
 			W.overlays += image('icons/effects/effects.dmi',icon_state = "#673910")
 			remove_self(5)
 	return TRUE


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes specific walls more resistant to thermite, disassembly, or being beaten apart. This PR also nerfs the overtuned weld time of unreinforced walls and adds presets that would allow someone to easily map in the now rebalanced walls.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This PR introduces more variety in wall types defenses against specific attacks, allowing for mapping in different walls for various levels of security. the Origin Reason for this PR was that Steel Reinforced Steel Walls were completely unused.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
thermited steel and plasteel reinforced along with unreinforced variants of plasteel and steel walls, determining that all walls except for plasteel or plasteel reinforced variants were destroyed with one application; all variants other than steel reinforced left no girder behind.
welded steel, plasteel, plasteel reinforced plasteel, and steel reinforced walls, determining that it took longer to weld the plasteel variants than the steel variants.
beat the added types of walls to pieces with hammers, determining that each hammer type was able to damage the proper walls, and that the v wall was possible to damage with an acceptable ROB value. Hammer types tested: Makeshift, Basic, Ironhammer, and One Star.
![hammers](https://github.com/discordia-space/CEV-Eris/assets/65709050/332079bb-b6e6-4232-b7ef-8cc7bb987f9d)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
balance: rebalanced walls
code: Added new wall type presets for mappers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
