### PR TITLE
Fixes excelsior rebooter duplication

### DIFF
--- a/code/game/machinery/excelsior/redirector.dm
+++ b/code/game/machinery/excelsior/redirector.dm
@@ -108,6 +108,9 @@
 		return
 	to_chat(user, SPAN_NOTICE("You start rebooting \the [src] with new information. Your hands start moving by themselves like they're remotely guided to input new information."))
 	if(do_after(user, 15 SECONDS, src))
+		if(!rebootTimer)
+			to_chat(user, SPAN_NOTICE("\The [src] was already rebooted!"))
+			return
 		to_chat(user, SPAN_NOTICE("You succesfully reboot \the [src]. Your hands are no longer moving on their own."))
 		deltimer(rebootTimer)
 		var/datum/faction/excelsior/commies = get_faction_by_id(FACTION_EXCELSIOR)
@@ -126,6 +129,9 @@
 	for (var/datum/antagonist/A in commies.members)
 		to_chat(A.owner.current, SPAN_EXCEL_NOTIF("The [src]'s antenna is being bent by someone! Stop them."))
 	if(do_after(user, 1 MINUTE, src))
+		if(antennaBent)
+			to_chat(user, SPAN_NOTICE("\The [src]'s antenna is already bent!"))
+			return
 		stopRedirecting()
 		antennaBent = TRUE
 		icon_state = "redirector_bent"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Blocks spamming the action from causing multiple reboot requests (fucking spammers , when do we get proper do_Afters????)

## Why It's Good For The Game
fIX

## Testing
Ran a local server and tried to spam the actions again, the attempts after the first one were always blocked.
## Changelog
:cl:
fix: Fixed rebooting the excelsior redirector multiple-times.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
