### PR TITLE
Better cyber plant functionality

### DIFF
--- a/code/game/objects/structures/cyberplants.dm
+++ b/code/game/objects/structures/cyberplants.dm
@@ -82,9 +82,12 @@
 	var/color_of_choice = input("Choose a color.", "\"FluorescEnt\" configuration", custom_color) as color|null
 	custom_color = color_of_choice
 	if(!interference)
-		change_plant()
 		change_color()
 		update_icon()
+
+/obj/structure/cyberplant/AltClick(atom/A, params)
+	change_plant()
+	update_icon()
 
 /obj/structure/cyberplant/proc/prepare_icon(var/state)
 	if(!state)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This lets you Alt click a cyberplant to change the plant, instead of it changing every time you choose a new color

## Why It's Good For The Game

QoL, and what if you wanted a certain design? It would be better to just alt click instead of clicking then click ok on the color picker.

## Testing


https://github.com/user-attachments/assets/1219c0dc-f204-4084-ac92-5ec1c6fa1bc4



## Changelog
:cl:
add: You can now change the plant on a cyberplant by alt clicking it
fix: Changing a cyber plant's color no longer changes the design with it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
