### PR TITLE
Bleeding Limb Help-Grab rework and Wound-Clamping nerf

### DIFF
--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -74,8 +74,7 @@
 		else
 			visible_message(SPAN_NOTICE("[user] finishes putting pressure on [H]'s wounds."))
 			for(var/datum/wound/W in bodypart.wounds)
-				W.current_stage++
-				W.bleed_timer -= 5
+				W.clamped = TRUE
 	//do not kill the grab
 
 

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -75,6 +75,7 @@
 			visible_message(SPAN_NOTICE("[user] finishes putting pressure on [H]'s wounds."))
 			for(var/datum/wound/W in bodypart.wounds)
 				W.clamped = TRUE
+			bodypart.stopBleeding()
 	//do not kill the grab
 
 

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -143,6 +143,7 @@
 	proc/open_wound(damage)
 		src.damage += damage
 		bleed_timer += damage
+		clamped = FALSE
 
 		while(src.current_stage > 1 && src.damage_list[current_stage-1] <= src.damage / src.amount)
 			src.current_stage--


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR swaps the effect of bleeding limb help-grab from lowering the wound stage and bleed timer to clamping the wounds and stopping the bleeding via Clamp effect. Additionally, the re-open wounds proc now undoes clamped status. This replaces buggy code that resulted in runtimes via direct wound stage meddling with code that does not runtime.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Clamped wounds shouldn't be immune to bleeding, and Wound Stage should not be directly manipulated.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Shot disciple with slaughtomatic after punching them, before fix pressuring their wounds runtimed, after fix it did not.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
balance: Clamped wounds do not stay clamped when re-opened.
balance: Pressuring wounds now clamps the wound until re-opened.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
