### PR TITLE
Remove Tracking Beacons from Comms deferred crate

### DIFF
--- a/code/game/objects/items/weapons/storage/deferred.dm
+++ b/code/game/objects/items/weapons/storage/deferred.dm
@@ -81,8 +81,8 @@
 
 /obj/item/storage/deferred/comms
 	name = "communications kit"
-	desc = "A box full of radios and beacons"
-	initial_contents = list(/obj/item/device/radio/beacon = 6, /obj/item/device/radio = 6)
+	desc = "A box full of radios"
+	initial_contents = list(/obj/item/device/radio = 6)
 
 /obj/item/storage/deferred/lights
 	name = "illumination kit"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
On the Serb Shuttle, there's a "Communications Kit" box, that has 6 radios, and 6 tracking beacons. Beacons that let anyone instantly teleport onto the Serb shuttle as soon as Serbs spawn. This is ridiculous, and they are not used as Serbs don't have access to teleportation gear.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
One Sci-bro cucking skilled Serbs by just teleporting to their shuttle and completely disabling it in 2 minutes without leaving a trace is demoralizing. Why bother doing objectives if you're just going to get shafted anyways?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Yepp it's a box with six radios in it now.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
del: Removed tracking beacons from Communications Deferred box
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
