### PR TITLE
Floor-ripping fix

### DIFF
--- a/code/controllers/subsystems/staverbs.dm
+++ b/code/controllers/subsystems/staverbs.dm
@@ -94,12 +94,12 @@ SUBSYSTEM_DEF(statverbs)
 			SPAN_DANGER("[user] grabbed the edges of [target] with their hands!"),
 			"You grab the edges of [target] with your hands"
 		)
-		if(do_mob(user, target, target.flooring.removal_time * 3))
+		if(do_mob(user, target, target.flooring.removal_time * 3) && target.flooring.flags & TURF_REMOVE_CROWBAR)
 			user.visible_message(
 				SPAN_DANGER("[user] roughly tore plating off from [target]!"),
 				"You tore the plating off from [target]"
 			)
-			target.make_plating(FALSE)
+			target.make_plating(TRUE, null, TRUE)
 		else
 			var/target_name = target ? "[target]" : "the floor"
 			user.visible_message(

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -86,7 +86,7 @@
 	transform = M
 
 /obj/item/material/shard/attackby(obj/item/I, mob/user)
-	if(QUALITY_WELDING in I.tool_qualities)
+	if(I.tool_qualities)
 		merge_shards(I, user)
 		return
 	return ..()
@@ -118,7 +118,18 @@
 
 	//Do a tool operation for each shard
 	for (var/obj/item/material/shard/S in shards)
-		if(I.use_tool(user, src, WORKTIME_NORMAL, QUALITY_WELDING, FAILCHANCE_VERY_EASY, required_stat = STAT_MEC))
+		var/quality
+		switch(S.material.name)
+			if(MATERIAL_STEEL, MATERIAL_PLASTEEL)
+				quality = QUALITY_HAMMERING
+			if(MATERIAL_GLASS, MATERIAL_RGLASS, MATERIAL_PLASMAGLASS, MATERIAL_RPLASMAGLASS)
+				quality = QUALITY_WELDING
+			if(MATERIAL_PLASTIC)
+				quality = QUALITY_ADHESIVE
+			else
+				quality = QUALITY_WELDING
+
+		if(I.use_tool(user, src, WORKTIME_NORMAL, quality, FAILCHANCE_VERY_EASY, required_stat = STAT_MEC))
 			//We meld each shard with ourselves
 			amount += S.amount
 			qdel(S)
@@ -135,6 +146,7 @@
 			update_icon()
 		else
 			//If we fail any of the operations, we abort it all
+			to_chat(user, SPAN_WARNING("You failed to merge [name]s! You might try using a better tool."))
 			break
 
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -89,7 +89,7 @@
 
 //This proc will set floor_type to null and the update_icon() proc will then change the icon_state of the turf
 //This proc auto corrects the grass tiles' siding.
-/turf/floor/proc/make_plating(var/place_product, var/defer_icon_update)
+/turf/floor/proc/make_plating(var/place_product, var/defer_icon_update, var/scraped)
 
 	overlays.Cut()
 	if(islist(decals))
@@ -104,7 +104,16 @@
 
 	if(flooring)
 		if(flooring.build_type && place_product)
-			new flooring.build_type(src)
+			var/obj/temp_tile = new flooring.build_type(src)
+			if(scraped && temp_tile)
+				var/materials = temp_tile.get_matter()
+				for(var/mat_name in materials)
+					var/material/material = get_material_by_name(mat_name)
+					if(!material)
+						continue
+
+					material.place_shard(src, materials[mat_name])
+				qdel(temp_tile)
 
 	//We attempt to get whatever should be under this floor
 	if(flooring)


### PR DESCRIPTION
## About The Pull Request

Fix for ripped off with ROB tiles disappearing. Now they drop metal shards co-responding to what materials they made of.
Also metal shards now can be merged with hammering and plastic shards can he glued/taped together

## Why It's Good For The Game

Materials now won't just vanish in the air and torn tiles can be recycled with hammers or more efficiently with autolathe

## Testing
Torn off few tiles near cryo as a BST and few plastic tiles in kitchen, then as a technomancer:
- Tried welding together metal shards. Got fail message suggesting using a different tool. Expected result achieved
- Tried hammering metal shards together. Two of 3 shards merged into two steel sheets taking some material from the last shard. Expected result achieved
- Tried welding together plastic shards. Got fail message suggesting using a different tool. Expected result achieved
- Tried taping together plastic shards with web tape. Two of 3 shards merged into two steel sheets taking some material from the last shard. Expected result achieved
- Just in case broke a window and welded together dropped shards. Still works as intended

## Changelog
:cl:
add: Torn with ROB tiles now drop shards of material
tweak: Shards now can be hammered, welded or glued depending on the material type
/:cl:
