### PR TITLE
carrion maw updated

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/carrion/identity_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/identity_spider.dm
@@ -8,7 +8,7 @@
 	if(!owner_mob)
 		return
 	if(wearer)
-		if(wearer.type == /mob/living/carbon/human)
+		if(ishuman(wearer))
 			var/obj/item/organ/internal/carrion/core/C = owner_mob.random_organ_by_process(BP_SPCORE)
 			C.absorbed_dna |= wearer.real_name
 			to_chat(owner_mob, SPAN_NOTICE("You absorb [wearer]'s DNA"))

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -136,10 +136,8 @@ var/list/holder_mob_icon_cache = list()
 		//Repeat this check
 		//If we're still on the turf a few frames later, then we have actually been dropped or thrown
 		//Release the mob accordingly
-		//addtimer(CALLBACK(src, PROC_REF(post_drop)), 3)
+		addtimer(CALLBACK(src, PROC_REF(post_drop)), 3)
 		//TODO: Uncomment the above once addtimer is ported
-		spawn(3)
-			post_drop()
 		return
 
 	if (istype(loc, /obj/item/storage))	//The second drop reads the container its placed into as the location
@@ -580,6 +578,18 @@ var/list/holder_mob_icon_cache = list()
 		if(I)
 			return I
 	return null
+
+//Holders for mice
+/obj/item/holder/carrion
+	name = "spider core"
+	desc = "A horrifying face on spider-like legs."
+	desc_dead = "A dead bio-weapon, it probably tastes horrible."
+	icon = 'icons/mob/animal.dmi'
+	icon_state = "spider_core"
+	slot_flags = SLOT_HEAD
+	origin_tech = list(TECH_BIO = 5)
+	w_class = ITEM_SIZE_NORMAL
+
 
 /*
 //Lizards

--- a/code/modules/mob/living/simple_animal/spider_core.dm
+++ b/code/modules/mob/living/simple_animal/spider_core.dm
@@ -24,6 +24,7 @@
 	hunger_enabled = FALSE
 	pass_flags = PASSTABLE
 	universal_understand = 1
+	holder_type = /obj/item/holder/carrion
 	density = TRUE //Should be 0, but then these things would be a nightmare to kill.
 	faction = "spiders"
 
@@ -35,7 +36,11 @@
 		/mob/living/simple_animal/spider_core/proc/generate_body))
 
 /mob/living/simple_animal/spider_core/death()
-	gibs(loc, null, /obj/effect/gibspawner/generic, "#666600", "#666600")
+	var/obj/item/organ/internal/core = locate(/obj/item/organ/internal/carrion/core) in contents
+	core.forceMove(loc)
+	core.status |= ORGAN_DEAD // todo: make wound somehow
+	core.refresh_damage()
+	playsound(loc, 'sound/voice/shriek1.ogg', 50)
 	qdel(src)
 	
 

--- a/code/modules/mob/living/simple_animal/spider_core.dm
+++ b/code/modules/mob/living/simple_animal/spider_core.dm
@@ -37,9 +37,10 @@
 
 /mob/living/simple_animal/spider_core/death()
 	var/obj/item/organ/internal/core = locate(/obj/item/organ/internal/carrion/core) in contents
-	core.forceMove(loc)
-	core.status |= ORGAN_DEAD // todo: make wound somehow
-	core.refresh_damage()
+	if(core)
+		core.forceMove(loc)
+		core.status |= ORGAN_DEAD // todo: make wound somehow
+		core.refresh_damage()
 	playsound(loc, 'sound/voice/shriek1.ogg', 50)
 	qdel(src)
 	

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -477,13 +477,18 @@
 				owner.carrion_hunger += 9
 				geneticpointgain = 10
 				chemgain = 50
-				var/obj/item/tastyspider = food
+				var/obj/item/holder/spiderholder = food
+				var/mob/living/simple_animal/spider_core/tastyspider = spiderholder.contained
 				var/obj/item/organ/internal/carrion/core/devoured = locate(/obj/item/organ/internal/carrion/core) in tastyspider.contents
 				var/obj/item/organ/internal/carrion/core/C = owner.random_organ_by_process(BP_SPCORE)
 				if(devoured && C)
 					C.absorbed_dna |= devoured.absorbed_dna
 				taste_description = "carrions taste heavenly, if only there was more!"
+				qdel(tastyspider)
 			else
+				if(istype(food, /obj/item/holder))
+					var/obj/item/holder/bland_animal = food
+					qdel(bland_animal.contained)
 				chemgain = 5
 				owner.carrion_hunger -= 1 //Prevents meat eating spam for infinate chems
 				taste_description = "this meat is bland."

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -401,8 +401,7 @@
 				for (var/obj/item/organ/internal/to_blacklist in E.internal_organs)
 					if (istype(to_blacklist, /obj/item/organ/internal/bone/))
 						blacklist += to_blacklist
-						continue
-					if (istype(to_blacklist, /obj/item/organ/internal/vital/brain/))
+					else if (istype(to_blacklist, /obj/item/organ/internal/vital/brain/))
 						blacklist += to_blacklist// removing bones from a valid_organs list based on
 				var/list/valid_organs = E.internal_organs - blacklist// E.internal_organs gibs the victim.
 				if (!valid_organs.len)
@@ -437,11 +436,15 @@
 				var/obj/item/organ/internal/carrion/core/G = owner.random_organ_by_process(BP_SPCORE)
 				if(O in G.associated_carrion_organs)
 					taste_description = "albeit delicious, your own organs carry no new genetic material"
+					chemgain = 50
 				else
 					owner.carrion_hunger += 3
 					geneticpointgain = 4
 					chemgain = 50
 					taste_description = "carrion organs taste heavenly, you need more!"
+					if(istype(O, /obj/item/organ/internal/carrion/core))
+						var/obj/item/organ/internal/carrion/core/devoured = O
+						G.absorbed_dna |= devoured.absorbed_dna
 			else if(istype(O, /obj/item/organ/internal))
 				var/organ_rotten = FALSE
 				if (O.status & ORGAN_DEAD)
@@ -477,7 +480,7 @@
 
 		var/chemvessel_efficiency = owner.get_organ_efficiency(OP_CHEMICALS)
 		if(chemvessel_efficiency > 1)
-			owner.carrion_stored_chemicals = min(owner.carrion_stored_chemicals + 0.01 * chemvessel_efficiency , 0.5 * chemvessel_efficiency)
+			owner.carrion_stored_chemicals = min(owner.carrion_stored_chemicals + 0.01 * chemvessel_efficiency * chemgain , 0.5 * chemvessel_efficiency)
 
 		to_chat(owner, SPAN_NOTICE("You consume \the [food], [taste_description]."))
 		visible_message(SPAN_DANGER("[owner] devours \the [food]!"))
@@ -555,7 +558,7 @@
 			continue
 		toxin_attack(creature, rand(1, 3))
 
-/obj/effect/decal/cleanable/solid_biomass/attackby(var/obj/item/I, var/mob/user)
+/obj/effect/decal/cleanable/carrion_puddle/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/mop) || istype(I, /obj/item/soap))
 		to_chat(user, SPAN_NOTICE("You started cleaning this [src]."))
 		if(do_after(user, 3 SECONDS, src))

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -473,12 +473,15 @@
 			taste_description = "human meat is satisfying."
 
 		else
-			if(istype(food, /mob/living/simple_animal/spider_core))
+			if(istype(food, /obj/item/holder/carrion))
 				owner.carrion_hunger += 9
 				geneticpointgain = 10
 				chemgain = 50
-				var/obj/item/organ/internal/carrion/core/devoured = locate(/obj/item/organ/internal/carrion/core) in contents
-				G.absorbed_dna |= devoured.absorbed_dna
+				var/obj/item/tastyspider = food
+				var/obj/item/organ/internal/carrion/core/devoured = locate(/obj/item/organ/internal/carrion/core) in tastyspider.contents
+				var/obj/item/organ/internal/carrion/core/C = owner.random_organ_by_process(BP_SPCORE)
+				if(devoured && C)
+					C.absorbed_dna |= devoured.absorbed_dna
 				taste_description = "carrions taste heavenly, if only there was more!"
 			else
 				chemgain = 5

--- a/code/modules/organs/internal/internal_organ_processes.dm
+++ b/code/modules/organs/internal/internal_organ_processes.dm
@@ -259,6 +259,10 @@
 		if(carrion_hunger < max_hunger)
 			carrion_hunger = min(carrion_hunger + (round(1* (maw_efficiency / 100))), max_hunger)
 		else
+			if(ingested.has_reagent("nutriment", 1))
+				ingested.remove_reagent("nutriment", 1)
+			else
+				nutrition = max(0, nutrition - 20) // equivalent to a unit of nutriment
 			to_chat(src, SPAN_WARNING("Your hunger is restless!"))
 		carrion_last_hunger = world.time
 


### PR DESCRIPTION
## About The Pull Request
This PR updates the Carrion maw in a few ways.

-  The maw now applies chemgain as a multiplier to gained carrion chems and not just nutriment.
-  The code intended for cleanable puddles now define their behavior instead of overriding solid biomass puddle effect.
-  Eating a carrion core now transfers all of the core's disguises.
- Having maxed carrion hunger now increases human hunger, or if there is nutriment in the stomach, absorbs an equivalent amount.
- Carrion maw can now eat from holders.

Additionally:
- Spider core simple mob now drops the carrion core organ in a dead state when killed instead of gibbing, and can be picked up.
- Carrion organs are now worth more bio-tech than normal.
- A spawn call has been replaced with a timer.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Carrion can be better, and now it is.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Confirmed toxic puddle now takes three seconds to clean.
Confirmed chemical regeneration effect by consuming monkey organ.
Confirmed scale and effect of maxed carrion hunger on human hunger/nutriment.
Confirmed dropped mouse holder still returns mouse to floor.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
add: Eating another carrion's core with your maw gives you the other carrion's disguises
balance: carrion over-hunger is now punished by making your human form hungry
tweak: carrion maw now works with holders.
tweak: carrions now drop as an inert item if the core is killed.
fix:balance: Carrion Toxic Puddles now take time to clean
fix: eating with carrion maw provides proper chem value
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
