### PR TITLE
pellets now spread via trajectory

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -162,6 +162,7 @@
 				newbullet.original = original
 				newbullet.def_zone = def_zone
 				newbullet.kill_count = kill_count // they all hit the floor
+				newbullet.muzzle_type = null //fixes redundant muzzle flare
 				var/newoffset = rand(1,8) * (num == 1 ? 1 : -1) // up to 8 degrees in both directions, applied randomly each time
 				newbullet.setup_trajectory(get_turf(src), get_turf(original), 0, 0, newoffset)
 				newbullet.Process()

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -100,12 +100,12 @@
 	var/entropy = 10	//higher means the pellets divide more across body parts with distance
 	var/pellet_to_knockback_ratio = 0
 	wounding_mult = WOUNDING_SMALL
-	matter = list(MATERIAL_STEEL = 0.4)
+	matter = list(MATERIAL_STEEL = 0.1)
 
-/obj/item/projectile/bullet/pellet/launch_from_gun(atom/target, mob/user, obj/item/gun/launcher, target_zone, x_offset=0, y_offset=0, angle_offset)
-	for(var/entry in matter) // this allows for the projectile in the casing having the correct matter
-		matter[entry] /= pellets // yet disallows for pellet shrapnel created on impact multiplying the matter count
+/obj/item/projectile/bullet/pellet/get_matter()
 	. = ..()
+	for(var/entry in matter) // this results in the projectile in the casing sending correct data
+		.[entry] *= pellets
 
 /obj/item/projectile/bullet/pellet/Bumped()
 	. = ..()
@@ -158,6 +158,12 @@
 			for(var/num in 1 to 2)
 				var/obj/item/projectile/bullet/pellet/newbullet = new type(loc)
 				newbullet.pellets = dividedpellets
+				for(var/i in newbullet.damage_types)
+					newbullet.damage_types[i] = damage_types[i]
+				newbullet.armor_divisor = armor_divisor
+				newbullet.penetrating = penetrating
+				newbullet.ricochet_ability = ricochet_ability
+				newbullet.step_delay = step_delay
 				newbullet.location = trajectory.return_location() // will produce pixel loc datum
 				newbullet.original = original
 				newbullet.def_zone = def_zone

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -95,9 +95,9 @@
 	damage_types = list(BRUTE = 15)
 	//icon_state = "bullet" //TODO: would be nice to have it's own icon state
 	var/pellets = 4			//number of pellets
-	var/range_step = 2		//projectile will lose a fragment each time it travels this distance. Can be a non-integer.
+	var/range_step = 2		//projectile will lose a fragment each time it travels this distance.
 	var/base_spread = 90	//lower means the pellets spread more across body parts. If zero then this is considered a shrapnel explosion instead of a shrapnel cone
-	var/spread_step = 10	//higher means the pellets spread more across body parts with distance
+	var/entropy = 10	//higher means the pellets divide more across body parts with distance
 	var/pellet_to_knockback_ratio = 0
 	wounding_mult = WOUNDING_SMALL
 	matter = list(MATERIAL_STEEL = 0.4)
@@ -111,25 +111,18 @@
 	. = ..()
 	bumped = 0 //can hit all mobs in a tile. pellets is decremented inside attack_mob so this should be fine.
 
-/obj/item/projectile/bullet/pellet/proc/get_pellets(var/distance)
-	var/pellet_loss = round((distance - 1)/range_step) //pellets lost due to distance
-	var/remaining = pellets - pellet_loss
-	if (remaining < 0)
-		return 0
-	return ROUND_PROB(remaining)
-
 /obj/item/projectile/bullet/pellet/attack_mob(var/mob/living/target_mob, var/distance, var/miss_modifier)
 
 
-	var/total_pellets = get_pellets(distance)
+	var/total_pellets = pellets
 	if (total_pellets <= 0)
 		return 1
-	var/spread = max(base_spread - (spread_step*distance), 0)
+	var/spread = max(base_spread - (entropy*distance), 0)
 
 	//shrapnel explosions miss prone mobs with a chance that increases with distance
 	var/prone_chance = 0
 	if(!base_spread)
-		prone_chance = max(spread_step*(distance - 2), 0)
+		prone_chance = max(entropy*(distance - 2), 0)
 
 	var/hits = 0
 	for (var/i in 1 to total_pellets)
@@ -154,11 +147,25 @@
 	return 0
 
 /obj/item/projectile/bullet/pellet/get_structure_damage()
-	var/distance = get_dist(loc, starting)
-	return ..() * get_pellets(distance)
+	return ..() * pellets
 
 /obj/item/projectile/bullet/pellet/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, var/glide_size_override = 0)
 	. = ..()
+	var/distance = get_dist(loc, starting)
+	if(distance && (distance % range_step == 0))
+		if(pellets >= 3)
+			var/dividedpellets = round(pellets/3)
+			for(var/num in 1 to 2)
+				var/obj/item/projectile/bullet/pellet/newbullet = new type(loc)
+				newbullet.pellets = dividedpellets
+				newbullet.location = trajectory.return_location() // will produce pixel loc datum
+				newbullet.original = original
+				newbullet.def_zone = def_zone
+				newbullet.kill_count = kill_count // they all hit the floor
+				var/newoffset = rand(1,8) * (num == 1 ? 1 : -1) // up to 8 degrees in both directions, applied randomly each time
+				newbullet.setup_trajectory(get_turf(src), get_turf(original), 0, 0, newoffset)
+				newbullet.Process()
+			pellets -= dividedpellets*2
 
 	//If this is a shrapnel explosion, allow mobs that are prone to get hit, too
 	if(. && !base_spread && isturf(loc))

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -318,7 +318,7 @@ There are important things regarding this file:
 	armor_divisor = 1
 	pellets = 6
 	range_step = 1
-	spread_step = 10
+	entropy = 10
 	pellet_to_knockback_ratio = 2
 	recoil = 5
 	matter = list(MATERIAL_STEEL = 0.6)

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -321,7 +321,6 @@ There are important things regarding this file:
 	entropy = 10
 	pellet_to_knockback_ratio = 2
 	recoil = 5
-	matter = list(MATERIAL_STEEL = 0.6)
 
 /obj/item/projectile/bullet/pellet/shotgun/Initialize()
 	. = ..()

--- a/code/modules/projectiles/projectile/fragment.dm
+++ b/code/modules/projectiles/projectile/fragment.dm
@@ -24,6 +24,7 @@
 	damage_types = list(BRUTE = 8, HALLOSS = 12)
 	embed = FALSE
 	sharp = FALSE
+	matter = list(MATERIAL_PLASTIC = 0.1)
 
 /obj/item/projectile/bullet/pellet/fragment/rubber/weak
 	icon_state = "rubber"

--- a/code/modules/projectiles/projectile/fragment.dm
+++ b/code/modules/projectiles/projectile/fragment.dm
@@ -3,7 +3,7 @@
 	range_step = 2
 
 	base_spread = 0 //causes it to be treated as a shrapnel explosion instead of cone
-	spread_step = 20
+	entropy = 20
 
 	silenced = TRUE //embedding messages are still produced so it's kind of weird when enabled.
 	no_attack_log = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR replaces pellet count decreasing with distance with a cloud of pellets diverging as they move
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Shotguns should live!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Fired shotgun at window and buckled to chair Disciple from a distance, fired shotgun at distant tile, point-blanked Disciple with shotgun, found concerning issues with stinger grenade but as normal frag grenades worked fine, concluded it probably isn't pellets doing it. Additionally shot fuhrer to death with an appropriate number of buckshot shells fired.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
balance: fix: Shotgun spreadshot now actually spreads rather than weakening.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
