### PR TITLE
Superglue is printable with an advanced tools disk + superglue buffs

### DIFF
--- a/code/datums/autolathe/tools.dm
+++ b/code/datums/autolathe/tools.dm
@@ -159,3 +159,6 @@
 /datum/design/autolathe/tool/rpd
 	name = "rapid piping device"
 	build_path = /obj/item/rpd
+
+/datum/design/autolathe/tool/superglue
+	build_path = /obj/item/tool/tape_roll/glue

--- a/code/game/objects/items/weapons/design_disks/technomancers.dm
+++ b/code/game/objects/items/weapons/design_disks/technomancers.dm
@@ -50,6 +50,7 @@
 		/datum/design/autolathe/tool/combi_driver,
 		/datum/design/autolathe/tool/armature_cutter,
 		/datum/design/autolathe/tool/weldertool_adv,
+		/datum/design/autolathe/tool/superglue,
 		/datum/design/autolathe/part/diamondblade,
 		/datum/design/autolathe/tool/rpd,
 		/datum/design/autolathe/container/hcase_engi,

--- a/code/game/objects/items/weapons/tools/tape.dm
+++ b/code/game/objects/items/weapons/tools/tape.dm
@@ -49,8 +49,8 @@
 	desc = "A bucket of milky white fluid. Can be used to stick things together, but unlike tape, it cannot be used to seal things."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "glue"
-	tool_qualities = list(QUALITY_ADHESIVE = 40, QUALITY_CAUTERIZING = 5) // Better than duct tape, but can't seal things and is mostly used in crafting - also, it's glue, so it can be used as an extremely shitty way of sealing wounds
-	matter = list(MATERIAL_BIOMATTER = 30)
+	tool_qualities = list(QUALITY_ADHESIVE = 50, QUALITY_CAUTERIZING = 5) // Better than duct tape, but can't seal things and is mostly used in crafting - also, it's glue, so it can be used as an extremely shitty way of sealing wounds
+	matter = list(MATERIAL_PLASTIC = 20)
 	worksound = NO_WORKSOUND
 
 /obj/item/tool/tape_roll/attack(mob/living/carbon/human/H, mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Add superglue to 'Technomancers IJIRO-451 Advanced Tools' disk.

Change superglue's materials from 30 biomatter to 20 plastic, the same as fiber tape, making it printable by all fabricators.

Change superglue's adhesive stat from 40 to 50. This makes superglue contribute 3 mechanical stat instead of 2 to the techno-tribalism enforcer, allowing technomancers to create 15-mechanical oddities at roundstart.


I specifically chose superglue and not fiber tape because fiber tape's current stats would let technomancers create 30-mechanical oddities which I think is too drastic of a buff.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Mechanical is an important stat to technomancers, yet it's the only one they have no reliable access to. This PR would finally let them create oddities with mechanical stats without relying on finding some of the rarest junkpile items in the game.

## Testing

![image](https://github.com/user-attachments/assets/cf4641c1-13e1-4231-a7d1-e288ff4f9d4b)
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
balance: Superglue can now be printed with an advanced tool disk
balance: Superglue is now made of 20 plastic instead of 30 biomatter
balance: Superglue now has 50 adhesive stat instead of 40.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
