### PR TITLE
Fixing K.A.R.L mining tool

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -40,7 +40,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		var/mob/living/carbon/human/H = user
 		if(H.blocking)
 			H.stop_blocking()
-	if(ishuman(user) && !(user == A) && !(user.loc == A) && (w_class >=  ITEM_SIZE_NORMAL) && wielded && user.a_intent == I_HURT && !istype(src, /obj/item/gun) && !istype(A, /obj/structure) && !istype(A, /turf/simulated/wall) && A.loc != user)
+	if(ishuman(user) && !(user == A) && !(user.loc == A) && (w_class >=  ITEM_SIZE_NORMAL) && wielded && user.a_intent == I_HURT && !istype(src, /obj/item/gun) && !istype(A, /obj/structure) && !istype(A, /turf/simulated/wall) && A.loc != user && !no_swing)
 		swing_attack(A, user, params)
 		if(istype(A, /turf/simulated/floor)) // shitty hack so you can attack floors while wielding a large weapon
 			return A.attackby(src, user, params)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -29,6 +29,7 @@
 	var/extended_reach = FALSE		//Wielded spears can hit alive things one tile further.
 	var/ready = FALSE				//All weapons that are ITEM_SIZE_BULKY or bigger have double tact, meaning you have to click twice.
 	var/no_double_tact = FALSE		//for when you,  for some inconceivable reason, want a bulky item to not have double tact
+	var/no_swing = FALSE            //for when you do not want an item to swing-attack
 	var/push_attack = FALSE			//Hammers and spears can push the victim away on hit when you aim groin.
 	//Why are we using vars instead of defines or anything else?
 	//Because we need them to be shown in the tool info UI.

--- a/code/game/objects/items/weapons/tools/karl.dm
+++ b/code/game/objects/items/weapons/tools/karl.dm
@@ -143,6 +143,7 @@
 /obj/item/tool/karl/proc/toggle_karl_mode(mob/user)
 	gunmode = !gunmode
 	to_chat(user, SPAN_NOTICE("\The [src] switches to [gunmode ? "gun" : "tool"] mode."))
+	no_double_tact = gunmode ? FALSE : TRUE  // No double tact in gunmode
 	update_icon()
 	update_wear_icon()
 

--- a/code/game/objects/items/weapons/tools/karl.dm
+++ b/code/game/objects/items/weapons/tools/karl.dm
@@ -96,6 +96,7 @@
 			if(!cell.fully_charged())
 				if(isPumping)
 					to_chat(user, SPAN_NOTICE("You are already pumping \the [src] to recharge it."))
+					return
 				var/pumping_time = wielded ? 1 SECOND : 2 SECONDS
 				isPumping = TRUE
 				if(do_after(user, pumping_time))
@@ -118,12 +119,20 @@
 	. = ..()
 	if(.)
 		to_chat(user, SPAN_NOTICE("A dangerous energy blade now covers the edges of the tool."))
-		force = WEAPON_FORCE_ROBUST  // Increased damage when KARL is turned on
+		update_force()
 
 /obj/item/tool/karl/turn_off(mob/user)
-	to_chat(user, SPAN_NOTICE("The energy blade swiftly retracts."))
-	force = initial(force)  // Back to standard damage when KARL is turned off
 	..()
+	to_chat(user, SPAN_NOTICE("The energy blade swiftly retracts."))
+	update_force()
+
+/obj/item/tool/karl/proc/update_force()
+	if(gunmode)
+		force = WEAPON_FORCE_NORMAL
+	else if(switched_on)
+		force = WEAPON_FORCE_ROBUST  // Increased damage when KARL is turned on
+	else
+		force = initial(force)  // Back to standard damage when KARL is turned off
 
 // Same values than /obj/item/proc/use_tool
 /obj/item/tool/karl/use_tool(mob/living/user, atom/target, base_time, required_quality, fail_chance, required_stat, instant_finish_tier = 110, forced_sound = null, sound_repeat = 2.5 SECONDS)
@@ -143,7 +152,9 @@
 /obj/item/tool/karl/proc/toggle_karl_mode(mob/user)
 	gunmode = !gunmode
 	to_chat(user, SPAN_NOTICE("\The [src] switches to [gunmode ? "gun" : "tool"] mode."))
-	no_double_tact = gunmode ? FALSE : TRUE  // No double tact in gunmode
+	no_double_tact = gunmode ? TRUE : FALSE  // No double tact in gunmode
+	no_swing = gunmode ? TRUE : FALSE  // No swinging in gunmode
+	update_force()
 	update_icon()
 	update_wear_icon()
 

--- a/code/game/objects/items/weapons/tools/karl.dm
+++ b/code/game/objects/items/weapons/tools/karl.dm
@@ -42,6 +42,7 @@
 	var/projectile			// Holder for bullettype
 	var/shot_sound 			// What sound should play when the gun fires
 	var/reqpower = 10		// Power needed to shoot
+	var/isPumping = FALSE   // Whether someone is currently pumping the KARL to recharge it
 
 /obj/item/tool/karl/New()
 	. = ..()
@@ -93,13 +94,18 @@
 	if(gunmode)
 		if(cell)
 			if(!cell.fully_charged())
+				if(isPumping)
+					to_chat(user, SPAN_NOTICE("You are already pumping \the [src] to recharge it."))
 				var/pumping_time = wielded ? 1 SECOND : 2 SECONDS
+				isPumping = TRUE
 				if(do_after(user, pumping_time))
 					if(cell)  // Check the cell is still there in case big brain player chose to remove it during pumping
 						cell.give(use_power_cost * 1 SECOND) // Enough to use the tool during 1 second
 						to_chat(user, SPAN_NOTICE("You recharge \the [src] by pumping it, cell charge at [round(cell.percent())]%."))
 						// Continue pumping till user cancels the pumping
+						isPumping = FALSE
 						attack_self(user)
+				isPumping = FALSE
 			else
 				to_chat(user, SPAN_NOTICE("\The [src]\'cell is fully charged'."))
 		else

--- a/code/game/objects/items/weapons/tools/karl.dm
+++ b/code/game/objects/items/weapons/tools/karl.dm
@@ -118,9 +118,11 @@
 	. = ..()
 	if(.)
 		to_chat(user, SPAN_NOTICE("A dangerous energy blade now covers the edges of the tool."))
+		force = WEAPON_FORCE_ROBUST  // Increased damage when KARL is turned on
 
 /obj/item/tool/karl/turn_off(mob/user)
 	to_chat(user, SPAN_NOTICE("The energy blade swiftly retracts."))
+	force = initial(force)  // Back to standard damage when KARL is turned off
 	..()
 
 // Same values than /obj/item/proc/use_tool


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Fixes the exploit of recharging the K.A.R.L instantly by spamming the recharge action to launch several of them in parallel. 
* Fixes the missing heightened damage of axe mode when the energy edge is turned on
* Lowers the damage of K.A.R.L in gun mode (should not hit as hard as unpowered axe mode)
* Fixes the attack behaviour of K.A.R.L in gun mode (no more swinging or double tapping, basically it now behaves as a normal gun)
* Add a new `no_swing` variable to items, analog to `no_double_tact` but for swinging instead of double tapping.

## Why It's Good For The Game

Remove recharge exploit and fix the K.A.R.L behaviour in gun/axe mode.

## Testing

* Spawned a K.A.R.L
* Checked the `force` variable depending on axe/gun mode and turned-on/off.
* Checked the recharge mode by spamming Unique-action in gun mode
* Checked the attack behaviour by swinging a few time in axe mode and in gun mode

## Changelog
:cl: Hyperio
fix: Fixed exploit recharge of K.A.R.L
fix: Fixed K.A.R.L damage in axe and gun mode, turned on and off
fix: Fixed attack behaviour of K.A.R.L in gun mode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
