### PR TITLE
Coins Modernized

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -106,10 +106,10 @@
 #define COIN_GOLD "Gold coin"
 #define COIN_SILVER "Silver coin"
 #define COIN_DIAMOND "Diamond coin"
-#define COIN_IRON "Iron coin"
+#define COIN_PLASTEEL "Plasteel coin"
 #define COIN_PLASMA "Solid plasma coin"
 #define COIN_URANIUM "Uranium coin"
-#define COIN_PLATINUM "Platunum coin"
+#define COIN_PLATINUM "Platinum coin"
 
 #define SHARD_SHARD "shard"
 #define SHARD_SHRAPNEL "shrapnel"

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -86,7 +86,7 @@
 	if(prob(50))
 		to_add = pick(/obj/item/spacecash/bundle/c10,/obj/item/spacecash/bundle/c100,/obj/item/spacecash/bundle/c1000,/obj/item/spacecash/bundle/c20,/obj/item/spacecash/bundle/c200,/obj/item/spacecash/bundle/c50,/obj/item/spacecash/bundle/c500)
 		new to_add(src)
-	to_add = pick(/obj/item/coin/silver, /obj/item/coin/silver, /obj/item/coin/gold, /obj/item/coin/iron, /obj/item/coin/iron, /obj/item/coin/iron)
+	to_add = pick(/obj/item/coin/silver, /obj/item/coin/silver, /obj/item/coin/gold, /obj/item/coin/plasteel, /obj/item/coin/plasteel, /obj/item/coin/plasteel)
 	new to_add(src)
 	if(prob(20))
 		new /obj/item/card/id/randomassistant(src)

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -68,7 +68,7 @@
 		if(63 to 64)
 			var/t = rand(4,7)
 			for(var/i = 0, i < t, ++i)
-				var/newcoin = pick(/obj/item/coin/silver, /obj/item/coin/silver, /obj/item/coin/silver, /obj/item/coin/iron, /obj/item/coin/iron, /obj/item/coin/iron, /obj/item/coin/gold, /obj/item/coin/diamond, /obj/item/coin/plasma, /obj/item/coin/uranium, /obj/item/coin/platinum)
+				var/newcoin = pick(/obj/item/coin/silver, /obj/item/coin/silver, /obj/item/coin/silver, /obj/item/coin/plasteel, /obj/item/coin/plasteel, /obj/item/coin/plasteel, /obj/item/coin/gold, /obj/item/coin/diamond, /obj/item/coin/plasma, /obj/item/coin/uranium, /obj/item/coin/platinum)
 				new newcoin(src)
 		if(65 to 68)
 			var/t = rand(4,7)

--- a/code/modules/mining/coins.dm
+++ b/code/modules/mining/coins.dm
@@ -20,30 +20,44 @@
 /obj/item/coin/gold
 	name = COIN_GOLD
 	icon_state = "coin_gold"
+	matter = list(MATERIAL_GOLD = 0.2)
+	price_tag = 10
 
 /obj/item/coin/silver
 	name = COIN_SILVER
 	icon_state = "coin_silver"
+	matter = list(MATERIAL_SILVER = 0.2)
+	price_tag = 8
 
 /obj/item/coin/diamond
 	name = COIN_DIAMOND
 	icon_state = "coin_diamond"
+	matter = list(MATERIAL_DIAMOND = 0.2)
+	price_tag = 20
 
-/obj/item/coin/iron
-	name = COIN_IRON
+/obj/item/coin/plasteel
+	name = COIN_PLASTEEL
 	icon_state = "coin_iron"
+	matter = list(MATERIAL_PLASTEEL = 0.2)
+	price_tag = 6
 
 /obj/item/coin/plasma
 	name = COIN_PLASMA
 	icon_state = "coin_plasma"
+	matter = list(MATERIAL_PLASMA = 0.2)
+	price_tag = 6
 
 /obj/item/coin/uranium
 	name = COIN_URANIUM
 	icon_state = "coin_uranium"
+	matter = list(MATERIAL_URANIUM = 0.2)
+	price_tag = 10
 
 /obj/item/coin/platinum
 	name = COIN_PLATINUM
 	icon_state = "coin_adamantine"
+	matter = list(MATERIAL_PLATINUM = 0.2)
+	price_tag = 16
 
 /obj/item/coin/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/stack/cable_coil))

--- a/code/modules/mining/money_bag.dm
+++ b/code/modules/mining/money_bag.dm
@@ -15,7 +15,7 @@
 	var/amt_gold = 0
 	var/amt_silver = 0
 	var/amt_diamond = 0
-	var/amt_iron = 0
+	var/amt_plasteel = 0
 	var/amt_plasma = 0
 	var/amt_uranium = 0
 
@@ -24,8 +24,8 @@
 			amt_diamond++;
 		if (istype(C,/obj/item/coin/plasma))
 			amt_plasma++;
-		if (istype(C,/obj/item/coin/iron))
-			amt_iron++;
+		if (istype(C,/obj/item/coin/plasteel))
+			amt_plasteel++;
 		if (istype(C,/obj/item/coin/silver))
 			amt_silver++;
 		if (istype(C,/obj/item/coin/gold))
@@ -38,8 +38,8 @@
 		dat += text("Gold coins: [amt_gold] <A href='?src=\ref[src];remove=gold'>Remove one</A><br>")
 	if (amt_silver)
 		dat += text("Silver coins: [amt_silver] <A href='?src=\ref[src];remove=silver'>Remove one</A><br>")
-	if (amt_iron)
-		dat += text("Metal coins: [amt_iron] <A href='?src=\ref[src];remove=iron'>Remove one</A><br>")
+	if (amt_plasteel)
+		dat += text("Metal coins: [amt_plasteel] <A href='?src=\ref[src];remove=plasteel'>Remove one</A><br>")
 	if (amt_diamond)
 		dat += text("Diamond coins: [amt_diamond] <A href='?src=\ref[src];remove=diamond'>Remove one</A><br>")
 	if (amt_plasma)
@@ -73,11 +73,11 @@
 				COIN = locate(/obj/item/coin/gold,src.contents)
 			if(MATERIAL_SILVER)
 				COIN = locate(/obj/item/coin/silver,src.contents)
-			if("iron")
-				COIN = locate(/obj/item/coin/iron,src.contents)
+			if(MATERIAL_PLASTEEL)
+				COIN = locate(/obj/item/coin/plasteel,src.contents)
 			if(MATERIAL_DIAMOND)
 				COIN = locate(/obj/item/coin/diamond,src.contents)
-			if("plasma")
+			if(MATERIAL_PLASMA)
 				COIN = locate(/obj/item/coin/plasma,src.contents)
 			if(MATERIAL_URANIUM)
 				COIN = locate(/obj/item/coin/uranium,src.contents)

--- a/code/modules/mining/money_bag.dm
+++ b/code/modules/mining/money_bag.dm
@@ -39,7 +39,7 @@
 	if (amt_silver)
 		dat += text("Silver coins: [amt_silver] <A href='?src=\ref[src];remove=silver'>Remove one</A><br>")
 	if (amt_plasteel)
-		dat += text("Metal coins: [amt_plasteel] <A href='?src=\ref[src];remove=plasteel'>Remove one</A><br>")
+		dat += text("Plasteel coins: [amt_plasteel] <A href='?src=\ref[src];remove=plasteel'>Remove one</A><br>")
 	if (amt_diamond)
 		dat += text("Diamond coins: [amt_diamond] <A href='?src=\ref[src];remove=diamond'>Remove one</A><br>")
 	if (amt_plasma)
@@ -83,7 +83,7 @@
 				COIN = locate(/obj/item/coin/uranium,src.contents)
 		if(!COIN)
 			return
-		COIN.loc = src.loc
+		COIN.forceMove(get_turf(src))
 	return
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR modernizes Coins, making them more usable in the current economy of Eris.
This is done by giving them two vars- Price Tag and Matter, and by replacing the useless Iron Coin with an identically appearing Plasteel Coin. Additionally, Money Bags were made more functional, although they were not made obtainable.

## Why It's Good For The Game
The Material Barter Economy would benefit from being able to use the type of coin found in Wallets to craft items. Coins should have value.


## Testing
Spawned Plasteel Coin, Moneybag, and Vault Variant Moneybag, added and removed coins from Moneybag with resulting coins dropped on turf.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
add: Added Plasteel Coin
del: Removed Iron Coin
fix: Coins now moderately valuable for use and trade.
spellcheck: Platinum coin no longer spelled as Platunum coin.
code: Moneybag no longer shoves coins in the person holding the moneybag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
