### PR TITLE
IH setup runtime resolution

### DIFF
--- a/code/datums/components/clothing_sanity_protection.dm
+++ b/code/datums/components/clothing_sanity_protection.dm
@@ -13,7 +13,7 @@
 /datum/component/clothing_sanity_protection/proc/handle_sanity_buffs(mob/living/carbon/human/user)
 	SIGNAL_HANDLER
 	var/obj/item/current_parent = parent
-	if(current_parent.is_worn())
+	if(current_parent.is_worn() && user.sanity)
 		user.sanity.environment_cap_coeff *= environment_cap_buff
 		RegisterSignal(user, COMSIG_CLOTH_DROPPED, PROC_REF(handle_sanity_debuff))
 		current_user = user


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes Mannequins no longer cause runtimes on equipping sanity-protecting masks.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtime Bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Selected IH Operative in Setup, did not runtime.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
code: fix: fixed runtime on selecting IH in setup
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
