### PR TITLE
Finalizes Poison Damages

### DIFF
--- a/code/__DEFINES/damage_organs.dm
+++ b/code/__DEFINES/damage_organs.dm
@@ -188,6 +188,7 @@
 #define IWOUND_3_MINUTES 90
 #define IWOUND_4_MINUTES 120
 #define IWOUND_5_MINUTES 150
+#define IWOUND_HALF_MINUTE 15
 
 // Organ generation
 #define ORGAN_HAS_BONES			(1<<0)

--- a/code/modules/organs/internal/internal_wounds/_internal_wound.dm
+++ b/code/modules/organs/internal/internal_wounds/_internal_wound.dm
@@ -140,8 +140,17 @@
 			current_hallucination_tick = 0
 
 /datum/internal_wound/proc/progress()
-	if(!((characteristic_flag & IWOUND_PROGRESS) || (characteristic_flag & IWOUND_AGGRAVATION)))
-		return
+	if(!(characteristic_flag & IWOUND_AGGRAVATION) ) // if the aggravation flag is not present
+		if(!(characteristic_flag & IWOUND_PROGRESS)) // and the progress tag is not present
+			return // then return
+	else if(!(characteristic_flag & IWOUND_PROGRESS)) // but if the aggravation tag IS present, but progress tag isn't, then custom process
+		++current_progression_tick
+		if(current_progression_tick >= progression_threshold)
+			current_progression_tick = 0
+		else
+			return
+	// and if both are present, progress tag has priority.
+
 	var/obj/item/organ/O = parent
 	var/obj/item/organ/external/E = parent ? O.parent : null
 	var/mob/living/carbon/human/H = parent ? O.owner : null
@@ -151,7 +160,7 @@
 		++severity
 	else
 		characteristic_flag &= ~(IWOUND_PROGRESS|IWOUND_PROGRESS_DEATH)	// Lets us remove the wound from processing
-		if(next_wound && ispath(next_wound, /datum/component))
+		if(next_wound && ispath(next_wound, /datum/internal_wound))
 			var/chosen_wound_type = pick(subtypesof(next_wound))
 			SEND_SIGNAL_OLD(parent, COMSIG_IORGAN_ADD_WOUND, chosen_wound_type)
 

--- a/code/modules/organs/internal/internal_wounds/organic.dm
+++ b/code/modules/organs/internal/internal_wounds/organic.dm
@@ -141,6 +141,7 @@
 	severity_max = 4
 	hal_damage = IWOUND_LIGHT_DAMAGE
 	characteristic_flag = IWOUND_CAN_DAMAGE|IWOUND_AGGRAVATION
+	progression_threshold = IWOUND_HALF_MINUTE
 
 /datum/internal_wound/organic/poisoning/pustule
 	name = "pustule"
@@ -359,12 +360,14 @@
 	name = "genetic damage"
 	treatments_chem = list(CE_GENEHEAL = 1)
 	characteristic_flag = IWOUND_AGGRAVATION // this wound is hidden
+	progression_threshold = IWOUND_5_MINUTES
 	next_wound = /datum/internal_wound/organic/catastrophicgenedamage
 
 /datum/internal_wound/organic/catastrophicgenedamage
 	name = "catastrophic genetic damage"
 	severity_max = IORGAN_STANDARD_HEALTH
 	characteristic_flag = IWOUND_AGGRAVATION | IWOUND_CAN_DAMAGE
+	progression_threshold = IWOUND_5_MINUTES
 	hal_damage = IWOUND_HEAVY_DAMAGE
 	treatments_chem = list(CE_GENEHEAL = 2)
 

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -57,18 +57,12 @@
 	heating_point = 723 // supposedly amatoxin is heat resistant so I raised its heat temp by 200 - vode-code
 	heating_products = list("toxin")
 
-/datum/reagent/toxin/amatoxin/on_mob_add(mob/living/L)
-	data["timestart"] = REALTIMEOFDAY
-	data["effectcount"] = 0
-
 /datum/reagent/toxin/amatoxin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	. = ..()
 	if(ishuman(M))
 		var/mob/living/carbon/human/poorsap = M
-		if(REALTIMEOFDAY > (data["timestart"] + (data["effectcount"] * 5 MINUTES)))
-			for(var/obj/item/organ/internal/tokill in poorsap.organ_list_by_process(OP_LIVER) | poorsap.organ_list_by_process(OP_KIDNEYS)) // amanitin is slow but it kills HARD.
-				tokill.add_wound(/datum/internal_wound/organic/genedamage)
-			data["effectcount"] += 1
+		for(var/obj/item/organ/internal/tokill in poorsap.organ_list_by_process(OP_LIVER) | poorsap.organ_list_by_process(OP_KIDNEYS)) // amanitin is slow but it kills HARD.
+			tokill.add_wound(/datum/internal_wound/organic/genedamage)
 
 /datum/reagent/toxin/amatoxin/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
 	affect_blood(M, alien, effect_multiplier)	// amanitin doesn't metabolize in the digestive tract, instead absorbing nearly perfectly.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes the Aggravation woundtag use a slower progression system customizable per-wound. Additionally, a missed typecheck for wound type progression has been rectified, and Amanita now uses a 5 minute timer on the wound itself rather than on the reagent.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
 Slower poison deaths, cleaner code.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Applied Amanitin and Chlorine to test subjects and monitored wounds in medbay.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
balance: Poison no longer kills as fast.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
