### PR TITLE
mouse lifetime limit fixed

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -86,9 +86,6 @@
 					squeals++
 					last_squealgain = world.time
 
-	else
-		if ((world.time - timeofdeath) > decompose_time)
-			dust()
 
 
 //Pixel offsetting as they scamper around


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR allows mice to survive the 30 minute mark.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mouse can live, as a treat!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Before the PR, testing shows that once you leave a mouse alone to think about life for a brief time after it's been thirty minutes, it will shrivel up into a skeleton. After the PR, testing shows both mice tested with, brown and gray, survived.
![image](https://github.com/user-attachments/assets/3ba8a7bb-0b8b-4b09-af97-96429d1b3b71)
![image](https://github.com/user-attachments/assets/8401b52c-b75c-4316-8b12-215d888977b6)
Killed Tom, Confirmed Tom became remains thirty minutes later.
![image](https://github.com/user-attachments/assets/f28362fb-6c2c-42ad-8bea-266af6227373)

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
add: Mice can now live.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
