### PR TITLE
Cooking Adjustments 2

### DIFF
--- a/code/modules/cooking_with_jane/cooking_items/cooking_containers.dm
+++ b/code/modules/cooking_with_jane/cooking_items/cooking_containers.dm
@@ -54,10 +54,6 @@
 	log_debug("cooking_container/attackby() called!")
 	#endif
 
-	if(istype(used_item, /obj/item/tool/shovel))
-		do_empty(user, target=null, reagent_clear = FALSE)
-		return
-
 	if(!tracker && (contents.len || reagents.total_volume != 0))
 		to_chat(user, "The [src] is full. Empty its contents first.")
 	else

--- a/code/modules/cooking_with_jane/recipes/_read_me.dm
+++ b/code/modules/cooking_with_jane/recipes/_read_me.dm
@@ -27,7 +27,7 @@ list(<CWJ_STEP_CLASS><_OPTIONAL>, <REQUIRED_ARGS>, <CUSTOM_ARGS>=value)
 			Add a grown item to the recipe. The item is inserted in the container.
 			The product inherits reagents if able, and its quality scales with the plant's potency.
 			<REQUIRED_ARGS>:
-				plantname - the NAME of the SEED DATUM of the plant being added.
+				kitchen_tag - the kitchen_tag string of the SEED DATUM of the plant being added. This can mean multiple produce items have the same kitchen_tag. This is intentional.
 			Example: list(CWJ_ADD_PRODUCE, "banana")
 
 		CWJ_USE_TOOL

--- a/code/modules/cooking_with_jane/recipes/recipe.dm
+++ b/code/modules/cooking_with_jane/recipes/recipe.dm
@@ -533,7 +533,7 @@
 	cooking_container = PAN
 	product_type = /obj/item/reagent_containers/food/snacks/rofflewaffles
 	step_builder = list(
-		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/rofflewaffles, qmod=0.5),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/waffles, qmod=0.5),
 		list(CWJ_ADD_REAGENT, "psilocybin", 5),
 		CWJ_BEGIN_EXCLUSIVE_OPTIONS,
 		list(CWJ_ADD_REAGENT_OPTIONAL, "pwine", 5, base=6, remain_percent=0.1, prod_desc="The fancy wine soaks up into the fluffy waffles."),

--- a/code/modules/cooking_with_jane/recipes/recipe.dm
+++ b/code/modules/cooking_with_jane/recipes/recipe.dm
@@ -34,9 +34,7 @@
 		list(CWJ_ADD_REAGENT, "blackpepper", 1),
 		//Add some mushrooms to give it some zest. Only one kind is allowed!
 		CWJ_BEGIN_EXCLUSIVE_OPTIONS,
-		list(CWJ_ADD_PRODUCE_OPTIONAL, "mushrooms", qmod=0.2),
-		list(CWJ_ADD_PRODUCE_OPTIONAL, "reishi", qmod=0.4),
-		list(CWJ_ADD_PRODUCE_OPTIONAL, "amanita", qmod=0.4),
+		list(CWJ_ADD_PRODUCE_OPTIONAL, "mushroom", qmod=0.4),
 		list(CWJ_ADD_PRODUCE_OPTIONAL, "plumphelmet", qmod=0.4),
 		CWJ_END_EXCLUSIVE_OPTIONS,
 
@@ -115,9 +113,7 @@
 		list(CWJ_ADD_REAGENT, "sodiumchloride", 1),
 		list(CWJ_ADD_REAGENT, "blackpepper", 1),
 		CWJ_BEGIN_EXCLUSIVE_OPTIONS,
-		list(CWJ_ADD_PRODUCE_OPTIONAL, "mushrooms", qmod=0.2),
-		list(CWJ_ADD_PRODUCE_OPTIONAL, "reishi", qmod=0.4),
-		list(CWJ_ADD_PRODUCE_OPTIONAL, "amanita", qmod=0.4),
+		list(CWJ_ADD_PRODUCE_OPTIONAL, "mushroom", qmod=0.4),
 		list(CWJ_ADD_PRODUCE_OPTIONAL, "plumphelmet", qmod=0.4),
 		CWJ_END_EXCLUSIVE_OPTIONS,
 		list(CWJ_ADD_REAGENT_OPTIONAL, "honey", 3, base=3),
@@ -143,9 +139,7 @@
 		list(CWJ_ADD_REAGENT, "sodiumchloride", 1),
 		list(CWJ_ADD_REAGENT, "blackpepper", 1),
 		CWJ_BEGIN_EXCLUSIVE_OPTIONS,
-		list(CWJ_ADD_PRODUCE_OPTIONAL, "mushrooms", qmod=0.2),
-		list(CWJ_ADD_PRODUCE_OPTIONAL, "reishi", qmod=0.4),
-		list(CWJ_ADD_PRODUCE_OPTIONAL, "amanita", qmod=0.4),
+		list(CWJ_ADD_PRODUCE_OPTIONAL, "mushroom", qmod=0.4),
 		list(CWJ_ADD_PRODUCE_OPTIONAL, "plumphelmet", qmod=0.4),
 		CWJ_END_EXCLUSIVE_OPTIONS,
 		CWJ_BEGIN_EXCLUSIVE_OPTIONS,
@@ -311,7 +305,7 @@
 	step_builder = list(
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/meat/xenomeat, qmod=0.5),
 		list(CWJ_ADD_REAGENT, "soysauce", 5),
-		list(CWJ_USE_TOOL, QUALITY_CUTTING, 1)
+		list(CWJ_USE_TOOL, QUALITY_CUTTING, 15)
 	)
 
 /datum/cooking_with_jane/recipe/sashimi
@@ -321,7 +315,7 @@
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/meat/carp, qmod=0.5),
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/meat/carp, qmod=0.5),
 		list(CWJ_ADD_REAGENT, "soysauce", 5),
-		list(CWJ_USE_TOOL, QUALITY_CUTTING, 1)
+		list(CWJ_USE_TOOL, QUALITY_CUTTING, 15)
 	)
 
 /datum/cooking_with_jane/recipe/chawanmushi
@@ -329,7 +323,7 @@
 	product_type = /obj/item/reagent_containers/food/snacks/chawanmushi
 	step_builder = list(
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/egg, qmod=0.5),
-		list(CWJ_ADD_PRODUCE, "mushrooms", qmod=0.2),
+		list(CWJ_ADD_PRODUCE, "mushroom", qmod=0.2),
 		list(CWJ_ADD_REAGENT, "water", 5),
 		list(CWJ_ADD_REAGENT, "soysauce", 5),
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/egg, qmod=0.5),
@@ -531,7 +525,7 @@
 		list(CWJ_ADD_REAGENT_OPTIONAL, "honey", 3, base=3),
 		list(CWJ_ADD_REAGENT, "milk", 5, base=1),
 		list(CWJ_ADD_REAGENT, "flour", 5, base=1),
-		list(CWJ_USE_TOOL, QUALITY_CUTTING, 1),
+		list(CWJ_USE_TOOL, QUALITY_CUTTING, 15),
 		list(CWJ_USE_OVEN, J_LO, 5 SECONDS)
 	)
 
@@ -558,7 +552,7 @@
 	step_builder = list(
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5),
 		list(CWJ_ADD_REAGENT, "cherryjelly", 5),
-		list(CWJ_USE_TOOL, QUALITY_CUTTING, 1)
+		list(CWJ_USE_TOOL, QUALITY_CUTTING, 15)
 	)
 
 /datum/cooking_with_jane/recipe/amanitajellytoast
@@ -567,7 +561,7 @@
 	step_builder = list(
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5),
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/jelly/amanita, qmod=0.5),
-		list(CWJ_USE_TOOL, QUALITY_CUTTING, 1)
+		list(CWJ_USE_TOOL, QUALITY_CUTTING, 15)
 	)
 
 /datum/cooking_with_jane/recipe/slimetoast
@@ -576,7 +570,7 @@
 	step_builder = list(
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5),
 		list(CWJ_ADD_REAGENT, "slimejelly", 5),
-		list(CWJ_USE_TOOL, QUALITY_CUTTING, 1)
+		list(CWJ_USE_TOOL, QUALITY_CUTTING, 15)
 	)
 
 /datum/cooking_with_jane/recipe/stuffing
@@ -1117,7 +1111,7 @@
 	step_builder = list(
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/doughslice, qmod=0.5),
 		list(CWJ_ADD_REAGENT_OPTIONAL, "flour", 1, base=1),
-		list(CWJ_USE_TOOL, QUALITY_CUTTING, 1)
+		list(CWJ_USE_TOOL, QUALITY_CUTTING, 15)
 	)
 
 /datum/cooking_with_jane/recipe/boiledspaghetti
@@ -1210,11 +1204,11 @@
 		list(CWJ_ADD_REAGENT_OPTIONAL, "water", 5),
 		list(CWJ_ADD_REAGENT_OPTIONAL, "flour", 5),
 		list(CWJ_ADD_PRODUCE, "tomato", qmod=0.2),
-		list(CWJ_ADD_PRODUCE, "mushrooms", qmod=0.2),
-		list(CWJ_ADD_PRODUCE, "mushrooms", qmod=0.2),
-		list(CWJ_ADD_PRODUCE, "mushrooms", qmod=0.2),
-		list(CWJ_ADD_PRODUCE, "mushrooms", qmod=0.2),
-		list(CWJ_ADD_PRODUCE, "mushrooms", qmod=0.2),
+		list(CWJ_ADD_PRODUCE, "mushroom", qmod=0.2),
+		list(CWJ_ADD_PRODUCE, "mushroom", qmod=0.2),
+		list(CWJ_ADD_PRODUCE, "mushroom", qmod=0.2),
+		list(CWJ_ADD_PRODUCE, "mushroom", qmod=0.2),
+		list(CWJ_ADD_PRODUCE, "mushroom", qmod=0.2),
 		list(CWJ_USE_OVEN, J_MED, 35 SECONDS)
 	)
 
@@ -1230,7 +1224,7 @@
 		list(CWJ_ADD_PRODUCE, "eggplant", qmod=0.2),
 		list(CWJ_ADD_PRODUCE, "cabbage", qmod=0.2),
 		list(CWJ_ADD_PRODUCE, "carrot", qmod=0.2),
-		list(CWJ_ADD_PRODUCE, "mushrooms", qmod=0.2),
+		list(CWJ_ADD_PRODUCE, "mushroom", qmod=0.2),
 		list(CWJ_USE_OVEN, J_MED, 35 SECONDS)
 	)
 
@@ -1493,7 +1487,7 @@
 		list(CWJ_ADD_REAGENT_OPTIONAL, "sodiumchloride", 1, base=1),
 		list(CWJ_ADD_PRODUCE, "carrot"),
 		list(CWJ_ADD_PRODUCE, "potato"),
-		list(CWJ_ADD_PRODUCE, "mushrooms"),
+		list(CWJ_ADD_PRODUCE, "mushroom"),
 		list(CWJ_ADD_PRODUCE, "tomato"),
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/meat, qmod=0.5),
 		list(CWJ_USE_STOVE, J_MED, 15 SECONDS)
@@ -1537,11 +1531,10 @@
 		list(CWJ_ADD_REAGENT, "milk", 5),
 		list(CWJ_ADD_REAGENT, "sodiumchloride", 1),
 		list(CWJ_ADD_REAGENT, "blackpepper", 1),
-		list(CWJ_ADD_PRODUCE, "mushrooms", qmod=0.2),
+		list(CWJ_ADD_PRODUCE, "mushroom", qmod=0.2),
 		list(CWJ_USE_STOVE, J_LO, 5 SECONDS),
 		CWJ_BEGIN_EXCLUSIVE_OPTIONS,
-		list(CWJ_ADD_PRODUCE_OPTIONAL, "reishi", qmod=0.4),
-		list(CWJ_ADD_PRODUCE_OPTIONAL, "amanita", qmod=0.4),
+		list(CWJ_ADD_PRODUCE_OPTIONAL, "mushroom", qmod=0.4),
 		list(CWJ_ADD_PRODUCE_OPTIONAL, "plumphelmet", qmod=0.4),
 		CWJ_END_EXCLUSIVE_OPTIONS,
 		list(CWJ_USE_STOVE, J_MED, 15 SECONDS)
@@ -1675,9 +1668,7 @@
 		list(CWJ_ADD_ITEM_OPTIONAL, /obj/item/reagent_containers/food/snacks/butterslice, base=3),
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cheesewedge, qmod=0.5),
 		CWJ_BEGIN_EXCLUSIVE_OPTIONS,
-		list(CWJ_ADD_PRODUCE_OPTIONAL, "mushrooms", qmod=0.2),
-		list(CWJ_ADD_PRODUCE_OPTIONAL, "reishi", qmod=0.4),
-		list(CWJ_ADD_PRODUCE_OPTIONAL, "amanita", qmod=0.4),
+		list(CWJ_ADD_PRODUCE_OPTIONAL, "mushroom", qmod=0.4),
 		list(CWJ_ADD_PRODUCE_OPTIONAL, "plumphelmet", qmod=0.4),
 		CWJ_END_EXCLUSIVE_OPTIONS,
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cheesewedge, qmod=0.5),

--- a/code/modules/cooking_with_jane/step_defines.dm
+++ b/code/modules/cooking_with_jane/step_defines.dm
@@ -50,7 +50,7 @@
 	tooltip_image = image('icons/emoji.dmi', icon_state="gear")
 
 //Calculate how well the recipe step was followed to the letter.
-/datum/cooking_with_jane/recipe_step/proc/calculate_quality(var/obj/added_item, var/obj/item/reagent_containers/cooking_with_jane/cooking_container/container)
+/datum/cooking_with_jane/recipe_step/proc/calculate_quality(var/obj/added_item, var/obj/item/reagent_containers/cooking_with_jane/cooking_container/container, var/mob/living/user)
 	return 0
 
 //Check if the conditions of a recipe step was followed correctly.

--- a/code/modules/cooking_with_jane/step_types/add_produce.dm
+++ b/code/modules/cooking_with_jane/step_types/add_produce.dm
@@ -4,7 +4,7 @@
 	var/required_produce_type
 	var/base_potency
 	var/reagent_skip = FALSE
-	var/inherited_quality_modifier
+	var/inherited_quality_modifier = 1
 
 	var/list/exclude_reagents = list()
 

--- a/code/modules/cooking_with_jane/step_types/use_tool.dm
+++ b/code/modules/cooking_with_jane/step_types/use_tool.dm
@@ -47,5 +47,5 @@
 		raw_quality = (our_tool.get_tool_quality(tool_type) - tool_quality) * inherited_quality_modifier
 	else
 		raw_quality = ((our_tool.get_tool_quality(tool_type) * -1) - tool_quality) * inherited_quality_modifier //Purposefully mucking up a recipe should invert the positive bonus into a negative
-		to_chat(usr, SPAN_NOTICE("You deliberately apply the [added_item] poorly, resulting in a worse dish."))
+		to_chat(usr, SPAN_NOTICE("You apply the [added_item] with ill intent, resulting in a worse dish."))
 	return clamp_quality(raw_quality)

--- a/code/modules/cooking_with_jane/step_types/use_tool.dm
+++ b/code/modules/cooking_with_jane/step_types/use_tool.dm
@@ -3,7 +3,7 @@
 	class=CWJ_USE_ITEM
 	var/tool_type
 	var/tool_quality
-	var/inherited_quality_modifier = 0.1
+	var/inherited_quality_modifier = 1
 
 //item_type: The type path of the object we are looking for.
 //base_quality_award: The quality awarded by following this step.
@@ -42,5 +42,10 @@
 //Think about a way to make this more intuitive?
 /datum/cooking_with_jane/recipe_step/use_tool/calculate_quality(var/obj/added_item)
 	var/obj/item/tool/our_tool = added_item
-	var/raw_quality = (our_tool.get_tool_quality(tool_type) - tool_quality) * inherited_quality_modifier
+	var/raw_quality
+	if(usr.a_intent == I_HELP)
+		raw_quality = (our_tool.get_tool_quality(tool_type) - tool_quality) * inherited_quality_modifier
+	else
+		raw_quality = ((our_tool.get_tool_quality(tool_type) * -1) - tool_quality) * inherited_quality_modifier //Purposefully mucking up a recipe should invert the positive bonus into a negative
+		to_chat(usr, SPAN_NOTICE("You deliberately apply the [added_item] poorly, resulting in a worse dish."))
 	return clamp_quality(raw_quality)

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -342,7 +342,7 @@
 
 //Mushrooms/varieties.
 /datum/seed/mushroom
-	name = "mushrooms"
+	name = "mushroom"
 	seed_name = "chanterelle"
 	seed_noun = "spores"
 	display_name = "chanterelle mushrooms"

--- a/code/modules/hydroponics/seed_packets.dm
+++ b/code/modules/hydroponics/seed_packets.dm
@@ -170,7 +170,7 @@ var/global/list/plant_seed_sprites = list()
 	seed_type = "libertycap"
 
 /obj/item/seeds/chantermycelium
-	seed_type = "mushrooms"
+	seed_type = "mushroom"
 
 /obj/item/seeds/towermycelium
 	seed_type = "towercap"

--- a/code/modules/reagents/bonsai.dm
+++ b/code/modules/reagents/bonsai.dm
@@ -54,7 +54,7 @@
 					"corn",
 					"eggplant",
 					"chili",
-					"mushrooms",
+					"mushroom",
 					"wheat",
 					"potato",
 					"rice")]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removed relic spatula scooping from containers.
Adjusted cwj recipes readme to reflect usage of kitchen_tags.
Honored kitchen_tags for mushroom, which is used by children as well, changing recipes and "mushrooms" tags to "mushroom".
Inherited quality modifier changes so player action is more impactful.
Added purposeful misuse of tools, so player action is more impactful.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Confusion removal good. Player feeling able to measure their personal impact onto something, also good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tested locally, was able to use reishi, libertyduff, chantrelle, and other mushroom children in place of "mushroom".
Tested tool behavior as well.
![Code_iqpfUt7F7V](https://github.com/discordia-space/CEV-Eris/assets/11076040/57b13a85-f075-4c0c-97a6-1616c40ef7c9)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
add: Misusing tools on recipes negatively impact food quality
tweak: Changed "Mushrooms" to "Mushroom" so the cooking tracker stops saying "add a mushrooms"
balance: rebalanced inherited quality modifiers to a default of 1
fix: fixed forgotten spatula scooping from cooking containers inhand
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
