### PR TITLE
tasteless nutriment no longer runtimes

### DIFF
--- a/code/modules/mob/living/carbon/taste.dm
+++ b/code/modules/mob/living/carbon/taste.dm
@@ -23,6 +23,8 @@ calculate text size per text.
 				continue
 			if(R.id == "nutriment")
 				var/list/t = R.get_data()
+				if(!t) // no data, nutriment made from no source?
+					continue
 				for(var/i in 1 to t.len)
 					var/A = t[i]
 					if(!(A in tastes))

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3489,7 +3489,9 @@
 	slice_path = /obj/item/reagent_containers/food/snacks/doughslice
 	slices_num = 3
 	center_of_mass = list("x"=16, "y"=16)
-	preloaded_reagents = list("protein" = 1, "nutriment" = 3)
+	nutriment_desc = list("dough" = 3)
+	nutriment_amt = 3
+	preloaded_reagents = list("protein" = 1)
 	taste_tag = list(BLAND_FOOD,FLOURY_FOOD)
 
 /obj/item/reagent_containers/food/snacks/doughslice


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR ensures that even if nutriment doesn't have a taste, drinking it still works. This is necessary because nutriment can be created without a taste as a decay product of roach chems.
Additionally, this PR adds nutriment data to the flat dough item, rectifying its lacking taste.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nutriment is made to be eaten.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Heated Diplopterum to its decay threshold, separated nutriment, drank it after fix, intended result occurred.
Cooked Spider Meat Pie, ate from Spider Meat Pie, runtime did not occur.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
fix: nutriment made via roach chem decay is now fully drinkable.
fix: Flat Dough and derivatives are now more edible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
