### PR TITLE
Fix atmos

### DIFF
--- a/code/ZAS/Connection.dm
+++ b/code/ZAS/Connection.dm
@@ -97,13 +97,14 @@ Class Procs:
 	return !(state & CONNECTION_INVALID)
 
 /connection/proc/erase()
-	edge.remove_connection(src)
+	if(edge)
+		edge.remove_connection(src)
 	state |= CONNECTION_INVALID
 	//world << "Connection Erased: [state]"
 
 /connection/proc/update()
 	//world << "Updated, \..."
-	if(!istype(A,/turf))
+	if(!A.is_simulated)
 		//world << "Invalid A."
 		erase()
 		return
@@ -118,10 +119,8 @@ Class Procs:
 	else
 		mark_direct()
 
-	var/b_is_space = !istype(B,/turf)
-
 	if(state & CONNECTION_SPACE)
-		if(!b_is_space)
+		if(B.is_simulated)
 			//world << "Invalid B."
 			erase()
 			return
@@ -131,16 +130,16 @@ Class Procs:
 				erase()
 				//world << "erased."
 				return
-			else
+			if(edge)
 				edge.remove_connection(src)
 				edge = SSair.get_edge(A.zone, B)
 				edge.add_connection(src)
-				zoneA = A.zone
+			zoneA = A.zone
 
 		//world << "valid."
 		return
 
-	else if(b_is_space)
+	else if(!B.is_simulated)
 		//world << "Invalid B."
 		erase()
 		return

--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -54,7 +54,7 @@
 
 		var/previously_open = open_directions
 		open_directions = 0
-		var/list/postponed
+		var/list/postponed = list()
 		#ifdef ZLEVELS
 		for(var/d = 1, d < 64, d *= 2)
 		#else
@@ -96,8 +96,6 @@
 						//    we are blocking them and not blocking ourselves - this prevents tiny zones from forming on doorways.
 						if(((block & ZONE_BLOCKED) && !(r_block & ZONE_BLOCKED)) || ((r_block & ZONE_BLOCKED) && !(s_block & ZONE_BLOCKED)))
 							//Postpone this tile rather than exit, since a connection can still be made.
-							if(!postponed)
-								postponed = list()
 							postponed.Add(neighbour_turf)
 						else
 							neighbour_turf.zone.add(src)
@@ -106,6 +104,10 @@
 							#endif
 					else if(neighbour_turf.zone != zone)
 						SSair.connect(src, neighbour_turf)
+			else if(zone)
+				SSair.connect(src, neighbour_turf)
+			else // This tile does not yet have a valid zone, but likely to get one from other neighbours
+				postponed.Add(neighbour_turf)
 
 		if(!TURF_HAS_VALID_ZONE(src)) //Still no zone, make a new one.
 			var/zone/newzone = new/zone()

--- a/code/controllers/subsystems/air.dm
+++ b/code/controllers/subsystems/air.dm
@@ -329,6 +329,8 @@ SUBSYSTEM_DEF(air)
 	#ifdef ZASDBG
 	ASSERT(isturf(A))
 	ASSERT(isturf(B))
+	if(istype(B, /turf/space))
+		return FALSE
 	#endif
 
 	var/ablock = A.c_airblock(B)


### PR DESCRIPTION
## About The Pull Request

Makes the gas go round.
Specifically between connected rooms and out in space, if there is a breach.

## Why It's Good For The Game

Having a functional gas simulation again would be nice I guess.

## Testing

Flying around as a ghost, deleting walls, doors and windows to see if rooms are being vented properly.
Plasma flooded a room and opened nearby doors.

## Changelog
:cl:
fix: Fixed atmos not working a lot of the time.
/:cl: