### PR TITLE
Fix Liberty HUD not working & unify functions

### DIFF
--- a/code/_onclick/hud/screen_objects/base_screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/base_screen_objects.dm
@@ -452,7 +452,8 @@
 	if(!ishuman(parentmob))
 		return FALSE
 	var/mob/living/carbon/human/H = parentmob
-	H?.sanity?.ui_interact(H)
+	H.sanity.ui_interact(H)
+	H.sanity.print_desires()
 	return TRUE
 
 /obj/screen/sanity_alt
@@ -527,7 +528,7 @@
 	if(!ishuman(parentmob))
 		return FALSE
 	var/mob/living/carbon/human/H = parentmob
-	H.nano_ui_interact(H)
+	H.sanity.ui_interact(H)
 	H.sanity.print_desires()
 	return	TRUE
 


### PR DESCRIPTION
## About The Pull Request

This PR unifies sanity button interaction between Liberty and Eris HUDs, but mainly fixes first one not opening new stats menu.

## Why It's Good For The Game

Working and unified UI iterations are always good, duh.

## Testing

Launched game and clicked on sanity hud button, all good.

## Changelog
:cl:
add: unified sanity button interaction between Liberty and Eris HUDs, both list desires now.
fix: fixed Liberty HUD sanity button not opening sanity UI.
/:cl:
