### PR TITLE
crew records now Nano instead of TGUI

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/records.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/records.dm
@@ -9,22 +9,22 @@
 	size = 14
 	requires_ntnet = TRUE
 	available_on_ntnet = TRUE
-	nanomodule_path = /datum/nano_module/tgui/records
+	nanomodule_path = /datum/nano_module/records
 	usage_flags = PROGRAM_ALL
 
-/datum/nano_module/tgui/records
+/datum/nano_module/records
 	name = "Crew Records"
 	var/datum/computer_file/report/crew_record/active_record
 	var/message = null
 
-/datum/nano_module/tgui/records/ui_data(mob/user)
+/datum/nano_module/records/nano_ui_data(mob/user)
 	var/list/data = host.initial_data()
 	var/list/user_access = get_record_access(user)
 
 	data["message"] = message
 	if(active_record)
-		data["front_pic"] = icon2base64html(active_record.photo_front)
-		data["side_pic"] = icon2base64html(active_record.photo_side)
+		user << browse_rsc(active_record.photo_front, "front_[active_record.uid].png")
+		user << browse_rsc(active_record.photo_side, "side_[active_record.uid].png")
 		data["pic_edit"] = check_access(user, access_heads) || check_access(user, access_security)
 		data += active_record.generate_nano_data(user_access)
 	else
@@ -46,14 +46,17 @@
 
 	
 
-/datum/nano_module/tgui/records/ui_interact(mob/user, datum/tgui/ui = null)
-	ui = SStgui.try_update_ui(user, src, ui || currentui)
+/datum/nano_module/records/nano_ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = NANOUI_FOCUS, state = GLOB.default_state)
+	var/list/data = nano_ui_data(user)
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		currentui = new(user, src, "CrewRecords", name)
-		currentui.open()
+		ui = new(user, src, ui_key, "crew_records.tmpl", name, 700, 540, state = state)
+		ui.auto_update_layout = 1
+		ui.set_initial_data(data)
+		ui.open()
 
 
-/datum/nano_module/tgui/records/proc/get_record_access(var/mob/user)
+/datum/nano_module/records/proc/get_record_access(var/mob/user)
 	var/list/user_access = using_access || user.GetAccess()
 
 	var/obj/item/modular_computer/PC = nano_host()
@@ -63,7 +66,7 @@
 
 	return user_access
 
-/datum/nano_module/tgui/records/proc/edit_field(var/mob/user, var/field_ID)
+/datum/nano_module/records/proc/edit_field(var/mob/user, var/field_ID)
 	var/datum/computer_file/report/crew_record/R = active_record
 	if(!R)
 		return
@@ -74,69 +77,69 @@
 		to_chat(user, "<span class='notice'>\The [nano_host()] flashes an \"Access Denied\" warning.</span>")
 		return
 	F.ask_value(user)
+	nano_ui_interact(usr)
 
-/datum/nano_module/tgui/records/ui_act(action, params)
+/datum/nano_module/records/Topic(href, href_list)
 	if(..())
 		return 1
-	switch(action)
-	
-		if("clear_active")
-			active_record = null
-			return 1
-		if("clear_message")
-			message = null
-			return 1
-		if("set_active")
-			var/ID = text2num(params["set_active"])
-			for(var/datum/computer_file/report/crew_record/R in GLOB.all_crew_records)
-				if(R.uid == ID)
-					active_record = R
-					break
-			return 1
-		if("new_record")
-			if(!check_access(usr, access_heads))
-				to_chat(usr, "Access Denied.")
-				return
-			active_record = new/datum/computer_file/report/crew_record()
-			GLOB.all_crew_records.Add(active_record)
-			return 1
-		if("print_active")
-			if(!active_record)
-				return
-			print_text(record_to_html(active_record, get_record_access(usr)), usr)
-			return 1
-		if("search")
-			var/field_name = params["search"]
-			var/search = sanitize(input("Enter the value for search for.") as null|text)
-			if(!search)
-				return 1
-			for(var/datum/computer_file/report/crew_record/R in GLOB.all_crew_records)
-				var/datum/report_field/field = R.field_from_name(field_name)
-				if(lowertext(field.get_value()) == lowertext(search))
-					active_record = R
-					return 1
-			message = "Unable to find record containing '[search]'"
-			return 1
+	if(href_list["clear_active"])
+		active_record = null
+		return TRUE
+	else if(href_list["clear_message"])
+		message = null
+		return TRUE
+	if(href_list["set_active"])
+		var/ID = text2num(href_list["set_active"])
+		for(var/datum/computer_file/report/crew_record/R in GLOB.all_crew_records)
+			if(R.uid == ID)
+				active_record = R
+				break
+		return TRUE
+	if(href_list["new_record"])
+		if(!check_access(usr, access_heads))
+			to_chat(usr, "Access Denied.")
+			return
+		active_record = new/datum/computer_file/report/crew_record()
+		GLOB.all_crew_records.Add(active_record)
+		return TRUE
+	if(href_list["print_active"])
+		if(!active_record)
+			return
+		print_text(record_to_html(active_record, get_record_access(usr)), usr)
+		return TRUE
+	if(href_list["search"])
+		var/field_name = href_list["search"]
+		var/search = sanitize(input("Enter the value for search for.") as null|text)
+		if(!search)
+			return TRUE
+		for(var/datum/computer_file/report/crew_record/R in GLOB.all_crew_records)
+			var/datum/report_field/field = R.field_from_name(field_name)
+			if(lowertext(field.get_value()) == lowertext(search))
+				active_record = R
+				return TRUE
+		message = "Unable to find record containing '[search]'"
+		return TRUE
 
 	var/datum/computer_file/report/crew_record/R = active_record
 	if(!istype(R))
-		return 1
-	switch(action)
-		if("edit_photo_front")
-			var/photo = get_photo(usr)
-			if(photo && active_record)
-				active_record.photo_front = photo
-			return 1
-		if("edit_photo_side")
-			var/photo = get_photo(usr)
-			if(photo && active_record)
-				active_record.photo_side = photo
-			return 1
-		if("edit_field")
-			edit_field(usr, text2num(params["edit_field"]))
-			return 1
+		return TRUE
 
-/datum/nano_module/tgui/records/proc/get_photo(var/mob/user)
+	if(href_list["edit_photo_front"])
+		var/photo = get_photo(usr)
+		if(photo && active_record)
+			active_record.photo_front = photo
+		return TRUE
+	if(href_list["edit_photo_side"])
+		var/photo = get_photo(usr)
+		if(photo && active_record)
+			active_record.photo_side = photo
+			nano_ui_interact(usr)
+		return TRUE
+	if(href_list["edit_field"])
+		edit_field(usr, text2num(href_list["edit_field"]))
+		return TRUE
+
+/datum/nano_module/records/proc/get_photo(var/mob/user)
 	if(istype(user.get_active_hand(), /obj/item/photo))
 		var/obj/item/photo/photo = user.get_active_hand()
 		return photo.img

--- a/nano/templates/crew_records.tmpl
+++ b/nano/templates/crew_records.tmpl
@@ -27,32 +27,25 @@
 				{{/if}}
 				{{if value.needs_big_box}}
 					<div style="display: inline-block;">
+				{{else}}
+					<div class='itemBody'>
+				{{/if}}
+				{{if value.value}}
 					{{:value.value}}
-					{{else}}
-						{{if value.list_value}}
-							{{for value.list_value}}
-								{{:value}}
-							{{/for}}
+				{{else}}
+					{{if value.list_value}}
+						{{if value.list_value[0]}}
+							{{:value.list_value}}
 						{{else}}
-							{{if value.list_clumps}}
-								{{for value.list_clumps}}
-									{{for value}}
-										{{:value}}
-									{{/for}}
-								{{/for}}
-							{{else}}
-								{{if value.links}}
-									{{for 1 to value.links.len}}
-										{{for value.links}}
-											
-								{{/if}}
-							{{/if}}
+							Unset
+						{{/if}}
+					{{else}}
+						{{if value.list_clumps}}
+							{{:jQuery.map(value.list_clumps, function(index, mapped){return [mapped,": ", index.join(", ")].join("")}).join("<br>")}}
 						{{/if}}
 					{{/if}}
-					</div>
-				{{else}}
-					<div class='itemBody'>{{:value.value}}</div>
 				{{/if}}
+				</div>
 			</div>
 		{{/if}}
 	{{/for}}


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR restores crew records to their former NanoUI glory, now with the actual features I tried to implement earlier, and that last missing bit of reactivity it needed to feel smooth.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The TGUI version wasn't as functional as the NanoUI version, plus this is better suited for Byond as a whole.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Confirmed the old features still worked, both from the NanoUI Program and the Records Overhaul, and confirmed the new UI formatted things right.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog
:cl: chickenish
refactor: crew records returns to NanoUI.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
