### PR TITLE
Slime fix

### DIFF
--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -906,7 +906,7 @@
 
 /datum/chemical_reaction/slime/freeze/on_reaction(var/datum/reagents/holder)
 	..()
-	addtimer(CALLBACK(src, PROC_REF(do_freeze), get_turf(holder.my_atom))50)
+	addtimer(CALLBACK(src, PROC_REF(do_freeze), get_turf(holder.my_atom))50,)
 
 /datum/chemical_reaction/slime/freeze/proc/do_freeze(turf/target)
 	playsound(target, 'sound/effects/phasein.ogg', 100, 1)

--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -906,7 +906,7 @@
 
 /datum/chemical_reaction/slime/freeze/on_reaction(var/datum/reagents/holder)
 	..()
-	addtimer(CALLBACK(src, PROC_REF(do_freeze), get_turf(holder.my_atom)), 500)
+	addtimer(CALLBACK(src, PROC_REF(do_freeze), get_turf(holder.my_atom)), 5 SECONDS)
 
 /datum/chemical_reaction/slime/freeze/proc/do_freeze(turf/target)
 	playsound(target, 'sound/effects/phasein.ogg', 100, 1)
@@ -934,7 +934,7 @@
 
 /datum/chemical_reaction/slime/fire/on_reaction(var/datum/reagents/holder)
 	..()
-	addtimer(CALLBACK(src, PROC_REF(do_fire), get_turf(holder.my_atom), 5 SECONDS))
+	addtimer(CALLBACK(src, PROC_REF(do_fire), get_turf(holder.my_atom)), 5 SECONDS)
 
 /datum/chemical_reaction/slime/fire/proc/do_fire(turf/target)
 	for(var/turf/simulated/floor/target_tile in range(0, target))
@@ -1053,7 +1053,7 @@
 
 /datum/chemical_reaction/slime/explosion/on_reaction(var/datum/reagents/holder)
 	..()
-	addtimer(CALLBACK(src, PROC_REF(do_explode), get_turf(holder.my_atom), 5 SECONDS))
+	addtimer(CALLBACK(src, PROC_REF(do_explode), get_turf(holder.my_atom)), 5 SECONDS)
 
 /datum/chemical_reaction/slime/explosion/proc/do_explode(turf/target)
 	explosion(target, 600, 50)

--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -906,7 +906,7 @@
 
 /datum/chemical_reaction/slime/freeze/on_reaction(var/datum/reagents/holder)
 	..()
-	addtimer(CALLBACK(src, PROC_REF(do_freeze), get_turf(holder.my_atom))50,)
+	addtimer(CALLBACK(src, PROC_REF(do_freeze), get_turf(holder.my_atom)), 500)
 
 /datum/chemical_reaction/slime/freeze/proc/do_freeze(turf/target)
 	playsound(target, 'sound/effects/phasein.ogg', 100, 1)

--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -906,7 +906,7 @@
 
 /datum/chemical_reaction/slime/freeze/on_reaction(var/datum/reagents/holder)
 	..()
-	addtimer(CALLBACK(src, PROC_REF(do_freeze), get_turf(holder.my_atom), 30))
+	addtimer(CALLBACK(src, PROC_REF(do_freeze), get_turf(holder.my_atom), 50 SECONDS))
 
 /datum/chemical_reaction/slime/freeze/proc/do_freeze(turf/target)
 	playsound(target, 'sound/effects/phasein.ogg', 100, 1)

--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -906,7 +906,7 @@
 
 /datum/chemical_reaction/slime/freeze/on_reaction(var/datum/reagents/holder)
 	..()
-	addtimer(CALLBACK(src, PROC_REF(do_freeze), get_turf(holder.my_atom), 50 SECONDS))
+	addtimer(CALLBACK(src, PROC_REF(do_freeze), get_turf(holder.my_atom))50)
 
 /datum/chemical_reaction/slime/freeze/proc/do_freeze(turf/target)
 	playsound(target, 'sound/effects/phasein.ogg', 100, 1)

--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -906,7 +906,7 @@
 
 /datum/chemical_reaction/slime/freeze/on_reaction(var/datum/reagents/holder)
 	..()
-	addtimer(CALLBACK(src, PROC_REF(do_freeze), get_turf(holder.my_atom), 5 SECONDS))
+	addtimer(CALLBACK(src, PROC_REF(do_freeze), get_turf(holder.my_atom), 30))
 
 /datum/chemical_reaction/slime/freeze/proc/do_freeze(turf/target)
 	playsound(target, 'sound/effects/phasein.ogg', 100, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes typos which prevented slime core timers from working
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
certain slime cores no longer instantly activate, making them more useful for their intended purpose
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Activated each affected slime core and counted if the delay matches what it should be
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: oil, orange and dark blue slime cores now activate after 5 seconds instead of instantly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
