### PR TITLE
Fixes a silly forklift runtime

### DIFF
--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -903,7 +903,7 @@
 	platform.forceMove(src)
 
 /obj/item/mech_equipment/forklifting_system/Destroy()
-	if(currentlyLifting)
+	if(!QDELETED(currentlyLifting))
 		ejectLifting(get_turf(src))
 	if(platform)
 		QDEL_NULL(platform)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Properly null-checks a object before doing other checks.

## Why It's Good For The Game
Its good for the devs!

## Testing
Ran a local server a few times , was unable to get the forklift ejecting null runtime
## Changelog
:cl:
fix: Fixed a runtime relating to forklift bars
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
