### PR TITLE
Revert "chaos level now automatically increases hourly"

### DIFF
--- a/code/game/gamemodes/storyteller.dm
+++ b/code/game/gamemodes/storyteller.dm
@@ -67,7 +67,7 @@ GLOBAL_VAR_INIT(chaos_level, 1) //Works as global multiplier for all storyteller
 
 	var/votable = TRUE
 	//whether or not the players can vote for it. If this is set to false, it can only be activated by being forced by admins.
-	var/last_chaos_hour = 0
+
 
 
 /********************************
@@ -111,7 +111,6 @@ GLOBAL_VAR_INIT(chaos_level, 1) //Works as global multiplier for all storyteller
 
 /datum/storyteller/proc/set_up()
 	build_event_pools()
-	last_chaos_hour = REALTIMEOFDAY
 	set_timer()
 	set_up_events()
 
@@ -154,9 +153,6 @@ GLOBAL_VAR_INIT(chaos_level, 1) //Works as global multiplier for all storyteller
 
 	last_tick = world.time
 	next_tick = last_tick + tick_interval
-	if(REALTIMEOFDAY > last_chaos_hour + 1 HOUR)
-		GLOB.chaos_level += 1
-		last_chaos_hour += 1 HOUR
 
 
 


### PR DESCRIPTION
Reverts discordia-space/CEV-Eris#8488

This PR won't fix the issue of greenshifts on Eris and it will help guarantee a boring TDM-fest later on in the round. (aka 4 people roll traitor and decide to buy all the default gear they can through the uplink instead of actually prepping)
Greenshifts are a player issue created by lack of gimmicks , some gameplay aspects contribute to this , most notably the lack of content relating to non-combat , research and exploration.