### PR TITLE
Better 515 compatibility

### DIFF
--- a/code/_onclick/hud/HUD_element/HUD_element.dm
+++ b/code/_onclick/hud/HUD_element/HUD_element.dm
@@ -53,7 +53,6 @@ element identifiers are used to manage different hud parts for clients, f.e. the
 
 	var/_clickProc //called when element is clicked
 	var/_holder	//object that used with called proc
-	var/list/_procArguments	//arguments that can be passed to proc
 
 	var/list/_data //internal storage that can be utilized by _clickProc
 
@@ -104,12 +103,9 @@ element identifiers are used to manage different hud parts for clients, f.e. the
 	return QDEL_HINT_QUEUE
 
 /HUD_element/Click(location,control,params)
-	if (_clickProc)
+	if(_clickProc)
 		if(_holder)
-			if(_procArguments)
-				call(_holder, _clickProc)(arglist(_procArguments))
-			else
-				call(_holder, _clickProc)(arglist(list(src, usr, location, control, params)))
+			call(_holder, _clickProc)(src, usr, location, control, params)
 		else
 			call(_clickProc)(src, usr, location, control, params)
 

--- a/code/_onclick/hud/HUD_element/external_procs.dm
+++ b/code/_onclick/hud/HUD_element/external_procs.dm
@@ -62,7 +62,7 @@ getAlignmentHorizontal() -> alignmentHorizontal
 setAlignment(var/horizontal, var/vertical) -> src
 - sets alignment behavior for element, relative to parent, null arguments indicate not to change the relevant alignment
 - look HUD_defines.dm for arguments
-	
+
 
 getPositionX() -> x
 getPositionY() -> y
@@ -143,10 +143,9 @@ alignElements(var/horizontal, var/vertical, var/list/HUD_element/targets) -> /HU
 	if(_disconnectElement(element))
 		return element
 
-/HUD_element/proc/setClickProc(P, var/holder, var/list/arguments)
+/HUD_element/proc/setClickProc(P, holder)
 	_clickProc = P
 	_holder = holder
-	_procArguments = arguments
 	return src
 
 /HUD_element/proc/getClickProc()
@@ -479,7 +478,7 @@ alignElements(var/horizontal, var/vertical, var/list/HUD_element/targets) -> /HU
 	if(!is_associative(additionsData))
 		error("OverlayData list is not associative")
 		return
-		
+
 	for (var/additionName in additionsData)
 		var/list/data = additionsData[additionName]
 		if(!is_associative(data))
@@ -504,7 +503,7 @@ alignElements(var/horizontal, var/vertical, var/list/HUD_element/targets) -> /HU
 		_iconsBuffer["[additionType]_[additionName]"] = null
 		updateIcon()
 		return src
-	
+
 	if(!data)
 		data = list()
 		if(additionType == HUD_ICON_UNDERLAY)
@@ -522,7 +521,7 @@ alignElements(var/horizontal, var/vertical, var/list/HUD_element/targets) -> /HU
 
 	setIconAdditionAlpha(additionType, additionName, alpha, noIconUpdate = TRUE)
 	setIconAdditionColor(additionType, additionName, color, noIconUpdate = TRUE)
-	
+
 	_assembleAndBufferIcon(additionType, additionName, data)
 	updateIcon()
 
@@ -658,9 +657,9 @@ alignElements(var/horizontal, var/vertical, var/list/HUD_element/targets) -> /HU
 		qdel(debugBox)
 	/*
 		I.DrawBox(ReadRGB(COLOR_BLACK),0,0,getWidth(),getHeight())
-		I.DrawBox(ReadRGB(debugColor),1,1,getWidth()-1,getHeight()-1) 
+		I.DrawBox(ReadRGB(debugColor),1,1,getWidth()-1,getHeight()-1)
 		setIconOverlay(HUD_OVERLAY_DEBUG,I, alpha = 80)*/
-	
+
 	updateIcon()
 
 // mob clicks overrides

--- a/code/datums/mutable_appearance.dm
+++ b/code/datums/mutable_appearance.dm
@@ -2,13 +2,6 @@
 // Basically use them instead of images for overlays/underlays and when changing an object's appearance if you're doing so with any regularity.
 // Unless you need the overlay/underlay to have a different direction than the base object. Then you have to use an image due to a bug.
 
-// Mutable appearances are children of images, just so you know.
-
-/mutable_appearance/New()
-	..()
-	plane = FLOAT_PLANE // No clue why this is 0 by default yet images are on FLOAT_PLANE
-						// And yes this does have to be in the constructor, BYOND ignores it if you set it as a normal var
-
 // Helper similar to image()
 /proc/mutable_appearance(icon, icon_state = "", layer = FLOAT_LAYER, plane = FLOAT_PLANE)
 	var/mutable_appearance/MA = new()

--- a/code/modules/mob/inventory/slots.dm
+++ b/code/modules/mob/inventory/slots.dm
@@ -61,21 +61,21 @@
 	id = slot_back
 	req_organ = BP_CHEST
 	req_slot_flags = SLOT_BACK
-	update_proc = /mob/proc/update_inv_back
+	update_proc = TYPE_PROC_REF(/mob, update_inv_back)
 
 /datum/inventory_slot/mask
 	name = "Mask"
 	id = slot_wear_mask
 	req_organ = BP_HEAD
 	req_slot_flags = SLOT_MASK
-	update_proc = /mob/proc/update_inv_wear_mask
+	update_proc = TYPE_PROC_REF(/mob, update_inv_wear_mask)
 
 /datum/inventory_slot/handcuffs
 	name = "Handcuffs"
 	id = slot_handcuffed
 	req_organ = list(BP_L_ARM, BP_R_ARM)
 	req_type = /obj/item/handcuffs
-	update_proc = /mob/proc/update_inv_handcuffed
+	update_proc = TYPE_PROC_REF(/mob, update_inv_handcuffed)
 
 /datum/inventory_slot/handcuffs/can_equip(obj/item/I, mob/living/carbon/human/owner, disable_warning)
 	if(..())
@@ -90,7 +90,7 @@
 	id = slot_legcuffed
 	req_organ = list(BP_L_LEG, BP_R_LEG)
 	req_type = /obj/item/legcuffs
-	update_proc = /mob/proc/update_inv_legcuffed
+	update_proc = TYPE_PROC_REF(/mob, update_inv_legcuffed)
 
 
 /datum/inventory_slot/hand
@@ -107,32 +107,32 @@
 	name = "Left hand"
 	id = slot_l_hand
 	req_organ = list(BP_L_ARM = ORGAN_SHOULD_BE_FINE)
-	update_proc = /mob/proc/update_inv_l_hand
+	update_proc = TYPE_PROC_REF(/mob, update_inv_l_hand)
 
 /datum/inventory_slot/hand/rigth
 	name = "Right hand"
 	id = slot_r_hand
 	req_organ = list(BP_R_ARM = ORGAN_SHOULD_BE_FINE)
-	update_proc = /mob/proc/update_inv_r_hand
+	update_proc = TYPE_PROC_REF(/mob, update_inv_r_hand)
 
 /datum/inventory_slot/belt
 	name = "belt"
 	id = slot_belt
 	req_organ = BP_CHEST
 	req_slot_flags = SLOT_BELT
-	update_proc = /mob/proc/update_inv_belt
+	update_proc = TYPE_PROC_REF(/mob, update_inv_belt)
 
 /datum/inventory_slot/id
 	name = "ID card"
 	id = slot_wear_id
 	req_slot_flags = SLOT_ID
-	update_proc = /mob/proc/update_inv_wear_id
+	update_proc = TYPE_PROC_REF(/mob, update_inv_wear_id)
 
 
 /datum/inventory_slot/ear
 	req_organ = BP_HEAD
 	req_slot_flags = SLOT_EARS|SLOT_TWOEARS
-	update_proc = /mob/proc/update_inv_ears
+	update_proc = TYPE_PROC_REF(/mob, update_inv_ears)
 
 /datum/inventory_slot/ear/can_equip(obj/item/I, mob/living/carbon/human/owner, disable_warning)
 	if(I.slot_flags & SLOT_TWOEARS)
@@ -156,48 +156,48 @@
 	id = slot_glasses
 	req_organ = BP_HEAD
 	req_slot_flags = SLOT_EYES
-	update_proc = /mob/proc/update_inv_glasses
+	update_proc = TYPE_PROC_REF(/mob, update_inv_glasses)
 
 /datum/inventory_slot/gloves
 	name = "Gloves"
 	id = slot_gloves
 	req_organ = list(BP_L_ARM, BP_R_ARM)
 	req_slot_flags = SLOT_GLOVES
-	update_proc = /mob/proc/update_inv_gloves
+	update_proc = TYPE_PROC_REF(/mob, update_inv_gloves)
 
 /datum/inventory_slot/head
 	name = "Head"
 	id = slot_head
 	req_organ = BP_HEAD
 	req_slot_flags = SLOT_HEAD
-	update_proc = /mob/proc/update_inv_head
+	update_proc = TYPE_PROC_REF(/mob, update_inv_head)
 
 /datum/inventory_slot/shoes
 	name = "Shoes"
 	id = slot_shoes
 	req_organ = list(BP_L_LEG, BP_R_LEG)
 	req_slot_flags = SLOT_FEET
-	update_proc = /mob/proc/update_inv_shoes
+	update_proc = TYPE_PROC_REF(/mob, update_inv_shoes)
 
 /datum/inventory_slot/wear_suit
 	name = "Wear suit"
 	id = slot_wear_suit
 	req_organ = BP_CHEST
 	req_slot_flags = SLOT_OCLOTHING
-	update_proc = /mob/proc/update_inv_wear_suit
+	update_proc = TYPE_PROC_REF(/mob, update_inv_wear_suit)
 
 /datum/inventory_slot/uniform
 	name = "Uniform"
 	id = slot_w_uniform
 	req_organ = BP_CHEST
 	req_slot_flags = SLOT_ICLOTHING
-	update_proc = /mob/proc/update_inv_w_uniform
+	update_proc = TYPE_PROC_REF(/mob, update_inv_w_uniform)
 
 /datum/inventory_slot/store
 	req_item_in_slot = slot_w_uniform
 	req_slot_flags = SLOT_POCKET
 	max_w_class = ITEM_SIZE_SMALL
-	update_proc = /mob/proc/update_inv_pockets
+	update_proc = TYPE_PROC_REF(/mob, update_inv_pockets)
 
 /datum/inventory_slot/store/can_equip(obj/item/I, mob/living/carbon/human/owner, disable_warning)
 	if(I.slot_flags & SLOT_DENYPOCKET)
@@ -222,7 +222,7 @@
 	name = "Store"
 	id = slot_s_store
 	req_item_in_slot = slot_wear_suit
-	update_proc = /mob/proc/update_inv_s_store
+	update_proc = TYPE_PROC_REF(/mob, update_inv_s_store)
 
 /datum/inventory_slot/suit_store/can_equip(obj/item/I, mob/living/carbon/human/owner, disable_warning)
 	var/obj/item/wear_suit = owner.get_equipped_item(slot_wear_suit)


### PR DESCRIPTION
## About The Pull Request

Fixes hopefully the last bug caused by hosting Eris on 515 version of BYOND.
It's about clothing sprites not being updated properly.

Also there were changes to `mutable_appearance` in BYOND about two weeks ago, some of the related code didn't compile and is now being removed.

## Why It's Good For The Game

Fixes good.

## Testing

Launched local before the fix, observed the bug.
Applied code changes.
Launched local and observed no bug.

Messed with reagent containers a bit, made sure their overlays aren't looking funny (since "icons and reagent overlays tweaks" was the stated reason for adding the now removed code).

## Changelog
:cl: SirRichardFrancis, MLGTASTICa
fix: Fixed clothing-related case of 515 incompatibility.
/:cl: