### PR TITLE
Mining generation fixes

### DIFF
--- a/code/modules/mining/drilling/deep_drill.dm
+++ b/code/modules/mining/drilling/deep_drill.dm
@@ -43,7 +43,7 @@
 		MATERIAL_PLASTIC = /obj/item/ore/coal
 		)
 
-/obj/machinery/mining/deep_drill/Initialize()
+/obj/machinery/mining/deep_drill/LateInitialize()
 	. = ..()
 	cave_gen = locate(/obj/cave_generator)
 	update_icon()

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -149,8 +149,9 @@
 		for(var/oretype in typesof(/ore)-/ore)
 			var/ore/OD = new oretype()
 			ore_data[OD.name] = OD
-			ores_processing[OD.name] = 0
-			ores_stored[OD.name] = 0
+	for(var/ore/OD in ore_data)
+		ores_processing[OD.name] = 0
+		ores_stored[OD.name] = 0
 
 	spawn()
 		//Locate our output and input machinery.

--- a/code/modules/random_map/automata/caves.dm
+++ b/code/modules/random_map/automata/caves.dm
@@ -40,6 +40,10 @@
 
 // Create ore turfs.
 /datum/random_map/automata/cave_system/cleanup()
+	if(!ore_data || !ore_data.len)
+		for(var/oretype in typesof(/ore)-/ore)
+			var/ore/OD = new oretype()
+			ore_data[OD.name] = OD
 	var/ore_count = round(map.len/20)
 	while((ore_count>0) && (ore_turfs.len>0))
 		if(!priority_process) sleep(-1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes the deep drill wait until mapload to locate the cave generator obj. Additionally, multiple ore processors can function in the same game, and the cave generator can generate oredata without needing the assistance of an ore processor.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mining is a good feature and should work.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Before fix:
Failed to wrench deep drill, runtime appeared.
Visited asteroid, walls appeared, floors appeared, ore did not.
After fix:
Used deep drill, entered cave successfully, fought golems successfully.
Visited asteroid, walls appeared, floor appeared, some walls were made with ore.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
