### PR TITLE
Add "Fix air" proc

### DIFF
--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -282,15 +282,15 @@
 		initial_gas["oxygen"] = initial_oxygen
 
 	var/initial_carbon_dioxide = initial(carbon_dioxide)
-	if(initial_oxygen)
+	if(initial_carbon_dioxide )
 		initial_gas["carbon_dioxide"] = initial_carbon_dioxide
 
 	var/initial_nitrogen = initial(nitrogen)
-	if(initial_oxygen)
+	if(initial_nitrogen)
 		initial_gas["nitrogen"] = initial_nitrogen
 
 	var/initial_plasma = initial(plasma)
-	if(initial_oxygen)
+	if(initial_plasma )
 		initial_gas["plasma"] = initial_plasma
 
 	air.gas = initial_gas

--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -273,6 +273,30 @@
 	air.copy_from(zone.air)
 	air.group_multiplier = 1
 
+/turf/proc/reset_air()
+	QDEL_NULL(fire)
+	var/list/initial_gas = new
+
+	var/initial_oxygen = initial(oxygen)
+	if(initial_oxygen)
+		initial_gas["oxygen"] = initial_oxygen
+
+	var/initial_carbon_dioxide = initial(carbon_dioxide)
+	if(initial_oxygen)
+		initial_gas["carbon_dioxide"] = initial_carbon_dioxide
+
+	var/initial_nitrogen = initial(nitrogen)
+	if(initial_oxygen)
+		initial_gas["nitrogen"] = initial_nitrogen
+
+	var/initial_plasma = initial(plasma)
+	if(initial_oxygen)
+		initial_gas["plasma"] = initial_plasma
+
+	air.gas = initial_gas
+	air.temperature = initial(temperature)
+	air.update_values()
+
 
 // LINDA proc placeholder, used for compatibility with some tgstation code
 /turf/proc/GetAtmosAdjacentTurfs(alldir = FALSE)

--- a/code/controllers/subsystems/air.dm
+++ b/code/controllers/subsystems/air.dm
@@ -375,7 +375,7 @@ SUBSYSTEM_DEF(air)
 
 	var/direct = !(block & ZONE_BLOCKED)
 
-	if(!istype(B, /turf/space))
+	if(!istype(B, /turf/space) && B.is_simulated && A.is_simulated)
 		if(min(A.zone.contents.len, B.zone.contents.len) < ZONE_MIN_SIZE || (direct && (equivalent_pressure(A.zone, B.zone) || times_fired == 0)))
 			merge(A.zone, B.zone)
 			return

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -74,6 +74,7 @@
 	var/turf/T = get_turf(src)
 	if(T)
 		T.hotspot_expose(700,125)
+	if(user && user.hud_used)
 		user.hud_used.updatePlaneMasters(user)
 
 


### PR DESCRIPTION
## About The Pull Request

Added a way for admins to unfuck the atmos.

## Why It's Good For The Game

Sometimes it's nice to have an option like that.
Also Jeff requested it.
![image](https://github.com/discordia-space/CEV-Eris/assets/65828539/00bf8c5b-5c84-493d-b988-e6c1741eb6bf)

## Testing

Flooded hallways with plasma.
Watched it all burn for a moment.
Pressed "Fix air" button.
Observed plasma fires disappear and air alarms clearing.

## Changelog
:cl:
admin: Added "Fix air" button to "Admin" tab
/:cl: