### PR TITLE
Artist statue sanity effects

### DIFF
--- a/code/__HELPERS/artwork_names.dm
+++ b/code/__HELPERS/artwork_names.dm
@@ -106,6 +106,7 @@ GLOBAL_LIST_INIT(art_description_types_statue, file2list("strings/artist_strings
 	var/description_artwork_statue = pick(description_artwork_statue_verb,description_artwork_statue_stationary)
 
 	var/description_statue = "[description_artwork_statue] [get_artwork_description()]"
+	description_statue += qualitydesc
 	desc += " [description_statue]"
 	return description_statue
 

--- a/code/game/objects/structures/artwork_statue.dm
+++ b/code/game/objects/structures/artwork_statue.dm
@@ -1,3 +1,4 @@
+
 /obj/structure/artwork_statue
 	name = "Weird Statue"
 	desc = "A work of art that reflects the ideas of its creator."
@@ -6,15 +7,35 @@
 	density = TRUE
 	spawn_frequency = 0
 	price_tag = 500
+	sanity_damage = 0
+	var/qualitydesc = null
 
 /obj/structure/artwork_statue/Initialize()
 	. = ..()
 	name = get_artwork_name(TRUE)
 	icon_state = "artwork_statue_[rand(1,6)]"
 
-	var/sanity_value = 2 + rand(0,2)
-	AddComponent(/datum/component/atom_sanity, sanity_value, "")
+//weighted bell curve from -6 to 6. 17% chance of 0, ~0.4% chance of either 6, ~1.5% of either 5, and so on.
+//extremely sanity rending/healing statues are possible but very rare.
+	var/sanity_value = (rand(1,4) - rand(1,4)) - (rand(1,4) - rand(1,4))
+	sanity_damage = sanity_value
 	price_tag += rand(0,5000)
+	switch(sanity_value)
+		if(4.9 to 6.1)
+			price_tag += 1500//there's a market for art so bad it's good
+			qualitydesc = " \ <br><br>How <span class='danger'>awful</span>. It's like a car crash- hard to look away."
+		if(1 to 4.8)
+			price_tag -= 500
+			qualitydesc = " \ <br><br>This artwork is quite <span class='warning'>unpleasant</span> to look at."
+		if(0)
+			price_tag -= 1000//far worse than bad art is uninteresting art
+			qualitydesc = " \ <br><br>A very mediocre piece of art."
+		if(-4.8 to -1)
+			price_tag += 1000
+			qualitydesc = " \ <br><br>A <span class='green'>beautiful</span> piece of artwork."
+		if(-6.1 to -4.9 )
+			price_tag += 2500
+			qualitydesc = " \ <br><br>A stunning artwork. Looking at it fills you with <span class='blue'>awe</span>."
 
 /obj/structure/artwork_statue/attackby(obj/item/I, mob/living/user)
 	if(I.has_quality(QUALITY_BOLT_TURNING))
@@ -24,7 +45,3 @@
 		return
 	. = ..()
 
-/obj/structure/artwork_statue/get_item_cost(export)
-	. = ..()
-	GET_COMPONENT(comp_sanity, /datum/component/atom_sanity)
-	. += comp_sanity.affect * 100

--- a/code/game/objects/structures/artwork_statue.dm
+++ b/code/game/objects/structures/artwork_statue.dm
@@ -15,9 +15,9 @@
 	name = get_artwork_name(TRUE)
 	icon_state = "artwork_statue_[rand(1,6)]"
 
-//weighted bell curve from -6 to 6. 17% chance of 0, ~0.4% chance of either 6, ~1.5% of either 5, and so on.
+//weighted bell curve from -6 to 6, slight favour to positive numbers
 //extremely sanity rending/healing statues are possible but very rare.
-	var/sanity_value = (rand(1,4) - rand(1,4)) - (rand(1,4) - rand(1,4))
+	var/sanity_value = clamp((rand(1,4) - rand(1,4)) - (rand(1,4) - rand(1,4)) + rand(0,1), -6, 6)
 	sanity_damage = sanity_value
 	price_tag += rand(0,5000)
 	switch(sanity_value)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is the most complete part of that silly artist pr I abandoned a while ago, polished up a bit

- Artist statues now use the sanity damage var instead of the (seemingly non-functional) component
- The sanity effects of artist statues now vary more, with a chance to harm sanity instead of healing it, a small chance to be nothing (shitty art) and a very tiny chance to be quite strong
- There is now a tell in the description of artist statues that lets you know whether they affect sanity positively or negatively

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes the (currently broken(?)) statue sanity effects, making artist statues a practical good beyond just immediately dumping them into the cargo bay.

The negative statues also open up a lot of opportunities for tomfoolery around putting sanity rending artwork outside people's departments. Inflict psychological warfare on ironhammer with your art commissions
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Made a bunch of statues on a test server. 
Example of the quality tell at the bottom of statue descs:
![image](https://github.com/discordia-space/CEV-Eris/assets/45698967/80322bff-30fe-4798-b2db-450e11d1f624)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
add: Artist statues can now harm sanity as well as heal it. You can now tell whether artist statues harm or heal sanity from their description.
fix: Artist statue sanity effects now work again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
