### PR TITLE
destructive analyzer change of function

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -154,17 +154,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	files.check_item_for_tech(I)
 	files.adjust_research_points(files.experiments.get_object_research_value(I))
 	files.experiments.do_research_object(I)
-	var/list/matter = I.get_matter()
-	if(linked_lathe && matter)
-		for(var/t in matter)
-			if(t in linked_lathe.unsuitable_materials)
-				continue
-
-			if(!linked_lathe.stored_material[t])
-				linked_lathe.stored_material[t] = 0
-
-			linked_lathe.stored_material[t] += matter[t] * linked_destroy.decon_mod
-			linked_lathe.stored_material[t] = min(linked_lathe.stored_material[t], linked_lathe.storage_capacity)
 
 /obj/machinery/computer/rdconsole/Topic(href, href_list) // Oh boy here we go.
 	if(..())


### PR DESCRIPTION
destructive analyzer no longer sends materials directly to linked lathe destructive analyzer now always drops 1x the mats deconstructed

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR swaps the function of machine parts in the Destructive Analyzer from changing how much matter is recovered from the destroyed subject to changing how much time it takes to finish the analysis.
Additionally, a more robust system for matter production is used, one which drops the materials on the analyzer's tile rather than attempting to send it to the Protolathe linked to the linked Console.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Research should not be limited purely by money.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Destroyed batteries, stacks of materials, and singular materials successfully via Destructive Analysis, with correct matter outputs.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
add: Destructive Analyzer now drops 1x material input on tile
tweak: machine parts of Destructive Analyzer now responsible for speed of analysis
balance: machine parts of Destructive Analyzer no longer responsible for feeding Protolathe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
