### PR TITLE
Blood loss fix

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -813,6 +813,8 @@
 
 		//UNCONSCIOUS. NO-ONE IS HOME
 		if(getOxyLoss() > (species.total_health/2))
+			if(stat == CONSCIOUS)
+				to_chat(src, SPAN_DANGER("You feel your consciousness become increasingly distant from the physical world."))
 			Paralyse(3)
 
 		if(hallucination_power)

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -107,7 +107,7 @@
 
 	if(GetComponent(/datum/component/internal_wound/organic/parenchyma))
 		owner.mutation_index++
-	
+
 	SEND_SIGNAL(src, COMSIG_ADDVAL)
 
 /obj/item/organ/internal/proc/handle_organ_eff()
@@ -211,7 +211,8 @@
 					break
 			if(BV)
 				BV.current_blood = max(BV.current_blood - blood_req, 0)
-			if(!damage && BV?.current_blood == 0)	//When all blood from the organ and blood vessel is lost,
+			var/datum/component/internal_wound/currentcomponent = GetExactComponent(/datum/component/internal_wound/organic/oxy/blood_loss)
+			if(!(BV?.current_blood) && !(currentcomponent?.name == "blood loss"))
 				add_wound(/datum/component/internal_wound/organic/oxy/blood_loss)
 
 		return

--- a/code/modules/organs/internal/internal_organ_processes.dm
+++ b/code/modules/organs/internal/internal_organ_processes.dm
@@ -148,7 +148,6 @@
 
 	if(blood_volume < total_blood_req)
 		status_flags |= BLEEDOUT
-		adjustOxyLoss(ROUND_PROB(2.5))
 		if(prob(15))
 			to_chat(src, SPAN_WARNING("Your organs feel extremely heavy."))
 	else

--- a/code/modules/organs/internal/internal_organ_processes.dm
+++ b/code/modules/organs/internal/internal_organ_processes.dm
@@ -159,6 +159,11 @@
 		adjustOxyLoss(20)
 		if(prob(15))
 			to_chat(src, SPAN_WARNING("You feel extremely [pick("dizzy","woosey","faint")]."))
+	else if(blood_volume < total_blood_req)
+		eye_blurry = max(eye_blurry,6)
+		adjustOxyLoss(4.5) // this damage threshold kills people with good airflow
+		if(prob(15))
+			to_chat(src, SPAN_WARNING("You feel highly [pick("dizzy","woosey","faint")]."))
 	else if(blood_volume < blood_bad)
 		eye_blurry = max(eye_blurry,6)
 		adjustOxyLoss(2)

--- a/code/modules/organs/internal/internal_organ_processes.dm
+++ b/code/modules/organs/internal/internal_organ_processes.dm
@@ -148,6 +148,7 @@
 
 	if(blood_volume < total_blood_req)
 		status_flags |= BLEEDOUT
+		adjustOxyLoss(ROUND_PROB(2.5))
 		if(prob(15))
 			to_chat(src, SPAN_WARNING("Your organs feel extremely heavy."))
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If a human drops below 40% blood, they take oxygen damage over time at a rate high enough to outpace natural recovery.
This leads to unconsciousness followed by death. 

## Why It's Good For The Game

Increases lethality of bleeding wounds. This allows bullets to kill, while still allowing medical attention to delay the target's demise.

## Testing
Increased damage due to bloodloss was tested and timed on multiple dummies. A set amount of blood was drained, with me continuously looking at the amount of oxygen damage through VV, and time to die compared to without the increased damage measured using a stopwatch.  
Blood loss wounds was tested by draining 420 units of blood from a human alongside giving the human a dose of dexalin. The dexalin would prevent death from suffocation, allowing enough time for the wounds to appear on a med bodyscanner.

## Changelog
:cl:
balance: Humans will now receive increased oxygen damage if one loses a large portion of their blood
add: Unconsciousness due to oxygen damage will now play a unique message
fix: Blood loss wounds have been fixed to appear. If a human has lost a large amount of blood and is on dexalin, they can receive wounds on their organs, eventually causing the organ to die
/:cl:
