### PR TITLE
Insulated technomancer helmet's icon can be swapped with a wrench

### DIFF
--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -80,7 +80,7 @@
 
 /obj/item/clothing/head/armor/helmet/technomancer
 	name = "insulated technomancer helmet"
-	desc = "A piece of armor used in hostile work conditions to protect the head. Comes with a built-in flashlight."
+	desc = "A piece of armor used in hostile work conditions to protect the head. Comes with a built-in flashlight. The appearance of the visor can be changed with a wrench."
 	body_parts_covered = HEAD|EARS|EYES|FACE
 	item_flags = THICKMATERIAL
 	flags_inv = BLOCKHEADHAIR|HIDEEARS|HIDEEYES|HIDEFACE
@@ -103,6 +103,18 @@
 /obj/item/clothing/head/armor/helmet/technomancer/New()
 	. = ..()
 	icon_state = pick(list("technohelmet_visor", "technohelmet_googles"))
+
+/obj/item/clothing/head/armor/helmet/technomancer/attackby(obj/item/W, mob/user)
+	if(QUALITY_BOLT_TURNING in W.tool_qualities)
+		if(icon_state == "technohelmet_visor")
+			icon_state = "technohelmet_googles"
+			to_chat(usr, "You reconfigure the [src]'s visor to look like a pair of goggles.")
+			return
+		else if(icon_state == "technohelmet_googles")
+			icon_state = "technohelmet_visor"
+			to_chat(usr, "You reconfigure the [src]'s goggles to look like a visor.")
+			return
+	. = ..()
 
 /obj/item/clothing/head/armor/helmet/technomancer_old
 	name = "reinforced technomancer helmet"

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -80,7 +80,8 @@
 
 /obj/item/clothing/head/armor/helmet/technomancer
 	name = "insulated technomancer helmet"
-	desc = "A piece of armor used in hostile work conditions to protect the head. Comes with a built-in flashlight. The appearance of the visor can be changed with a wrench."
+	desc = "A piece of armor used in hostile work conditions to protect the head. Comes with a built-in flashlight."
+	description_info = "The appearance of the visor can be changed with a wrench."
 	body_parts_covered = HEAD|EARS|EYES|FACE
 	item_flags = THICKMATERIAL
 	flags_inv = BLOCKHEADHAIR|HIDEEARS|HIDEEYES|HIDEFACE
@@ -106,11 +107,11 @@
 
 /obj/item/clothing/head/armor/helmet/technomancer/attackby(obj/item/W, mob/user)
 	if(QUALITY_BOLT_TURNING in W.tool_qualities)
-		if(icon_state == "technohelmet_visor")
+		if (icon_state == "technohelmet_visor")
 			icon_state = "technohelmet_googles"
 			to_chat(usr, "You reconfigure the [src]'s visor to look like a pair of goggles.")
 			return
-		else if(icon_state == "technohelmet_googles")
+		else
 			icon_state = "technohelmet_visor"
 			to_chat(usr, "You reconfigure the [src]'s goggles to look like a visor.")
 			return

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -107,7 +107,7 @@
 
 /obj/item/clothing/head/armor/helmet/technomancer/attackby(obj/item/W, mob/user)
 	if(QUALITY_BOLT_TURNING in W.tool_qualities)
-		if (icon_state == "technohelmet_visor")
+		if(icon_state == "technohelmet_visor")
 			icon_state = "technohelmet_googles"
 			to_chat(usr, "You reconfigure the [src]'s visor to look like a pair of goggles.")
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The insulated technomancer helmet spawns with one of two icons currently. This PR lets the icon be swapped to the other and vice versa with a wrench.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I don't like the goggles appearance. Let people choose how they want to look, instead of relying on RNG.

## Testing

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

Used a wrench on the helmet. Works.
![image](https://github.com/user-attachments/assets/70b89fe1-6414-4ead-930a-ea9bddd910a7)


## Changelog
:cl:
tweak: insulated technomancer helmet's appearance can be changed with a wrench.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
