### PR TITLE
Reduce Potency Explosive Effectiveness (Botany)

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -237,7 +237,7 @@
 
 		create_spores(origin_turf)
 
-		var/flood_dist = min(10,max(1,get_trait(TRAIT_POTENCY)/15))
+		var/flood_dist = min(10,max(1,get_trait(TRAIT_POTENCY)/50))
 		var/list/open_turfs = list()
 		var/list/closed_turfs = list()
 		var/list/valid_turfs = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Seems like the abusers found out Botany is incredibly strong if you have patience to spend an hour or two brute forcing mutation paths or get incredibly lucky. So instead of letting someone else gut my beloved Botany of anything interesting or fun, I am nerfing the exploitative feature directly: Explosive Fruit Radius Size.

Potency affects many parts of a plant, from reagent volume to power generation. Explosive Fruit, a 1% chance mutation, is one of those affected parts. Players can, through brute force, get this trait under an hour. Then, using easy chemistry access, boost potency to 100. Then, using the guild, access to the Arbor and it's 'hidden' inventory can unlock a 300 potency disk.

Previous, 300 potency = 21x21 grid explosion / 100 potency = 7x7 grid explosion.

Now: 300 potency = 9x9 / 100 potency = 5x5

Reminder: 300 potency is **only obtainable through the guild, through trading with the NT Faith, then the Arbor, it is very borderline impossible without.**
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This heavily scales back possible powergaming to make department-destroying fruit by implementing diminishing returns for ridiculously higher potency, without fully gutting them and making the effort/time unrewarding.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![dreamseeker_h2MEBSI1v4](https://github.com/discordia-space/CEV-Eris/assets/11076040/7e5beb51-e422-4af1-9e93-57dfa1a4f36e)
300 potency explosion

![dreamseeker_mlTDx1Toak](https://github.com/discordia-space/CEV-Eris/assets/11076040/fe59746e-d95e-4d56-99ca-0ebaefe53166)
100 potency explosion
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
balance: rebalanced botany explosive trait to be less effective at higher potency
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
