### PR TITLE
Fix Sanctify group litany, clarify descriptions

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/group.dm
+++ b/code/modules/core_implant/cruciform/rituals/group.dm
@@ -172,10 +172,39 @@
 	stat_buff = STAT_TGH
 	stat_message = "You feel like you're getting sturdier."
 
+/datum/ritual/group/cruciform/sanctify
+	name = "Sanctify"
+	desc = "Sanctify the land you tread. Available to anyone who know the words."
+	phrase = "Benedicite loco isto."
+	phrases = list(
+		"Benedicite loco isto.",
+		"Benedic hoc petimus Patris.",
+		"Nos obsecro te removere percula huius loci.",
+		"Ne malorum tangere terram",
+		"Frase quinta",
+		"Frase sexta",
+		"Frase septima"
+	)
+	effect_type = /datum/group_ritual_effect/cruciform/sanctify
+	high_ritual = FALSE
+
+/datum/ritual/group/cruciform/sanctify/step_check(mob/living/carbon/human/H)
+	return TRUE
+
+/datum/group_ritual_effect/cruciform/sanctify/trigger_success(mob/starter, list/participants)
+	..()
+	var/area/A = get_area(starter)
+	A?.sanctify()
+	for(var/obj/machinery/power/nt_obelisk/O in GLOB.all_obelisk)
+		O.force_active = max(60, O.force_active)
+
+/area/proc/sanctify()
+	SEND_SIGNAL_OLD(src, COMSIG_AREA_SANCTIFY)
+	return
 
 /datum/ritual/group/cruciform/crusade
 	name = "Crusade"
-	desc = "Reveal crusade litanies to disciples. Depends on participants amount."
+	desc = "Reveal crusade litanies to disciples. Requires at least six participants."
 	phrase = "Locutus est Dominus ad Mosen dicens."
 	phrases = list(
 		"Locutus est Dominus ad Mosen dicens.",
@@ -214,33 +243,3 @@
 		CI.known_rituals |= initial(C.name)
 		C = /datum/ritual/cruciform/crusader/flash
 		CI.known_rituals |= initial(C.name)
-
-/datum/ritual/group/cruciform/sanctify
-	name = "Sanctify"
-	desc = "Sanctify the land you tread."
-	phrase = "Benedicite loco isto."
-	phrases = list(
-		"Benedicite loco isto.",
-		"Benedic hoc petimus Patris.",
-		"Nos obsecro te removere percula huius loci.",
-		"Ne malorum tangere terram",
-		"Frase quinta",
-		"Frase sexta",
-		"Frase septima"
-	)
-	effect_type = /datum/group_ritual_effect/cruciform/sanctify
-	high_ritual = FALSE
-
-/datum/ritual/group/cruciform/sanctify/step_check(mob/living/carbon/human/H)
-	return TRUE
-
-/datum/group_ritual_effect/cruciform/sanctify/trigger_success(mob/starter, list/participants)
-	..()
-	var/area/A = get_area(starter)
-	A?.sanctify()
-	for(var/obj/machinery/power/nt_obelisk/O in GLOB.all_obelisk)
-		O.force_active = max(60, O.force_active)
-
-/area/proc/sanctify()
-	SEND_SIGNAL_OLD(src, COMSIG_AREA_SANCTIFY)
-	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sanctify was crashing people, and turned the books into cognito hazards. For some reason, moving it above Crusade in the same file fixes this. I also clarified that Sanctify doesn't need an acolyte or preacher, and Crusade needs at least six participants while I was dubbing around.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfixes good. Clarity consistency also good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
[EzLODLwXpI.webm](https://github.com/user-attachments/assets/a7d656a9-5df2-4ab5-949f-c46d1bb55088)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl:
tweak: clarified Sanctify group litany not needing an acolyte or preacher
tweak: clarified Crusade group litany needing six participants
fix: fixed Sanctify group litany from crashing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
