### PR TITLE
Canto of courage fix

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/group.dm
+++ b/code/modules/core_implant/cruciform/rituals/group.dm
@@ -124,7 +124,7 @@
 	stat_buff = STAT_ROB
 
 /datum/ritual/group/cruciform/stat/vigilance
-	name = "Canto of Courage"
+	name = "Chant of Observance"
 	desc = "Boosts Vigilance stat to 3 + 2 for each participant."
 	phrase = "Vigilia exemplum imitari debemus."
 	phrases = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Two group litanies (ROB and VIG) had the same name, which lead to ROB litany not being displayed in the book.
This renames VIG litany to Chant of Observance
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![изображение](https://github.com/user-attachments/assets/73fe00d9-8b49-42cd-b1e1-26983cd189cf)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: group litany for robustness now properly shows up in the book
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
