### PR TITLE
Stack fixes

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -298,6 +298,7 @@
 		else
 			repairing = stack.split(amount_needed)
 			if (repairing)
+				repairing.loc = src;
 				transfer = repairing.amount
 
 		if (transfer)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -296,9 +296,8 @@
 			if (!transfer)
 				to_chat(user, SPAN_WARNING("You must weld or remove \the [repairing] from \the [src] before you can add anything else."))
 		else
-			repairing = stack.split(amount_needed)
+			repairing = stack.split(amount_needed, src)
 			if (repairing)
-				repairing.loc = src
 				transfer = repairing.amount
 
 		if (transfer)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -298,7 +298,7 @@
 		else
 			repairing = stack.split(amount_needed)
 			if (repairing)
-				repairing.loc = src;
+				repairing.loc = src
 				transfer = repairing.amount
 
 		if (transfer)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -296,7 +296,7 @@
 			if (!transfer)
 				to_chat(user, SPAN_WARNING("You must weld or remove \the [repairing] from \the [src] before you can add anything else."))
 		else
-			repairing = stack.split(amount_needed, src)
+			repairing = stack.split(amount_needed)
 			if (repairing)
 				transfer = repairing.amount
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -304,7 +304,7 @@
 
 	var/orig_amount = src.amount
 	if (transfer && src.use(transfer))
-		var/obj/item/stack/S = new src.type(src.loc, transfer)
+		var/obj/item/stack/S = new src.type(loc, transfer)
 		S.color = color
 
 		if (prob(transfer/orig_amount * 100))

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -40,6 +40,7 @@
 	.=..()
 	if (amount)
 		src.amount = amount
+	update_icon()
 
 /obj/item/stack/Initialize()
 	. = ..()
@@ -49,15 +50,6 @@
 	if (rand_min || rand_max)
 		amount = rand(rand_min, rand_max)
 		amount = round(amount, 1) //Just in case
-	update_icon()
-	if(automerge)
-		return INITIALIZE_HINT_LATELOAD
-
-//do this a little later because trying to merge with uninitialized stacks is an easy way to cause runtimes
-/obj/item/stack/LateInitialize()
-	. = ..()
-	if(automerge)
-		merge_loc_stacks()
 
 /obj/item/stack/update_icon()
 	if(novariants)
@@ -300,7 +292,7 @@
 	return 0
 
 //creates a new stack with the specified amount
-/obj/item/stack/proc/split(var/tamount, var/stack_loc)
+/obj/item/stack/proc/split(var/tamount)
 	if (!splittable)
 		return null
 	if (!amount)
@@ -312,7 +304,7 @@
 
 	var/orig_amount = src.amount
 	if (transfer && src.use(transfer))
-		var/obj/item/stack/S = new src.type(stack_loc, transfer)
+		var/obj/item/stack/S = new src.type(src.loc, transfer)
 		S.color = color
 
 		if (prob(transfer/orig_amount * 100))
@@ -363,7 +355,7 @@
 
 /obj/item/stack/attack_hand(mob/user as mob)
 	if (user.get_inactive_hand() == src)
-		var/obj/item/stack/F = src.split(1, user.get_active_hand_slot())
+		var/obj/item/stack/F = src.split(1)
 		if (F)
 			user.put_in_hands(F)
 			src.add_fingerprint(user)
@@ -404,8 +396,6 @@
 	if (!usr.IsAdvancedToolUser())
 		return
 
-
-
 	var/quantity = input(usr,
 	"This stack contains [amount]/[max_amount]. How many would you like to split off into a new stack?\n\
 	The new stack will be put into your hands if possible", "Split Stack", round(amount * 0.5)) as null|num
@@ -420,7 +410,7 @@
 	if (!isnum(quantity) || quantity < 1)
 		return
 
-	var/obj/item/stack/S = split(round(quantity, 1), NULLSPACE)
+	var/obj/item/stack/S = split(round(quantity, 1))
 	if (istype(S))
 		//Try to put the new stack into the user's hands
 		if (!(usr.put_in_hands(S)))

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -302,12 +302,12 @@
 
 	var/transfer = max(min(tamount, src.amount, initial(max_amount)), 0)
 
-	var/orig_amount = src.amount
-	if (transfer && src.use(transfer))
+	var/orig_amount = amount
+	if(transfer && use(transfer))
 		var/obj/item/stack/S = new src.type(loc, transfer)
 		S.color = color
 
-		if (prob(transfer/orig_amount * 100))
+		if(prob(transfer/orig_amount * 100))
 			transfer_fingerprints_to(S)
 			if(blood_DNA)
 				if(!S.blood_DNA || !istype(S.blood_DNA, /list))	//if our list of DNA doesn't exist yet (or isn't a list) initialise it.

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -362,8 +362,8 @@
 			F.add_fingerprint(user)
 
 			spawn(0)
-			if (src && usr.machine==src)
-				src.interact(usr)
+			if (src && user.machine == src)
+				interact(user)
 	else
 		..()
 


### PR DESCRIPTION
## About The Pull Request
- fixes stack duplication when splitting into an empty hand (newly split stack was immediately merging with the old one causing them to add their amounts)
- fixes stacks with 0 sheets forming when merging with another stack
- properly updates icons for freshly split stacks

## Why It's Good For The Game

Fixes good.

## Testing
splitted and merged stacks with an empty hand and the split verb to make sure that the amount of sheets doesn't increase

## Changelog
:cl:
fix: Stacks can no longer be duped by splitting with an empty hand, no more 0 sheet stacks, icons update properly
