### PR TITLE
Fixes SSchunks duplication cases (Stairs , Fallingoff)

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -340,7 +340,8 @@
 
 		// Movement has either failed by Bump(), or we get moved to a new Turf after entering
 		// Either way , both should count as failures, the move is not on the aimed turf after all -SPCR 2024
-		if(!..() || loc != NewLoc)
+		. - ..()
+		if(!. || loc != NewLoc)
 			return FALSE
 
 		if(Dir != olddir)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -340,7 +340,7 @@
 
 		// Movement has either failed by Bump(), or we get moved to a new Turf after entering
 		// Either way , both should count as failures, the move is not on the aimed turf after all -SPCR 2024
-		. - ..()
+		. = ..()
 		if(!. || loc != NewLoc)
 			return FALSE
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -338,7 +338,10 @@
 		var/atom/oldloc = src.loc
 		var/olddir = dir //we can't override this without sacrificing the rest of movable/New()
 
-		. = ..()
+		// Movement has either failed by Bump(), or we get moved to a new Turf after entering
+		// Either way , both should count as failures, the move is not on the aimed turf after all -SPCR 2024
+		if(!..() || loc != NewLoc)
+			return FALSE
 
 		if(Dir != olddir)
 			dir = olddir

--- a/code/modules/unit_tests/step_override.dm
+++ b/code/modules/unit_tests/step_override.dm
@@ -11,8 +11,11 @@
 /datum/unit_test/step_override/proc/TestStep(type_to_test)
 	var/atom/movable/AM = allocate(type_to_test) // alloc spawns them at 20,20,1||20,21,1
 	var/turf/T = get_turf(AM)
+	var/turf/D = locate(T.x, T.y + 1, T.z)
+	T.ChangeTurf(/turf/simulated/floor)
+	D.ChangeTurf(/turf/simulated/floor)
 
 	. = step(AM, NORTH)
 	. = . && T.x == AM.x
-	. = . && T.y + 1 == AM.y // eh?
+	. = . && (T.y + 1) == AM.y // eh?
 	. = . && T.z == AM.z

--- a/code/modules/unit_tests/step_override.dm
+++ b/code/modules/unit_tests/step_override.dm
@@ -14,6 +14,7 @@
 	var/turf/D = locate(T.x, T.y + 1, T.z)
 	T.ChangeTurf(/turf/simulated/floor)
 	D.ChangeTurf(/turf/simulated/floor)
+	a
 
 	. = step(AM, NORTH)
 	. = . && T.x == AM.x

--- a/code/modules/unit_tests/step_override.dm
+++ b/code/modules/unit_tests/step_override.dm
@@ -12,9 +12,8 @@
 	var/atom/movable/AM = allocate(type_to_test) // alloc spawns them at 20,20,1||20,21,1
 	var/turf/T = get_turf(AM)
 	var/turf/D = locate(T.x, T.y + 1, T.z)
-	T.ChangeTurf(/turf/simulated/floor)
-	D.ChangeTurf(/turf/simulated/floor)
-	a
+	T.ChangeTurf(/turf/floor)
+	D.ChangeTurf(/turf/floor)
 
 	. = step(AM, NORTH)
 	. = . && T.x == AM.x


### PR DESCRIPTION


## About The Pull Request
This PR fixes some cases in which SSchunks mobs were duplicated
## Why It's Good For The Game
BUG fix.
## Testing
Ran a local server , tested falling down , examinations/speaking was no longer doubled.

## Changelog
:cl:
fix: Fixed movement_signals being duplicated when a atom that falls/moves is re-located by other atoms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
