### PR TITLE
Group litanies feedback

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/group.dm
+++ b/code/modules/core_implant/cruciform/rituals/group.dm
@@ -30,6 +30,7 @@
 	var/stat_buff
 	var/buff_value = 3
 	var/aditional_value = 2
+	var/stat_message = "You feel like you're getting better."
 
 /datum/group_ritual_effect/cruciform/stat/trigger_success(var/mob/starter, var/list/participants)
 	. = ..()
@@ -43,6 +44,7 @@
 		return FALSE
 	if(!get_active_mutation(M, MUTATION_ATHEIST))
 		M.stats.changeStat(stat_buff, buff_value + cnt * aditional_value)
+		to_chat(M, SPAN_NOTICE(stat_message))
 
 /datum/ritual/group/cruciform/stat/mechanical
 	name = "Pounding Whisper"
@@ -64,6 +66,7 @@
 
 /datum/group_ritual_effect/cruciform/stat/mechanical
 	stat_buff = STAT_MEC
+	stat_message = "You feel like you're getting smarter."
 
 
 /datum/ritual/group/cruciform/stat/cognition
@@ -83,6 +86,7 @@
 
 /datum/group_ritual_effect/cruciform/stat/cognition
 	stat_buff = STAT_COG
+	stat_message = "You feel like you're getting smarter."
 
 
 
@@ -103,6 +107,7 @@
 
 /datum/group_ritual_effect/cruciform/stat/biology
 	stat_buff = STAT_BIO
+	stat_message = "You feel like you're getting smarter."
 
 
 /datum/ritual/group/cruciform/stat/robustness
@@ -122,6 +127,7 @@
 
 /datum/group_ritual_effect/cruciform/stat/robustness
 	stat_buff = STAT_ROB
+	stat_message = "You feel like you're getting stronger."
 
 /datum/ritual/group/cruciform/stat/vigilance
 	name = "Canto of Courage"
@@ -140,6 +146,7 @@
 
 /datum/group_ritual_effect/cruciform/stat/vigilance
 	stat_buff = STAT_VIG
+	stat_message = "You feel like you're getting more vigilant."
 
 
 /datum/ritual/group/cruciform/stat/toughness
@@ -160,6 +167,7 @@
 
 /datum/group_ritual_effect/cruciform/stat/toughness
 	stat_buff = STAT_TGH
+	stat_message = "You feel like you're getting sturdier."
 
 
 /datum/ritual/group/cruciform/crusade


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Group statboosting litanies now send to each participant a message that their stats were increased.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Clueless believers will no longer think that praying to God is useless.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Performed every group statboosting litany.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: group litanies show message when stats are increased
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
