### PR TITLE
Links Security Status to Sechuds

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -368,18 +368,13 @@ var/list/rank_prefix = list(\
 				perpname = src.name
 
 			// Retrieve crew member record
-			var/datum/computer_file/report/crew_record/E = get_crewmember_record(perpname)
-
-			if(E)
-				// Check if user has security HUD again
-				if(hasHUD(usr,"security"))
-					to_chat(usr, "<b>Name:</b> [E.get_name()]")
-					to_chat(usr, "<b>Criminal Status:</b> [E.get_criminalStatus()]")
-					to_chat(usr, "<b>Details:</b> [E.get_secRecord()]")
-					read = 1
-
-			if(!read)
-				to_chat(usr, "\red Unable to locate a data core entry for this person.")
+			var/datum/computer_file/report/crew_record/crew_record = get_crewmember_record(perpname)
+			if(crew_record && hasHUD(usr, "security"))
+				to_chat(usr, "<b>Name:</b> [crew_record.get_name()]")
+				to_chat(usr, "<b>Criminal Status:</b> [crew_record.get_criminalStatus()]")
+				to_chat(usr, "<b>Details:</b> [crew_record.get_secRecord()]")
+			else
+				to_chat(usr, span_red("Unable to locate a data core entry for this person."))
 
 	if(href_list["secrecordComment"])
 		if(hasHUD(usr,"security"))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -367,19 +367,16 @@ var/list/rank_prefix = list(\
 			else
 				perpname = src.name
 
-			for(var/datum/data/record/E in data_core.general)
-				if(E.fields["name"] == perpname)
-					for(var/datum/data/record/R in data_core.security)
-						if(R.fields["id"] == E.fields["id"])
-							if(hasHUD(usr,"security"))
-								to_chat(usr, "<b>Name:</b> [R.fields["name"]]	<b>Criminal Status:</b> [R.fields["criminal"]]")
-								to_chat(usr, "<b>Minor Crimes:</b> [R.fields["mi_crim"]]")
-								to_chat(usr, "<b>Details:</b> [R.fields["mi_crim_d"]]")
-								to_chat(usr, "<b>Major Crimes:</b> [R.fields["ma_crim"]]")
-								to_chat(usr, "<b>Details:</b> [R.fields["ma_crim_d"]]")
-								to_chat(usr, "<b>Notes:</b> [R.fields["notes"]]")
-								to_chat(usr, "<a href='?src=\ref[src];secrecordComment=`'>\[View Comment Log\]</a>")
-								read = 1
+			// Retrieve crew member record
+			var/datum/computer_file/report/crew_record/E = get_crewmember_record(perpname)
+
+			if(E)
+				// Check if user has security HUD again
+				if(hasHUD(usr,"security"))
+					to_chat(usr, "<b>Name:</b> [E.get_name()]")
+					to_chat(usr, "<b>Criminal Status:</b> [E.get_criminalStatus()]")
+					to_chat(usr, "<b>Details:</b> [E.get_secRecord()]")
+					read = 1
 
 			if(!read)
 				to_chat(usr, "\red Unable to locate a data core entry for this person.")
@@ -1348,7 +1345,7 @@ var/list/rank_prefix = list(\
 	reset_view(A)
 
 /mob/living/carbon/human/proc/resuscitate()
-	
+
 	var/obj/item/organ/internal/vital/heart_organ = random_organ_by_process(OP_HEART)
 	var/obj/item/organ/internal/vital/brain_organ = random_organ_by_process(BP_BRAIN)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1345,7 +1345,6 @@ var/list/rank_prefix = list(\
 	reset_view(A)
 
 /mob/living/carbon/human/proc/resuscitate()
-
 	var/obj/item/organ/internal/vital/heart_organ = random_organ_by_process(OP_HEART)
 	var/obj/item/organ/internal/vital/brain_organ = random_organ_by_process(BP_BRAIN)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -359,7 +359,6 @@ var/list/rank_prefix = list(\
 	if(href_list["secrecord"])
 		if(hasHUD(usr,"security"))
 			var/perpname = "wot"
-			var/read = 0
 
 			var/obj/item/card/id/id = GetIdCard()
 			if(istype(id))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR  links  the security record. field from crew records to sechuds allowing them to be seen by those wearing sechuds
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows for much Better   in field keeping up to date with incidents. and problems without having to run to a computer every 
![image](https://github.com/discordia-space/CEV-Eris/assets/60349436/2f1122c9-9c91-4d9a-8edb-fc41598be4b0)

single time just to see a person's history.  
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
spawned in as operative.
 edited secrecords from console
viewed myself with sechuds
Records appeared as normal 

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: sechuds now draw their information from the crew record program. 
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
