### PR TITLE
Sabotage yourself now

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -7,7 +7,7 @@
 	item_state = "baton"
 	slot_flags = SLOT_BELT
 	description_info = "Highly effective against uninsulated people. High change to disarm when aimed at arms."
-	description_antag = "Can be saboutaged by inserting plasma into its battery cell. Upon being turned on it will blow"
+	description_antag = "Can be sabotaged by inserting plasma into its battery cell. Upon being turned on it will blow"
 	force = WEAPON_FORCE_PAINFUL
 	sharp = FALSE
 	edge = FALSE

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -17,7 +17,7 @@
 	icon = 'icons/obj/rig_modules.dmi'
 	desc = "A back-mounted hardsuit deployment and control mechanism."
 	slot_flags = SLOT_BACK
-	description_antag = "If this rig contains a chemical dispenser, its contents can be saboutaged. They will show as another reagent as long as its the majority in the beaker. You can also insert plasma into its powercell or replace the air tank inside"
+	description_antag = "If this rig contains a chemical dispenser, its contents can be sabotaged. They will show as another reagent as long as its the majority in the beaker. You can also insert plasma into its powercell or replace the air tank inside"
 	description_info = "A highly capable modular RIG system. Can hold modules which provide additional functionality. Also has a chance to completely deflect ballistic projectiles depending on the bullet protection."
 	req_one_access = list()
 	req_access = list()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -65,7 +65,7 @@
 	name = "area power controller"
 	desc = "A control terminal for the area electrical systems."
 	description_info = "Controls all of this area's machinery."
-	description_antag = "Can be unlocked by pulsing the lock wire. Can also be saboutaged by inserting plasma into its cell, making it blow whenever its turned on"
+	description_antag = "Can be unlocked by pulsing the lock wire. Can also be sabotaged by inserting plasma into its cell, making it blow whenever its turned on"
 
 	icon_state = "apc0"
 	anchored = TRUE


### PR DESCRIPTION
## About The Pull Request
Typo fix from saboutage to sabotage

## Why It's Good For The Game

Typo fix

## Testing
It's descriptive text without special effects. None needed.

## Changelog
:cl: Xoxeyos
spellcheck: Sabotage yourself, NOW! Saboutage is now sabotage.
/:cl:
