### PR TITLE
can now examine empty containers while smart

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -379,7 +379,7 @@ its easier to just keep the beam vertical.
 			else if(length(reagents.reagent_list))
 				output += SPAN_NOTICE("\nIt contains [reagents.total_volume] units of [user.can_see_reagents() ? reagents.reagent_list[1].name : "something"]")
 			else
-				output += SPAN_NOTICE("It contains nothing.")
+				output += SPAN_NOTICE("\nIt's dry.")
 		else if(reagent_flags & AMOUNT_VISIBLE)
 			output += SPAN_NOTICE("[reagents.total_volume ? "\nIt has [reagents.total_volume] units left." : "\nIt's empty."]")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR lets you examine empty transparent reagent containers while cog 35, bio 50, or otherwise able to discern reagents, without triggering a runtime. Additionally, it adds "It's dry.".
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This logic works, the previous logic does not.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Examined an empty beaker with and without science goggles before fix, empty beaker runtimed with science goggles. After fix, empty beaker examine did not runtime regardless.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
fix: High intelligence characters can now comprehend the possibility of a beaker not containing any reagents.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
