### PR TITLE
Refactor Pressure Tank to fix airlocks

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -173,6 +173,7 @@
 #include "code\ATMOSPHERICS\mainspipe.dm"
 #include "code\ATMOSPHERICS\pipes.dm"
 #include "code\ATMOSPHERICS\components\portables_connector.dm"
+#include "code\ATMOSPHERICS\components\tank.dm"
 #include "code\ATMOSPHERICS\components\tvalve.dm"
 #include "code\ATMOSPHERICS\components\valve.dm"
 #include "code\ATMOSPHERICS\components\binary_devices\binary_atmos_base.dm"

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -22,7 +22,7 @@
 	var/on = FALSE
 	use_power = NO_POWER_USE
 
-/obj/machinery/atmospherics/tank/New()
+/obj/machinery/atmospherics/tank/LateInitialize()
 	icon_state = "air"
 	initialize_directions = dir
 	..()

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -165,7 +165,7 @@
 	name = "Pressure Tank (Carbon Dioxide)"
 	icon_state = "co2_map"
 
-/obj/machinery/atmospherics/tank/carbon_dioxide/New()
+/obj/machinery/atmospherics/tank/carbon_dioxide/LateInitialize()
 	air_temporary = new
 	air_temporary.volume = volume
 	air_temporary.temperature = T20C

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -34,19 +34,20 @@
 	return 1
 
 /obj/machinery/atmospherics/tank/Destroy()
-	loc = null
+    if(air_temporary)
+        loc.assume_air(air_temporary)
+        QDEL_NULL(air_temporary)
 
-	if(node)
-		node.disconnect(src)
-		qdel(network)
+    ..()
+    loc = null
 
-	node = null
-	if(air_temporary)
-		loc.assume_air(air_temporary)
-		QDEL_NULL(air_temporary)
+    if(node)
+        node.disconnect(src)
+        qdel(network)
 
-	..()
-	return QDEL_HINT_QUEUE
+    node = null
+
+    return QDEL_HINT_QUEUE
 
 /obj/machinery/atmospherics/tank/update_underlays()
 	if(..())

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -153,7 +153,7 @@
 	name = "Pressure Tank (Nitrogen)"
 	icon_state = "n2_map"
 
-/obj/machinery/atmospherics/tank/nitrogen/New()
+/obj/machinery/atmospherics/tank/nitrogen/LateInitialize()
 	air_temporary = new
 	air_temporary.volume = volume
 	air_temporary.temperature = T20C

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -120,11 +120,9 @@
 	air_temporary = new
 	air_temporary.volume = volume
 	air_temporary.temperature = T20C
-
 	air_temporary.adjust_gas("oxygen", (start_pressure)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
-
-	..()
 	icon_state = "o2"
+	..()
 
 /obj/machinery/atmospherics/tank/nitrogen
 	name = "Pressure Tank (Nitrogen)"

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -34,20 +34,18 @@
 	return 1
 
 /obj/machinery/atmospherics/tank/Destroy()
-    if(air_temporary)
-        loc.assume_air(air_temporary)
-        QDEL_NULL(air_temporary)
+	..()
+	if(air_temporary)
+		loc.assume_air(air_temporary)
+		QDEL_NULL(air_temporary)
 
-    ..()
-    loc = null
+	loc = null
+	if(node)
+		node.disconnect(src)
+		qdel(network)
+		node = null
 
-    if(node)
-        node.disconnect(src)
-        qdel(network)
-
-    node = null
-
-    return QDEL_HINT_QUEUE
+	return QDEL_HINT_QUEUE
 
 /obj/machinery/atmospherics/tank/update_underlays()
 	if(check_icon_cache())

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -1,0 +1,208 @@
+/obj/machinery/atmospherics/tank
+	icon = 'icons/atmos/tank.dmi'
+	icon_state = "air_map"
+
+	name = "Pressure Tank"
+	desc = "A large vessel containing pressurized gas."
+
+	var/datum/gas_mixture/air_temporary // used when reconstructing a pipeline that broke
+	var/volume = 10000 //in liters, 1 meters by 1 meters by 2 meters ~tweaked it a little to simulate a pressure tank without needing to recode them yet
+	var/start_pressure = 25*ONE_ATMOSPHERE
+
+	level = BELOW_PLATING_LEVEL
+	dir = SOUTH
+	initialize_directions = SOUTH
+	density = TRUE
+	layer = ABOVE_WINDOW_LAYER
+
+	var/obj/machinery/atmospherics/node
+
+	var/datum/pipe_network/network
+
+	var/on = FALSE
+	use_power = NO_POWER_USE
+
+/obj/machinery/atmospherics/tank/New()
+	icon_state = "air"
+	initialize_directions = dir
+	..()
+
+/obj/machinery/atmospherics/tank/Process()
+	..()
+	if(network)
+		network.update = 1
+	return 1
+
+/obj/machinery/atmospherics/tank/Destroy()
+	loc = null
+
+	if(node)
+		node.disconnect(src)
+		qdel(network)
+
+	node = null
+	if(air_temporary)
+		loc.assume_air(air_temporary)
+		QDEL_NULL(air_temporary)
+
+	..()
+	return QDEL_HINT_QUEUE
+
+/obj/machinery/atmospherics/tank/update_underlays()
+	if(..())
+		underlays.Cut()
+		var/turf/T = get_turf(src)
+		if(!istype(T))
+			return
+		add_underlay(T, node, dir)
+
+/obj/machinery/atmospherics/tank/hide()
+	update_underlays()
+
+/obj/machinery/atmospherics/tank/atmos_init()
+	if(node) return
+
+	var/node_connect = dir
+
+	for(var/obj/machinery/atmospherics/target in get_step(src, node_connect))
+		if(target.initialize_directions & get_dir(target, src))
+			if (check_connect_types(target, src))
+				node = target
+				break
+
+	update_underlays()
+
+/obj/machinery/atmospherics/tank/disconnect(obj/machinery/atmospherics/reference)
+	if(reference==node)
+		qdel(network)
+		node = null
+
+	update_underlays()
+
+	return null
+
+// Housekeeping and pipe network stuff below
+/obj/machinery/atmospherics/tank/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
+	if(reference == node)
+		network = new_network
+
+	if(new_network.normal_members.Find(src))
+		return 0
+
+	new_network.normal_members += src
+
+	return null
+
+/obj/machinery/atmospherics/tank/build_network()
+	if(!network && node)
+		network = new /datum/pipe_network()
+		network.normal_members += src
+		network.build_network(node, src)
+
+/obj/machinery/atmospherics/tank/return_network(obj/machinery/atmospherics/reference)
+	build_network()
+
+	if(reference==node)
+		return network
+
+
+	return null
+
+/obj/machinery/atmospherics/tank/reassign_network(datum/pipe_network/old_network, datum/pipe_network/new_network)
+	if(network == old_network)
+		network = new_network
+
+	return 1
+
+/obj/machinery/atmospherics/tank/return_network_air(datum/pipe_network/reference)
+	return air_temporary
+
+/obj/machinery/atmospherics/tank/return_air()
+    return air_temporary
+
+/obj/machinery/atmospherics/tank/air
+	name = "Pressure Tank (Air)"
+	icon_state = "air_map"
+
+/obj/machinery/atmospherics/tank/air/New()
+	air_temporary = new
+	air_temporary.volume = volume
+	air_temporary.temperature = T20C
+
+	air_temporary.adjust_multi("oxygen",  (start_pressure*O2STANDARD)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature), \
+	                           "nitrogen",(start_pressure*N2STANDARD)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
+
+
+	..()
+	icon_state = "air"
+
+/obj/machinery/atmospherics/tank/oxygen
+	name = "Pressure Tank (Oxygen)"
+	icon_state = "o2_map"
+
+/obj/machinery/atmospherics/tank/oxygen/New()
+	air_temporary = new
+	air_temporary.volume = volume
+	air_temporary.temperature = T20C
+
+	air_temporary.adjust_gas("oxygen", (start_pressure)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
+
+	..()
+	icon_state = "o2"
+
+/obj/machinery/atmospherics/tank/nitrogen
+	name = "Pressure Tank (Nitrogen)"
+	icon_state = "n2_map"
+
+/obj/machinery/atmospherics/tank/nitrogen/New()
+	air_temporary = new
+	air_temporary.volume = volume
+	air_temporary.temperature = T20C
+
+	air_temporary.adjust_gas("nitrogen", (start_pressure)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
+
+	..()
+	icon_state = "n2"
+
+/obj/machinery/atmospherics/tank/carbon_dioxide
+	name = "Pressure Tank (Carbon Dioxide)"
+	icon_state = "co2_map"
+
+/obj/machinery/atmospherics/tank/carbon_dioxide/New()
+	air_temporary = new
+	air_temporary.volume = volume
+	air_temporary.temperature = T20C
+
+	air_temporary.adjust_gas("carbon_dioxide", (start_pressure)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
+
+	..()
+	icon_state = "co2"
+
+/obj/machinery/atmospherics/tank/plasma
+	name = "Pressure Tank (Plasma)"
+	description_antag = "Will blind people if they do not wear face-covering gear"
+	icon_state = "plasma_map"
+
+/obj/machinery/atmospherics/tank/plasma/New()
+	air_temporary = new
+	air_temporary.volume = volume
+	air_temporary.temperature = T20C
+
+	air_temporary.adjust_gas("plasma", (start_pressure)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
+
+	..()
+	icon_state = "plasma"
+
+/obj/machinery/atmospherics/tank/nitrous_oxide
+	name = "Pressure Tank (Nitrous Oxide)"
+	icon_state = "n2o_map"
+
+/obj/machinery/atmospherics/tank/nitrous_oxide/New()
+	air_temporary = new
+	air_temporary.volume = volume
+	air_temporary.temperature = T0C
+
+	air_temporary.adjust_gas("sleeping_agent", (start_pressure)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
+
+	..()
+	icon_state = "n2o"

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -123,7 +123,7 @@
 	name = "Pressure Tank (Air)"
 	icon_state = "air_map"
 
-/obj/machinery/atmospherics/tank/air/New()
+/obj/machinery/atmospherics/tank/air/LateInitialize()
 	air_temporary = new
 	air_temporary.volume = volume
 	air_temporary.temperature = T20C

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -113,8 +113,6 @@
 	if(network == old_network)
 		network = new_network
 
-	return 1
-
 /obj/machinery/atmospherics/tank/return_network_air(datum/pipe_network/reference)
 	return air_temporary
 

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -139,7 +139,7 @@
 	name = "Pressure Tank (Oxygen)"
 	icon_state = "o2_map"
 
-/obj/machinery/atmospherics/tank/oxygen/New()
+/obj/machinery/atmospherics/tank/oxygen/LateInitialize()
 	air_temporary = new
 	air_temporary.volume = volume
 	air_temporary.temperature = T20C

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -157,11 +157,9 @@
 	air_temporary = new
 	air_temporary.volume = volume
 	air_temporary.temperature = T20C
-
 	air_temporary.adjust_gas("nitrogen", (start_pressure)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
-
-	..()
 	icon_state = "n2"
+	..()
 
 /obj/machinery/atmospherics/tank/carbon_dioxide
 	name = "Pressure Tank (Carbon Dioxide)"

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -171,11 +171,9 @@
 	air_temporary = new
 	air_temporary.volume = volume
 	air_temporary.temperature = T20C
-
 	air_temporary.adjust_gas("carbon_dioxide", (start_pressure)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
-
-	..()
 	icon_state = "co2"
+	..()
 
 /obj/machinery/atmospherics/tank/plasma
 	name = "Pressure Tank (Plasma)"

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -186,11 +186,9 @@
 	air_temporary = new
 	air_temporary.volume = volume
 	air_temporary.temperature = T20C
-
 	air_temporary.adjust_gas("plasma", (start_pressure)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
-
-	..()
 	icon_state = "plasma"
+	..()
 
 /obj/machinery/atmospherics/tank/nitrous_oxide
 	name = "Pressure Tank (Nitrous Oxide)"

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -190,7 +190,7 @@
 	name = "Pressure Tank (Nitrous Oxide)"
 	icon_state = "n2o_map"
 
-/obj/machinery/atmospherics/tank/nitrous_oxide/New()
+/obj/machinery/atmospherics/tank/nitrous_oxide/LateInitialize()
 	air_temporary = new
 	air_temporary.volume = volume
 	air_temporary.temperature = T0C

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -107,13 +107,10 @@
 	air_temporary = new
 	air_temporary.volume = volume
 	air_temporary.temperature = T20C
-
 	air_temporary.adjust_multi("oxygen",  (start_pressure*O2STANDARD)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature), \
 	                           "nitrogen",(start_pressure*N2STANDARD)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
-
-
-	..()
 	icon_state = "air"
+	..()
 
 /obj/machinery/atmospherics/tank/oxygen
 	name = "Pressure Tank (Oxygen)"

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -80,8 +80,6 @@
 
 	update_underlays()
 
-	return null
-
 // Housekeeping and pipe network stuff below
 /obj/machinery/atmospherics/tank/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
 	if(reference == node)

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -1,26 +1,18 @@
 /obj/machinery/atmospherics/tank
-	icon = 'icons/atmos/tank.dmi'
-	icon_state = "air_map"
-
 	name = "Pressure Tank"
 	desc = "A large vessel containing pressurized gas."
-
-	var/datum/gas_mixture/air_temporary // used when reconstructing a pipeline that broke
-	var/volume = 10000 //in liters, 1 meters by 1 meters by 2 meters ~tweaked it a little to simulate a pressure tank without needing to recode them yet
-	var/start_pressure = 25*ONE_ATMOSPHERE
-
-	level = BELOW_PLATING_LEVEL
+	icon = 'icons/atmos/tank.dmi'
+	icon_state = "air_map"
 	dir = SOUTH
-	initialize_directions = SOUTH
 	density = TRUE
 	layer = ABOVE_WINDOW_LAYER
-
-	var/obj/machinery/atmospherics/node
-
-	var/datum/pipe_network/network
-
-	var/on = FALSE
 	use_power = NO_POWER_USE
+
+	var/volume = 10000 //in liters, 1 meters by 1 meters by 2 meters ~tweaked it a little to simulate a pressure tank without needing to recode them yet
+	var/start_pressure = 25*ONE_ATMOSPHERE
+	var/obj/machinery/atmospherics/node
+	var/datum/gas_mixture/air_temporary // used when reconstructing a pipeline that broke
+	var/datum/pipe_network/network
 
 /obj/machinery/atmospherics/tank/LateInitialize()
 	icon_state = "air"

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -50,12 +50,11 @@
     return QDEL_HINT_QUEUE
 
 /obj/machinery/atmospherics/tank/update_underlays()
-	if(..())
+	if(check_icon_cache())
 		underlays.Cut()
 		var/turf/T = get_turf(src)
-		if(!istype(T))
-			return
-		add_underlay(T, node, dir)
+		if(stype(T))
+			add_underlay(T, node, dir)
 
 /obj/machinery/atmospherics/tank/hide()
 	update_underlays()

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -202,8 +202,6 @@
 	air_temporary = new
 	air_temporary.volume = volume
 	air_temporary.temperature = T0C
-
 	air_temporary.adjust_gas("sleeping_agent", (start_pressure)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
-
-	..()
 	icon_state = "n2o"
+	..()

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -61,13 +61,12 @@
 	update_underlays()
 
 /obj/machinery/atmospherics/tank/atmos_init()
-	if(node) return
+	if(node)
+		return
 
-	var/node_connect = dir
-
-	for(var/obj/machinery/atmospherics/target in get_step(src, node_connect))
+	for(var/obj/machinery/atmospherics/target in get_step(src, dir))
 		if(target.initialize_directions & get_dir(target, src))
-			if (check_connect_types(target, src))
+			if(check_connect_types(target, src))
 				node = target
 				break
 

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -88,11 +88,9 @@
 		network = new_network
 
 	if(new_network.normal_members.Find(src))
-		return 0
+		return FALSE
 
 	new_network.normal_members += src
-
-	return null
 
 /obj/machinery/atmospherics/tank/build_network()
 	if(!network && node)

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -102,12 +102,8 @@
 
 /obj/machinery/atmospherics/tank/return_network(obj/machinery/atmospherics/reference)
 	build_network()
-
-	if(reference==node)
+	if(reference == node)
 		return network
-
-
-	return null
 
 /obj/machinery/atmospherics/tank/reassign_network(datum/pipe_network/old_network, datum/pipe_network/new_network)
 	if(network == old_network)

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -178,7 +178,7 @@
 	description_antag = "Will blind people if they do not wear face-covering gear"
 	icon_state = "plasma_map"
 
-/obj/machinery/atmospherics/tank/plasma/New()
+/obj/machinery/atmospherics/tank/plasma/LateInitialize()
 	air_temporary = new
 	air_temporary.volume = volume
 	air_temporary.temperature = T20C

--- a/code/ATMOSPHERICS/components/tank.dm
+++ b/code/ATMOSPHERICS/components/tank.dm
@@ -30,8 +30,8 @@
 /obj/machinery/atmospherics/tank/Process()
 	..()
 	if(network)
-		network.update = 1
-	return 1
+		network.update = TRUE
+	return TRUE
 
 /obj/machinery/atmospherics/tank/Destroy()
 	..()

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -72,8 +72,6 @@
 	return QDEL_HINT_QUEUE
 
 /obj/machinery/atmospherics/pipe/attackby(obj/item/I, mob/user)
-	if (istype(src, /obj/machinery/atmospherics/tank))
-		return ..()
 	if (istype(src, /obj/machinery/atmospherics/pipe/vent))
 		return ..()
 
@@ -114,25 +112,7 @@
 	pipe_color = new_color
 	update_icon()
 
-/*
-/obj/machinery/atmospherics/pipe/add_underlay(var/obj/machinery/atmospherics/node, var/direction)
-	if(istype(src, /obj/machinery/atmospherics/tank))	//todo: move tanks to unary devices
-		return ..()
-
-	if(node)
-		var/temp_dir = get_dir(src, node)
-		underlays += icon_manager.get_atmos_icon("pipe_underlay_intact", temp_dir, color_cache_name(node))
-		return temp_dir
-	else if(direction)
-		underlays += icon_manager.get_atmos_icon("pipe_underlay_exposed", direction, pipe_color)
-	else
-		return null
-*/
-
 /obj/machinery/atmospherics/pipe/color_cache_name(var/obj/machinery/atmospherics/node)
-	if(istype(src, /obj/machinery/atmospherics/tank))
-		return ..()
-
 	if(istype(node, /obj/machinery/atmospherics/pipe/manifold) || istype(node, /obj/machinery/atmospherics/pipe/manifold4w))
 		if(pipe_color == node.pipe_color)
 			return node.pipe_color

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -72,7 +72,7 @@
 	return QDEL_HINT_QUEUE
 
 /obj/machinery/atmospherics/pipe/attackby(obj/item/I, mob/user)
-	if (istype(src, /obj/machinery/atmospherics/pipe/tank))
+	if (istype(src, /obj/machinery/atmospherics/tank))
 		return ..()
 	if (istype(src, /obj/machinery/atmospherics/pipe/vent))
 		return ..()
@@ -116,7 +116,7 @@
 
 /*
 /obj/machinery/atmospherics/pipe/add_underlay(var/obj/machinery/atmospherics/node, var/direction)
-	if(istype(src, /obj/machinery/atmospherics/pipe/tank))	//todo: move tanks to unary devices
+	if(istype(src, /obj/machinery/atmospherics/tank))	//todo: move tanks to unary devices
 		return ..()
 
 	if(node)
@@ -130,7 +130,7 @@
 */
 
 /obj/machinery/atmospherics/pipe/color_cache_name(var/obj/machinery/atmospherics/node)
-	if(istype(src, /obj/machinery/atmospherics/pipe/tank))
+	if(istype(src, /obj/machinery/atmospherics/tank))
 		return ..()
 
 	if(istype(node, /obj/machinery/atmospherics/pipe/manifold) || istype(node, /obj/machinery/atmospherics/pipe/manifold4w))
@@ -1034,166 +1034,6 @@
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
 
-
-/obj/machinery/atmospherics/pipe/tank
-	icon = 'icons/atmos/tank.dmi'
-	icon_state = "air_map"
-
-	name = "Pressure Tank"
-	desc = "A large vessel containing pressurized gas."
-
-	volume = 10000 //in liters, 1 meters by 1 meters by 2 meters ~tweaked it a little to simulate a pressure tank without needing to recode them yet
-	var/start_pressure = 25*ONE_ATMOSPHERE
-
-	level = BELOW_PLATING_LEVEL
-	dir = SOUTH
-	initialize_directions = SOUTH
-	density = TRUE
-	layer = ABOVE_WINDOW_LAYER
-
-/obj/machinery/atmospherics/pipe/tank/New()
-	icon_state = "air"
-	initialize_directions = dir
-	..()
-
-/obj/machinery/atmospherics/pipe/tank/Process()
-	if(!parent)
-		..()
-	else
-		. = PROCESS_KILL
-
-/obj/machinery/atmospherics/pipe/tank/Destroy()
-	if(node1)
-		node1.disconnect(src)
-
-	. = ..()
-
-/obj/machinery/atmospherics/pipe/tank/pipeline_expansion()
-	return list(node1)
-
-/obj/machinery/atmospherics/pipe/tank/update_underlays()
-	if(..())
-		underlays.Cut()
-		var/turf/T = get_turf(src)
-		if(!istype(T))
-			return
-		add_underlay(T, node1, dir)
-
-/obj/machinery/atmospherics/pipe/tank/hide()
-	update_underlays()
-
-/obj/machinery/atmospherics/pipe/tank/atmos_init()
-	var/connect_direction = dir
-
-	for(var/obj/machinery/atmospherics/target in get_step(src, connect_direction))
-		if(target.initialize_directions & get_dir(target, src))
-			if (check_connect_types(target, src))
-				node1 = target
-				break
-
-	update_underlays()
-
-/obj/machinery/atmospherics/pipe/tank/disconnect(obj/machinery/atmospherics/reference)
-	if(reference == node1)
-		if(istype(node1, /obj/machinery/atmospherics/pipe))
-			QDEL_NULL(parent)
-		node1 = null
-
-	update_underlays()
-
-	return null
-
-/obj/machinery/atmospherics/pipe/tank/attackby(var/obj/item/W as obj, var/mob/user as mob)
-	if(istype(W, /obj/item/device/pipe_painter))
-		return
-
-/obj/machinery/atmospherics/pipe/tank/air
-	name = "Pressure Tank (Air)"
-	icon_state = "air_map"
-
-/obj/machinery/atmospherics/pipe/tank/air/New()
-	air_temporary = new
-	air_temporary.volume = volume
-	air_temporary.temperature = T20C
-
-	air_temporary.adjust_multi("oxygen",  (start_pressure*O2STANDARD)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature), \
-	                           "nitrogen",(start_pressure*N2STANDARD)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
-
-
-	..()
-	icon_state = "air"
-
-/obj/machinery/atmospherics/pipe/tank/oxygen
-	name = "Pressure Tank (Oxygen)"
-	icon_state = "o2_map"
-
-/obj/machinery/atmospherics/pipe/tank/oxygen/New()
-	air_temporary = new
-	air_temporary.volume = volume
-	air_temporary.temperature = T20C
-
-	air_temporary.adjust_gas("oxygen", (start_pressure)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
-
-	..()
-	icon_state = "o2"
-
-/obj/machinery/atmospherics/pipe/tank/nitrogen
-	name = "Pressure Tank (Nitrogen)"
-	icon_state = "n2_map"
-
-/obj/machinery/atmospherics/pipe/tank/nitrogen/New()
-	air_temporary = new
-	air_temporary.volume = volume
-	air_temporary.temperature = T20C
-
-	air_temporary.adjust_gas("nitrogen", (start_pressure)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
-
-	..()
-	icon_state = "n2"
-
-/obj/machinery/atmospherics/pipe/tank/carbon_dioxide
-	name = "Pressure Tank (Carbon Dioxide)"
-	icon_state = "co2_map"
-
-/obj/machinery/atmospherics/pipe/tank/carbon_dioxide/New()
-	air_temporary = new
-	air_temporary.volume = volume
-	air_temporary.temperature = T20C
-
-	air_temporary.adjust_gas("carbon_dioxide", (start_pressure)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
-
-	..()
-	icon_state = "co2"
-
-/obj/machinery/atmospherics/pipe/tank/plasma
-	name = "Pressure Tank (Plasma)"
-	description_antag = "Will blind people if they do not wear face-covering gear"
-	icon_state = "plasma_map"
-
-/obj/machinery/atmospherics/pipe/tank/plasma/New()
-	air_temporary = new
-	air_temporary.volume = volume
-	air_temporary.temperature = T20C
-
-	air_temporary.adjust_gas("plasma", (start_pressure)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
-
-	..()
-	icon_state = "plasma"
-
-/obj/machinery/atmospherics/pipe/tank/nitrous_oxide
-	name = "Pressure Tank (Nitrous Oxide)"
-	icon_state = "n2o_map"
-
-/obj/machinery/atmospherics/pipe/tank/nitrous_oxide/New()
-	air_temporary = new
-	air_temporary.volume = volume
-	air_temporary.temperature = T0C
-
-	air_temporary.adjust_gas("sleeping_agent", (start_pressure)*(air_temporary.volume)/(R_IDEAL_GAS_EQUATION*air_temporary.temperature))
-
-	..()
-	icon_state = "n2o"
-
 /obj/machinery/atmospherics/pipe/vent
 	icon = 'icons/obj/atmospherics/pipe_vent.dmi'
 	icon_state = "intact"
@@ -1209,7 +1049,6 @@
 	initialize_directions = SOUTH
 
 	var/build_killswitch = 1
-
 
 /obj/machinery/atmospherics/pipe/vent/New()
 	initialize_directions = dir

--- a/code/game/objects/items/devices/pipe_painter.dm
+++ b/code/game/objects/items/devices/pipe_painter.dm
@@ -17,7 +17,7 @@
 	if(!proximity)
 		return
 
-	if(!istype(A,/obj/machinery/atmospherics/pipe) || istype(A,/obj/machinery/atmospherics/tank) || istype(A,/obj/machinery/atmospherics/pipe/vent) || istype(A,/obj/machinery/atmospherics/pipe/simple/heat_exchanging) || istype(A,/obj/machinery/atmospherics/pipe/simple/insulated) || !in_range(user, A))
+	if(!istype(A,/obj/machinery/atmospherics/pipe) || istype(A,/obj/machinery/atmospherics/pipe/vent) || istype(A,/obj/machinery/atmospherics/pipe/simple/heat_exchanging) || istype(A,/obj/machinery/atmospherics/pipe/simple/insulated) || !in_range(user, A))
 		return
 	var/obj/machinery/atmospherics/pipe/P = A
 

--- a/code/game/objects/items/devices/pipe_painter.dm
+++ b/code/game/objects/items/devices/pipe_painter.dm
@@ -17,7 +17,7 @@
 	if(!proximity)
 		return
 
-	if(!istype(A,/obj/machinery/atmospherics/pipe) || istype(A,/obj/machinery/atmospherics/pipe/tank) || istype(A,/obj/machinery/atmospherics/pipe/vent) || istype(A,/obj/machinery/atmospherics/pipe/simple/heat_exchanging) || istype(A,/obj/machinery/atmospherics/pipe/simple/insulated) || !in_range(user, A))
+	if(!istype(A,/obj/machinery/atmospherics/pipe) || istype(A,/obj/machinery/atmospherics/tank) || istype(A,/obj/machinery/atmospherics/pipe/vent) || istype(A,/obj/machinery/atmospherics/pipe/simple/heat_exchanging) || istype(A,/obj/machinery/atmospherics/pipe/simple/insulated) || !in_range(user, A))
 		return
 	var/obj/machinery/atmospherics/pipe/P = A
 

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -398,7 +398,7 @@
 /turf/floor/tiled/techmaint_panels,
 /area/eris/maintenance/section1deck5central)
 "abm" = (
-/obj/machinery/atmospherics/pipe/tank/air,
+/obj/machinery/atmospherics/tank/air,
 /turf/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck5starboard)
 "abn" = (
@@ -1014,7 +1014,7 @@
 /turf/floor/tiled/dark,
 /area/eris/security/prison)
 "acE" = (
-/obj/machinery/atmospherics/pipe/tank/air,
+/obj/machinery/atmospherics/tank/air,
 /obj/machinery/camera/network/security{
 	dir = 8
 	},
@@ -6302,7 +6302,7 @@
 /turf/floor/tiled/steel,
 /area/eris/hallway/side/eschangarb)
 "apa" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 1;
 	initialize_directions = 0
 	},
@@ -6865,7 +6865,7 @@
 /turf/floor/tiled/dark,
 /area/eris/rnd/podbay)
 "aqs" = (
-/obj/machinery/atmospherics/pipe/tank/air,
+/obj/machinery/atmospherics/tank/air,
 /turf/floor/tiled/dark,
 /area/eris/rnd/podbay)
 "aqt" = (
@@ -7554,7 +7554,7 @@
 /turf/wall/low/with_glass/smart,
 /area/eris/hallway/side/section3starboard)
 "arR" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 8
 	},
 /turf/floor/tiled/techmaint,
@@ -10595,7 +10595,7 @@
 /turf/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
 "azX" = (
-/obj/machinery/atmospherics/pipe/tank/oxygen{
+/obj/machinery/atmospherics/tank/oxygen{
 	dir = 4
 	},
 /turf/floor/tiled/steel/brown_platform,
@@ -11043,7 +11043,7 @@
 /turf/floor/tiled/steel/cargo,
 /area/eris/maintenance/section3deck2starboard)
 "aAW" = (
-/obj/machinery/atmospherics/pipe/tank/plasma{
+/obj/machinery/atmospherics/tank/plasma{
 	dir = 4
 	},
 /turf/floor/tiled/steel/brown_platform,
@@ -14625,7 +14625,7 @@
 /turf/floor/tiled/steel,
 /area/eris/hallway/side/eschangarb)
 "aLw" = (
-/obj/machinery/atmospherics/pipe/tank/air,
+/obj/machinery/atmospherics/tank/air,
 /turf/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "aLx" = (
@@ -15834,7 +15834,7 @@
 /turf/floor/tiled/steel/bluecorner,
 /area/eris/security/prisoncells)
 "aPv" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 8
 	},
 /turf/floor/tiled/dark/gray_platform,
@@ -16436,7 +16436,7 @@
 /turf/wall,
 /area/eris/maintenance/section4deck5port)
 "aQw" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 8
 	},
 /turf/floor/plating,
@@ -19236,7 +19236,7 @@
 /turf/open,
 /area/eris/security/prisoncells)
 "aXa" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 4
 	},
 /turf/floor/plating/under,
@@ -19317,7 +19317,7 @@
 /turf/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "aXm" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 8
 	},
 /turf/floor/plating/under,
@@ -23085,7 +23085,7 @@
 /turf/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck4central)
 "beN" = (
-/obj/machinery/atmospherics/pipe/tank/air,
+/obj/machinery/atmospherics/tank/air,
 /turf/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
 "beO" = (
@@ -23094,7 +23094,7 @@
 /turf/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
 "beP" = (
-/obj/machinery/atmospherics/pipe/tank/air,
+/obj/machinery/atmospherics/tank/air,
 /turf/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck1central)
 "beQ" = (
@@ -30380,7 +30380,7 @@
 /turf/floor/tiled/steel,
 /area/eris/hallway/main/section1)
 "bwC" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 4
 	},
 /obj/structure/railing,
@@ -31246,7 +31246,7 @@
 /turf/floor/tiled/steel,
 /area/eris/hallway/main/section2)
 "byA" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 8
 	},
 /obj/structure/railing,
@@ -33834,7 +33834,7 @@
 /turf/floor/plating,
 /area/eris/maintenance/section4deck4port)
 "bFc" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 4
 	},
 /obj/structure/railing{
@@ -34138,7 +34138,7 @@
 	},
 /area/eris/command/tcommsat/chamber)
 "bFH" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 8
 	},
 /obj/structure/railing{
@@ -34873,7 +34873,7 @@
 /turf/floor/wood,
 /area/eris/crew_quarters/hydroponics)
 "bHr" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 4
 	},
 /turf/floor/tiled/steel,
@@ -58033,7 +58033,7 @@
 /turf/floor/tiled/steel/techfloor_grid,
 /area/eris/engineering/breakroom)
 "cNa" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 4
 	},
 /turf/floor/plating/under,
@@ -58922,13 +58922,13 @@
 	},
 /area/shuttle/mining/station)
 "cPO" = (
-/obj/machinery/atmospherics/pipe/tank/air,
+/obj/machinery/atmospherics/tank/air,
 /turf/shuttle/floor/mining{
 	icon_state = "12,21"
 	},
 /area/shuttle/mining/station)
 "cPP" = (
-/obj/machinery/atmospherics/pipe/tank/air,
+/obj/machinery/atmospherics/tank/air,
 /turf/shuttle/floor/mining{
 	icon_state = "13,21"
 	},
@@ -61163,7 +61163,7 @@
 /turf/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck3port)
 "cWa" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 1;
 	initialize_directions = 0
 	},
@@ -74423,7 +74423,7 @@
 /turf/floor/plating/under,
 /area/eris/medical/medbay)
 "dBk" = (
-/obj/machinery/atmospherics/pipe/tank/oxygen{
+/obj/machinery/atmospherics/tank/oxygen{
 	dir = 8
 	},
 /turf/floor/tiled/white/brown_platform,
@@ -76997,7 +76997,7 @@
 /area/eris/maintenance/section4deck2port)
 "dHx" = (
 /obj/effect/floor_decal/rust,
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 1;
 	initialize_directions = 0
 	},
@@ -81562,7 +81562,7 @@
 /turf/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck1starboard)
 "dUS" = (
-/obj/machinery/atmospherics/pipe/tank/air,
+/obj/machinery/atmospherics/tank/air,
 /turf/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck1port)
 "dUT" = (
@@ -82972,7 +82972,7 @@
 /turf/wall/low/with_glass/reinforced,
 /area/eris/quartermaster/office)
 "dYk" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 8
 	},
 /obj/structure/railing{
@@ -88895,7 +88895,7 @@
 	},
 /area/shuttle/research/station)
 "enr" = (
-/obj/machinery/atmospherics/pipe/tank/air,
+/obj/machinery/atmospherics/tank/air,
 /turf/shuttle/floor/science{
 	icon_state = "5,5"
 	},
@@ -92894,7 +92894,7 @@
 /turf/floor/tiled/steel,
 /area/eris/hallway/side/section3starboard)
 "exh" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 8
 	},
 /obj/machinery/alarm{
@@ -95722,7 +95722,7 @@
 /turf/floor/tiled/white,
 /area/eris/rnd/xenobiology/xenoflora)
 "eDP" = (
-/obj/machinery/atmospherics/pipe/tank/air,
+/obj/machinery/atmospherics/tank/air,
 /obj/structure/sign/atmos_air{
 	pixel_y = 32
 	},

--- a/maps/CEVEris/centcomm.dmm
+++ b/maps/CEVEris/centcomm.dmm
@@ -3670,7 +3670,7 @@
 	},
 /area/centcom/raider_base)
 "oz" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 4;
 	start_pressure = 740.5
 	},

--- a/maps/pulsar/pulsar.dmm
+++ b/maps/pulsar/pulsar.dmm
@@ -1143,7 +1143,7 @@
 /turf/floor/plating/under,
 /area/outpost/pulsar/maintenance)
 "LT" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/tank/air{
 	dir = 8
 	},
 /turf/floor/tiled/steel/brown_platform,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Airlocks involving pressure tanks were not behaving proper since Walls 2: Electric Boogaloo and other ZAS changes. This refactors them to behave more like portable_atmospherics, and work.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fixes good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
[dreamseeker_SG9n094ZUN.webm](https://github.com/user-attachments/assets/82bc8e98-092d-471c-bf73-d064686d241d)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
fix: airlocks empty/refill proper
refactor: pressure tanks from pipes to machines/atmospherics/tank
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
