### PR TITLE
Damaged floors now produce Shard when pried off

### DIFF
--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -128,7 +128,7 @@
 				if(is_damaged())
 					if(I.use_tool(user, src, flooring.removal_time, tool_type, FAILCHANCE_VERY_EASY, required_stat = STAT_MEC))
 						to_chat(user, SPAN_NOTICE("You remove the broken [flooring.descriptor]."))
-						make_plating()
+						make_plating(TRUE, null, TRUE)
 					return
 				else if(flooring.flags & TURF_IS_FRAGILE)
 					if(I.use_tool(user, src, flooring.removal_time, tool_type, FAILCHANCE_VERY_EASY, required_stat = STAT_MEC))
@@ -138,7 +138,7 @@
 				else if(flooring.flags & TURF_REMOVE_CROWBAR)
 					if(I.use_tool(user, src, flooring.removal_time, tool_type, FAILCHANCE_VERY_EASY, required_stat = STAT_MEC))
 						to_chat(user, SPAN_NOTICE("You lever off the [flooring.descriptor]."))
-						make_plating(1)
+						make_plating(TRUE)
 					return
 				return
 
@@ -146,21 +146,21 @@
 				if((!(is_damaged()) && !is_plating()) || flooring.flags & TURF_REMOVE_SCREWDRIVER)
 					if(I.use_tool(user, src, flooring.removal_time*1.5, tool_type, FAILCHANCE_VERY_EASY, required_stat = STAT_MEC))
 						to_chat(user, SPAN_NOTICE("You unscrew and remove the [flooring.descriptor]."))
-						make_plating(1)
+						make_plating(TRUE)
 				return
 
 			if(QUALITY_BOLT_TURNING)
 				if(flooring.flags & TURF_REMOVE_WRENCH)
 					if(I.use_tool(user, src, flooring.removal_time, tool_type, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
 						to_chat(user, SPAN_NOTICE("You unwrench and remove the [flooring.descriptor]."))
-						make_plating(1)
+						make_plating(TRUE)
 				return
 
 			if(QUALITY_SHOVELING)
 				if(flooring.flags & TURF_REMOVE_SHOVEL)
 					if(I.use_tool(user, src, flooring.removal_time, tool_type, FAILCHANCE_VERY_EASY, required_stat = STAT_MEC))
 						to_chat(user, SPAN_NOTICE("You shovel off the [flooring.descriptor]."))
-						make_plating(1)
+						make_plating(TRUE)
 				return
 
 			if(QUALITY_WELDING)
@@ -179,7 +179,7 @@
 					to_chat(user, SPAN_NOTICE("You start cutting through the [flooring.descriptor]."))
 					if(I.use_tool(user, src, flooring.removal_time, tool_type, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
 						to_chat(user, SPAN_NOTICE("You cut through and remove the [flooring.descriptor]."))
-						make_plating(1)
+						make_plating(TRUE)
 
 			if(ABORT_CHECK)
 				return


### PR DESCRIPTION
## About The Pull Request
This PR ensures that damaged floors transfer their materials to a shard when pried off, instead of said matter being deleted.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This gap has been asking to be filled and this change is good enough.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Damaged floor, upon prying floor Steel Shrapnel with Matter of 1 Steel was spawned. Upon prying intact floor, tile was produced as standard.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
tweak: balance: Prying damaged flooring now produces scrap metal instead of deleting the floor with no returns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
