### PR TITLE
Rigged flashlights no longer runtime during Process()

### DIFF
--- a/code/game/objects/items/devices/lighting/toggleable/flashlight.dm
+++ b/code/game/objects/items/devices/lighting/toggleable/flashlight.dm
@@ -243,7 +243,7 @@
 			if(ismob(src.loc))
 				to_chat(src.loc, SPAN_WARNING("Your flashlight dies. You are alone now."))
 			turn_off()
-		else if(cell.percent() <= 25)
+		else if(cell?.percent() <= 25)
 			apply_power_deficiency()
 
 /obj/item/device/lighting/toggleable/flashlight/attack(mob/living/M, mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds a null check after a use call in the Process enables rigged cells to self-destruct.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtime Bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
used rigged flashlight before fix- runtimed. after fix, rigged flashlight did not runtime when detonating.
