### PR TITLE
Bonsai size fix

### DIFF
--- a/code/modules/reagents/bonsai.dm
+++ b/code/modules/reagents/bonsai.dm
@@ -12,6 +12,7 @@
 	icon = 'icons/obj/bonsai.dmi'
 	icon_state = "bonsai_1"
 	layer = ABOVE_OBJ_LAYER
+	w_class = ITEM_SIZE_NORMAL
 
 	volume = 100 //Average bottle volume
 	reagent_flags = OPENCONTAINER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
adds a w_class for the bonsai so you cant put it in your pocket anymore, just in your hand/backpack
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
even when it was the placeholder sprite it was a bit weird to have a bonsai tree in your pocket, even more weird with the resprite. this fix the issue. you can only get it in your hand and backpack, not the pockets
## Testing

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->
tested, it doesnt fit in the pockets, or the belt/back, can still be placed in the backpack and being held manually.
doesnt change its functionality, works the same with no issue
## Changelog
:cl:
tweak: tweaked the laurelin bonsai size class

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
