### PR TITLE
Adds Hepatitis and Liver Regeneration

### DIFF
--- a/code/modules/organs/internal/internal_organ_processes.dm
+++ b/code/modules/organs/internal/internal_organ_processes.dm
@@ -93,7 +93,7 @@
 
 	if(toxin_damage > 0 && liver)
 		liver.take_damage(toxin_damage, TOX)
-	else if(liver?.damage)
+	else if(liver)
 		for(var/tocheck in liver.wounddatums)
 			if(ispath(tocheck, /datum/internal_wound/organic/hepatitis)) // low level inflammation
 				var/datum/internal_wound/treathis = liver.wounddatums[tocheck]

--- a/code/modules/organs/internal/internal_organ_processes.dm
+++ b/code/modules/organs/internal/internal_organ_processes.dm
@@ -93,6 +93,17 @@
 
 	if(toxin_damage > 0 && liver)
 		liver.take_damage(toxin_damage, TOX)
+	else if(liver?.damage)
+		for(var/tocheck in liver.wounddatums)
+			if(ispath(tocheck, /datum/internal_wound/organic/hepatitis)) // low level inflammation
+				var/datum/internal_wound/treathis = liver.wounddatums[tocheck]
+				treathis.treatment()
+			else if(ispath(tocheck, /datum/internal_wound/organic/fibrosis))
+				var/datum/internal_wound/treathis = liver.wounddatums[tocheck]
+				treathis.treatment_slow(max(1, round(liver_efficiency/32))) // fibrosis cures better the healthier the liver is, but isn't incurable before it reaches a worse state
+			else if (ispath(tocheck, /datum/internal_wound/organic/edge) || ispath(tocheck, /datum/internal_wound/organic/sharp) || ispath(tocheck, /datum/internal_wound/organic/blunt))
+				var/datum/internal_wound/treathis = liver.wounddatums[tocheck]
+				treathis.treatment_slow(max(1, round(liver_efficiency/16))) // liver regenerates good
 
 	// Blood loss or liver damage make you lose nutriments
 	var/blood_volume = get_blood_volume()

--- a/code/modules/organs/internal/internal_wounds/_internal_wound.dm
+++ b/code/modules/organs/internal/internal_wounds/_internal_wound.dm
@@ -144,7 +144,7 @@
 			return // then return
 	else if(!(characteristic_flag & IWOUND_PROGRESS)) // but if the aggravation tag IS present, but progress tag isn't, then custom process
 		++current_progression_tick
-		if(current_progression_tick >= progression_threshold)
+		if(current_progression_tick >= progression_threshold || severity == severity_max)
 			current_progression_tick = 0
 		else
 			return
@@ -230,9 +230,18 @@
 		if(initial(characteristic_flag) & IWOUND_PROGRESS)
 			characteristic_flag |= IWOUND_PROGRESS
 	else
-		if(!used_autodoc && scar && ispath(scar, /datum/component))
+		if(!used_autodoc && scar && ispath(scar, /datum/internal_wound))
 			SEND_SIGNAL_OLD(parent, COMSIG_IORGAN_ADD_WOUND, pick(subtypesof(scar)))
 		SEND_SIGNAL_OLD(parent, COMSIG_IORGAN_REMOVE_WOUND, src)
+
+/datum/internal_wound/proc/treatment_slow(amount = 1)
+	var/treatmentamount = min(amount, current_progression_tick)
+	current_progression_tick = current_progression_tick - treatmentamount
+	if(current_progression_tick <= 0)
+		current_progression_tick = progression_threshold-1
+		treatment()
+	if(!QDELING(src) && treatmentamount < amount)
+		treatment_slow(amount - treatmentamount)
 
 /datum/internal_wound/proc/apply_effects()
 	var/obj/item/organ/internal/O = parent

--- a/code/modules/organs/internal/internal_wounds/organic.dm
+++ b/code/modules/organs/internal/internal_wounds/organic.dm
@@ -157,6 +157,32 @@
 	name = "foreign accumulation"
 	hal_damage = IWOUND_MEDIUM_DAMAGE
 
+/datum/internal_wound/organic/hepatitis
+	name = "inflammation"
+	characteristic_flag = IWOUND_AGGRAVATION
+	organ_efficiency_multiplier = -0.10 // not in top condition, not dying yet though
+	next_wound = /datum/internal_wound/organic/fibrosis
+	progression_threshold = IWOUND_HALF_MINUTE
+
+/datum/internal_wound/organic/fibrosis
+	characteristic_flag = IWOUND_CAN_DAMAGE|IWOUND_AGGRAVATION
+	severity_max = 4
+	next_wound = /datum/internal_wound/organic/cirrhosis
+	progression_threshold = IWOUND_HALF_MINUTE
+
+/datum/internal_wound/organic/fibrosis/scarred
+	name = "scarring"
+
+
+/datum/internal_wound/organic/cirrhosis
+	characteristic_flag = IWOUND_CAN_DAMAGE|IWOUND_AGGRAVATION
+	severity_max = 4
+	progression_threshold = IWOUND_1_MINUTE
+
+
+/datum/internal_wound/organic/cirrhosis/scarred
+	name = "severe scarring"
+
 /*
 /datum/internal_wound/organic/poisoning/swelling
 	name = "light swelling"

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -17,3 +17,15 @@
 	organ_efficiency = list(OP_LIVER = 150)
 	specific_organ_size = 1.2
 	desc = "You will need twice the amount of booze for this one to fail."
+
+/obj/item/organ/internal/liver/get_possible_wounds(damage_type, sharp, edge)
+	if(damage_type == TOX) // partial override
+		var/list/possible_wounds = list()
+		if(BP_IS_ORGANIC(src) || BP_IS_ASSISTED(src))
+			possible_wounds += /datum/internal_wound/organic/hepatitis
+		. = possible_wounds
+	else
+		. = ..()
+	
+
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds a Liver-specific chain of Tox wounds, that being the Hepatitis->Fibrosis->Cirrhosis chain. Hepatitis cures quickly when removed from the source of the inflammation, Fibrosis cures slowly, and Cirrhosis does not cure at all without an auto-doc. Additionally, Brute wounds cure slowly when the Liver is not under threat by toxicity.
Fibrosis and Brute regeneration are accelerated by Anti-Tox.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Providing a self-regenerating minor buffer for liver damage is beneficial to the place of toxins in the game.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Confirmed effect with Chlorine, low doses of Blattedin, and a bottle of vodka on separate disciples- effects were acceptable.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
add: Liver now self-regenerates while under toxic capacity, at a rate boosted by anti-tox.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
