### PR TITLE
chaos level now automatically increases hourly

### DIFF
--- a/code/game/gamemodes/storyteller.dm
+++ b/code/game/gamemodes/storyteller.dm
@@ -67,7 +67,7 @@ GLOBAL_VAR_INIT(chaos_level, 1) //Works as global multiplier for all storyteller
 
 	var/votable = TRUE
 	//whether or not the players can vote for it. If this is set to false, it can only be activated by being forced by admins.
-
+	var/last_chaos_hour = 0
 
 
 /********************************
@@ -111,6 +111,7 @@ GLOBAL_VAR_INIT(chaos_level, 1) //Works as global multiplier for all storyteller
 
 /datum/storyteller/proc/set_up()
 	build_event_pools()
+	last_chaos_hour = REALTIMEOFDAY
 	set_timer()
 	set_up_events()
 
@@ -153,6 +154,9 @@ GLOBAL_VAR_INIT(chaos_level, 1) //Works as global multiplier for all storyteller
 
 	last_tick = world.time
 	next_tick = last_tick + tick_interval
+	if(REALTIMEOFDAY > last_chaos_hour + 1 HOUR)
+		GLOB.chaos_level += 1
+		last_chaos_hour += 1 HOUR
 
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR increases the Chaos Level once per hour.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Destination? Death.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
tested the chaos level increase timing- it does not increase the level roundstart, but does increase it an appropriate cycle.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
balance: Bluespace Chaos now infuses the ship over time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
