### PR TITLE
Njoy makes you immune to grain

### DIFF
--- a/code/modules/sanity_grain/sanity_grain.dm
+++ b/code/modules/sanity_grain/sanity_grain.dm
@@ -29,7 +29,14 @@
 		PERK_HOLY_LIGHT,               // Aura
 	)
 
+	// Suppressital clears the mind
+	if(S.getPerk(PERK_NJOY))
+		grain.icon_state = ""
+		return
+
 	var/state = "[rand(1, 9)] "
+
+	//Some perks reduce the amount of grain even at low sanity. This is either because the character is used to bad conditions, or faith clears their mind.
 	for(var/perk in S.perks ? light_grain_perks : list())
 		if(S.getPerk(perk))
 			switch(new_level)


### PR DESCRIPTION
## About The Pull Request

Ingesting Njoy now removed grain from your screen

## Why It's Good For The Game

Aside from helping Njoy actually remove the negative effects of low sanity, it also acts as a good visual indicator:
When the grain appears, you know you need to take another pill.

## Testing

Run, went insane, popped a pill, all good.

## Changelog
:cl:
tweak: Njoy removes grain effect from low sanity
/:cl: