### PR TITLE
Update nanites.dm

### DIFF
--- a/code/modules/reagents/reagents/nanites.dm
+++ b/code/modules/reagents/reagents/nanites.dm
@@ -307,14 +307,7 @@
 	overdose = REAGENTS_OVERDOSE / 6
 
 /datum/reagent/nanites/fbp/repair/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
-	if(!..())
-		return
-	M.add_chemical_effect(CE_MECH_REPAIR, 0.25)
-
-/datum/reagent/nanites/fbp/repair/overdose(mob/living/carbon/M, alien)
-	if(!..())
-		return
-	M.add_chemical_effect(CE_MECH_REPAIR, 0.75)
+	M.add_chemical_effect(CE_MECH_REPAIR, 0.75)	//This plus two other metals will be enough to heal wounds
 
 /* Uncomment when CE_MECH_REPLENISH has a use
 // "Blood" restore


### PR DESCRIPTION
## About The Pull Request

Band-aid fixtng FBP nanites, now they are at least working

## Why It's Good For The Game

Not working chem = not gud for game => Fixed chem = Good for the game

## Testing

Broke my own ribcage with with a cleaver to test if repair works
Then started up test server, drunk 10u. of nanites [VV shows 0.75 CE_MECH_REPAIR]. Made few organ wounds to myself in a natural way, organ wounds don't heal because CE_MECH_REPAIR is lower than 0.85. Added aluminum, iron and copper to nanites [VV shows 0,9 CE_MECH_REPAIR]. Wounds healed.

## Changelog
:cl:
fix: repair nanites for FBP now work correctly and heal
/:cl: