### PR TITLE
Hysteria and Selfharm no longer trigger black magic that makes the game believe the sanity datum is a human

### DIFF
--- a/code/modules/sanity/breakdowns.dm
+++ b/code/modules/sanity/breakdowns.dm
@@ -201,7 +201,9 @@
 
 /datum/breakdown/negative/selfharm/occur()
 	spawn(delay)
-		++holder?.owner.suppress_communication
+		if(ishuman(holder?.owner))
+			var/mob/living/carbon/human/tobreakdown = holder.owner
+			++tobreakdown.suppress_communication
 	return ..()
 
 /datum/breakdown/negative/selfharm/conclude()
@@ -240,9 +242,11 @@
 
 /datum/breakdown/negative/hysteric/occur()
 	spawn(delay)
-		holder?.owner.SetWeakened(4)
-		holder?.owner.SetStunned(4)
-		++holder?.owner.suppress_communication
+		if(ishuman(holder?.owner))
+			var/mob/living/carbon/human/tobreakdown = holder.owner
+			tobreakdown.SetWeakened(4)
+			tobreakdown.SetStunned(4)
+			++tobreakdown.suppress_communication
 	return ..()
 
 /datum/breakdown/negative/hysteric/conclude()


### PR DESCRIPTION
 that needs to find its owner
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR changes the formatting of the nullchecks on Hysteria and Selfharm breakdowns to prevent type mismatch of sanity-human.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It would runtime every time the sanity datum tried to find its owner to tell it to shut up because the human's sanity though it itself was human, and therefore had no owner. This abomination of a process cannot continue.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Before fix, spawned disciple, gave Hysteria, waited without deleting disciple, runtime. After fix, identical processes for Hysteria and Self-Harm, no runtime.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
