### PR TITLE
Blacklists Excelsior's heavy armor's pieces from spawning

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -186,6 +186,7 @@
 		bio = 0,
 		rad = 0
 	)
+	spawn_frequency = 1
 
 /obj/item/clothing/gloves/knuckles
 	name = "knuckle gloves"

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -186,7 +186,7 @@
 		bio = 0,
 		rad = 0
 	)
-	spawn_frequency = 3
+	spawn_blacklisted = TRUE
 
 /obj/item/clothing/gloves/knuckles
 	name = "knuckle gloves"

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -186,7 +186,7 @@
 		bio = 0,
 		rad = 0
 	)
-	spawn_frequency = 1
+	spawn_frequency = 3
 
 /obj/item/clothing/gloves/knuckles
 	name = "knuckle gloves"

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -644,7 +644,7 @@
 	siemens_coefficient = 1
 	species_restricted = list(SPECIES_HUMAN)
 	price_tag = 150
-	spawn_frequency = 3
+	spawn_blacklisted = TRUE
 
 /obj/item/clothing/head/armor/faceshield/paramedic
 	name = "Moebius paramedic helmet"

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -644,6 +644,7 @@
 	siemens_coefficient = 1
 	species_restricted = list(SPECIES_HUMAN)
 	price_tag = 150
+	spawn_frequency = 1
 
 /obj/item/clothing/head/armor/faceshield/paramedic
 	name = "Moebius paramedic helmet"

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -644,7 +644,7 @@
 	siemens_coefficient = 1
 	species_restricted = list(SPECIES_HUMAN)
 	price_tag = 150
-	spawn_frequency = 1
+	spawn_frequency = 3
 
 /obj/item/clothing/head/armor/faceshield/paramedic
 	name = "Moebius paramedic helmet"

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -121,7 +121,7 @@
 	)
 	can_hold_knife = TRUE
 	style = STYLE_NEG_HIGH
-	spawn_frequency = 1
+	spawn_frequency = 3
 
 /obj/item/clothing/shoes/artist_shoes
 	name = "Pointy Shoes"

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -121,7 +121,7 @@
 	)
 	can_hold_knife = TRUE
 	style = STYLE_NEG_HIGH
-	spawn_frequency = 3
+	spawn_blacklisted = TRUE
 
 /obj/item/clothing/shoes/artist_shoes
 	name = "Pointy Shoes"

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -121,6 +121,7 @@
 	)
 	can_hold_knife = TRUE
 	style = STYLE_NEG_HIGH
+	spawn_frequency = 1
 
 /obj/item/clothing/shoes/artist_shoes
 	name = "Pointy Shoes"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -289,6 +289,7 @@
 		MATERIAL_PLASTIC = 45,
 		MATERIAL_PLASTEEL = 25,
 	)
+	spawn_blacklisted = TRUE
 
 /obj/item/clothing/suit/armor/bulletproof/full
 	name = "full bulletproof vest"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -289,7 +289,7 @@
 		MATERIAL_PLASTIC = 45,
 		MATERIAL_PLASTEEL = 25,
 	)
-	spawn_blacklisted = TRUE
+	spawn_frequency = 1
 
 /obj/item/clothing/suit/armor/bulletproof/full
 	name = "full bulletproof vest"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -289,7 +289,7 @@
 		MATERIAL_PLASTIC = 45,
 		MATERIAL_PLASTEEL = 25,
 	)
-	spawn_frequency = 1
+	spawn_frequency = 3
 
 /obj/item/clothing/suit/armor/bulletproof/full
 	name = "full bulletproof vest"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -289,7 +289,7 @@
 		MATERIAL_PLASTIC = 45,
 		MATERIAL_PLASTEEL = 25,
 	)
-	spawn_frequency = 3
+	spawn_blacklisted = TRUE
 
 /obj/item/clothing/suit/armor/bulletproof/full
 	name = "full bulletproof vest"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Blacklists Excelsior Excelsior's heavy armor's pieces from spawning per request and as labeled as an oversight.

## Why It's Good For The Game

It stops Excelsior's heavy armor's pieces from spawning at all and being too easy to obtain except for Excelsior infiltrations.

## Testing

Queries of the described items.

## Changelog
:cl:
fix: Excelsior's heavy armor's pieces are blacklisted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
