### PR TITLE
Stat panel fixes

### DIFF
--- a/code/controllers/subsystems/statpanel.dm
+++ b/code/controllers/subsystems/statpanel.dm
@@ -75,12 +75,12 @@ SUBSYSTEM_DEF(statpanels)
 					if(turf_content in overrides)
 						continue
 					if(LAZYLEN(turfitems) < 30) // Only create images for the first 30 items on the turf, for performance reasons
-						if(!(REF(turf_content) in cached_images))
-							target << browse_rsc(getFlatIcon(turf_content, no_anim = TRUE), "[REF(turf_content)].png")
-							cached_images += REF(turf_content)
-						turfitems[++turfitems.len] = list("[turf_content.name]", REF(turf_content), "[REF(turf_content)].png")
+						if(!("\ref[turf_content]" in cached_images))
+							target << browse_rsc(getFlatIcon(turf_content, no_anim = TRUE), "\ref[turf_content].png")
+							cached_images += "\ref[turf_content]"
+						turfitems[++turfitems.len] = list("[turf_content.name]", "\ref[turf_content]", "\ref[turf_content].png")
 					else
-						turfitems[++turfitems.len] = list("[turf_content.name]", REF(turf_content))
+						turfitems[++turfitems.len] = list("[turf_content.name]", "\ref[turf_content]")
 				turfitems = url_encode(json_encode(turfitems))
 				target << output("[turfitems];", "statbrowser:update_listedturf")
 		if(MC_TICK_CHECK)

--- a/code/game/antagonist/antagonist_factions.dm
+++ b/code/game/antagonist/antagonist_factions.dm
@@ -17,7 +17,7 @@
 	var/list/members = list()
 	var/list/leaders = list()
 
-	var/list/verbs = list()	//List of verbs, used by this faction members
+	var/list/faction_datum_verbs = list()	//List of verbs, used by this faction members
 	var/list/leader_verbs = list()
 
 /datum/faction/New()
@@ -39,7 +39,7 @@
 	if(objectives.len)
 		member.set_objectives(objectives)
 
-	add_verb(member.owner.current, verbs)
+	add_verb(member.owner.current, faction_datum_verbs)
 	add_icons(member)
 	update_members()
 	return TRUE
@@ -102,7 +102,7 @@
 		to_chat(member.owner.current, SPAN_WARNING("You are no longer a member of the [name]."))
 
 	if(member.owner && member.owner.current)
-		member.owner.current.verbs.Remove(verbs)
+		member.owner.current.verbs.Remove(faction_datum_verbs)
 
 	update_members()
 	return TRUE

--- a/code/game/antagonist/station/revolutionary/excel_faction.dm
+++ b/code/game/antagonist/station/revolutionary/excel_faction.dm
@@ -13,7 +13,7 @@
 	hud_indicator = "excelsior"
 
 	possible_antags = list(ROLE_EXCELSIOR_REV)
-	verbs = list(/datum/faction/excelsior/proc/communicate_verb,
+	faction_datum_verbs = list(/datum/faction/excelsior/proc/communicate_verb,
 				/datum/faction/excelsior/proc/summon_stash)
 
 	var/stash_holder = null

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -174,3 +174,83 @@
 	if(eyeobj)
 		return eyeobj
 	return src
+
+/client/verb/fix_chat()
+	set name = "Fix Chat"
+	set category = "OOC"
+
+	if(!chatOutput || !istype(chatOutput))
+		var/action = alert(src, "Invalid Chat Output data found!\nRecreate data?", "", "Yes", "Cancel")
+		if(action != "Recreate Chat Output data")
+			return
+		chatOutput = new /datum/chatOutput(src)
+		chatOutput.start()
+		action = alert(src, "Goon chat is reloading.\nWait a bit and see if it\'s fixed.", "", "Fixed", "Nope")
+		if(action == "Fixed")
+			log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by re-creating the chatOutput datum.")
+		else
+			chatOutput.load()
+			action = alert(src, "Give it a moment.\nIt may also try to load twice.", "", "Fixed", "Nope")
+			if(action == "Fixed")
+				log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by re-creating the chatOutput datum and forcing a load()")
+			else
+				action = alert(src, "Try closing byond and reconnecting.\nCould also disable fancy chat and re-enable oldchat.", "", "Thanks anyways", "Switch to old chat")
+				if(action == "Switch to old chat")
+					winset(src, "output", "is-visible=true;is-disabled=false")
+					winset(src, "browseroutput", "is-visible=false")
+				log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window after recreating the chatOutput and forcing a load()")
+	else if(chatOutput.loaded)
+		var/action = alert(src, "Do you want to force a reload, wiping the chat log or just refresh the chat window?", "", "Force Reload", "Refresh", "Cancel")
+		switch (action)
+			if("Force Reload")
+				chatOutput.loaded = FALSE
+				chatOutput.start() //this is likely to fail since it asks , but we should try it anyways so we know.
+				action = alert(src, "Goon chat is reloading.\nWait a bit and see if it\'s fixed.", "", "Fixed", "Nope")
+				if(action == "Fixed")
+					log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a start()")
+				else
+					chatOutput.load()
+					action = alert(src, "Give it a moment.\nIt may also try to load twice.", "", "Fixed", "Nope")
+					if(action == "Fixed")
+						log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a load()")
+					else
+						action = alert(src, "Try closing byond and reconnecting.\nCould also disable fancy chat and re-enable oldchat.", "", "Thanks anyways", "Switch to old chat")
+						if(action == "Switch to old chat")
+							winset(src, "output", "is-visible=true;is-disabled=false")
+							winset(src, "browseroutput", "is-visible=false")
+						log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window forcing a start() and forcing a load()")
+
+			if("Refresh")
+				chatOutput.showChat()
+				action = alert(src, "Goon chat is refreshing.\nWait a bit and see if it\'s fixed.", "", "Fixed", "Nope")
+				if(action == "Fixed")
+					log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a show()")
+				else
+					chatOutput.loaded = FALSE
+					chatOutput.load()
+					action = alert(src, "Give it a moment.", "", "Fixed", "Nope")
+					if(action == "Fixed")
+						log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a load()")
+					else
+						action = alert(src, "Try closing byond and reconnecting.\nCould also disable fancy chat and re-enable oldchat.", "", "Thanks anyways", "Switch to old chat")
+						if(action == "Switch to old chat")
+							winset(src, "output", "is-visible=true;is-disabled=false")
+							winset(src, "browseroutput", "is-visible=false")
+						log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window forcing a show() and forcing a load()")
+		return
+	else
+		chatOutput.start()
+		var/action = alert(src, "Manually loading Chat.\nWait a bit and see if it\'s fixed.", "", "Fixed", "Nope")
+		if(action == "Fixed")
+			log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by manually calling start()")
+		else
+			chatOutput.load()
+			alert(src, "Give it a moment.\nIt may also try to load twice.", "", "Fixed", "Nope")
+			if(action == "Fixed")
+				log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by manually calling start() and forcing a load()")
+			else
+				action = alert(src, "Try closing byond and reconnecting.\nCould also disable fancy chat and re-enable oldchat.", "", "Thanks anyways", "Switch to old chat")
+				if(action == "Switch to old chat")
+					winset(src, "output", list2params(list("on-show" = "", "is-disabled" = "false", "is-visible" = "true")))
+					winset(src, "browseroutput", "is-disabled=true;is-visible=false")
+				log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window after manually calling start() and forcing a load()")


### PR DESCRIPTION
## About The Pull Request

Returned the "Fix Chat" verb that was accidentally removed (probably assumed it to be redundant because of another "Fix Chat" verb that we have, but which is unticked in .dme, can't really tell by now).
Changed the way (mostly broken) icons of on-turf items are referenced, to be in line with RIG module icons, since these apparently worked well on live server.

## Why It's Good For The Game

Fixes good.

## Testing

Checked that "Fix Chat" verb appears in OOC tab, activates and works as intended (reverted to old chat and back to goon chat).

Issues with on-turf Icons is something that only appeared on live server, I am literally unable to reproduce it on local server, both before and after the changes it worked well for me.
![image](https://github.com/discordia-space/CEV-Eris/assets/65828539/e989b842-f159-424e-bfe2-f56e467bc1a6)

## Changelog
:cl:
fix: Returned "Fix Chat" verb to it's proper place in OOC tab
/:cl: