### PR TITLE
Pilots of mechs that break apart are injured

### DIFF
--- a/code/modules/mechs/mech.dm
+++ b/code/modules/mechs/mech.dm
@@ -167,7 +167,8 @@
 	selected_system = null
 
 	for(var/mob/living/Pilot in pilots)
-		eject(Pilot)
+		eject(Pilot, TRUE, TRUE)
+
 	pilots = null
 	var/obj/item/mech_equipment/forklifting_system/lifter = locate() in contents
 	if(lifter)

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -229,8 +229,10 @@
 			access_card.access |= pilot.GetAccess()
 			to_chat(pilot, SPAN_NOTICE("Security access permissions synchronized."))
 
-/mob/living/exosuit/proc/eject(mob/living/user, silent)
-	if(!user || !(user in src.contents)) return
+/mob/living/exosuit/proc/eject(mob/living/user, silent, mech_death)
+	if(!user || !(user in src.contents))
+		return
+
 	if(body && body.has_hatch)
 		if(hatch_closed)
 			if(hatch_locked)
@@ -247,6 +249,12 @@
 		to_chat(user, SPAN_NOTICE("You climb out of \the [src]."))
 
 	user.forceMove(get_turf(src))
+
+	if(mech_death)
+		user.apply_damages(30, 30)	//Give them bruises and burns
+		//Mobs process every 2 seconds but both handle_statuses() and handle_status_effects() decrements by 1
+		user.AdjustWeakened(4)
+
 	//LAZYREMOVE(user.additional_vision_handlers, src)
 	if(user in pilots)
 		a_intent = I_HURT

--- a/code/modules/mechs/mech_life.dm
+++ b/code/modules/mechs/mech_life.dm
@@ -113,7 +113,7 @@
 	// Eject the pilots
 	hatch_locked = FALSE // So they can get out
 	for(var/pilot in pilots)
-		eject(pilot, silent=TRUE)
+		eject(pilot, TRUE, TRUE)
 
 	// Salvage moves into the wreck unless we're exploding violently.
 	var/obj/wreck = new wreckage_path(drop_location(), src, gibbed)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a parameter to eject() on living/exosuit that is set to TRUE when the mech is destroyed. Any pilots ejected when TRUE are moderately injured and briefly knocked down.

## Why It's Good For The Game

You can't just walk away from a mech wreckage unscathed.

## Testing

Called death() on a mech and can confirm you come out injured and knocked down.

## Changelog
:cl:
balance: Pilots crawl out of mech wreckages with injuries.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
