### PR TITLE
Fixing power consumption everywhere

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -44,6 +44,7 @@
 /obj/machinery/optable/unbuckle_mob()
 	. = ..()
 	check_victim()
+	set_power_use(IDLE_POWER_USE)
 
 /obj/machinery/optable/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group || (height==0)) return 1
@@ -83,6 +84,7 @@
 		O.loc = loc
 	add_fingerprint(user)
 	buckle_mob(C)
+	set_power_use(ACTIVE_POWER_USE)
 
 
 /obj/machinery/optable/MouseDrop_T(mob/target, mob/user)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -189,7 +189,7 @@
 			M.client.perspective = EYE_PERSPECTIVE
 			M.client.eye = src
 		M.forceMove(src)
-		update_use_power(2)
+		set_power_use(ACTIVE_POWER_USE)
 		occupant = M
 		update_icon()
 
@@ -205,7 +205,7 @@
 		if(A == beaker)
 			continue
 		A.forceMove(loc)
-	update_use_power(1)
+	set_power_use(IDLE_POWER_USE)
 	update_icon()
 	toggle_filter()
 

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -57,7 +57,7 @@
 	src.occupant.forceMove(loc)
 	src.occupant.reset_view()
 	src.occupant = null
-	update_use_power(1)
+	set_power_use(IDLE_POWER_USE)
 	update_icon()
 
 /obj/machinery/bodyscanner/AltClick(mob/user)
@@ -67,7 +67,7 @@
 /obj/machinery/bodyscanner/proc/set_occupant(var/mob/living/L)
 	L.forceMove(src)
 	src.occupant = L
-	update_use_power(2)
+	set_power_use(ACTIVE_POWER_USE)
 	update_icon()
 	src.add_fingerprint(usr)
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -165,14 +165,14 @@
 	if (!regulating_temperature)
 		//check for when we should start adjusting temperature
 		if(get_danger_level(environment.temperature, TLV["temperature"]) || abs(environment.temperature - target_temperature) > 2)
-			update_use_power(2)
+			set_power_use(ACTIVE_POWER_USE)
 			regulating_temperature = 1
 			visible_message("\The [src] clicks as it starts up.",\
 			"You hear a click and a faint electronic hum.")
 	else
 		//check for when we should stop adjusting temperature
 		if (!get_danger_level(environment.temperature, TLV["temperature"]) && abs(environment.temperature - target_temperature) <= 0.5)
-			update_use_power(1)
+			set_power_use(IDLE_POWER_USE)
 			regulating_temperature = 0
 			visible_message("\The [src] clicks quietly.",\
 			"You hear a click as a faint electronic humming stops.")

--- a/code/game/machinery/antigrav.dm
+++ b/code/game/machinery/antigrav.dm
@@ -34,7 +34,7 @@
 		start_anim()
 
 	on = TRUE
-	use_power = ACTIVE_POWER_USE
+	set_power_use(ACTIVE_POWER_USE)
 	update_icon()
 
 /obj/machinery/antigrav/examine(mob/user, extra_description = "")
@@ -53,7 +53,7 @@
 		stop_anim()
 
 	on = FALSE
-	use_power = IDLE_POWER_USE
+	set_power_use(IDLE_POWER_USE)
 	update_icon()
 
 /obj/machinery/antigrav/Process()

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -185,7 +185,7 @@
 
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/Process()
 	if(!on || (stat & (NOPOWER|BROKEN)))
-		update_use_power(0)
+		set_power_use(NO_POWER_USE)
 		last_flow_rate = 0
 		last_power_draw = 0
 		return 0

--- a/code/game/machinery/autodoc.dm
+++ b/code/game/machinery/autodoc.dm
@@ -73,7 +73,7 @@
 	occupant.unset_machine()
 	occupant = null
 	autodoc_processor.set_patient(null)
-	update_use_power(1)
+	set_power_use(IDLE_POWER_USE)
 	update_icon()
 
 /obj/machinery/autodoc/proc/set_occupant(var/mob/living/L)
@@ -86,7 +86,7 @@
 	else
 		autodoc_processor.set_patient(L)
 		nano_ui_interact(L)
-		update_use_power(2)
+		set_power_use(ACTIVE_POWER_USE)
 		L.set_machine(src)
 	update_icon()
 

--- a/code/game/machinery/autodoc_excelsior.dm
+++ b/code/game/machinery/autodoc_excelsior.dm
@@ -105,7 +105,7 @@
 	occupant.unset_machine()
 	occupant = null
 	autodoc_processor.set_patient(null)
-	update_use_power(1)
+	set_power_use(IDLE_POWER_USE)
 	update_icon()
 
 /obj/machinery/excelsior_autodoc/proc/set_occupant(mob/living/user)
@@ -116,7 +116,7 @@
 	user.forceMove(src)
 	occupant = user
 	autodoc_processor.set_patient(user)
-	update_use_power(2)
+	set_power_use(ACTIVE_POWER_USE)
 	user.set_machine(src)
 	cover_state = image(icon, "opened")
 	cover_state.layer = 4.5

--- a/code/game/machinery/autolathe/autolathe.dm
+++ b/code/game/machinery/autolathe/autolathe.dm
@@ -815,7 +815,7 @@
 		working = FALSE
 		next_file()
 
-	use_power = working ? ACTIVE_POWER_USE : IDLE_POWER_USE
+	set_power_use(working ? ACTIVE_POWER_USE : IDLE_POWER_USE)
 
 	special_process()
 	update_icon()

--- a/code/game/machinery/autolathe_disk_cloner.dm
+++ b/code/game/machinery/autolathe_disk_cloner.dm
@@ -176,6 +176,7 @@
 
 /obj/machinery/autolathe_disk_cloner/proc/copy()
 	copying = TRUE
+	set_power_use(ACTIVE_POWER_USE)
 	SSnano.update_uis(src)
 	update_icon()
 	if(original && copy && !copy.used_capacity)
@@ -226,6 +227,7 @@
 			sleep(copying_delay)
 
 	copying = FALSE
+	set_power_use(IDLE_POWER_USE)
 	SSnano.update_uis(src)
 	update_icon()
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -280,7 +280,7 @@
 //	occupant.metabslow = 0
 	occupant = null
 	current_heat_capacity = initial(current_heat_capacity)
-	update_use_power(1)
+	set_power_use(IDLE_POWER_USE)
 	update_icon()
 	return
 
@@ -310,7 +310,7 @@
 		to_chat(M, SPAN_NOTICE("<b>You feel a cold liquid surround you. Your skin starts to freeze up.</b>"))
 	occupant = M
 	current_heat_capacity = HEAT_CAPACITY_HUMAN
-	update_use_power(2)
+	set_power_use(ACTIVE_POWER_USE)
 //	M.metabslow = 1
 	add_fingerprint(usr)
 	update_icon()

--- a/code/game/machinery/excelsior/boombox.dm
+++ b/code/game/machinery/excelsior/boombox.dm
@@ -7,7 +7,7 @@
 	icon_state = "boombox_off"
 	idle_power_usage = 10
 	active_power_usage = 60
-	use_power = TRUE
+	use_power = IDLE_POWER_USE
 	circuit = /obj/item/electronics/circuitboard/excelsior_boombox
 	var/active = FALSE
 	var/update_time = 0 // Made so callbacks can't be spamed
@@ -31,14 +31,27 @@
 	else
 		icon_state = "boombox_on"
 
+/obj/machinery/excelsior_boombox/power_change()
+	..()
+	if(active && !powered())
+		toggle_active()
+	update_icon()
+
 /obj/machinery/excelsior_boombox/proc/toggle_active()
-    if (active || (stat & (BROKEN|NOPOWER)))
-        active = FALSE
-    else
-        active = TRUE
-        if (world.time >= update_time + 30 SECONDS)
-            send_propaganda()
-            update_time = world.time
+	if (stat & (BROKEN|NOPOWER))
+		active = FALSE
+		set_power_use(NO_POWER_USE)
+		return FALSE
+	else if (active)
+		active = FALSE
+		set_power_use(IDLE_POWER_USE)
+		return FALSE
+	else
+		active = TRUE
+		set_power_use(ACTIVE_POWER_USE)
+		if (world.time >= update_time + 30 SECONDS)
+			send_propaganda()
+			update_time = world.time
 
 /obj/machinery/excelsior_boombox/proc/send_propaganda()
     if (active)

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -95,7 +95,7 @@ var/list/floor_light_cache = list()
 			return
 
 		on = !on
-		if(on) use_power = ACTIVE_POWER_USE
+		if(on) set_power_use(ACTIVE_POWER_USE)
 		visible_message("<span class='notice'>\The [user] turns \the [src] [on ? "on" : "off"].</span>")
 		update_brightness()
 		return
@@ -104,11 +104,11 @@ var/list/floor_light_cache = list()
 	..()
 	var/need_update
 	if((!anchored || broken()) && on)
-		use_power = NO_POWER_USE
+		set_power_use(NO_POWER_USE)
 		on = FALSE
 		need_update = 1
 	else if(use_power && !on)
-		use_power = NO_POWER_USE
+		set_power_use(NO_POWER_USE)
 		need_update = 1
 	if(need_update)
 		update_brightness()
@@ -118,7 +118,7 @@ var/list/floor_light_cache = list()
 		if(light_range != default_light_range || light_power != default_light_power || light_color != default_light_colour)
 			set_light(default_light_range, default_light_power, default_light_colour)
 	else
-		use_power = NO_POWER_USE
+		set_power_use(NO_POWER_USE)
 		if(light_range || light_power)
 			set_light(0)
 

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -95,7 +95,8 @@ var/list/floor_light_cache = list()
 			return
 
 		on = !on
-		if(on) set_power_use(ACTIVE_POWER_USE)
+		if(on)
+			set_power_use(ACTIVE_POWER_USE)
 		visible_message("<span class='notice'>\The [user] turns \the [src] [on ? "on" : "off"].</span>")
 		update_brightness()
 		return

--- a/code/game/machinery/gym.dm
+++ b/code/game/machinery/gym.dm
@@ -33,8 +33,7 @@
 
 /obj/machinery/gym/power_change()
 	..()
-	if(stat & BROKEN || stat & NOPOWER)
-		update_icon()
+	update_icon()
 
 /obj/machinery/gym/emag_act(remaining_charges, mob/user, emag_source)
 	emagged = TRUE
@@ -72,7 +71,7 @@
 	occupant.unset_machine()
 	occupant = null
 
-	update_use_power(1)
+	set_power_use(IDLE_POWER_USE)
 	update_icon()
 
 /obj/machinery/gym/attack_hand(mob/user)
@@ -100,7 +99,7 @@
 
 	user.forceMove(src)
 	occupant = user
-	update_use_power(2)
+	set_power_use(ACTIVE_POWER_USE)
 	user.set_machine(src)
 
 	add_fingerprint(user)

--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -27,9 +27,10 @@
 
 /obj/machinery/holosign/proc/toggle()
 	if (stat & (BROKEN|NOPOWER))
+		set_power_use(NO_POWER_USE)
 		return
 	lit = !lit
-	use_power = lit ? 2 : 1
+	set_power_use(lit ? 2 : 1)
 	update_icon()
 
 /obj/machinery/holosign/update_icon()
@@ -41,7 +42,7 @@
 /obj/machinery/holosign/power_change()
 	if (stat & NOPOWER)
 		lit = 0
-		use_power = NO_POWER_USE
+		set_power_use(NO_POWER_USE)
 	update_icon()
 
 /obj/machinery/holosign/surgery

--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -30,7 +30,7 @@
 		set_power_use(NO_POWER_USE)
 		return
 	lit = !lit
-	set_power_use(lit ? 2 : 1)
+	set_power_use(lit ? ACTIVE_POWER_USE : IDLE_POWER_USE)
 	update_icon()
 
 /obj/machinery/holosign/update_icon()

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -318,7 +318,7 @@
 
 /obj/machinery/media/jukebox/proc/StopPlaying()
 	playing = 0
-	update_use_power(1)
+	set_power_use(IDLE_POWER_USE)
 	update_icon()
 	var/datum/component/atom_sanity/S = GetComponent(/datum/component/atom_sanity)
 	S.affect = 0
@@ -330,7 +330,7 @@
 	playing = 1
 	var/datum/component/atom_sanity/S = GetComponent(/datum/component/atom_sanity)
 	S.affect = sanity_value
-	update_use_power(2)
+	set_power_use(ACTIVE_POWER_USE)
 	update_icon()
 	start_stop_song()
 	updateDialog()

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -408,7 +408,7 @@
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "barrelfire"
 	desc = "A fire in an old barrel. Perfect for campouts in the far corners of the ship."
-	use_power = FALSE
+	use_power = NO_POWER_USE
 	idle_power_usage = 0
 	active_power_usage = 0
 	dinger = FALSE

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -9,7 +9,7 @@
 	anchored = TRUE
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 5
-	active_power_usage = 100
+	active_power_usage = 250
 	reagent_flags = NO_REACT
 	var/global/max_n_of_items = 999 // Sorry but the BYOND infinite loop detector doesn't look things over 1000.
 	var/icon_on = "smartfridge"
@@ -292,6 +292,10 @@
 /obj/machinery/smartfridge/power_change()
 	var/old_stat = stat
 	..()
+	if(powered())
+		set_power_use(ACTIVE_POWER_USE)
+	else
+		set_power_use(IDLE_POWER_USE)
 	if(old_stat != stat)
 		update_icon()
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -123,6 +123,8 @@
 		set_dir(d)
 	GLOB.machines += src
 	InitCircuit()
+	power_change()
+	update_power_use()
 	START_PROCESSING(SSmachines, src)
 
 	return INITIALIZE_HINT_LATELOAD
@@ -142,7 +144,8 @@
 	return ..()
 
 /obj/machinery/Process()//If you dont use process or power why are you here
-	return PROCESS_KILL
+	if(!(use_power || idle_power_usage || active_power_usage))
+		return PROCESS_KILL
 
 /obj/machinery/emp_act(severity)
 	if(use_power && !stat)

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -150,10 +150,10 @@
 
 		// Update power usage:
 		if(on)
-			use_power = ACTIVE_POWER_USE
 			active_power_usage = electricity_level*15
+			set_power_use(ACTIVE_POWER_USE)
 		else
-			use_power = NO_POWER_USE
+			set_power_use(NO_POWER_USE)
 
 
 		// Overload conditions:

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -121,9 +121,9 @@
 
 	if(cell && !cell.fully_charged())
 		cell.give((active_power_usage*CELLRATE)*efficiency)
-		update_use_power(ACTIVE_POWER_USE)
+		set_power_use(ACTIVE_POWER_USE)
 	else
-		update_use_power(IDLE_POWER_USE)
+		set_power_use(IDLE_POWER_USE)
 	update_icon()
 
 /obj/machinery/recharger/emp_act(severity)

--- a/code/game/machinery/recycle_vendor.dm
+++ b/code/game/machinery/recycle_vendor.dm
@@ -7,6 +7,8 @@
 	anchored = TRUE
 	density = TRUE
 	use_power = IDLE_POWER_USE
+	idle_power_usage = 211	//same as softdrinks vendor
+	var/vend_power_usage = 500
 
 	var/obj/machinery/amesilo/silo
 	var/list/saleworthy_items = list()
@@ -232,6 +234,7 @@
 	playsound(loc, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 50, 1)
 	silo.addmaterial(combinedmats)
 	spawn_money(combinedvalue, loc)
+	use_power(vend_power_usage)
 	silo.updatesubsidy()
 	flick("recycle_vend", src)
 	update_icon()
@@ -452,6 +455,7 @@
 	anchored = TRUE
 	density = TRUE
 	use_power = IDLE_POWER_USE
+	idle_power_usage = 1000	//same as bluespace relay
 	var/prime = FALSE
 
 	// Can't use subtypeof(), since we have lots of useless materials

--- a/code/game/machinery/repairstation.dm
+++ b/code/game/machinery/repairstation.dm
@@ -97,14 +97,14 @@
 
 	to_chat(R, SPAN_NOTICE("Commencing repairs. Please stand by."))
 	repairing = R
-	update_use_power(ACTIVE_POWER_USE)
+	set_power_use(ACTIVE_POWER_USE)
 
 /obj/machinery/repair_station/proc/stop_repairing()
 	if(!repairing)
 		return
 
 	repairing = null
-	update_use_power(IDLE_POWER_USE)
+	set_power_use(IDLE_POWER_USE)
 
 /obj/machinery/repair_station/attackby(var/obj/item/O, var/mob/user)
 	.=..()

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -13,8 +13,8 @@
 	var/variants = list("Diamond", "Heart", "Cherry","Bar","Lemon", "Watermelon", "Seven")
 	var/weights = list("Diamond" = 10, "Heart" = 8, "Cherry" = 8,"Bar" = 6,"Lemon" = 4, "Watermelon" = 2, "Seven" = 1)
 	var/icon_type
-	use_power = TRUE
-	idle_power_usage = 10
+	use_power = IDLE_POWER_USE
+	idle_power_usage = 250
 
 /obj/machinery/slotmachine/New()
 	..()

--- a/code/game/machinery/smelter.dm
+++ b/code/game/machinery/smelter.dm
@@ -62,18 +62,18 @@
 /obj/machinery/smelter/Process()
 	if(stat & BROKEN || stat & NOPOWER)
 		progress = 0
-		use_power(0)
+		set_power_use(NO_POWER_USE)
 		update_icon()
 		return
 
 	if(current_item)
-		use_power(2)
+		set_power_use(ACTIVE_POWER_USE)
 		progress += speed
 		progress += item_speed_bonus(current_item)
 		if(progress >= 100)
 			smelt()
 			grab()
-			use_power(1)
+			set_power_use(IDLE_POWER_USE)
 		update_icon()
 	else
 		grab()

--- a/code/game/machinery/sorter.dm
+++ b/code/game/machinery/sorter.dm
@@ -98,7 +98,7 @@
 /obj/machinery/sorter/Process()
 	if(stat & BROKEN || stat & NOPOWER)
 		progress = 0
-		use_power(0)
+		set_power_use(NO_POWER_USE)
 		update_icon()
 		return
 
@@ -106,12 +106,12 @@
 		return
 
 	if(current_item)
-		use_power(2)
+		set_power_use(ACTIVE_POWER_USE)
 		progress += speed
 		if(progress >= 100)
 			sort(current_item)
 			grab()
-			use_power(1)
+			set_power_use(IDLE_POWER_USE)
 		update_icon()
 	else
 		grab()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -258,7 +258,7 @@
 	if(OCCUPANT && !locked)
 		locked = TRUE //Let's lock it for good measure
 
-	use_power = ACTIVE_POWER_USE
+	set_power_use(ACTIVE_POWER_USE)
 
 	update_icon()
 	updateUsrDialog()
@@ -289,7 +289,7 @@
 		locked = FALSE
 		eject_occupant(OCCUPANT) //Mixing up these two lines causes bug. DO NOT DO IT.
 
-	use_power = IDLE_POWER_USE
+	set_power_use(IDLE_POWER_USE)
 	isUV = FALSE //Cycle ends
 	update_icon()
 	updateUsrDialog()

--- a/code/game/machinery/supplybeacon.dm
+++ b/code/game/machinery/supplybeacon.dm
@@ -58,7 +58,7 @@
 /obj/machinery/power/supply_beacon/attack_hand(var/mob/user)
 
 	if(expended)
-		use_power = NO_POWER_USE
+		set_power_use(NO_POWER_USE)
 		to_chat(user, SPAN_WARNING("\The [src] has used up its charge."))
 		return
 
@@ -80,7 +80,7 @@
 		return
 	set_light(3, 3, COLOR_LIGHTING_ORANGE_MACHINERY)
 	icon_state = "beacon_active"
-	use_power = IDLE_POWER_USE
+	set_power_use(IDLE_POWER_USE)
 	if(user) to_chat(user, SPAN_NOTICE("You activate the beacon. The supply drop will be dispatched soon."))
 
 /obj/machinery/power/supply_beacon/proc/deactivate(var/mob/user, var/permanent)
@@ -90,7 +90,7 @@
 	else
 		icon_state = "beacon"
 	set_light(0)
-	use_power = NO_POWER_USE
+	set_power_use(NO_POWER_USE)
 	target_drop_time = null
 	if(user) to_chat(user, SPAN_NOTICE("You deactivate the beacon."))
 

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -334,8 +334,8 @@
 		src.engaged = 1
 		mhub.icon_state = "tele1"
 		use_power(5000)
-		update_use_power(2)
-		mhub.update_use_power(2)
+		set_power_use(ACTIVE_POWER_USE)
+		mhub.set_power_use(ACTIVE_POWER_USE)
 		for(var/mob/O in hearers(src, null))
 			O.show_message(SPAN_NOTICE("Teleporter engaged!"), 2)
 	src.add_fingerprint(usr)
@@ -350,8 +350,8 @@
 		src.engaged = 0
 		mhub.icon_state = "tele0"
 		mhub.accurate = 0
-		mhub.update_use_power(1)
-		update_use_power(1)
+		mhub.set_power_use(IDLE_POWER_USE)
+		set_power_use(IDLE_POWER_USE)
 		for(var/mob/O in hearers(src, null))
 			O.show_message(SPAN_NOTICE("Teleporter disengaged!"), 2)
 	src.add_fingerprint(usr)

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -72,7 +72,7 @@
 				qdel(HH)
 
 			state = WASHSTATE_FULLCLOSEDDOOR
-			use_power = IDLE_POWER_USE
+			set_power_use(IDLE_POWER_USE)
 			update_icon()
 
 /obj/machinery/washing_machine/examine(mob/user, extra_description = "")
@@ -97,7 +97,7 @@
 	tick = WASH_BASETIME
 	for(var/atom/A in contents)
 		tick += WASH_ADDTIME
-	use_power = ACTIVE_POWER_USE
+	set_power_use(ACTIVE_POWER_USE)
 	update_icon()
 
 /obj/machinery/washing_machine/verb/climb_out()

--- a/code/modules/aberrants/organs/machinery/medi-sarcophagus.dm
+++ b/code/modules/aberrants/organs/machinery/medi-sarcophagus.dm
@@ -50,7 +50,7 @@
 		horror_occupant = null
 		accompanying_loot = null
 
-		update_use_power(1)
+		set_power_use(IDLE_POWER_USE)
 		update_icon()
 		toggle_filter()
 

--- a/code/modules/biomatter_manipulation/bioreactor/loader.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/loader.dm
@@ -27,9 +27,9 @@
 
 /obj/machinery/multistructure/bioreactor_part/loader/Process()
 	if(!MS || !MS_bioreactor.is_operational() || !MS_bioreactor.chamber_solution)
-		use_power(1)
+		use_power(idle_power_usage)	//not very optimised. Can be done better
 		return
-	use_power(2)
+	use_power(active_power_usage)
 	if(contents.len)
 		for(var/atom/movable/A in contents)
 			var/obj/machinery/multistructure/bioreactor_part/platform/empty_platform = MS_bioreactor.get_unoccupied_platform()

--- a/code/modules/biomatter_manipulation/bioreactor/platform.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/platform.dm
@@ -20,10 +20,10 @@
 
 /obj/machinery/multistructure/bioreactor_part/platform/Process()
 	if(!MS)
-		use_power(1)
+		use_power(idle_power_usage)
 		return
 	if((!is_breached() || MS_bioreactor.is_operational()) && MS_bioreactor.chamber_solution)
-		use_power(2)
+		use_power(active_power_usage)
 		for(var/atom/movable/M in loc)
 
 			//mob processing
@@ -77,7 +77,7 @@
 					target.forceMove(MS_bioreactor.misc_output)
 	else
 		//if our machine is non operational, let's go idle powermode and pump out solution
-		use_power(1)
+		use_power(idle_power_usage)
 		if(MS_bioreactor.chamber_solution)
 			MS_bioreactor.pump_solution()
 

--- a/code/modules/biomatter_manipulation/bioreactor/unloader.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/unloader.dm
@@ -10,9 +10,9 @@
 
 /obj/machinery/multistructure/bioreactor_part/unloader/Process()
 	if(!MS)
-		use_power(1)
+		use_power(idle_power_usage)
 		return
-	use_power(2)
+	use_power(active_power_usage)
 	if(contents.len)
 		var/obj/item/misc = locate() in contents
 		if(misc)

--- a/code/modules/biomatter_manipulation/solidifier.dm
+++ b/code/modules/biomatter_manipulation/solidifier.dm
@@ -52,6 +52,7 @@
 				container.reagents.trans_id_to(src, MATERIAL_BIOMATTER, quantity, TRUE)
 		if(reagents.get_reagent_amount(MATERIAL_BIOMATTER) >= BIOMATTER_PER_SHEET)
 			process_biomatter()
+			use_power(active_power_usage)
 		else
 			abort("Insufficient amount of biomatter.")
 

--- a/code/modules/cooking_with_jane/cooking_appliances/grill.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/grill.dm
@@ -17,7 +17,7 @@
 	var/list/cooking_timestamp = list(0, 0) //Timestamp of when cooking initialized so we know if the prep was disturbed at any point.
 	var/list/items[2]
 
-	use_power = 0
+	use_power = NO_POWER_USE
 	interact_offline = TRUE
 
 	var/stored_wood = 0

--- a/code/modules/core_implant/cruciform/machinery/obelisk.dm
+++ b/code/modules/core_implant/cruciform/machinery/obelisk.dm
@@ -76,9 +76,9 @@ GLOBAL_LIST_EMPTY(all_obelisk)
 	update_icon()
 
 	if(!active)
-		use_power = IDLE_POWER_USE
+		set_power_use(IDLE_POWER_USE)
 	else
-		use_power = ACTIVE_POWER_USE
+		set_power_use(ACTIVE_POWER_USE)
 
 	if(ticks_to_next_process > 0)
 		ticks_to_next_process--

--- a/code/modules/genetics/stationary_scanner.dm
+++ b/code/modules/genetics/stationary_scanner.dm
@@ -66,7 +66,7 @@
 	han_solo.reset_view()
 	han_solo.unset_machine()
 	han_solo = null
-	update_use_power(1)
+	set_power_use(IDLE_POWER_USE)
 	update_icon()
 
 
@@ -76,7 +76,7 @@
 	add_fingerprint(user)
 	user.forceMove(src)
 	han_solo = user
-	update_use_power(2)
+	set_power_use(ACTIVE_POWER_USE)
 	user.set_machine(src)
 	update_icon()
 

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -188,7 +188,7 @@
 			damaged = 1
 			loadProgram(holodeck_programs["turnoff"], 0)
 			active = 0
-			use_power = IDLE_POWER_USE
+			set_power_use(IDLE_POWER_USE)
 			for(var/mob/M in range(10,src))
 				M.show_message("The holodeck overloads!")
 
@@ -239,7 +239,7 @@
 			linkedholodeck.update_gravity()
 
 		active = 0
-		use_power = IDLE_POWER_USE
+		set_power_use(IDLE_POWER_USE)
 
 
 /obj/machinery/computer/HolodeckControl/proc/loadProgram(var/datum/holodeck_program/HP, var/check_delay = 1)
@@ -260,7 +260,7 @@
 
 	last_change = world.time
 	active = 1
-	use_power = ACTIVE_POWER_USE
+	set_power_use(ACTIVE_POWER_USE)
 
 	for(var/item in holographic_objs)
 		derez(item)
@@ -318,7 +318,7 @@
 
 	last_gravity_change = world.time
 	active = 1
-	use_power = ACTIVE_POWER_USE
+	set_power_use(ACTIVE_POWER_USE)
 
 
 	if(A.has_gravity)
@@ -335,7 +335,7 @@
 	linkedholodeck.has_gravity = TRUE
 
 	active = 0
-	use_power = IDLE_POWER_USE
+	set_power_use(IDLE_POWER_USE)
 
 /obj/machinery/computer/HolodeckControl/Exodus
 	linkedholodeck_area = /area/holodeck/alphadeck

--- a/code/modules/holomap/holomap.dm
+++ b/code/modules/holomap/holomap.dm
@@ -128,7 +128,7 @@
 			GLOB.moved_event.register(watching_mob, src, /obj/machinery/holomap/proc/checkPosition)
 			GLOB.dir_set_event.register(watching_mob, src, /obj/machinery/holomap/proc/checkPosition)
 			GLOB.destroyed_event.register(watching_mob, src, /obj/machinery/holomap/proc/stopWatching)
-			update_use_power(ACTIVE_POWER_USE)
+			set_power_use(ACTIVE_POWER_USE)
 			if(bogus)
 				to_chat(user, SPAN_WARNING("The holomap has failed to initialize. This area of space cannot be mapped."))
 			else
@@ -157,7 +157,7 @@
 		GLOB.dir_set_event.unregister(watching_mob, src)
 		GLOB.destroyed_event.unregister(watching_mob, src)
 	watching_mob = null
-	update_use_power(IDLE_POWER_USE)
+	set_power_use(IDLE_POWER_USE)
 
 /obj/machinery/holomap/power_change()
 	. = ..()

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -20,12 +20,12 @@
 
 /obj/machinery/botany/proc/start_task()
 	// UI is updated by "return 1" in Topic()
-	use_power = ACTIVE_POWER_USE
+	set_power_use(ACTIVE_POWER_USE)
 
 	addtimer(CALLBACK(src, PROC_REF(finish_task)), action_time)
 
 /obj/machinery/botany/proc/finish_task()
-	use_power = IDLE_POWER_USE
+	set_power_use(IDLE_POWER_USE)
 	SSnano.update_uis(src)
 	if(failed_task)
 		failed_task = FALSE

--- a/code/modules/mechs/mech_recharger.dm
+++ b/code/modules/mechs/mech_recharger.dm
@@ -59,14 +59,14 @@
 		active_power_usage = min(max_power_usage, (cell.maxcharge*cell.max_chargerate)/CELLRATE)
 
 		cell.give(active_power_usage*CELLRATE*efficiency)
-		update_use_power(ACTIVE_POWER_USE)
+		set_power_use(ACTIVE_POWER_USE)
 
 		if(cell.fully_charged())
 			charging.occupant_message(SPAN_NOTICE("Fully charged."))
 		else
 			done = FALSE
 	else
-		update_use_power(IDLE_POWER_USE)
+		set_power_use(IDLE_POWER_USE)
 
 	if(repair && charging.health < initial(charging.health))
 		charging.health = min(charging.health + repair, initial(charging.health))
@@ -101,4 +101,4 @@
 		return
 
 	charging = null
-	update_use_power(IDLE_POWER_USE)
+	set_power_use(IDLE_POWER_USE)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -304,9 +304,10 @@ var/list/ai_verbs_default = list(
 	powered_ai = ai
 	powered_ai.psupply = src
 	forceMove(powered_ai.loc)
+	anchored = TRUE	//keep anchored! If unachored for any reason - it can't take power with set_power_use()
 
 	..()
-	use_power(1) // Just incase we need to wake up the power system.
+	use_power(IDLE_POWER_USE) // Just incase we need to wake up the power system.
 
 /obj/machinery/ai_powersupply/Destroy()
 	. = ..()
@@ -320,14 +321,14 @@ var/list/ai_verbs_default = list(
 		qdel(src)
 		return
 	if(powered_ai.APU_power)
-		use_power = NO_POWER_USE
+		set_power_use(NO_POWER_USE)
 		return
 	if(!powered_ai.anchored)
 		loc = powered_ai.loc
-		use_power = NO_POWER_USE
+		set_power_use(NO_POWER_USE)
 		use_power(50000) // Less optimalised but only called if AI is unwrenched. This prevents usage of wrenching as method to keep AI operational without power. Intellicard is for that.
 	if(powered_ai.anchored)
-		use_power = ACTIVE_POWER_USE
+		set_power_use(ACTIVE_POWER_USE)
 
 /mob/living/silicon/ai/proc/ai_movement_up()
 	set category = "Silicon Commands"

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -135,5 +135,6 @@
 
 	if(user && fabricator && !((fabricator.stat & NOPOWER) || !fabricator.produce_drones || fabricator.drone_progress < 100))
 		fabricator.create_drone(user.client, aibound)
+		fabricator.use_power(fabricator.active_power_usage)
 		return 1
 	return

--- a/code/modules/modular_computers/NTNet/NTNet_relay.dm
+++ b/code/modules/modular_computers/NTNet/NTNet_relay.dm
@@ -38,9 +38,9 @@
 
 /obj/machinery/ntnet_relay/Process()
 	if(operable())
-		use_power = ACTIVE_POWER_USE
+		set_power_use(ACTIVE_POWER_USE)
 	else
-		use_power = IDLE_POWER_USE
+		set_power_use(IDLE_POWER_USE)
 
 	if(dos_overload)
 		dos_overload = max(0, dos_overload - dos_dissipate)

--- a/code/modules/onestar/os_turret.dm
+++ b/code/modules/onestar/os_turret.dm
@@ -60,9 +60,9 @@
 		return
 
 	if(!on_cooldown)
-		use_power = IDLE_POWER_USE
+		set_power_use(IDLE_POWER_USE)
 	else
-		use_power = ACTIVE_POWER_USE
+		set_power_use(ACTIVE_POWER_USE)
 		return
 
 	update_icon()

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -175,7 +175,7 @@
 		return
 	if(!use_power) //need some juice to kickstart
 		use_power(idle_power_usage*5)
-	use_power = !use_power
+	set_power_use(!use_power)
 	update_icon()
 
 /obj/machinery/shipsensors/Process()

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -175,7 +175,7 @@
 		return
 	if(!use_power) //need some juice to kickstart
 		use_power(idle_power_usage*5)
-	set_power_use(!use_power)
+	set_power_use(use_power ? IDLE_POWER_USE : NO_POWER_USE)
 	update_icon()
 
 /obj/machinery/shipsensors/Process()

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -198,10 +198,10 @@
 /obj/machinery/power/am_control_unit/proc/toggle_power()
 	active = !active
 	if(active)
-		use_power = ACTIVE_POWER_USE
+		set_power_use(ACTIVE_POWER_USE)
 		visible_message("The [src.name] starts up.")
 	else
-		use_power = IDLE_POWER_USE
+		set_power_use(IDLE_POWER_USE)
 		visible_message("The [src.name] shuts down.")
 	update_icon()
 	return

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -264,12 +264,12 @@ var/const/GRAV_NEEDS_WRENCH = 3
 	if(new_state) // If we turned on
 		if(!gravity_is_on)
 			grav_on()
-		set_power_use(2)
+		set_power_use(ACTIVE_POWER_USE)
 	else
 		if(gravity_is_on)
 			grav_off()
 		set_light(0)
-		set_power_use(1)
+		set_power_use(IDLE_POWER_USE)
 	update_icon()
 	src.updateUsrDialog()
 

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -26,7 +26,6 @@ var/const/GRAV_NEEDS_WRENCH = 3
 	health = 800
 	maxHealth = 800
 	unacidable = 1
-	var/sprite_number = 0
 
 /obj/machinery/gravity_generator/update_icon()
 	..()
@@ -101,7 +100,6 @@ var/const/GRAV_NEEDS_WRENCH = 3
 	idle_power_usage = 0
 	active_power_usage = 3000
 	power_channel = STATIC_ENVIRON
-	sprite_number = 8
 	use_power = IDLE_POWER_USE
 	interact_offline = 1
 	var/on = TRUE
@@ -123,9 +121,8 @@ var/const/GRAV_NEEDS_WRENCH = 3
 	middle.cut_overlays()
 	charge_count = 0
 	breaker = 0
-	grav_off()
-	set_power()
 	set_state(0)
+	set_power()	//this should go after set_state(0) to for proper power consuption settings
 	investigate_log("has broken down.", "gravity")
 
 /obj/machinery/gravity_generator/main/set_fix()
@@ -250,10 +247,11 @@ var/const/GRAV_NEEDS_WRENCH = 3
 // Set the charging state based on power/breaker.
 /obj/machinery/gravity_generator/main/proc/set_power()
 	var/new_state = 0
-	if(stat & (NOPOWER|BROKEN) || !breaker)
+	if(stat & (NOPOWER|BROKEN))
 		new_state = 0
-	else if(breaker)
-		new_state = 1
+		set_power_use(NO_POWER_USE)
+	else
+		new_state = breaker
 
 	charging_state = new_state ? POWER_UP : POWER_DOWN // Startup sequence animation.
 	investigate_log("is now [charging_state == POWER_UP ? "charging" : "discharging"].", "gravity")
@@ -261,18 +259,17 @@ var/const/GRAV_NEEDS_WRENCH = 3
 
 // Set the state of the gravity.
 /obj/machinery/gravity_generator/main/proc/set_state(var/new_state)
-	if(new_state == on)
-		var/pulse = 0.5 * sin(2 * M_PI * PULSE_FREQ * world.time) + 0.5
-		set_light(3+pulse, 3+pulse, "#8AD55D")
-		return
-	on = new_state
 	charging_state = POWER_IDLE
-	use_power = on ? 2 : 1
+	on = new_state
 	if(new_state) // If we turned on
-		grav_on()
+		if(!gravity_is_on)
+			grav_on()
+		set_power_use(2)
 	else
-		grav_off()
+		if(gravity_is_on)
+			grav_off()
 		set_light(0)
+		set_power_use(1)
 	update_icon()
 	src.updateUsrDialog()
 
@@ -311,6 +308,9 @@ var/const/GRAV_NEEDS_WRENCH = 3
 /obj/machinery/gravity_generator/main/Process()
 	if(stat & BROKEN)
 		return
+	if(charge_count >= 1)
+		var/pulse = 0.5 * sin(2 * M_PI * PULSE_FREQ * world.time) + 0.5
+		set_light(3+pulse, 3+pulse, "#8AD55D")
 	if(charging_state != POWER_IDLE)
 		if(charging_state == POWER_UP && charge_count >= 100)
 			set_state(1)
@@ -318,6 +318,7 @@ var/const/GRAV_NEEDS_WRENCH = 3
 			set_state(0)
 		else
 			if(charging_state == POWER_UP)
+				use_power(active_power_usage * 3)
 				charge_count += 2
 
 			else if(charging_state == POWER_DOWN)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -326,20 +326,23 @@
 					message_admins("LOG: Rigged light explosion, last touched by [fingerprintslast]")
 
 					explode()
-			else if( prob( min(60, switchcount*switchcount*0.01) ) )
+			else if( prob( min(60, switchcount*switchcount*0.1) ) )
 				if(status == LIGHT_OK && trigger)
 					status = LIGHT_BURNED
 					icon_state = "[base_state]-burned"
 					on = FALSE
-					set_light(0)
+					set_light(0, 0)
+					active_power_usage = 0 //burnt => no power flow => no power consumption
+					idle_power_usage = 0
 			else
-				use_power = ACTIVE_POWER_USE
 				set_light(brightness_range, brightness_power, brightness_color)
+				active_power_usage = light_power * light_range * 10
+				set_power_use(ACTIVE_POWER_USE)
 	else
-		use_power = IDLE_POWER_USE
 		set_light(0)
+		idle_power_usage = (light_power + light_range) * 0.1
+		set_power_use(IDLE_POWER_USE)
 
-	active_power_usage = ((light_range + light_power) * 10)
 	if(on != on_gs)
 		on_gs = on
 
@@ -582,6 +585,7 @@
 	L.update()
 
 	status = LIGHT_EMPTY
+	set_light(0, 0)
 	update()
 
 	// If the target is a mob, try to put the bulb in mob's hand
@@ -604,6 +608,7 @@
 			s.set_up(3, 1, src)
 			s.start()
 	status = LIGHT_BROKEN
+	set_light(0, 0)
 	update()
 
 /obj/machinery/light/proc/fix()

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -100,8 +100,8 @@
 	if(powered(power_channel))
 		stat &= ~NOPOWER
 	else
-
 		stat |= NOPOWER
+	update_power_use()
 	return
 
 // connect the machine to a powernet if a node cable is present on the turf

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -349,7 +349,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 					user.visible_message("[user.name] closes the [src.name]'s access panel.", \
 						"You close the access panel.")
 					construction_state = 3
-					use_power = IDLE_POWER_USE
+					set_power_use(IDLE_POWER_USE)
 					update_icon()
 					return
 			if(construction_state == 3)
@@ -357,7 +357,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 					user.visible_message("[user.name] closes the [src.name]'s access panel.", \
 						"You close the access panel.")
 					construction_state = 2
-					use_power = NO_POWER_USE
+					set_power_use(NO_POWER_USE)
 					update_state()
 					update_icon()
 					return

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -42,7 +42,7 @@
 
 /obj/machinery/particle_accelerator/control_box/update_state()
 	if(construction_state < 3)
-		update_use_power(0)
+		set_power_use(NO_POWER_USE)
 		assembled = 0
 		active = 0
 		for(var/obj/structure/particle_accelerator/part in connected_parts)
@@ -52,7 +52,7 @@
 		connected_parts = list()
 		return
 	if(!part_scan())
-		update_use_power(1)
+		set_power_use(IDLE_POWER_USE)
 		active = 0
 		connected_parts = list()
 
@@ -141,9 +141,9 @@
 	..()
 	if(stat & NOPOWER)
 		active = 0
-		update_use_power(0)
+		set_power_use(NO_POWER_USE)
 	else if(!stat && construction_state == 3)
-		update_use_power(1)
+		set_power_use(IDLE_POWER_USE)
 	return
 
 
@@ -216,13 +216,13 @@
 	message_admins("PA Control Computer turned [active ?"ON":"OFF"] by [key_name(usr, usr.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[usr]'>?</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
 	log_game("PA Control Computer turned [active ?"ON":"OFF"] by [usr.ckey]([usr]) in ([x],[y],[z])")
 	if(src.active)
-		update_use_power(2)
+		set_power_use(ACTIVE_POWER_USE)
 		for(var/obj/structure/particle_accelerator/part in connected_parts)
 			part.strength = src.strength
 			part.powered = 1
 			part.update_icon()
 	else
-		update_use_power(1)
+		set_power_use(IDLE_POWER_USE)
 		for(var/obj/structure/particle_accelerator/part in connected_parts)
 			part.strength = null
 			part.powered = 0

--- a/code/modules/pulsar_engine/pulsar_consoles.dm
+++ b/code/modules/pulsar_engine/pulsar_consoles.dm
@@ -193,6 +193,8 @@
 		console_area = get_area(pulsar_console) //Area stored so reconnections are cheaper.
 
 	portal = locate() in get_area(src)
+	if(portal)
+		portal_active = TRUE
 
 /obj/machinery/power/pulsar_power_bridge/Process()
 	if(powernet && pulsar_console)

--- a/code/modules/reagents/machinery/grinder.dm
+++ b/code/modules/reagents/machinery/grinder.dm
@@ -237,6 +237,7 @@
 
 	playsound(loc, 'sound/machines/blender.ogg', 50, 1)
 	inuse = 1
+	use_power(active_power_usage)
 
 	// Reset the machine.
 	spawn(60)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -333,7 +333,7 @@
 // charge the gas reservoir and perform flush if ready
 /obj/machinery/disposal/Process()
 	if(!air_contents || (stat & BROKEN))			// nothing can happen if broken
-		update_use_power(0)
+		set_power_use(NO_POWER_USE)
 		return
 
 	flush_count++
@@ -350,7 +350,7 @@
 		flush()
 
 	if(mode != DISPOSALS_CHARGING)
-		update_use_power(1)
+		set_power_use(IDLE_POWER_USE)
 	else if(air_contents.return_pressure() >= SEND_PRESSURE)
 		mode = DISPOSALS_CHARGED
 		update()
@@ -359,7 +359,7 @@
 
 /obj/machinery/disposal/proc/pressurize()
 	if(stat & NOPOWER)			// won't charge if no power
-		update_use_power(0)
+		set_power_use(NO_POWER_USE)
 		return
 
 	var/atom/L = loc						// recharging from loc turf

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -142,7 +142,7 @@
 	idle_power_usage = 0
 	for(var/obj/machinery/shield/shield_tile in deployed_shields)
 		idle_power_usage += shield_tile.shield_idle_power
-	update_use_power(1)
+	set_power_use(IDLE_POWER_USE)
 
 /obj/machinery/shieldgen/proc/shields_down()
 	if(!active) return 0 //If it's already off, how did this get called?
@@ -152,7 +152,7 @@
 
 	collapse_shields()
 
-	update_use_power(0)
+	set_power_use(NO_POWER_USE)
 
 /obj/machinery/shieldgen/proc/create_shields()
 	for(var/turf/target_tile in range(2, src))

--- a/code/modules/trade/machinery/trade_beacon.dm
+++ b/code/modules/trade/machinery/trade_beacon.dm
@@ -4,6 +4,9 @@
 	anchored = TRUE
 	density = TRUE
 	var/entropy_value = 2
+	use_power = IDLE_POWER_USE
+	idle_power_usage = 500
+	active_power_usage = 5000
 
 /obj/machinery/trade_beacon/attackby(obj/item/I, mob/user)
 	if(default_deconstruction(I, user))
@@ -19,6 +22,7 @@
 	do_sparks(5, 0, loc)
 	bluespace_entropy(entropy_value, get_turf(src))
 	playsound(loc, "sparks", 50, 1)
+	use_power(active_power_usage)
 
 /obj/machinery/trade_beacon/sending
 	name = "sending trade beacon"


### PR DESCRIPTION
## About The Pull Request
![photo_2024-08-17_19-28-47](https://github.com/user-attachments/assets/008cb2b3-5054-4a19-8020-cb93358cb78f)

This PR rewrites power consumption of light fixtures, rewrites A LOT of legacy and not so legacy power consumption code generally restoring power consumption of machines. Eris can loose it's power again! Yay!

On a sidenote: might impact startup times a little but it's definitely worth it

## Why It's Good For The Game

Those changes fix old code to work as it was intended and create actual need for technomancers to maintain power production enriching their gameplay loop in some way

## Testing

A dozen of test launches powering whole ship up and down, researching results and tinkering with separate machines.
All seems good!
EDIT: Cut off Pulsar from the ship and let it run for a while to see everything depowers correctly. Ran around the ship turning off APCs, turning on and off their separate channels. Power consumption stayed within predicted values.
Tested separate functions of machines like autolathe, trading beakons, disk cloners and many others. Power consumption gone up when active and gone down when machine finished processing.
Manually viewed variables of all machines on the ship to check if they are in the right power mode and consuming right ammounts of power. Nothing unusual

## Changelog
:cl:
tweak: Tweaked light power consumption
fix: Fixed everything not consuming power when it should have consumed it (notably: sleepers, AI, operating table and many others)
fix: Fixed Excelsior boombox working without power
fix: Fixed gym machines not updating their sprites when powered back up
fix: Fixed Pulsar power bridge incorrectly showing status of Pulsar portal
fix: Rewrote some gravity generator code to show it's status correctly, pulse-glow more consistently and consume power
/:cl: