### PR TITLE
Fixes shutter buttons breaking for rounds that play near 24:00 GMT and reach 00:00

### DIFF
--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -138,6 +138,7 @@
 	. = ..()
 	radio_conn = SSradio.add_object(src, BLAST_DOOR_FREQ, RADIO_BLASTDOORS)
 	AddComponent(/datum/component/overlay_manager)
+	return INITIALIZE_HINT_LATELOAD
 
 /// Update status at initialization!
 /obj/machinery/button/remote/blast_door/LateInitialize()

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -138,7 +138,6 @@
 	. = ..()
 	radio_conn = SSradio.add_object(src, BLAST_DOOR_FREQ, RADIO_BLASTDOORS)
 	AddComponent(/datum/component/overlay_manager)
-	return INITIALIZE_HINT_LATELOAD
 
 /// Update status at initialization!
 /obj/machinery/button/remote/blast_door/LateInitialize()

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -88,7 +88,7 @@
 	if(stat & NOPOWER)
 		return
 	/// prevent command spam
-	if(last_message > world.timeofday)
+	if(last_message > world.time)
 		return
 	switch(signal.data["message"])
 		if("DATA_DOOR_OPENED")
@@ -109,7 +109,7 @@
 			broadcast_status()
 		if("CMD_DOOR_STATE")
 			broadcast_status()
-	last_message = world.timeofday + 1 SECONDS
+	last_message = world.time + 1 SECONDS
 
 // Proc: Bumped()
 // Parameters: 1 (AM - Atom that tried to walk through this object)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fiexs the issue that tends to occur during eris rounds a lot since we have a lot of rounds during that timestamp

## Why It's Good For The Game
They work.... at last... even at 1:00 EEST
## Testing
I didnt have the time to test it nor the resources to emulate time ,but its preety obvious what was happening with how this was not a reproducible bug most of the time.

## Changelog
:cl:
fix: Fixed Blast Doors refusing to work past 24:00 GMT
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
