### PR TITLE
hysteric and selfharm breakdowns now nullcheck after delay

### DIFF
--- a/code/modules/sanity/breakdowns.dm
+++ b/code/modules/sanity/breakdowns.dm
@@ -201,7 +201,7 @@
 
 /datum/breakdown/negative/selfharm/occur()
 	spawn(delay)
-		++holder.owner.suppress_communication
+		++holder?.owner.suppress_communication
 	return ..()
 
 /datum/breakdown/negative/selfharm/conclude()
@@ -240,9 +240,9 @@
 
 /datum/breakdown/negative/hysteric/occur()
 	spawn(delay)
-		holder.owner.SetWeakened(4)
-		holder.owner.SetStunned(4)
-		++holder.owner.suppress_communication
+		holder?.owner.SetWeakened(4)
+		holder?.owner.SetStunned(4)
+		++holder?.owner.suppress_communication
 	return ..()
 
 /datum/breakdown/negative/hysteric/conclude()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes the Hysteric and Self-Harm breakdowns nullcheck after their inbuilt delay. This is necessary because on the event the human they are attached to is destroyed, their references become invalid, while their spawn() calls will still continue.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtimes are BAD
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Before fix:
Spawned Disciple, force-gave Hysteric breakdown, deleted Disciple, waited, runtime.
After fix:
Spawned Disciple, force-gave Hysteric breakdown, deleted disciple... waited... runtime did not appear!
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
fix: self-harm and hysteric breakdowns no longer cause a runtime when they begin shortly before the associated human is obliterated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
