### PR TITLE
Qdel hints now applied consistently

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -48,7 +48,7 @@ Pipelines + Other Objects -> Pipe network
 
 /obj/machinery/atmospherics/Destroy()
 	GLOB.atmos_machinery -= src
-	..()
+	. = ..()
 
 /obj/machinery/atmospherics/proc/atmos_init()
 	return

--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -56,7 +56,7 @@
 		node2.disconnect(src)
 		QDEL_NULL(network2)
 		node2 = null
-	..()
+	. = ..()
 
 
 /obj/machinery/atmospherics/binary/atmos_init()

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -22,7 +22,7 @@
 
 /obj/machinery/computer/Destroy()
 	GLOB.computer_list -= src
-	..()
+	. = ..()
 
 /obj/machinery/computer/Process()
 	if(stat & (NOPOWER|BROKEN))

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -56,7 +56,7 @@
 	UnregisterSignal(src, COMSIG_IORGAN_ADD_WOUND)
 	UnregisterSignal(src, COMSIG_IORGAN_REMOVE_WOUND)
 	UnregisterSignal(src, COMSIG_IORGAN_REFRESH_SELF)
-	..()
+	. = ..()
 
 /obj/item/organ/internal/removed()
 	UnregisterSignal(parent, COMSIG_IORGAN_WOUND_COUNT)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -230,7 +230,7 @@
 	if(flashlight_attachment)
 		flashlight_attachment.forceMove(get_turf(src))
 		flashlight_attachment = null
-	..()
+	. = ..()
 
 /obj/item/gun/proc/set_item_state(state, hands = TRUE, back = FALSE, onsuit = FALSE)
 	var/wield_state


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR ensures guns, internal organs, atmospheric machinery, and static computers use a qdel hint instead of relying on the basic fallback.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Relying on failsafes is unsafe, and this makes it just work normally again.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Enabled test compile option, before fix, all of the listed items gave failsafe warnings, after fix, no failsafe warnings for qdel hints remained.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: Chickenish
code: Qdel hints are now better
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
