### PR TITLE
Unknown Roachmind Fixes

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
@@ -131,5 +131,5 @@
 						else if(overseer && !comrade.overseer)
 							comrade.joinOvermind(overseer)
 				else
-					if(!overseer && istype(comrade, /mob/living/carbon/superior_animal/roach/fuhrer) || istype(comrade, /mob/living/carbon/superior_animal/roach/kaiser) && comrade.overseer)
+					if(!overseer && (istype(comrade, /mob/living/carbon/superior_animal/roach/fuhrer) || istype(comrade, /mob/living/carbon/superior_animal/roach/kaiser)) && comrade.overseer)
 						joinOvermind(comrade.overseer)

--- a/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
@@ -120,7 +120,7 @@
 							comrade.joinOvermind(overseer)
 							overseer.leader = comrade
 						else if(!overseer && comrade.overseer) // or if they have an overmind and we don't, we join
-							joinOvermind(overseer)
+							joinOvermind(comrade.overseer)
 				if(/mob/living/carbon/superior_animal/roach/kaiser) // only one possibility requires code with kaiser
 					if(istype(comrade, /mob/living/carbon/superior_animal/roach/fuhrer))
 						if(overseer && comrade.overseer)

--- a/code/modules/mob/living/carbon/superior_animal/roach/roachmind.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/roachmind.dm
@@ -33,7 +33,7 @@
 	var/list/highest[] // an overmind ruled by a fuhrer is subordinate to one ruled by a kaiser.
 	if(istype(leader, /mob/living/carbon/superior_animal/roach/kaiser))
 		highest += src
-	if(!istype(collatewith.leader, /mob/living/carbon/superior_animal/roach/kaiser))
+	if(istype(collatewith.leader, /mob/living/carbon/superior_animal/roach/kaiser))
 		highest += collatewith
 	if(length(highest) == 1)
 		if(highest[1] == src)

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/kaiser.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/kaiser.dm
@@ -106,6 +106,26 @@ Has ability of every roach.
 	gas_sac.clear_reagents()
 	return TRUE
 
+/mob/living/carbon/superior_animal/roach/kaiser/leaveOvermind()
+	var/mob/living/carbon/superior_animal/roach/new_leader
+	var/list/secondaries = list()
+	for(var/mob/living/carbon/superior_animal/roach/tocheck in overseer.members)
+		if(istype(tocheck, /mob/living/carbon/superior_animal/roach/kaiser))
+			new_leader = tocheck
+			overseer.leader = new_leader
+			break
+		else if(istype(tocheck, /mob/living/carbon/superior_animal/roach/fuhrer))
+			secondaries.Add()
+	if((!new_leader) && length(secondaries))
+		new_leader = secondaries[1]
+	if(!istype(new_leader, /mob/living/carbon/superior_animal/roach/kaiser))
+		for(var/datum/overmind/roachmind/subordinate in overseer.subordinates)
+			subordinate.superior = null
+	overseer.subordinates.Cut()
+	if(!new_leader && !QDELETED(overseer)) // kaiser is always the leader
+		qdel(overseer) // disband
+	. = ..()
+
 /mob/living/carbon/superior_animal/roach/kaiser/findTarget()
 	. = ..()
 	if(. && gas_attack())

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/kaiser.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/kaiser.dm
@@ -107,24 +107,23 @@ Has ability of every roach.
 	return TRUE
 
 /mob/living/carbon/superior_animal/roach/kaiser/leaveOvermind()
-	var/mob/living/carbon/superior_animal/roach/new_leader
-	var/list/secondaries = list()
+	var/mob/living/carbon/superior_animal/roach/backup
+	overseer.removeHarrier(src)
 	for(var/mob/living/carbon/superior_animal/roach/tocheck in overseer.members)
 		if(istype(tocheck, /mob/living/carbon/superior_animal/roach/kaiser))
-			new_leader = tocheck
-			overseer.leader = new_leader
-			break
+			overseer.leader = tocheck
+			overseer?.casualties.Remove(src)
+			overseer = null
+			return
 		else if(istype(tocheck, /mob/living/carbon/superior_animal/roach/fuhrer))
-			secondaries.Add()
-	if((!new_leader) && length(secondaries))
-		new_leader = secondaries[1]
-	if(!istype(new_leader, /mob/living/carbon/superior_animal/roach/kaiser))
-		for(var/datum/overmind/roachmind/subordinate in overseer.subordinates)
-			subordinate.superior = null
+			backup = tocheck
+	for(var/datum/overmind/roachmind/subordinate in overseer.subordinates) //by this point if there even is a new leader, it is a "mere fuhrer".
+		subordinate.superior = null
 	overseer.subordinates.Cut()
-	if(!new_leader && !QDELETED(overseer)) // kaiser is always the leader
+	overseer.leader = backup
+	if(!backup && !QDELETED(overseer)) // kaiser is always the leader
 		qdel(overseer) // disband
-	. = ..()
+	overseer = null
 
 /mob/living/carbon/superior_animal/roach/kaiser/findTarget()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR provides a variety of roachmind fixes, which may or may not prevent a runtime. Additionally, Kaisers now manage their overmind when they die.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Improvements Good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Triggered Kaiser event twenty times and Infestation event 40 times, no roachmind-related runtimes found.
Killed Kaiser without fuhrer in Overseer swarm- Overseer was destroyed; with fuhrer, fuhrer gained leadership instead.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
