### PR TITLE
Fix window interactions

### DIFF
--- a/code/game/objects/structures/low_wall.dm
+++ b/code/game/objects/structures/low_wall.dm
@@ -2,7 +2,7 @@
 // It goes over a turf, can have items and a full tile window on it, blocks movement, can be climbed over, and provides cover
 /turf/wall/low
 	name = "low wall"
-	desc = "" // TODO --KIROV
+	desc = "A waist-height wall, provides decent enough cover."
 	icon = 'icons/walls.dmi'
 	icon_state = "eris_low"
 	opacity = FALSE
@@ -116,12 +116,14 @@
 
 
 /turf/wall/low/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(window_type) // Full-tile glass blocks everything
-		return FALSE
 	if(isnull(mover)) // Air, fire, and flamethorower spread
-		if(blocks_air || (target && target.blocks_air))
+		if(window_type || blocks_air || (target && target.blocks_air))
 			return FALSE
 		return TRUE
+	if(window_type) // Full-tile glass blocks everything
+		if(mover.checkpass(PASSGLASS)) // Except for when it doesn't
+			return TRUE
+		return FALSE
 	if(istype(mover.loc, /turf/wall/low)) // Mover is located on a connected low wall
 		return TRUE
 	if(istype(mover, /obj/item/projectile))

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -212,5 +212,19 @@
 		to_chat(user, SPAN_DANGER("The wall crumbles under your touch!"))
 		dismantle_wall(user)
 		return
+	if(window_type)
+		if(user.a_intent == I_HURT)
+			playsound(src, 'sound/effects/glassknock.ogg', 100, 1, 10, 10)
+			user.do_attack_animation(src)
+			user.visible_message(SPAN_DANGER("\The [user] bangs against \the [src]!"),
+								SPAN_DANGER("You bang against \the [src]!"),
+								"You hear a banging sound.")
+		else
+			playsound(src, 'sound/effects/glassknock.ogg', 80, 1, 5, 5)
+			user.visible_message("[user.name] knocks on the [name].",
+								"You knock on the [name].",
+								"You hear a knocking sound.")
+		return
+
 	to_chat(user, SPAN_NOTICE("You push the wall, but nothing happens."))
 	playsound(src, 'sound/weapons/Genhit.ogg', 25, 1)

--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -92,7 +92,7 @@
 		if(right_angle_override)
 			sprite_state = "[wall_type]_[connection_type]_right_angle"
 
-		var/sprite_id = "[sprite_state]_[overlay_direction]"
+		var/sprite_id = "[ref(icon)]_[sprite_state]_[overlay_direction]"
 		if(appearance_cache[sprite_id] != null)
 			add_overlay(appearance_cache[sprite_id])
 		else
@@ -103,12 +103,12 @@
 		// WINDOW SPRITE //
 		if(window_type) // Glass on top of the low wall, if any
 			sprite_state = "[window_type]_[connection_type]"
-			sprite_id = "[sprite_state]_[overlay_direction]"
+			sprite_id = "[ref(icon)]_[sprite_state]_[overlay_direction]"
 			if(appearance_cache[sprite_id] != null)
 				add_overlay(appearance_cache[sprite_id])
 			else
 				var/image/image = image(icon, icon_state = sprite_state, dir = overlay_direction, layer = ABOVE_OBJ_LAYER)
-				image.alpha = 180
+				image.alpha = window_alpha
 				appearance_cache[sprite_id] = image.appearance
 				add_overlay(appearance_cache[sprite_id])
 
@@ -128,7 +128,7 @@
 					sprite_state = "[wall_type]_over_[full_wall_connection_type]"
 
 			if(add_extra_overlay)
-				sprite_id = "[sprite_state]_[overlay_direction]"
+				sprite_id = "[ref(icon)]_[sprite_state]_[overlay_direction]"
 				if(appearance_cache[sprite_id] != null)
 					add_overlay(appearance_cache[sprite_id])
 				else

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -18,6 +18,7 @@
 	var/max_health = 300
 	var/hardness = 60
 	var/ricochet_id = 0
+	var/window_alpha = 180 // If the wall gets a window, it will be this transparent
 	var/any_wall_connections[10] // List of booleans. 8 total directions, 10 is maximum value, 7 and 3 aren't used
 	var/full_wall_connections[10] // Used for adding extra overlays in cases when low and full walls meet
 	var/wall_style = "default" // Affects how the wall sprite is composed. Different styles have different levels of complexity, see update_icon() for details

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -43,10 +43,9 @@
 		return ..()
 	if(get_dist(O, affecting) > 1)
 		return TRUE
-	if(!istype(O) && !istype(O, /turf/wall/low))
-		return TRUE
-	if(O.affect_grab(assailant, affecting, state))
-		qdel(src)
+	if(istype(O, /obj) || istype(O, /turf/wall/low))
+		if(O.affect_grab(assailant, affecting, state))
+			qdel(src)
 	return TRUE
 
 /obj/item/grab/New(mob/user, mob/victim)


### PR DESCRIPTION
## About The Pull Request

I've been told a couple of days ago that full-tile windows can't be knocked at, can't tell lasers and bullets apart, and that low walls are not grab-fu certified.
Also I've apparently forgot to write low wall description, oopsie.

Additionally, wall icon updates are somewhat more customizable now, with appearance cache supporting use of multiple .dmi files for walls (where icon names match these from other used .dmi), as well as custom alpha value for windows based off the wall type.

## Why It's Good For The Game

Fixes cool.
Customization changes made on request from a downstream.

## Testing

Knocked on a window with harm and help intents.
Touched a low wall with no window.
Touched a regular wall.

Shot a window with a laser gun, observed laser pass right through.
Shot a window with ballistic gun, observed bullet impact the window.
Shot a low wall with no window with ballistic gun, observed bullet pass right through.

Used blue grab on a low wall with no window, observed grabbed mob being put on a low wall.
Used blue grab on a window, observed mob not moving anywhere.
Used blue grab on a regular wall, observed mob not moving anywhere.

## Changelog
:cl:
fix: Fixed several interactions with windows.
/:cl:
