### PR TITLE
Fixes missing insight when fulfilling a goal while already inspired

### DIFF
--- a/code/game/machinery/autolathe/artist_bench.dm
+++ b/code/game/machinery/autolathe/artist_bench.dm
@@ -62,7 +62,7 @@
 			if(H.stats.getPerk(PERK_ARTIST) && H.sanity.insight > 40)
 				ins_used = input("How much of your insight will you dedicate to this work? 40-[H.sanity.insight > 100 ? 100 : H.sanity.insight]","Insight Used") as null|num
 			else
-				ins_used = H.sanity.insight
+				ins_used = H.sanity.insight > 100 ? 100 : H.sanity.insight
 			create_art(ins_used, H)
 			return TRUE
 		return FALSE

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -352,7 +352,7 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 
 	owner.pick_individual_objective()
 	resting = 0
-	insight = 0
+	insight -= 100
 
 /datum/sanity/proc/onDamage(amount)
 	changeLevel(-SANITY_DAMAGE_HURT(amount, owner.stats.getStat(STAT_VIG)))

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -283,16 +283,16 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 
 /datum/sanity/proc/level_up()
 	rest_timer_active = FALSE
-	var/rest = input(owner, "How would you like to improve your stats?", "Rest complete", null) in list(
-		"Internalize your recent experiences",
-		"Focus on an oddity",
-		"Convert your fulfilled insight for later use"
+	var/rest = input(owner, "How would you like to improve your stats?", "Rest complete.", null) in list(
+		"Internalize your recent experiences.",
+		"Focus on an oddity.",
+		"Convert your fulfilled insight for later use."
 		)
 
 	if(rest == "Focus on an oddity")
 		if(owner.stats.getPerk(PERK_ARTIST))
 			to_chat(owner, SPAN_NOTICE("Your artistic mind prevents you from using an oddity."))
-			rest = "Internalize your recent experiences"
+			rest = "Internalize your recent experiences."
 		else
 			var/oddity_in_posession = FALSE
 
@@ -303,7 +303,7 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 
 			if(!oddity_in_posession)
 				to_chat(owner, SPAN_NOTICE("You do not have any oddities to use."))
-				rest = "Internalize your recent experiences"
+				rest = "Internalize your recent experiences."
 
 	switch(rest)
 
@@ -315,7 +315,7 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 					inspiration_items += I
 
 			if(inspiration_items.len)//should always work, but in case of bug, there is an else
-				var/obj/item/O = inspiration_items.len > 1 ? owner.client ? input(owner, "Select something to use as inspiration", "Level up") in inspiration_items : pick(inspiration_items) : inspiration_items[1]
+				var/obj/item/O = inspiration_items.len > 1 ? owner.client ? input(owner, "Select something to use as inspiration.", "Level up.") in inspiration_items : pick(inspiration_items) : inspiration_items[1]
 				if(!O)
 					return
 
@@ -323,7 +323,7 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 				var/list/L = I.calculate_statistics()
 				for(var/stat in L)
 					var/stat_up = L[stat] * 2
-					to_chat(owner, SPAN_NOTICE("Your [stat] stat goes up by [stat_up]"))
+					to_chat(owner, SPAN_NOTICE("Your [stat] stat goes up by [stat_up]."))
 					owner.stats.changeStat(stat, stat_up)
 
 				if(I.perk)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You lose ALL insight when you finish focusing, no matter if it goes over 100. This fixes the edge cases when you fulfill a goal right before finishing your current insight, and thus lose an additional 100 insight.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Buttcrack Berry Picker
fix: fixed losing all insight when you focus, instead of just your max cap
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
