### PR TITLE
swapped dsay darkmode colorations

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput_override.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_override.css
@@ -22,7 +22,7 @@
 .adminticket			{color: #386AFF;	font-weight: bold;}
 
 /* Radio: Misc */
-.deadsay				{color: #530FAD;}
+.deadsay				{color: #6600cc;}
 .angelsay				{color: #ffaa00;}
 .deptradio				{color: #ff00ff;}	/* when all other department colors fail */
 .newscaster				{color: #750000;}

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -303,7 +303,7 @@ em {
 }
 
 .deadsay {
-  color: #e2c1ff;
+  color: #6600cc;
 }
 
 .binarysay {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR swaps deadsay darkmode color to #6600cc.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Increases Contrast.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Confirmed color change.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
tweak: darkmode deadchat is slightly differently colored.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
