### PR TITLE
Limbgibs no longer runtime and neither does Mech Sleeper

### DIFF
--- a/code/modules/mechs/equipment/medical.dm
+++ b/code/modules/mechs/equipment/medical.dm
@@ -16,7 +16,7 @@
 	sleeper.forceMove(src)
 
 /obj/item/mech_equipment/sleeper/Destroy()
-	sleeper.go_out() //If for any reason you weren't outside already.
+	sleeper?.go_out() //If for any reason you weren't outside already.
 	QDEL_NULL(sleeper)
 	. = ..()
 

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -120,7 +120,7 @@
 		if(is_usable())
 			owner.internal_organs_by_efficiency[process] |= src
 		else
-			owner.internal_organs_by_efficiency[process] -= src
+			owner?.internal_organs_by_efficiency[process] -= src // dead organs don't necessarily have an owner
 
 /obj/item/organ/internal/proc/get_process_efficiency(process_define)
 	var/organ_eff = organ_efficiency[process_define]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR ensures that upon a limbgib or other removal, the produced organs do not runtime on process. Additionally, Mech Sleepers no longer runtime when destroyed with no occupant.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtimes Bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Dismembered monkey before and after fix, runtimed before but not after.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
fix: Removed Organs should now process properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
